### PR TITLE
fix(config): tolerate legacy/unknown keys in user config.yaml (closes #131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Cognithor are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
-## [unreleased]
+## [Unreleased]
 
 ### Added
 - **Qwen3.6 model registry + installer** (`cognithor models install <name>`).
@@ -41,6 +41,19 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   format the current Flutter client has never sent. File uploads from
   Flutter were silently dropped. The gate is now `metadata.file_base64`
   presence, covering the real message shape.
+
+### Fixed
+- **`config.yaml` with legacy keys no longer hard-crashes at startup**
+  (closes #131). Upgrading users whose `config.yaml` still contains fields
+  the current `CognithorConfig` no longer recognizes (e.g. `max_agents`,
+  `max_concurrent`, `memory_limit_mb`, `rag`) would hit
+  `pydantic_core.ValidationError: extra_forbidden` inside `load_config`
+  and be completely unable to launch. `load_config` now catches
+  `extra_forbidden` errors from the on-disk YAML read path, strips the
+  offending keys, logs a clear WARN listing them, and re-validates once.
+  `CognithorConfig` keeps `extra="forbid"` on the model itself so
+  programmatic construction in tests still catches typos — only the
+  user-supplied YAML is self-healing.
 
 ### Deferred
 - **Video input** is explicitly deferred. Qwen3.6-27B (VLM) can process

--- a/src/cognithor/config.py
+++ b/src/cognithor/config.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator, model_validator
 
 from cognithor.models import ModelConfig, SandboxConfig
 
@@ -3240,13 +3240,58 @@ def load_config(config_path: Path | None = None) -> CognithorConfig:
             if isinstance(val, str):
                 data["models"][role] = {"name": val}
 
-    # 6. Pydantic validates and fills defaults
-    cfg = CognithorConfig(**data)
+    # 6. Pydantic validates and fills defaults.
+    #    Legacy/unknown YAML keys (e.g. from old Jarvis versions) are stripped
+    #    with a warning instead of crashing the whole launch (see issue #131).
+    #    `extra="forbid"` is kept on the model so programmatic construction in
+    #    tests still catches typos — only user-supplied YAML is self-healing.
+    try:
+        cfg = CognithorConfig(**data)
+    except ValidationError as exc:
+        extra_errors = [e for e in exc.errors() if e.get("type") == "extra_forbidden"]
+        if not extra_errors:
+            raise
+        stripped = _strip_extra_forbidden_keys(data, extra_errors)
+        if stripped:
+            import logging
+
+            logging.getLogger("cognithor.config").warning(
+                "Unbekannte Felder in config.yaml ignoriert (bitte aus der Datei entfernen): %s",
+                ", ".join(stripped),
+            )
+        cfg = CognithorConfig(**data)
 
     # 7. Keyring fallback: fill empty API-key fields from OS Keyring
     _resolve_secrets(cfg)
 
     return cfg
+
+
+def _strip_extra_forbidden_keys(
+    data: dict[str, Any], extra_errors: list[dict[str, Any]]
+) -> list[str]:
+    """Remove keys flagged as ``extra_forbidden`` from ``data`` in-place.
+
+    Navigates the nested ``loc`` path from each Pydantic error and drops the
+    leaf key. Returns the dotted paths of keys actually removed so the caller
+    can report them to the user.
+    """
+    stripped: list[str] = []
+    for err in extra_errors:
+        loc = err.get("loc") or ()
+        if not loc:
+            continue
+        parent: Any = data
+        for key in loc[:-1]:
+            if not isinstance(parent, dict) or key not in parent:
+                parent = None
+                break
+            parent = parent[key]
+        leaf = loc[-1]
+        if isinstance(parent, dict) and leaf in parent:
+            del parent[leaf]
+            stripped.append(".".join(str(k) for k in loc))
+    return stripped
 
 
 def _resolve_secrets(config: CognithorConfig) -> None:

--- a/tests/config/test_legacy_keys.py
+++ b/tests/config/test_legacy_keys.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+import logging
+
+import pytest
+from pydantic import ValidationError
+
+from cognithor.config import CognithorConfig, load_config
+
+
+class TestLegacyTopLevelKeysAreTolerated:
+    """Legacy YAML keys must not crash `load_config` — issue #131.
+
+    A user upgrading from an older Jarvis version can have a `config.yaml`
+    with fields the current `CognithorConfig` no longer recognizes
+    (e.g. `max_agents`, `memory_limit_mb`, `rag`). `extra="forbid"` on
+    the model used to turn these into an unrecoverable launch crash.
+    """
+
+    def test_unknown_top_level_keys_are_stripped_with_warning(self, tmp_path, caplog):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text(
+            "max_agents: 1\n"
+            "max_concurrent: 1\n"
+            "memory_limit_mb: 2048\n"
+            "rag:\n"
+            "  enabled: false\n"
+            "language: de\n",
+            encoding="utf-8",
+        )
+
+        with caplog.at_level(logging.WARNING, logger="cognithor.config"):
+            cfg = load_config(cfg_file)
+
+        assert cfg is not None
+        assert cfg.language == "de"
+        warnings = " ".join(r.getMessage() for r in caplog.records)
+        for key in ("max_agents", "max_concurrent", "memory_limit_mb", "rag"):
+            assert key in warnings, (
+                f"Expected key '{key}' in deprecation warning, got: {warnings!r}"
+            )
+
+    def test_valid_config_without_unknown_keys_still_loads_clean(self, tmp_path, caplog):
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text("language: en\nowner_name: Tester\n", encoding="utf-8")
+
+        with caplog.at_level(logging.WARNING, logger="cognithor.config"):
+            cfg = load_config(cfg_file)
+
+        assert cfg.language == "en"
+        assert cfg.owner_name == "Tester"
+        unknown_warnings = [r for r in caplog.records if "Unbekannte Felder" in r.getMessage()]
+        assert unknown_warnings == []
+
+    def test_programmatic_construction_still_rejects_unknown_fields(self):
+        """The safety net on the model itself is preserved — dev/test code
+        paths that construct `CognithorConfig(**kwargs)` directly must keep
+        catching typos, only the on-disk YAML read path is tolerant."""
+        with pytest.raises(ValidationError):
+            CognithorConfig(definitely_not_a_field=1)
+
+    def test_real_errors_still_surface_unchanged(self, tmp_path):
+        """When the YAML has a *real* error (wrong type on a known field),
+        `load_config` must still raise — we only swallow extra_forbidden."""
+        cfg_file = tmp_path / "config.yaml"
+        cfg_file.write_text("language: 123\n", encoding="utf-8")
+        with pytest.raises(ValidationError):
+            load_config(cfg_file)


### PR DESCRIPTION
## Summary

Re-opens #133 (auto-closed when its branch was accidentally deleted during merge coordination with #132). History is the same commit, rebased on top of the newly-merged #132 — the only change vs. the original PR is the CHANGELOG merge into a single  section with subsections  (from #132),  (this PR) and  (from #132).

Closes #131 — upgrading users with a legacy  (containing fields like , , , ) were completely locked out of launching because  raised  and crashed.

## Root cause

 declares . This is the right default for catching typos in programmatic construction (tests, internal code). But it is the wrong default for reading user-supplied YAML from disk — any renamed/removed config field becomes an unrecoverable crash on the next launch.

## Fix

 wraps the final  call in a single self-healing retry:

1. On , filter errors with .
2. Walk each error  tuple into the data dict and  the leaf key (supports nested paths).
3. Log a WARN listing every stripped dotted path so the user can clean up their YAML.
4. Re-validate once. Remaining errors surface unchanged.

The safety net on the model itself is preserved — dev/test code that does  still raises. Only the on-disk YAML read path is tolerant.

## Test plan

New  — 4 tests, all green:

-  — reproduces exact YAML from #131, asserts load succeeds + WARN contains every dropped key.
-  — clean YAML produces zero  warnings.
-  —  still raises.
-  —  (wrong-type on known field) still raises.

Regression: 51  +  tests pass. Ruff check + format clean.

## Superseded by

Replaces #133 (same content, just re-pushed after accidental branch delete).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
