### PR TITLE
fix(config): tolerate legacy/unknown keys in user config.yaml (closes #131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to Cognithor are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **`config.yaml` with legacy keys no longer hard-crashes at startup**
+  (closes #131). Upgrading users whose `config.yaml` still contains fields
+  the current `CognithorConfig` no longer recognizes (e.g. `max_agents`,
+  `max_concurrent`, `memory_limit_mb`, `rag`) would hit
+  `pydantic_core.ValidationError: extra_forbidden` inside `load_config`
+  and be completely unable to launch. `load_config` now catches
+  `extra_forbidden` errors from the on-disk YAML read path, strips the
+  offending keys, logs a clear WARN listing them, and re-validates once.
+  `CognithorConfig` keeps `extra="forbid"` on the model itself so
+  programmatic construction in tests still catches typos — only the
+  user-supplied YAML is self-healing.
+
 ## [0.92.4] -- 2026-04-22
 
 ### Added

--- a/src/cognithor/config.py
+++ b/src/cognithor/config.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from cognithor.models import ModelConfig, SandboxConfig
 
@@ -3240,13 +3240,58 @@ def load_config(config_path: Path | None = None) -> CognithorConfig:
             if isinstance(val, str):
                 data["models"][role] = {"name": val}
 
-    # 6. Pydantic validates and fills defaults
-    cfg = CognithorConfig(**data)
+    # 6. Pydantic validates and fills defaults.
+    #    Legacy/unknown YAML keys (e.g. from old Jarvis versions) are stripped
+    #    with a warning instead of crashing the whole launch (see issue #131).
+    #    `extra="forbid"` is kept on the model so programmatic construction in
+    #    tests still catches typos — only user-supplied YAML is self-healing.
+    try:
+        cfg = CognithorConfig(**data)
+    except ValidationError as exc:
+        extra_errors = [e for e in exc.errors() if e.get("type") == "extra_forbidden"]
+        if not extra_errors:
+            raise
+        stripped = _strip_extra_forbidden_keys(data, extra_errors)
+        if stripped:
+            import logging
+
+            logging.getLogger("cognithor.config").warning(
+                "Unbekannte Felder in config.yaml ignoriert (bitte aus der Datei entfernen): %s",
+                ", ".join(stripped),
+            )
+        cfg = CognithorConfig(**data)
 
     # 7. Keyring fallback: fill empty API-key fields from OS Keyring
     _resolve_secrets(cfg)
 
     return cfg
+
+
+def _strip_extra_forbidden_keys(
+    data: dict[str, Any], extra_errors: list[dict[str, Any]]
+) -> list[str]:
+    """Remove keys flagged as ``extra_forbidden`` from ``data`` in-place.
+
+    Navigates the nested ``loc`` path from each Pydantic error and drops the
+    leaf key. Returns the dotted paths of keys actually removed so the caller
+    can report them to the user.
+    """
+    stripped: list[str] = []
+    for err in extra_errors:
+        loc = err.get("loc") or ()
+        if not loc:
+            continue
+        parent: Any = data
+        for key in loc[:-1]:
+            if not isinstance(parent, dict) or key not in parent:
+                parent = None
+                break
+            parent = parent[key]
+        leaf = loc[-1]
+        if isinstance(parent, dict) and leaf in parent:
+            del parent[leaf]
+            stripped.append(".".join(str(k) for k in loc))
+    return stripped
 
 
 def _resolve_secrets(config: CognithorConfig) -> None:

--- a/tests/config/test_legacy_keys.py
+++ b/tests/config/test_legacy_keys.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from pydantic import ValidationError
+
+from cognithor.config import CognithorConfig, load_config
+
+
+class TestLegacyTopLevelKeysAreTolerated:
+    """Legacy YAML keys must not crash `load_config` — issue #131.
+
+    A user upgrading from an older Jarvis version can have a `config.yaml`
+    with fields the current `CognithorConfig` no longer recognizes
+    (e.g. `max_agents`, `memory_limit_mb`, `rag`). `extra="forbid"` on
+    the model used to turn these into an unrecoverable launch crash.
+    """
+
+    def test_unknown_top_level_keys_are_stripped_with_warning(self, tmp_path, caplog):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(
+            "max_agents: 1\n"
+            "max_concurrent: 1\n"
+            "memory_limit_mb: 2048\n"
+            "rag:\n"
+            "  enabled: false\n"
+            "language: de\n",
+            encoding="utf-8",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="cognithor.config"):
+            cfg = load_config(cfg_file)
+
+        assert cfg is not None
+        assert cfg.language == "de"
+        warnings = " ".join(r.getMessage() for r in caplog.records)
+        for key in ("max_agents", "max_concurrent", "memory_limit_mb", "rag"):
+            assert key in warnings, (
+                f"Expected key '{key}' in deprecation warning, got: {warnings!r}"
+            )
+
+    def test_valid_config_without_unknown_keys_still_loads_clean(self, tmp_path, caplog):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text("language: en\nowner_name: Tester\n", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="cognithor.config"):
+            cfg = load_config(cfg_file)
+
+        assert cfg.language == "en"
+        assert cfg.owner_name == "Tester"
+        unknown_warnings = [r for r in caplog.records if "Unbekannte Felder" in r.getMessage()]
+        assert unknown_warnings == []
+
+    def test_programmatic_construction_still_rejects_unknown_fields(self):
+        """The safety net on the model itself is preserved — dev/test code
+        paths that construct `CognithorConfig(**kwargs)` directly must keep
+        catching typos, only the on-disk YAML read path is tolerant."""
+        with pytest.raises(ValidationError):
+            CognithorConfig(definitely_not_a_field=1)
+
+    def test_real_errors_still_surface_unchanged(self, tmp_path):
+        """When the YAML has a *real* error (wrong type on a known field),
+        `load_config` must still raise — we only swallow extra_forbidden."""
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text("language: 123\n", encoding="utf-8")
+        with pytest.raises(ValidationError):
+            load_config(cfg_file)


### PR DESCRIPTION
## Summary

Fixes #131 — upgrading users with a legacy `~/.cognithor/config.yaml` were completely locked out of launching Cognithor because `load_config` raised `pydantic_core.ValidationError: 4 validation errors for CognithorConfig ... extra_forbidden` on fields like `max_agents`, `max_concurrent`, `memory_limit_mb`, and `rag` that used to exist in old Jarvis versions.

## Root cause

`CognithorConfig` declares `model_config = ConfigDict(extra="forbid")` (config.py:2560). This is the right default for catching typos in programmatic construction (tests, internal code) — it's what turned the old silent `jarvis_dir=` bug documented in prior memory into something detectable.

But it's the wrong default for **reading user-supplied YAML from disk**. Every time we remove or rename a config field, every user with that key in their `~/.cognithor/config.yaml` hits an unrecoverable crash on the next launch. There was already a manual migration for `jarvis_home → cognithor_home` at config.py:3223, but no general handling for fields that simply no longer exist.

## Fix

`load_config()` wraps the final `CognithorConfig(**data)` call in a single self-healing retry:

1. On `ValidationError`, filter errors where `type == "extra_forbidden"`.
2. Walk each error's `loc` tuple path into `data` and `del` the leaf key (supports nested sub-models too, e.g. `models.foo.legacy_key`).
3. Log a WARN listing all stripped dotted paths so the user can clean up their YAML.
4. Re-validate once. Any remaining error (including non-`extra_forbidden` problems) surfaces unchanged.

`CognithorConfig` keeps `extra="forbid"` on the model itself. Only the **on-disk YAML read path** is tolerant; programmatic construction in test and framework code still fails loudly on typos.

```python
try:
    cfg = CognithorConfig(**data)
except ValidationError as exc:
    extra_errors = [e for e in exc.errors() if e.get("type") == "extra_forbidden"]
    if not extra_errors:
        raise
    stripped = _strip_extra_forbidden_keys(data, extra_errors)
    if stripped:
        logging.getLogger("cognithor.config").warning(
            "Unbekannte Felder in config.yaml ignoriert "
            "(bitte aus der Datei entfernen): %s",
            ", ".join(stripped),
        )
    cfg = CognithorConfig(**data)
```

## Test plan

New `tests/config/test_legacy_keys.py` — **4 tests, all green**:

- `test_unknown_top_level_keys_are_stripped_with_warning` — reproduces the exact YAML from #131 (`max_agents`, `max_concurrent`, `memory_limit_mb`, `rag: {enabled: false}`) and asserts load succeeds, valid fields still load, and the WARN lists every dropped key.
- `test_valid_config_without_unknown_keys_still_loads_clean` — a clean YAML produces zero "Unbekannte Felder" warnings.
- `test_programmatic_construction_still_rejects_unknown_fields` — `CognithorConfig(definitely_not_a_field=1)` still raises `ValidationError` — the safety net on the model itself is preserved.
- `test_real_errors_still_surface_unchanged` — `language: 123` (wrong type on a known field, not extra_forbidden) still raises; we only swallow `extra_forbidden`.

**Regression:** `tests/config/` + `tests/test_bootstrap_and_config_fixes.py` — 51 passed.

**Ruff** check + format clean.

## User-visible behavior

Before this PR, launching with a legacy config:
```
pydantic_core._pydantic_core.ValidationError: 4 validation errors for CognithorConfig
max_agents
  Extra inputs are not permitted [type=extra_forbidden, ...]
...
[ERROR] Cognithor exited with an error.
```

After this PR:
```
WARNING  cognithor.config: Unbekannte Felder in config.yaml ignoriert
         (bitte aus der Datei entfernen):
         max_agents, max_concurrent, memory_limit_mb, rag
...normal startup continues...
```

Users still see the warning on every launch until they clean up their YAML, so the deprecation signal stays visible — we're just no longer blocking them from the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
