### PR TITLE
refactor(config): remove backward-compat JarvisConfig/jarvis_home aliases

### DIFF
--- a/src/cognithor/config.py
+++ b/src/cognithor/config.py
@@ -3721,5 +3721,3 @@ def _install_starter_procedures(procedures_dir: Path, created: list[str]) -> Non
                 created.append(str(target))
     except Exception:
         log.debug("starter_procedures_copy_skipped", exc_info=True)
-
-

--- a/src/cognithor/config.py
+++ b/src/cognithor/config.py
@@ -143,7 +143,7 @@ class GatekeeperConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    policies_dir: str = "policies"  # Relativ zu jarvis_home
+    policies_dir: str = "policies"  # Relativ zu cognithor_home
     default_risk_level: Literal["green", "yellow", "orange", "red"] = "yellow"
     max_blocked_retries: int = Field(default=3, ge=1, le=10)
 
@@ -797,7 +797,7 @@ class HeartbeatConfig(BaseModel):
     zwischen 1 und 1440 Minuten (24 Stunden)."""
 
     checklist_file: str = "HEARTBEAT.md"
-    """Dateiname der Checklist im ``jarvis_home``. Diese Datei enthaelt
+    """Dateiname der Checklist im ``cognithor_home``. Diese Datei enthaelt
     Text oder Bullet-Points, die beim Heartbeat an den Agenten
     uebermittelt werden. Falls die Datei nicht existiert, wird eine
     leere Nachricht gesendet."""
@@ -826,7 +826,7 @@ class PluginsConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     skills_dir: str = "skills"
-    """Relativer Name des Verzeichnisses im ``jarvis_home``, in dem
+    """Relativer Name des Verzeichnisses im ``cognithor_home``, in dem
     zusaetzliche Skills installiert werden. Der Standardwert ist
     ``skills``. Dies fuehrt dazu, dass externe Prozeduren in
     ``~/.cognithor/skills`` abgelegt werden."""
@@ -1977,7 +1977,7 @@ class SecurityConfig(BaseModel):
             str(Path(tempfile.gettempdir()) / "jarvis") + os.sep,
         ]
     )
-    # Wenn True, wird das Projektverzeichnis (jarvis_home Parent) automatisch
+    # Wenn True, wird das Projektverzeichnis (cognithor_home Parent) automatisch
     # zu allowed_paths hinzugefuegt, damit Cognithor in seine eigene Codebase
     # schreiben kann (z.B. Skripte erstellen, Code integrieren).
     allow_project_dir: bool = True
@@ -3027,13 +3027,6 @@ class CognithorConfig(BaseModel):
         """Pfad zur Cron-Konfiguration."""
         return self.cognithor_home / "cron" / "jobs.yaml"
 
-    # ---- Backward-compat alias ----
-
-    @property
-    def jarvis_home(self) -> Path:
-        """Deprecated alias for cognithor_home. Remove in v1.0."""
-        return self.cognithor_home
-
     # ---- Verzeichnisstruktur-Management ----
 
     def ensure_directories(self) -> list[str]:
@@ -3730,6 +3723,3 @@ def _install_starter_procedures(procedures_dir: Path, created: list[str]) -> Non
         log.debug("starter_procedures_copy_skipped", exc_info=True)
 
 
-# Backward-compat alias for code written against the pre-v1 name.
-# Remove in v1.0 (no external downstream users identified; this is a safety net).
-JarvisConfig = CognithorConfig


### PR DESCRIPTION
## Summary

Removes the backward-compat safety net added in #121:
- Module-level alias `JarvisConfig = CognithorConfig`
- `@property jarvis_home` shim on `CognithorConfig`
- 4 stale `jarvis_home` mentions in docstring/comment text

## Why now (not v1.0 as originally planned)

PR #121 kept these as a safety net for unseen out-of-tree consumers. A scan of `cognithor-packs` (the only known external codebase) confirmed **zero references**:

```
JarvisConfig: 0 matches
.jarvis_home: 0 matches
from jarvis: 0 matches
import jarvis: 0 matches
```

No external users → no need to wait for v1.0 → clean break now.

## What stays

- **YAML-key migration** (`jarvis_home: → cognithor_home:` in load_config) — user config files written before the rename still get transparent upgrade
- **`JARVIS_*` env var prefix** accepted in `_apply_env_overrides` — legacy env vars still work as documented

These handle user *data* (not code), so they stay regardless.

## Test plan

- [x] Full regression: **13,841 passed, 12 skipped, 0 failed** (13:34)
- [x] Ruff clean
- [x] `grep JarvisConfig src/ tests/` → 0 matches
- [x] `grep \.jarvis_home src/ tests/` → 0 matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)
