### PR TITLE
fix(install): unblock Reddit-reported install + /config bugs (#1, #4, #5)

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -618,7 +618,7 @@ echo.
 :: ============================================================
 call :log_section "8/10  Smoke-Test"
 
-"%VENV_DIR%\Scripts\python.exe" -c "import sys; import jarvis; print(f'  [OK] jarvis v{jarvis.__version__}'); sys.exit(0)"
+"%VENV_DIR%\Scripts\python.exe" -c "import sys; import cognithor; print(f'  [OK] cognithor v{cognithor.__version__}'); sys.exit(0)"
 if errorlevel 1 (
     call :log_msg "[FAIL] Import test failed!"
     echo   Try: pip install -e "%REPO_ROOT%[all]"

--- a/install.ps1
+++ b/install.ps1
@@ -284,7 +284,7 @@ function Main {
 
     # ── Step 9: Smoke test ────────────────────────────────────────────
     Write-Step "9/10" "Smoke-Test"
-    $smokeResult = & $venvPython -c "import jarvis; print(f'jarvis v{jarvis.__version__}')" 2>&1
+    $smokeResult = & $venvPython -c "import cognithor; print(f'cognithor v{cognithor.__version__}')" 2>&1
     if ($LASTEXITCODE -eq 0) {
         Write-OK "Import OK: $smokeResult"
     } else {

--- a/install.sh
+++ b/install.sh
@@ -736,7 +736,7 @@ install_cognithor() {
     fi
 
     # Install identity extras if missing
-    if ! python3 -c "import jarvis.identity" 2>/dev/null; then
+    if ! python3 -c "import cognithor.identity" 2>/dev/null; then
         echo "  [INFO] Installing identity module..."
         retry "pip install -e '.[identity]' --quiet 2>/dev/null" || echo "  [WARNING] Identity install failed"
     fi
@@ -754,7 +754,7 @@ install_cognithor() {
     fi
 
     # Verify installation
-    if python3 -c "import jarvis; print(f'Cognithor v{jarvis.__version__}')" 2>/dev/null; then
+    if python3 -c "import cognithor; print(f'Cognithor v{cognithor.__version__}')" 2>/dev/null; then
         success "Cognithor installed successfully"
     else
         fatal "Installation failed -- pip install encountered errors"
@@ -995,7 +995,7 @@ BindsTo=cognithor.service
 
 [Service]
 Type=simple
-ExecStart=${VENV_DIR}/bin/python -m uvicorn jarvis.channels.webui:create_app --host 127.0.0.1 --port 8080 --factory
+ExecStart=${VENV_DIR}/bin/python -m uvicorn cognithor.channels.webui:create_app --host 127.0.0.1 --port 8080 --factory
 WorkingDirectory=${COGNITHOR_HOME}
 EnvironmentFile=-${COGNITHOR_HOME}/.env
 Restart=on-failure

--- a/src/cognithor/channels/cli.py
+++ b/src/cognithor/channels/cli.py
@@ -239,7 +239,10 @@ class CliChannel(Channel):
                     config_path = getattr(self._config, "jarvis_home", None)
                     if config_path is not None:
                         config_path = config_path / "config.yaml"
-                _launch_config_tui(config_path)
+                # config_tui uses prompt_toolkit's sync API — running it in a
+                # separate thread avoids the "event loop already running" error
+                # from calling pt_prompt() inside this async handler.
+                await asyncio.to_thread(_launch_config_tui, config_path)
                 self._console.print(
                     f"[{COLOR_INFO}]Config geschlossen. Fortfahren mit Chat.[/{COLOR_INFO}]"
                 )

--- a/tests/test_channels/test_cli.py
+++ b/tests/test_channels/test_cli.py
@@ -125,6 +125,24 @@ class TestSlashCommands:
         assert "Unknown command" in call_args_str
 
     @pytest.mark.asyncio
+    async def test_config_runs_in_thread(self, cli_with_console: CliChannel) -> None:
+        """'/config' must offload the sync prompt_toolkit TUI to a worker thread.
+
+        Regression for Reddit feedback 2026-04-20: calling pt_prompt() inside
+        the active asyncio event loop raised `This is a blocking call, but
+        there is an async event loop running`. Fix wraps the call in
+        asyncio.to_thread().
+        """
+        with patch("cognithor.cli.config_tui.launch") as mock_launch:
+            mock_launch.return_value = None
+            result = await cli_with_console._handle_command("/config")
+        assert result is True
+        mock_launch.assert_called_once()
+        # Print acknowledgment uses "Config geschlossen"
+        printed = " ".join(str(c) for c in cli_with_console._console.print.call_args_list)
+        assert "Config geschlossen" in printed
+
+    @pytest.mark.asyncio
     async def test_case_insensitive(self, cli_with_console: CliChannel) -> None:
         """Commands sind case-insensitiv."""
         result = await cli_with_console._handle_command("/QUIT")


### PR DESCRIPTION
## Summary

Fixes three of the five bugs the Reddit user reported on 2026-04-20:

- **#1 install.sh silently stops at Flutter check** — root cause was `python -c "import jarvis"` still used in the post-install verify. Since the rebrand, `import jarvis` raises, then `fatal "Installation failed"` exits the script right after the Flutter build output scrolled past. Not actually a Flutter problem — looked like one. Fixed in `install.sh` (3 sites), `install.bat`, `install.ps1`.

- **#4 /config crashes with asyncio error** — `prompt_toolkit.prompt()` was called synchronously from inside an async slash-command handler. `asyncio.to_thread()` now isolates it in a worker thread. Regression test added.

- **#5 no auto-config files on first run** — caused by #1: `setup_directories()` (which runs `cognithor --init-only` to materialize config.yaml) only runs AFTER `install_cognithor()`, which was aborting on the bad import. Fixing #1 fixes #5 transitively.

Remaining 2 of 5 Reddit bugs (both already fixed in PR #119, just merged):
- #2 mixed JARVIS_*/COGNITHOR_* docs → done
- #3 JARVIS_HOME → "home" field crash → done

## Test plan

- [x] `tests/test_channels/test_cli.py` 46/46 pass including new `test_config_runs_in_thread`
- [x] `bash -n install.sh` syntax OK
- [x] Ruff clean on modified files

## Non-goals

- install.sh doesn't need a full rewrite — the import-check hang was the one blocking issue on Arch. Fixing it unblocks the subsequent `cognithor --init-only` invocation which then creates config.yaml via `ensure_directory_structure()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
