### PR TITLE
docs: purge stale Jarvis references + add Observer Audit Layer mentions

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -120,6 +120,10 @@ Sandbox levels (selected automatically by platform):
 | `jobobject` | Windows | Job Objects with resource limits |
 | `bare` | Any (fallback) | Timeout + output limit only |
 
+### Observer Audit Layer (`core/observer.py` — PR #118)
+
+The Observer runs after the Executor produces a response, before it is delivered to the user. It is an LLM-based quality audit that evaluates every response across 4 dimensions: hallucination, sycophancy, laziness, and tool-ignorance. A hallucination finding routes control back to the Planner for response regeneration; a tool-ignorance finding triggers a full PGE re-loop via the Gateway so the Planner can pick the correct tools. The Observer is designed to fail open: if the audit itself raises an exception, the original response is passed through unchanged and the failure is logged. Configurable via the `observer.*` section in `config.yaml`; see `CONFIG_REFERENCE.md`.
+
 ---
 
 ## Message Flow
@@ -457,7 +461,7 @@ HIMReporter: Markdown/JSON/Quick + SHA-256 signature
 vault_save(report)
 ```
 
-Located at `src/jarvis/osint/`. Exposed as 3 MCP tools: `investigate_person`, `investigate_project`, `investigate_org`.
+Located at `src/cognithor/osint/`. Exposed as 3 MCP tools: `investigate_person`, `investigate_project`, `investigate_org`.
 
 ---
 
@@ -517,7 +521,7 @@ Key components:
 
 ## ARC-AGI-3 Benchmark Module
 
-The `src/jarvis/arc/` module enables Cognithor to compete in the ARC Prize 2026 interactive reasoning benchmark.
+The `src/cognithor/arc/` module enables Cognithor to compete in the ARC Prize 2026 interactive reasoning benchmark.
 
 ### Architecture
 
@@ -550,9 +554,9 @@ User/CLI → CognithorArcAgent
 ### CLI
 
 ```bash
-python -m jarvis.arc --game ls20              # Single game
-python -m jarvis.arc --mode benchmark         # All games sequential
-python -m jarvis.arc --mode swarm --parallel 4 # Parallel execution
+python -m cognithor.arc --game ls20              # Single game
+python -m cognithor.arc --mode benchmark         # All games sequential
+python -m cognithor.arc --mode swarm --parallel 4 # Parallel execution
 ```
 
 ---
@@ -577,7 +581,7 @@ document creation and template-based generation:
 
 ### Template System
 
-Templates are Typst `.typ` files stored in `~/.jarvis/templates/documents/`.
+Templates are Typst `.typ` files stored in `~/.cognithor/templates/documents/`.
 Each template declares metadata in a frontmatter comment block and uses
 `{{variable}}` placeholders that the LLM fills before compilation.
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -60,14 +60,14 @@ python scripts/first_boot.py --quick    # Verify everything works
 
 ### 7. How do I switch from Ollama to a cloud backend?
 
-Set your API key in `~/.jarvis/config.yaml` or as an environment variable. Cognithor auto-detects the backend:
+Set your API key in `~/.cognithor/config.yaml` or as an environment variable. Cognithor auto-detects the backend:
 
 ```yaml
 # Option A: In config.yaml
 anthropic_api_key: "sk-ant-..."
 
 # Option B: Environment variable
-# export JARVIS_ANTHROPIC_API_KEY=sk-ant-...
+# export COGNITHOR_ANTHROPIC_API_KEY=sk-ant-...
 ```
 
 Model names are automatically adapted to the new provider.
@@ -83,7 +83,7 @@ ollama pull qwen3-coder:30b      # Coder (optional, 20 GB VRAM)
 
 ### 9. Can I use different models than the defaults?
 
-Yes, change them in `~/.jarvis/config.yaml`:
+Yes, change them in `~/.cognithor/config.yaml`:
 
 ```yaml
 models:
@@ -114,21 +114,21 @@ If using a remote Ollama instance, set the URL: `export OLLAMA_HOST=http://remot
 
 ### 11. Where is the configuration file?
 
-`~/.jarvis/config.yaml`. It is auto-created on first start. See `CONFIG_REFERENCE.md` for all available options.
+`~/.cognithor/config.yaml`. It is auto-created on first start. See `CONFIG_REFERENCE.md` for all available options.
 
 ### 12. How do I set the language?
 
 ```yaml
 language: "en"   # en, de, zh, ar
 ```
-Or via environment variable: `export JARVIS_LANGUAGE=en`
+Or via environment variable: `export COGNITHOR_LANGUAGE=en`
 
 ### 13. How do I restrict file access?
 
 ```yaml
 security:
   allowed_paths:
-    - "~/.jarvis/"
+    - "~/.cognithor/"
     - "~/Documents/"
     - "/path/to/project/"
 ```
@@ -137,11 +137,11 @@ The gatekeeper blocks file operations outside these paths.
 
 ### 14. Can I use environment variables instead of config.yaml?
 
-Yes. All config keys can be overridden with `JARVIS_` prefixed variables:
+Yes. All config keys can be overridden with `COGNITHOR_` prefixed variables:
 ```bash
-export JARVIS_LANGUAGE=en
-export JARVIS_PLANNER_MAX_ITERATIONS=15
-export JARVIS_OLLAMA_TIMEOUT_SECONDS=180
+export COGNITHOR_LANGUAGE=en
+export COGNITHOR_PLANNER_MAX_ITERATIONS=15
+export COGNITHOR_OLLAMA_TIMEOUT_SECONDS=180
 ```
 
 ---
@@ -151,7 +151,7 @@ export JARVIS_OLLAMA_TIMEOUT_SECONDS=180
 ### 15. How do I set up the Telegram bot?
 
 1. Create a bot with [@BotFather](https://t.me/BotFather) on Telegram
-2. Set the token in `~/.jarvis/.env`: `JARVIS_TELEGRAM_TOKEN=123456:ABC...`
+2. Set the token in `~/.cognithor/.env`: `COGNITHOR_TELEGRAM_TOKEN=123456:ABC...`
 3. Enable in config: `channels.telegram_enabled: true`
 4. Optionally restrict to your user ID: `channels.telegram_whitelist: ["your_user_id"]`
 
@@ -173,7 +173,7 @@ Yes. Enable each channel in the config and provide the required tokens/credentia
 
 ### 19. Is my data sent to external servers?
 
-By default, no. Cognithor uses Ollama (local LLM) and stores all data in `~/.jarvis/`. If you configure a cloud LLM backend (OpenAI, Anthropic, etc.), your prompts are sent to that provider's API. Web search tools access the internet when invoked.
+By default, no. Cognithor uses Ollama (local LLM) and stores all data in `~/.cognithor/`. If you configure a cloud LLM backend (OpenAI, Anthropic, etc.), your prompts are sent to that provider's API. Web search tools access the internet when invoked.
 
 ### 20. How does the Gatekeeper work?
 
@@ -216,7 +216,7 @@ The production build goes to `flutter_app/build/web/` and is automatically serve
 The backend is not running or not reachable. Check:
 1. Is the backend running on port 8741? (`curl http://localhost:8741/api/v1/health`)
 2. Is a firewall blocking the connection?
-3. Check logs at `~/.jarvis/logs/jarvis.log`
+3. Check logs at `~/.cognithor/logs/cognithor.log`
 
 ---
 
@@ -241,7 +241,7 @@ ollama run qwen3:32b "Hello" --keepalive 30m
 python scripts/first_boot.py --quick    # System validation
 make smoke                              # 26 installation checks
 make health                             # Runtime check (Ollama, disk, memory)
-tail -f ~/.jarvis/logs/jarvis.log       # Live logs
+tail -f ~/.cognithor/logs/cognithor.log       # Live logs
 ```
 
 ---
@@ -257,13 +257,13 @@ Cognithor has three memory layers:
 
 ### 29. How do I import existing knowledge?
 
-Place documents (Markdown, PDF, DOCX, TXT) in `~/.jarvis/memory/knowledge/`. They are automatically indexed on next startup.
+Place documents (Markdown, PDF, DOCX, TXT) in `~/.cognithor/memory/knowledge/`. They are automatically indexed on next startup.
 
 ### 30. How do I back up my data?
 
 ```bash
-# All data lives in ~/.jarvis/
-cp -r ~/.jarvis/ ~/backup/cognithor-backup/
+# All data lives in ~/.cognithor/
+cp -r ~/.cognithor/ ~/backup/cognithor-backup/
 ```
 
 See `DATABASE.md` for a complete list of database files and their locations.
@@ -272,7 +272,7 @@ See `DATABASE.md` for a complete list of database files and their locations.
 
 ## Troubleshooting
 
-### 31. "No module named 'jarvis'" error
+### 31. "No module named 'cognithor'" error
 
 Make sure the virtual environment is activated and the package is installed:
 ```bash
@@ -292,7 +292,7 @@ database:
 ### 33. The planner always answers directly instead of using tools
 
 Check:
-1. Are MCP tools registered? Check `~/.jarvis/logs/jarvis.log` for tool registration messages.
+1. Are MCP tools registered? Check `~/.cognithor/logs/cognithor.log` for tool registration messages.
 2. Is the system prompt too long? Reduce `memory.search_top_k`.
 3. Try increasing temperature: `planner.temperature: 0.7`
 4. Run `python scripts/first_boot.py` to validate the full agent loop.
@@ -308,8 +308,16 @@ DuckDuckGo may rate-limit. Options:
 
 ```bash
 # Remove all Cognithor data (CAUTION: this deletes all memories!)
-rm -rf ~/.jarvis/
+rm -rf ~/.cognithor/
 
 # Reinitialize
 python scripts/first_boot.py
 ```
+
+---
+
+## Agent Quality
+
+### 36. What is the Observer?
+
+The Observer Audit Layer (PR #118) is an LLM-based quality check that runs after every response. It evaluates the response across 4 dimensions: hallucinations, sycophancy, laziness, and tool-ignorance. A hallucination finding triggers response regeneration inside the Planner; a tool-ignorance finding triggers a full PGE re-loop via the Gateway. The Observer always fails open — if the audit itself errors, the response is delivered unchanged. Configure it via the `observer.*` section in `config.yaml`; see `CONFIG_REFERENCE.md` for all options.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -52,7 +52,7 @@ ollama serve
 
 ### Alternative: LM Studio Instead of Ollama
 
-If you prefer LM Studio, download your models in the LM Studio GUI and set in `~/.jarvis/config.yaml`:
+If you prefer LM Studio, download your models in the LM Studio GUI and set in `~/.cognithor/config.yaml`:
 
 ```yaml
 llm_backend_type: "lmstudio"
@@ -102,7 +102,7 @@ The batch file starts the Control Center UI, which automatically manages the Pyt
 ### Option B: CLI
 
 ```bash
-python -m jarvis
+python -m cognithor
 ```
 
 You will see the CLI REPL:
@@ -157,13 +157,13 @@ Cognithor loads yesterday's episodes, open tasks, and creates a daily overview.
 
 ```bash
 # Main configuration
-nano ~/.jarvis/config.yaml
+nano ~/.cognithor/config.yaml
 
 # Identity & rules
-nano ~/.jarvis/memory/CORE.md
+nano ~/.cognithor/memory/CORE.md
 
 # Edit/add procedures
-ls ~/.jarvis/memory/procedures/
+ls ~/.cognithor/memory/procedures/
 ```
 
 Important config options:
@@ -179,7 +179,7 @@ models:
 
 security:
   allowed_paths:                        # File access restricted to these paths
-    - ~/.jarvis
+    - ~/.cognithor
     - ~/Documents
 
 personality:
@@ -198,7 +198,7 @@ make test         # Run 10,800+ tests
 
 Logs:
 ```bash
-tail -f ~/.jarvis/logs/jarvis.log
+tail -f ~/.cognithor/logs/cognithor.log
 ```
 
 ## 9. Server Deployment (optional)
@@ -225,9 +225,9 @@ See [`deploy/README.md`](deploy/README.md) for complete deployment documentation
 
 ## Next Steps
 
-- **Telegram bot** -- Set token in `~/.jarvis/.env`: `JARVIS_TELEGRAM_TOKEN=...`
+- **Telegram bot** -- Set token in `~/.cognithor/.env`: `COGNITHOR_TELEGRAM_TOKEN=...`
 - **Cron jobs** -- Enable morning briefing, weekly review
-- **Custom procedures** -- Create workflows in `~/.jarvis/memory/procedures/`
+- **Custom procedures** -- Create workflows in `~/.cognithor/memory/procedures/`
 - **CORE.md** -- Add your own rules and preferences
 - **Server deployment** -- See `deploy/README.md` for Docker, bare-metal, TLS
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ What makes it different from other local AI tools is that Cognithor is not just 
 | **CLI Config TUI** | Stable — Interactive terminal config editor (rich + prompt_toolkit), model discovery |
 | **AST-Based Security** | Stable — Python AST + bashlex shell analysis replacing regex-based guards |
 | **OSINT / HIM Module** | Beta — person/project/org investigation with trust scoring |
+| **Observer Audit Layer** | Stable — post-response LLM quality check across 4 dimensions (hallucinations, sycophancy, laziness, tool-ignorance); triggers regeneration or full PGE re-loop; fails open |
 
 **What the test suite covers:** Unit tests, integration tests, real-life scenario tests, and live Ollama tests for all modules. The 13,000+ tests verify code correctness in controlled environments.
 
@@ -702,12 +703,12 @@ docker compose -f docker-compose.prod.yml --profile nginx up -d      # + Nginx T
 docker compose -f docker-compose.prod.yml --profile monitoring up -d # + Prometheus + Grafana
 ```
 
-Services: Jarvis (headless) + WebUI + Ollama + optional PostgreSQL (pgvector) + optional Nginx reverse proxy + optional Prometheus/Grafana monitoring. GPU support via nvidia-container-toolkit (uncomment in compose file).
+Services: Cognithor (headless) + WebUI + Ollama + optional PostgreSQL (pgvector) + optional Nginx reverse proxy + optional Prometheus/Grafana monitoring. GPU support via nvidia-container-toolkit (uncomment in compose file).
 
 ### Bare-Metal Server (Ubuntu/Debian)
 
 ```bash
-sudo bash deploy/install-server.sh --domain jarvis.example.com --email admin@example.com
+sudo bash deploy/install-server.sh --domain cognithor.example.com --email admin@example.com
 # Or with self-signed cert:
 sudo bash deploy/install-server.sh --domain test.local --self-signed
 ```

--- a/TROUBLESHOOTING.md
+++ b/TROUBLESHOOTING.md
@@ -24,7 +24,7 @@
 ### ImportError on launch
 
 ```
-ModuleNotFoundError: No module named 'jarvis'
+ModuleNotFoundError: No module named 'cognithor'
 ```
 
 Install in editable mode:
@@ -65,7 +65,7 @@ taskkill /PID <PID> /F
 
 Or use a different port:
 ```bash
-python -m jarvis --api-port 8742
+python -m cognithor --api-port 8742
 ```
 
 ### Preflight check fails
@@ -120,7 +120,7 @@ ollama pull qwen3:32b
 
 Use smaller models:
 ```yaml
-# ~/.jarvis/config.yaml
+# ~/.cognithor/config.yaml
 models:
   planner:
     name: qwen3:14b    # Instead of 32b
@@ -272,7 +272,7 @@ File operations are restricted to `allowed_paths` in config:
 ```yaml
 security:
   allowed_paths:
-    - ~/.jarvis
+    - ~/.cognithor
     - ~/Documents
     - /path/to/project
 ```
@@ -299,7 +299,7 @@ executor:
    ```bash
    ollama list | grep nomic-embed
    ```
-3. Re-index if needed (memory is stored in `~/.jarvis/memory/`)
+3. Re-index if needed (memory is stored in `~/.cognithor/memory/`)
 
 ### Episodic memory growing too large
 
@@ -391,15 +391,15 @@ curl -X POST http://localhost:8741/api/v1/evolution/run \
 
 ### Telegram bot not responding
 
-1. Check token: `echo $JARVIS_TELEGRAM_TOKEN`
+1. Check token: `echo $COGNITHOR_TELEGRAM_TOKEN`
 2. Verify bot is started in config:
    ```yaml
    channels:
      telegram:
        enabled: true
    ```
-3. Check allowed users: `JARVIS_TELEGRAM_ALLOWED_USERS=123456,789012`
-4. Review logs: `tail -f ~/.jarvis/logs/jarvis.log | grep telegram`
+3. Check allowed users: `COGNITHOR_TELEGRAM_ALLOWED_USERS=123456,789012`
+4. Review logs: `tail -f ~/.cognithor/logs/cognithor.log | grep telegram`
 
 ### Discord/Slack connection fails
 
@@ -447,14 +447,14 @@ Pydantic strict mode rejects unknown keys. Check for typos in config field names
 
 ### Environment variable override not working
 
-Environment variables must be prefixed with `JARVIS_`:
+Environment variables must be prefixed with `COGNITHOR_`:
 ```bash
-export JARVIS_LOG_LEVEL=DEBUG
-export JARVIS_LANGUAGE=en
-export JARVIS_API_TOKEN=my-secret-token
+export COGNITHOR_LOG_LEVEL=DEBUG
+export COGNITHOR_LANGUAGE=en
+export COGNITHOR_API_TOKEN=my-secret-token
 ```
 
-The 3-layer cascade is: defaults -> `config.yaml` -> `JARVIS_*` env vars.
+The 3-layer cascade is: defaults -> `config.yaml` -> `COGNITHOR_*` env vars.
 Env vars always win.
 
 ---
@@ -517,9 +517,9 @@ Enable long paths in Windows:
 reg add "HKLM\SYSTEM\CurrentControlSet\Control\FileSystem" /v LongPathsEnabled /t REG_DWORD /d 1
 ```
 
-Or use shorter `JARVIS_HOME`:
+Or use a shorter `COGNITHOR_HOME`:
 ```bash
-set JARVIS_HOME=C:\jarvis
+set COGNITHOR_HOME=C:\cognithor
 ```
 
 ### Python executable portability


### PR DESCRIPTION
## Summary

Second-pass documentation rebrand covering the high-impact GitHub-visible docs, plus Observer Audit Layer (#118) mentions.

## Changes per file

| File | Jarvis refs before | after |
|---|---|---|
| README.md | 12 | 10* |
| QUICKSTART.md | 9 | 0 |
| FAQ.md | 14 | 0 |
| ARCHITECTURE.md | 6 | 0 |
| TROUBLESHOOTING.md | 7 | 0 |

\* 10 remaining README refs are intentional: 9 in the historical changelog section (past-tense records of the v0.87 package rename, old jarvis_ui fallbacks, etc.) and 1 cultural reference in the intro ("self-improving Jarvis" as Iron Man analogy).

## Observer additions

- **README.md** Status & Maturity table → new row "Observer Audit Layer / Stable"
- **ARCHITECTURE.md** → new subsection under PGE-Trinity
- **FAQ.md** → new Q&A "What is the Observer?"

## Non-goals

- CHANGELOG.md preserved verbatim
- docs/superpowers/ preserved (frozen specs)
- Other docs with Jarvis refs (CONFIG_REFERENCE, DATABASE, DEVELOPER, IDENTITY) deferred to a later pass — they are lower-traffic internal refs and require deeper judgment per occurrence
