### PR TITLE
fix(flutter): bump frontend version to 0.92.4 + CI sync-check (#131 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,19 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   input. End-to-end video would require a direct Transformers/vLLM
   backend — tracked separately.
 
+### Fixed (continued)
+- **Flutter version mismatch overlay blocked the app on every 0.92.x
+  installer** (reported on #131 by @PCAssistSoftware). The Flutter
+  frontend hard-coded `kFrontendVersion = '0.91.0'` in
+  `connection_provider.dart` and `version: 0.91.0+1` in `pubspec.yaml`;
+  neither was bumped during the 0.92.x release cadence, so every fresh
+  0.92.x install reported itself as 0.91 to the backend, tripped the
+  major.minor compatibility check, and wedged users behind the "Version
+  Mismatch" overlay with no way out. Both constants are now bumped to
+  0.92.4 and a new `tests/test_flutter_version_sync.py` cross-checks the
+  Flutter version against `cognithor.__version__` so CI fails loudly if
+  a future release bump forgets Flutter.
+
 ## [0.92.4] -- 2026-04-22
 
 ### Added

--- a/flutter_app/lib/providers/connection_provider.dart
+++ b/flutter_app/lib/providers/connection_provider.dart
@@ -13,7 +13,7 @@ enum CognithorConnectionState { disconnected, connecting, connected, error }
 /// Frontend version — must match backend `__version__` (major.minor).
 /// See issue #111: version mismatch between Flutter and Python backend
 /// should block entry to the app.
-const String kFrontendVersion = '0.91.0';
+const String kFrontendVersion = '0.92.4';
 
 /// Extracts "major.minor" from a semver-ish string like "0.91.0" or "0.91.0+1".
 String? _majorMinor(String? v) {

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.91.0+1
+version: 0.92.4+1
 
 environment:
   sdk: ^3.11.1

--- a/tests/test_flutter_version_sync.py
+++ b/tests/test_flutter_version_sync.py
@@ -31,9 +31,9 @@ def _major_minor(v: str) -> str:
 class TestFlutterVersionInSyncWithBackend:
     def test_kfrontendversion_matches_backend_major_minor(self):
         src = CONNECTION_PROVIDER.read_text(encoding="utf-8")
-        match = re.search(
-            r"kFrontendVersion\s*=\s*'([^']+)'", src
-        ) or re.search(r'kFrontendVersion\s*=\s*"([^"]+)"', src)
+        match = re.search(r"kFrontendVersion\s*=\s*'([^']+)'", src) or re.search(
+            r'kFrontendVersion\s*=\s*"([^"]+)"', src
+        )
         assert match, (
             f"Could not find kFrontendVersion in {CONNECTION_PROVIDER}. "
             f"The release checklist / this cross-check needs updating."

--- a/tests/test_flutter_version_sync.py
+++ b/tests/test_flutter_version_sync.py
@@ -1,0 +1,58 @@
+"""Cross-repo guard: the Flutter frontend's `kFrontendVersion` constant and
+its `pubspec.yaml` version MUST stay in sync with the Python backend's
+`__version__` (major.minor).
+
+Without this, the 0.91 → 0.92 bump forgot both Flutter spots and every
+user on the Windows installer hit a "Version Mismatch" overlay that
+refused to let them use the app (reported on issue #131 by
+@PCAssistSoftware). The overlay can only be cleared by re-installing,
+which the user cannot do — the next installer carries the same stale
+constant. This test exists so the CI breaks loudly if a release bump
+ever forgets Flutter again.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import cognithor
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FLUTTER_APP = REPO_ROOT / "flutter_app"
+CONNECTION_PROVIDER = FLUTTER_APP / "lib" / "providers" / "connection_provider.dart"
+PUBSPEC = FLUTTER_APP / "pubspec.yaml"
+
+
+def _major_minor(v: str) -> str:
+    return ".".join(v.split(".")[:2])
+
+
+class TestFlutterVersionInSyncWithBackend:
+    def test_kfrontendversion_matches_backend_major_minor(self):
+        src = CONNECTION_PROVIDER.read_text(encoding="utf-8")
+        match = re.search(
+            r"kFrontendVersion\s*=\s*'([^']+)'", src
+        ) or re.search(r'kFrontendVersion\s*=\s*"([^"]+)"', src)
+        assert match, (
+            f"Could not find kFrontendVersion in {CONNECTION_PROVIDER}. "
+            f"The release checklist / this cross-check needs updating."
+        )
+        flutter_version = match.group(1)
+        assert _major_minor(flutter_version) == _major_minor(cognithor.__version__), (
+            f"Flutter kFrontendVersion={flutter_version!r} is out of sync with "
+            f"cognithor.__version__={cognithor.__version__!r}. The 'Version "
+            f"Mismatch' overlay will block every user. Bump "
+            f"{CONNECTION_PROVIDER.relative_to(REPO_ROOT)} and "
+            f"{PUBSPEC.relative_to(REPO_ROOT)} before release."
+        )
+
+    def test_pubspec_version_matches_backend_major_minor(self):
+        text = PUBSPEC.read_text(encoding="utf-8")
+        match = re.search(r"^version:\s*([0-9]+\.[0-9]+\.[0-9]+)", text, re.MULTILINE)
+        assert match, f"Could not find 'version:' in {PUBSPEC}."
+        pubspec_version = match.group(1)
+        assert _major_minor(pubspec_version) == _major_minor(cognithor.__version__), (
+            f"flutter_app/pubspec.yaml version={pubspec_version!r} is out of sync "
+            f"with cognithor.__version__={cognithor.__version__!r}."
+        )


### PR DESCRIPTION
## Summary

Fixes the second bug reported on #131 — the "Version Mismatch" overlay that blocks the Flutter UI on every fresh 0.92.x Windows install.

## Root cause

`flutter_app/lib/providers/connection_provider.dart:16` hard-codes:

```dart
const String kFrontendVersion = '0.91.0';
```

and `flutter_app/pubspec.yaml` still reads `version: 0.91.0+1`. Neither was bumped during any of the 0.92.x release cuts, so every 0.92.x installer packages a Flutter build that reports itself as `0.91` to the backend. `ConnectionProvider`'s major.minor compatibility check (`_majorMinor`) then flags a mismatch and `connection_guard.dart` renders the blocking overlay. The "Retry" button cannot clear it because the constant is baked into the Flutter bundle — only a new installer helps.

## Fix

1. **Bump both constants to `0.92.4`** to match `cognithor.__version__`.
2. **Add `tests/test_flutter_version_sync.py`** — two tests that regex out `kFrontendVersion` from the Dart source and `version:` from `pubspec.yaml`, then assert both match `cognithor.__version__` on major.minor. Runs in the Python CI matrix that was already green on PRs #132 / #134, so a future release forgetting Flutter will break CI loudly with an actionable error message.

This is the cheap, durable guard. A follow-up could swap the hard-coded constant for `package_info_plus` so pubspec becomes the single source of truth, but that is a larger change and not needed to unblock users today.

## Test plan

- `tests/test_flutter_version_sync.py` — 2 tests, both green:
    - `test_kfrontendversion_matches_backend_major_minor`
    - `test_pubspec_version_matches_backend_major_minor`
- Ruff clean.
- Manual verification: the regex in the test successfully locates the constant and matches against `cognithor.__version__`.

## User impact

Before: fresh install of 0.92.4 → Version Mismatch overlay → app unusable.

After the next release carrying this PR: fresh install of 0.92.5 (or whichever patch ships with this commit) → overlay does not fire → app launches normally.

Reported by @PCAssistSoftware on #131 after the legacy-config fix (PR #134) let him past the `pydantic_core.ValidationError` and exposed this second, independent bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
