### PR TITLE
fix(install): platform-aware sqlcipher dev package name (closes #116)

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -746,11 +746,21 @@ install_cognithor() {
         success "pysqlcipher3 available (GDPR encryption)"
     else
         echo "  [INFO] Installing pysqlcipher3 for GDPR encryption at rest..."
-        # System library required first
-        install_system_deps libsqlcipher-dev 2>/dev/null || true
+        # System sqlcipher dev headers — package name differs per platform.
+        # Passing a single name to a generic helper makes brew fuzzy-match
+        # to unrelated formulae (e.g. libserdes on macOS). Resolve per-PM here.
+        if command -v apt-get &>/dev/null; then
+            sudo apt-get install -y libsqlcipher-dev 2>/dev/null || true
+        elif command -v dnf &>/dev/null; then
+            sudo dnf install -y sqlcipher-devel 2>/dev/null || true
+        elif command -v pacman &>/dev/null; then
+            sudo pacman -S --noconfirm sqlcipher 2>/dev/null || true
+        elif command -v brew &>/dev/null; then
+            brew install sqlcipher 2>/dev/null || true
+        fi
         retry "pip install pysqlcipher3 --quiet 2>/dev/null" && \
             success "pysqlcipher3 installed" || \
-            warn "pysqlcipher3 install failed -- database encryption unavailable. Install libsqlcipher-dev (Ubuntu) or sqlcipher (macOS) and retry."
+            warn "pysqlcipher3 install failed -- database encryption unavailable. Install libsqlcipher-dev (Debian/Ubuntu), sqlcipher-devel (Fedora), or sqlcipher (macOS/Arch) and retry."
     fi
 
     # Verify installation


### PR DESCRIPTION
## Summary

Fixes #116. macOS user reported the installer looping 3 times trying to `brew install libserdes` (a completely unrelated Confluent Avro library) and failing.

## Root cause

`install.sh` line 750 called `install_system_deps libsqlcipher-dev` — passing the **Debian/Ubuntu** package name to the generic helper. On macOS, brew has no formula called `libsqlcipher-dev`, so it fuzzy-matched to `libserdes`. The user saw:

```
==> Formulae
libserdes

To install libserdes, run:
  brew install libserdes
```

... installed libserdes manually thinking it was required, then pysqlcipher3 still failed because the actual sqlcipher C library was never present.

## Fix

Resolve the package name per platform inline instead of relying on a one-size-fits-all helper:

| PM | Package name |
|---|---|
| apt-get | libsqlcipher-dev |
| dnf | sqlcipher-devel |
| pacman | sqlcipher |
| brew | sqlcipher |

Warning message updated to list all four correct names.

## Test plan

- [x] `bash -n install.sh` syntax OK
- [ ] Manual: macOS install (need user confirmation — unable to test locally on Windows)
