### PR TITLE
feat(vllm): opt-in vLLM backend with Flutter-driven lifecycle + GPU-aware model recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to Cognithor are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+- **vLLM as opt-in LLM backend** with full Flutter-driven lifecycle (install,
+  pull-image, start, stop, hot-switch) — spec at
+  `docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md`,
+  plan at `docs/superpowers/plans/2026-04-22-vllm-opt-in-backend.md`. Ollama
+  remains the default — vLLM is purely additive. Unlocks native FP4 on
+  Blackwell GPUs (RTX 50xx), FP8 on Ada, AWQ-INT4 on Ampere. Model registry
+  carries per-quantization entries with `min_compute_capability` and
+  `vram_gb_min` so the UI can disable models that don't fit the detected GPU
+  and auto-recommend the best fit. New `LlmBackendsScreen` and
+  `VllmSetupScreen` in Flutter. New FastAPI endpoints under
+  `/api/backends/vllm/*` including SSE-streamed pull progress. User guide
+  at `docs/vllm-user-guide.md`, manual test recipe at
+  `docs/vllm-manual-test.md`.
+
 ## [0.92.5] -- 2026-04-22
 
 ### Added

--- a/docs/superpowers/plans/2026-04-22-vllm-opt-in-backend.md
+++ b/docs/superpowers/plans/2026-04-22-vllm-opt-in-backend.md
@@ -34,7 +34,7 @@
 - `flutter_app/test/widgets/vllm_setup_screen_test.dart` — widget tests
 
 **Modified Python files:**
-- `src/cognithor/core/llm_backend.py` — add `LLMBadRequestError`, `VLLMNotReadyError`, `VLLMHardwareError`, `DockerError`; extend `LLMBackendType` enum with `VLLM`
+- `src/cognithor/core/llm_backend.py` — add `LLMBadRequestError`, `VLLMNotReadyError`, `VLLMHardwareError`, `VLLMDockerError`; extend `LLMBackendType` enum with `VLLM`
 - `src/cognithor/core/unified_llm.py` — per-backend `CircuitBreaker`, fail-flow dispatch, `backend_status` notification
 - `src/cognithor/config.py` — add `VLLMConfig` sub-model, embed on `CognithorConfig`
 - `src/cognithor/cli/model_registry.json` — new `vllm` provider section
@@ -73,7 +73,7 @@ from __future__ import annotations
 import pytest
 
 from cognithor.core.llm_backend import (
-    DockerError,
+    VLLMDockerError,
     LLMBackendError,
     LLMBadRequestError,
     VLLMHardwareError,
@@ -86,7 +86,7 @@ class TestErrorHierarchy:
         assert issubclass(LLMBadRequestError, LLMBackendError)
         assert issubclass(VLLMNotReadyError, LLMBackendError)
         assert issubclass(VLLMHardwareError, LLMBackendError)
-        assert issubclass(DockerError, LLMBackendError)
+        assert issubclass(VLLMDockerError, LLMBackendError)
 
     def test_errors_carry_recovery_hint(self):
         err = VLLMNotReadyError("container down", recovery_hint="Run: docker start vllm")
@@ -94,7 +94,7 @@ class TestErrorHierarchy:
         assert str(err) == "container down"
 
     def test_recovery_hint_defaults_to_empty(self):
-        err = DockerError("Docker not found")
+        err = VLLMDockerError("Docker not found")
         assert err.recovery_hint == ""
 
     def test_status_code_preserved_from_base(self):
@@ -145,7 +145,7 @@ class VLLMHardwareError(LLMBackendError):
     """NVIDIA GPU not detected, VRAM insufficient, or unsupported compute capability."""
 
 
-class DockerError(LLMBackendError):
+class VLLMDockerError(LLMBackendError):
     """Docker Desktop unreachable or wrong version."""
 ```
 
@@ -1267,7 +1267,7 @@ def pull_image(
     """Run ``docker pull`` streaming JSON progress to the callback.
 
     Raises:
-        DockerError: if the pull exits non-zero.
+        VLLMDockerError: if the pull exits non-zero.
     """
     cmd = ["docker", "pull", "--progress=auto", tag]
     proc = subprocess.Popen(
@@ -1293,7 +1293,7 @@ def pull_image(
         proc.wait()
 
     if proc.returncode != 0:
-        raise DockerError(
+        raise VLLMDockerError(
             f"docker pull {tag} failed with exit {proc.returncode}",
             recovery_hint="Check Docker Desktop is running and you have network access.",
         )
@@ -1301,10 +1301,10 @@ def pull_image(
     self.state.image_pulled = True
 ```
 
-Import `DockerError` at module top:
+Import `VLLMDockerError` at module top:
 
 ```python
-from cognithor.core.llm_backend import DockerError, VLLMHardwareError
+from cognithor.core.llm_backend import VLLMDockerError, VLLMHardwareError
 ```
 
 - [ ] **Step 4: Run test**

--- a/docs/superpowers/plans/2026-04-22-vllm-opt-in-backend.md
+++ b/docs/superpowers/plans/2026-04-22-vllm-opt-in-backend.md
@@ -1,0 +1,5184 @@
+# vLLM Opt-In Backend Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add vLLM as a first-class opt-in LLM backend alongside Ollama, with full Flutter-driven container lifecycle, GPU-aware model recommendation, and circuit-breaker-guarded fail-flow. Ollama stays default — vLLM is purely additive.
+
+**Architecture:** New `VLLMBackend` implements the existing `LLMBackend` ABC (template: `OpenAIBackend`). New `vllm_orchestrator.py` wraps `docker`/`nvidia-smi` subprocesses for lifecycle + hardware detection + model recommendation. `UnifiedLLMClient` gets per-backend `CircuitBreaker` wrapping. Flutter gets a dedicated `LlmBackendsScreen` + `VllmSetupScreen` with status-card UX and SSE progress streaming.
+
+**Tech Stack:** Python 3.12, Pydantic v2, pytest-asyncio, FastAPI (existing), httpx, Flutter 3.41.4 with `ChangeNotifier` state management, Inno Setup + Docker Desktop (user-managed). No new Python dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md` — read it before starting. All nine key decisions are locked.
+
+---
+
+## File Structure
+
+**New Python files:**
+- `src/cognithor/core/vllm_orchestrator.py` — ~450 LOC — hardware/docker/container lifecycle + recommendation
+- `src/cognithor/core/vllm_backend.py` — ~250 LOC — LLMBackend adapter for vLLM's OpenAI API
+- `tests/test_core/test_vllm_orchestrator.py` — orchestrator unit tests
+- `tests/test_core/test_vllm_backend.py` — backend unit tests
+- `tests/test_core/test_vllm_recommend_model.py` — recommendation-matrix tests
+- `tests/test_core/test_unified_llm_circuit_breaker.py` — UnifiedLLMClient + CB wiring
+- `tests/test_integration/test_vllm_fake_server.py` — fake vLLM-compatible server
+- `tests/test_vllm_registry_sync.py` — cross-repo guard
+- `docs/vllm-user-guide.md` — user-facing install + enable guide
+- `docs/vllm-manual-test.md` — smoke-test recipe for real hardware
+
+**New Flutter files:**
+- `flutter_app/lib/providers/llm_backend_provider.dart` — state + 2s polling
+- `flutter_app/lib/screens/llm_backends_screen.dart` — list view
+- `flutter_app/lib/screens/vllm_setup_screen.dart` — status cards + SSE progress
+- `flutter_app/test/widgets/llm_backends_screen_test.dart` — widget tests
+- `flutter_app/test/widgets/vllm_setup_screen_test.dart` — widget tests
+
+**Modified Python files:**
+- `src/cognithor/core/llm_backend.py` — add `LLMBadRequestError`, `VLLMNotReadyError`, `VLLMHardwareError`, `DockerError`; extend `LLMBackendType` enum with `VLLM`
+- `src/cognithor/core/unified_llm.py` — per-backend `CircuitBreaker`, fail-flow dispatch, `backend_status` notification
+- `src/cognithor/config.py` — add `VLLMConfig` sub-model, embed on `CognithorConfig`
+- `src/cognithor/cli/model_registry.json` — new `vllm` provider section
+- `src/cognithor/channels/api.py` — 7 new `/api/backends/*` endpoints including SSE streaming
+- `CHANGELOG.md` — feature note
+
+---
+
+## TDD Contract
+
+Every task follows: write failing test → run (red) → implement → run (green) → commit. No implementation without a test first. Commit after every green.
+
+**Test infrastructure already in place:** `tests/conftest.py` has shared fixtures. Use `pytest-asyncio`'s `asyncio_mode=auto` (already in `pyproject.toml`). Ruff + Ruff format are enforced in CI (`.github/workflows/ci.yml:ruff check src/ tests/` + `ruff format --check src/ tests/`).
+
+**Before EVERY commit:**
+```bash
+python -m ruff check src/cognithor/core/vllm_orchestrator.py src/cognithor/core/vllm_backend.py tests/
+python -m ruff format --check src/cognithor/core/vllm_orchestrator.py src/cognithor/core/vllm_backend.py tests/
+```
+Run them first, then commit. Remember PR #135 lesson — CI has a separate `ruff format --check` step.
+
+---
+
+## Task 1: Error Hierarchy Extensions
+
+**Files:**
+- Modify: `src/cognithor/core/llm_backend.py` (add 4 exception classes after the existing `LLMBackendError`)
+- Test: `tests/test_core/test_llm_backend_errors.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_core/test_llm_backend_errors.py
+from __future__ import annotations
+
+import pytest
+
+from cognithor.core.llm_backend import (
+    DockerError,
+    LLMBackendError,
+    LLMBadRequestError,
+    VLLMHardwareError,
+    VLLMNotReadyError,
+)
+
+
+class TestErrorHierarchy:
+    def test_all_vllm_errors_inherit_from_llm_backend_error(self):
+        assert issubclass(LLMBadRequestError, LLMBackendError)
+        assert issubclass(VLLMNotReadyError, LLMBackendError)
+        assert issubclass(VLLMHardwareError, LLMBackendError)
+        assert issubclass(DockerError, LLMBackendError)
+
+    def test_errors_carry_recovery_hint(self):
+        err = VLLMNotReadyError("container down", recovery_hint="Run: docker start vllm")
+        assert err.recovery_hint == "Run: docker start vllm"
+        assert str(err) == "container down"
+
+    def test_recovery_hint_defaults_to_empty(self):
+        err = DockerError("Docker not found")
+        assert err.recovery_hint == ""
+
+    def test_status_code_preserved_from_base(self):
+        err = LLMBadRequestError("context too long", status_code=400)
+        assert err.status_code == 400
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest tests/test_core/test_llm_backend_errors.py -v
+```
+Expected: `ImportError: cannot import name 'LLMBadRequestError' from 'cognithor.core.llm_backend'`
+
+- [ ] **Step 3: Add the exception classes**
+
+Add below the existing `LLMBackendError` class in `src/cognithor/core/llm_backend.py` (around line 80-85):
+
+```python
+class LLMBackendError(Exception):
+    """Error communicating with the LLM backend."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        recovery_hint: str = "",
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.recovery_hint = recovery_hint
+
+
+class LLMBadRequestError(LLMBackendError):
+    """Wraps HTTP 400 responses — user/context problem, not a backend fault.
+
+    Excluded from circuit-breaker failure counting via ``excluded_exceptions``
+    when the breaker is wired in ``UnifiedLLMClient``.
+    """
+
+
+class VLLMNotReadyError(LLMBackendError):
+    """vLLM container not running or model not loaded."""
+
+
+class VLLMHardwareError(LLMBackendError):
+    """NVIDIA GPU not detected, VRAM insufficient, or unsupported compute capability."""
+
+
+class DockerError(LLMBackendError):
+    """Docker Desktop unreachable or wrong version."""
+```
+
+(Modify the existing `LLMBackendError.__init__` to accept `recovery_hint` — that's the only change to the base class. All four new subclasses inherit without override.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+python -m pytest tests/test_core/test_llm_backend_errors.py -v
+```
+Expected: `4 passed`
+
+- [ ] **Step 5: Ruff + format + commit**
+
+```bash
+python -m ruff check src/cognithor/core/llm_backend.py tests/test_core/test_llm_backend_errors.py
+python -m ruff format --check src/cognithor/core/llm_backend.py tests/test_core/test_llm_backend_errors.py
+git add src/cognithor/core/llm_backend.py tests/test_core/test_llm_backend_errors.py
+git commit -m "feat(llm): add LLMBadRequestError + VLLM/Docker error subclasses"
+```
+
+---
+
+## Task 2: LLMBackendType Enum Extension
+
+**Files:**
+- Modify: `src/cognithor/core/llm_backend.py:38-46` (add `VLLM` member to `LLMBackendType` StrEnum)
+- Test: `tests/test_core/test_llm_backend_errors.py` (add test to existing file)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_core/test_llm_backend_errors.py`:
+
+```python
+class TestBackendTypeEnum:
+    def test_vllm_is_a_backend_type(self):
+        from cognithor.core.llm_backend import LLMBackendType
+        assert LLMBackendType.VLLM == "vllm"
+        assert LLMBackendType.VLLM.value == "vllm"
+
+    def test_vllm_value_matches_config_literal(self):
+        """config.CognithorConfig.llm_backend_type accepts "vllm" — keep enum aligned."""
+        from cognithor.core.llm_backend import LLMBackendType
+        assert "vllm" in {t.value for t in LLMBackendType}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest tests/test_core/test_llm_backend_errors.py::TestBackendTypeEnum -v
+```
+Expected: `AttributeError: VLLM`
+
+- [ ] **Step 3: Add enum member**
+
+In `src/cognithor/core/llm_backend.py`, modify the `LLMBackendType` StrEnum:
+
+```python
+class LLMBackendType(StrEnum):
+    """Supported LLM backends."""
+
+    OLLAMA = "ollama"
+    OPENAI = "openai"
+    ANTHROPIC = "anthropic"
+    GEMINI = "gemini"
+    LMSTUDIO = "lmstudio"
+    CLAUDE_CODE = "claude-code"
+    VLLM = "vllm"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+python -m pytest tests/test_core/test_llm_backend_errors.py -v
+```
+Expected: `6 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/llm_backend.py tests/test_core/test_llm_backend_errors.py && python -m ruff format --check src/cognithor/core/llm_backend.py tests/test_core/test_llm_backend_errors.py
+git add src/cognithor/core/llm_backend.py tests/test_core/test_llm_backend_errors.py
+git commit -m "feat(llm): register VLLM in LLMBackendType enum"
+```
+
+---
+
+## Task 3: VLLMConfig Pydantic Sub-Model
+
+**Files:**
+- Modify: `src/cognithor/config.py` (add `VLLMConfig` class; embed on `CognithorConfig`)
+- Test: `tests/config/test_vllm_config.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/config/test_vllm_config.py
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from cognithor.config import CognithorConfig, VLLMConfig
+
+
+class TestVLLMConfig:
+    def test_defaults(self):
+        c = VLLMConfig()
+        assert c.enabled is False
+        assert c.model == ""
+        assert c.docker_image == "vllm/vllm-openai:v0.19.1"
+        assert c.port == 8000
+        assert c.auto_stop_on_close is False
+        assert c.skip_hardware_check is False
+        assert c.request_timeout_seconds == 60
+
+    def test_rejects_unknown_fields(self):
+        with pytest.raises(ValidationError):
+            VLLMConfig(unknown_field=1)
+
+    def test_cognithor_config_has_vllm_sub_model(self):
+        c = CognithorConfig()
+        assert hasattr(c, "vllm")
+        assert isinstance(c.vllm, VLLMConfig)
+
+    def test_vllm_override(self):
+        c = CognithorConfig(vllm={"enabled": True, "port": 8042})
+        assert c.vllm.enabled is True
+        assert c.vllm.port == 8042
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest tests/config/test_vllm_config.py -v
+```
+Expected: `ImportError: cannot import name 'VLLMConfig' from 'cognithor.config'`
+
+- [ ] **Step 3: Add VLLMConfig class + embed on CognithorConfig**
+
+In `src/cognithor/config.py`, add a new class BEFORE `class CognithorConfig(BaseModel):`:
+
+```python
+class VLLMConfig(BaseModel):
+    """Configuration for the optional vLLM backend.
+
+    HF token is NOT stored here — read from top-level
+    ``config.huggingface_api_key`` which is keyring-backed via
+    ``SecretStore._SECRET_FIELDS``. Orchestrator passes it to
+    the container as ``-e HF_TOKEN=$value``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(default=False)
+    model: str = Field(default="")
+    docker_image: str = Field(default="vllm/vllm-openai:v0.19.1")
+    port: int = Field(default=8000, ge=1024, le=65535)
+    auto_stop_on_close: bool = Field(default=False)
+    skip_hardware_check: bool = Field(default=False)
+    request_timeout_seconds: int = Field(default=60, ge=5, le=600)
+```
+
+Then add the field inside `CognithorConfig` (search for `llm_backend_type` and place near it):
+
+```python
+vllm: VLLMConfig = Field(default_factory=VLLMConfig)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+python -m pytest tests/config/test_vllm_config.py -v
+```
+Expected: `4 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/config.py tests/config/test_vllm_config.py && python -m ruff format --check src/cognithor/config.py tests/config/test_vllm_config.py
+git add src/cognithor/config.py tests/config/test_vllm_config.py
+git commit -m "feat(config): add VLLMConfig sub-model"
+```
+
+---
+
+## Task 4: Model Registry — vLLM Provider Section
+
+**Files:**
+- Modify: `src/cognithor/cli/model_registry.json` (add `providers.vllm` section)
+- Test: `tests/test_core/test_model_registry_vllm.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_core/test_model_registry_vllm.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REGISTRY_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src" / "cognithor" / "cli" / "model_registry.json"
+)
+
+
+class TestVLLMRegistrySection:
+    def setup_method(self):
+        with open(REGISTRY_PATH, encoding="utf-8") as f:
+            self.registry = json.load(f)
+
+    def test_vllm_provider_exists(self):
+        assert "vllm" in self.registry["providers"]
+
+    def test_vllm_has_curated_models(self):
+        models = self.registry["providers"]["vllm"]["models"]
+        assert len(models) >= 5
+
+    def test_each_model_has_required_fields(self):
+        models = self.registry["providers"]["vllm"]["models"]
+        required = {
+            "id", "display_name", "base_model", "quantization",
+            "vram_gb_min", "min_compute_capability", "min_vllm_version",
+            "capability", "priority", "tested", "notes",
+        }
+        for m in models:
+            missing = required - set(m.keys())
+            assert not missing, f"Model {m.get('id')} missing fields: {missing}"
+
+    def test_priority_values_are_valid(self):
+        models = self.registry["providers"]["vllm"]["models"]
+        for m in models:
+            assert m["priority"] in ("premium", "standard", "fallback")
+
+    def test_compute_capability_is_parseable(self):
+        models = self.registry["providers"]["vllm"]["models"]
+        for m in models:
+            parts = m["min_compute_capability"].split(".")
+            assert len(parts) == 2
+            assert int(parts[0]) >= 7
+            assert int(parts[1]) >= 0
+
+    def test_vram_is_positive_integer(self):
+        models = self.registry["providers"]["vllm"]["models"]
+        for m in models:
+            assert isinstance(m["vram_gb_min"], int)
+            assert m["vram_gb_min"] > 0
+
+    def test_at_least_one_tested_model(self):
+        models = self.registry["providers"]["vllm"]["models"]
+        assert any(m["tested"] for m in models)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest tests/test_core/test_model_registry_vllm.py -v
+```
+Expected: `KeyError: 'vllm'`
+
+- [ ] **Step 3: Add vllm provider section to model_registry.json**
+
+In `src/cognithor/cli/model_registry.json`, find the existing `providers` object and add the `vllm` section with all 5 curated model entries EXACTLY as specified in the spec file `docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md` under "Model Registry" (lines 111-181). The entries are:
+
+1. `mmangkad/Qwen3.6-27B-NVFP4` — NVFP4, vram 14, cc 12.0, priority premium, tested false
+2. `Qwen/Qwen3.6-27B-FP8` — FP8, vram 32, cc 8.9, priority premium, tested false
+3. `cyankiwi/Qwen3.6-27B-AWQ-INT4` — AWQ-INT4, vram 16, cc 8.0, priority standard, tested false
+4. `Qwen/Qwen3.6-35B-A3B-FP8` — FP8, vram 40, cc 8.9, priority standard, tested false
+5. `Qwen/Qwen2.5-VL-7B-Instruct` — bf16, vram 16, cc 7.5, priority fallback, tested TRUE
+
+Copy the full JSON blocks from the spec verbatim. Also bump the registry's top-level `"updated"` timestamp to `"2026-04-22"`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+python -m pytest tests/test_core/test_model_registry_vllm.py -v
+```
+Expected: `7 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check tests/test_core/test_model_registry_vllm.py && python -m ruff format --check tests/test_core/test_model_registry_vllm.py
+git add src/cognithor/cli/model_registry.json tests/test_core/test_model_registry_vllm.py
+git commit -m "feat(registry): add vLLM provider section with 5 curated model entries"
+```
+
+---
+
+## Task 5: Orchestrator Dataclasses + Module Skeleton
+
+**Files:**
+- Create: `src/cognithor/core/vllm_orchestrator.py` (dataclasses only; methods added in later tasks)
+- Test: `tests/test_core/test_vllm_orchestrator.py` (new, initial dataclass tests)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_core/test_vllm_orchestrator.py
+from __future__ import annotations
+
+import pytest
+
+from cognithor.core.vllm_orchestrator import (
+    ContainerInfo,
+    DockerInfo,
+    HardwareInfo,
+    ModelEntry,
+    VLLMOrchestrator,
+    VLLMState,
+)
+
+
+class TestDataclasses:
+    def test_hardware_info_fields(self):
+        h = HardwareInfo(gpu_name="RTX 5090", vram_gb=32, compute_capability=(12, 0))
+        assert h.gpu_name == "RTX 5090"
+        assert h.vram_gb == 32
+        assert h.compute_capability == (12, 0)
+
+    def test_hardware_info_sm_as_string(self):
+        h = HardwareInfo(gpu_name="RTX 4090", vram_gb=24, compute_capability=(8, 9))
+        assert h.sm_string == "8.9"
+
+    def test_docker_info_fields(self):
+        d = DockerInfo(available=True, version="26.0.0", server_running=True)
+        assert d.available is True
+        assert d.version == "26.0.0"
+
+    def test_model_entry_from_dict(self):
+        m = ModelEntry.from_dict({
+            "id": "mmangkad/Qwen3.6-27B-NVFP4",
+            "display_name": "Qwen3.6-27B · NVFP4",
+            "base_model": "Qwen/Qwen3.6-27B",
+            "quantization": "NVFP4",
+            "vram_gb_min": 14,
+            "min_compute_capability": "12.0",
+            "min_vllm_version": "pending",
+            "capability": "vision",
+            "priority": "premium",
+            "tested": False,
+            "notes": "",
+        })
+        assert m.id == "mmangkad/Qwen3.6-27B-NVFP4"
+        assert m.min_cc_tuple == (12, 0)
+        assert m.vram_gb_min == 14
+        assert m.priority == "premium"
+
+    def test_vllm_state_initial(self):
+        s = VLLMState()
+        assert s.hardware_ok is False
+        assert s.docker_ok is False
+        assert s.container_running is False
+        assert s.current_model is None
+        assert s.hardware_info is None
+
+    def test_container_info(self):
+        c = ContainerInfo(container_id="abc123", port=8000, model="Qwen/Qwen3.6-27B-FP8")
+        assert c.container_id == "abc123"
+        assert c.port == 8000
+
+
+class TestOrchestratorInit:
+    def test_orchestrator_constructs_with_config(self):
+        orch = VLLMOrchestrator(
+            docker_image="vllm/vllm-openai:v0.19.1",
+            port=8000,
+            hf_token="hf_test",
+        )
+        assert orch.docker_image == "vllm/vllm-openai:v0.19.1"
+        assert orch.port == 8000
+        assert orch._hf_token == "hf_test"
+        assert orch.state.hardware_ok is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py -v
+```
+Expected: `ModuleNotFoundError: No module named 'cognithor.core.vllm_orchestrator'`
+
+- [ ] **Step 3: Create vllm_orchestrator.py skeleton**
+
+Create `src/cognithor/core/vllm_orchestrator.py`:
+
+```python
+"""vLLM lifecycle orchestrator — wraps docker/nvidia-smi subprocesses.
+
+Stateful manager: hardware detection, Docker readiness, image pull,
+container start/stop, model recommendation. No Docker-SDK dependency —
+pure `subprocess` calls.
+
+See spec: docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
+"""
+
+from __future__ import annotations
+
+import collections
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from cognithor.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+Priority = Literal["premium", "standard", "fallback"]
+Capability = Literal["vision", "text"]
+
+
+@dataclass
+class HardwareInfo:
+    """NVIDIA GPU detection result."""
+
+    gpu_name: str
+    vram_gb: int
+    compute_capability: tuple[int, int]
+
+    @property
+    def sm_string(self) -> str:
+        """Returns the compute capability as 'major.minor' string."""
+        return f"{self.compute_capability[0]}.{self.compute_capability[1]}"
+
+
+@dataclass
+class DockerInfo:
+    """Docker Desktop readiness."""
+
+    available: bool
+    version: str = ""
+    server_running: bool = False
+
+
+@dataclass
+class ContainerInfo:
+    """A running/started vLLM container."""
+
+    container_id: str
+    port: int
+    model: str
+
+
+@dataclass
+class ModelEntry:
+    """One row from the model_registry.json vllm provider section."""
+
+    id: str
+    display_name: str
+    base_model: str
+    quantization: str
+    vram_gb_min: int
+    min_compute_capability: str  # "12.0" / "8.9" etc.
+    min_vllm_version: str
+    capability: Capability
+    priority: Priority
+    tested: bool
+    notes: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ModelEntry:
+        return cls(
+            id=data["id"],
+            display_name=data["display_name"],
+            base_model=data["base_model"],
+            quantization=data["quantization"],
+            vram_gb_min=int(data["vram_gb_min"]),
+            min_compute_capability=data["min_compute_capability"],
+            min_vllm_version=data["min_vllm_version"],
+            capability=data["capability"],
+            priority=data["priority"],
+            tested=bool(data["tested"]),
+            notes=data.get("notes", ""),
+        )
+
+    @property
+    def min_cc_tuple(self) -> tuple[int, int]:
+        """Returns min_compute_capability as (major, minor) tuple."""
+        parts = self.min_compute_capability.split(".")
+        return (int(parts[0]), int(parts[1]))
+
+
+@dataclass
+class VLLMState:
+    """Aggregate state snapshot for UI rendering."""
+
+    hardware_ok: bool = False
+    hardware_info: HardwareInfo | None = None
+    docker_ok: bool = False
+    docker_info: DockerInfo | None = None
+    image_pulled: bool = False
+    container_running: bool = False
+    current_model: str | None = None
+    last_error: str | None = None
+
+
+class VLLMOrchestrator:
+    """Stateful vLLM lifecycle manager. Methods added in later tasks."""
+
+    def __init__(
+        self,
+        *,
+        docker_image: str = "vllm/vllm-openai:v0.19.1",
+        port: int = 8000,
+        hf_token: str = "",
+        log_ring_size: int = 500,
+    ) -> None:
+        self.docker_image = docker_image
+        self.port = port
+        self._hf_token = hf_token
+        self.state = VLLMState()
+        self._log_ring: collections.deque[str] = collections.deque(maxlen=log_ring_size)
+
+    def get_logs(self) -> list[str]:
+        """Snapshot of the container-log ring buffer."""
+        return list(self._log_ring)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py -v
+```
+Expected: `7 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py && python -m ruff format --check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git add src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git commit -m "feat(vllm): orchestrator dataclasses + module skeleton"
+```
+
+---
+
+## Task 6: Orchestrator `check_hardware()`
+
+**Files:**
+- Modify: `src/cognithor/core/vllm_orchestrator.py` (add method)
+- Modify: `tests/test_core/test_vllm_orchestrator.py` (add test class)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_core/test_vllm_orchestrator.py`:
+
+```python
+from unittest.mock import patch, MagicMock
+
+from cognithor.core.llm_backend import VLLMHardwareError
+
+
+class TestCheckHardware:
+    def _mk_orch(self):
+        return VLLMOrchestrator()
+
+    def test_detects_rtx_5090(self):
+        # nvidia-smi --query-gpu=name,memory.total,compute_cap --format=csv,noheader,nounits
+        # sample output: "NVIDIA GeForce RTX 5090, 32768, 12.0"
+        mock_result = MagicMock(returncode=0, stdout="NVIDIA GeForce RTX 5090, 32768, 12.0\n")
+        with patch("subprocess.run", return_value=mock_result):
+            info = self._mk_orch().check_hardware()
+        assert info.gpu_name == "NVIDIA GeForce RTX 5090"
+        assert info.vram_gb == 32
+        assert info.compute_capability == (12, 0)
+
+    def test_detects_rtx_4090(self):
+        mock_result = MagicMock(returncode=0, stdout="NVIDIA GeForce RTX 4090, 24564, 8.9\n")
+        with patch("subprocess.run", return_value=mock_result):
+            info = self._mk_orch().check_hardware()
+        assert info.gpu_name == "NVIDIA GeForce RTX 4090"
+        assert info.vram_gb == 24  # rounds down
+        assert info.compute_capability == (8, 9)
+
+    def test_raises_when_nvidia_smi_missing(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(VLLMHardwareError) as exc:
+                self._mk_orch().check_hardware()
+            assert "nvidia-smi" in str(exc.value).lower()
+
+    def test_raises_when_no_gpu_detected(self):
+        mock_result = MagicMock(returncode=0, stdout="")
+        with patch("subprocess.run", return_value=mock_result):
+            with pytest.raises(VLLMHardwareError):
+                self._mk_orch().check_hardware()
+
+    def test_raises_when_nvidia_smi_fails(self):
+        mock_result = MagicMock(returncode=9, stdout="", stderr="NVIDIA-SMI has failed")
+        with patch("subprocess.run", return_value=mock_result):
+            with pytest.raises(VLLMHardwareError):
+                self._mk_orch().check_hardware()
+
+    def test_picks_first_gpu_when_multiple(self):
+        mock_result = MagicMock(
+            returncode=0,
+            stdout="NVIDIA GeForce RTX 5090, 32768, 12.0\nNVIDIA GeForce RTX 3060, 12288, 8.6\n",
+        )
+        with patch("subprocess.run", return_value=mock_result):
+            info = self._mk_orch().check_hardware()
+        assert "5090" in info.gpu_name
+
+    def test_state_updated_after_success(self):
+        mock_result = MagicMock(returncode=0, stdout="NVIDIA GeForce RTX 4080, 16380, 8.9\n")
+        orch = self._mk_orch()
+        with patch("subprocess.run", return_value=mock_result):
+            orch.check_hardware()
+        assert orch.state.hardware_ok is True
+        assert orch.state.hardware_info is not None
+        assert orch.state.hardware_info.compute_capability == (8, 9)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py::TestCheckHardware -v
+```
+Expected: `AttributeError: 'VLLMOrchestrator' object has no attribute 'check_hardware'`
+
+- [ ] **Step 3: Implement `check_hardware()`**
+
+Add to `VLLMOrchestrator` class in `src/cognithor/core/vllm_orchestrator.py`:
+
+```python
+import subprocess
+
+from cognithor.core.llm_backend import VLLMHardwareError
+
+
+def check_hardware(self) -> HardwareInfo:
+    """Detect NVIDIA GPU. Raises VLLMHardwareError on any failure.
+
+    Parses ``nvidia-smi --query-gpu=name,memory.total,compute_cap
+    --format=csv,noheader,nounits``.
+    """
+    cmd = [
+        "nvidia-smi",
+        "--query-gpu=name,memory.total,compute_cap",
+        "--format=csv,noheader,nounits",
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+    except FileNotFoundError as exc:
+        raise VLLMHardwareError(
+            "nvidia-smi not found — NVIDIA driver not installed?",
+            recovery_hint="Install the NVIDIA GPU driver from nvidia.com.",
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise VLLMHardwareError(
+            "nvidia-smi timed out",
+            recovery_hint="Check GPU driver health.",
+        ) from exc
+
+    if result.returncode != 0:
+        raise VLLMHardwareError(
+            f"nvidia-smi failed: {result.stderr.strip() or 'unknown error'}",
+        )
+
+    first_line = result.stdout.strip().split("\n")[0] if result.stdout.strip() else ""
+    if not first_line:
+        raise VLLMHardwareError("No NVIDIA GPU detected")
+
+    parts = [p.strip() for p in first_line.split(",")]
+    if len(parts) < 3:
+        raise VLLMHardwareError(f"Unexpected nvidia-smi output: {first_line!r}")
+
+    gpu_name = parts[0]
+    try:
+        vram_mib = int(parts[1])
+        cc_parts = parts[2].split(".")
+        compute_capability = (int(cc_parts[0]), int(cc_parts[1]))
+    except (ValueError, IndexError) as exc:
+        raise VLLMHardwareError(f"Cannot parse nvidia-smi output: {first_line!r}") from exc
+
+    info = HardwareInfo(
+        gpu_name=gpu_name,
+        vram_gb=vram_mib // 1024,
+        compute_capability=compute_capability,
+    )
+    self.state.hardware_info = info
+    self.state.hardware_ok = True
+    return info
+```
+
+Put the method inside the `VLLMOrchestrator` class. Move `import subprocess` and `from cognithor.core.llm_backend import VLLMHardwareError` to module-level imports.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py::TestCheckHardware -v
+```
+Expected: `7 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py && python -m ruff format --check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git add src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git commit -m "feat(vllm): orchestrator check_hardware() via nvidia-smi"
+```
+
+---
+
+## Task 7: Orchestrator `check_docker()`
+
+**Files:**
+- Modify: `src/cognithor/core/vllm_orchestrator.py`
+- Modify: `tests/test_core/test_vllm_orchestrator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/test_core/test_vllm_orchestrator.py`:
+
+```python
+class TestCheckDocker:
+    def test_docker_running(self):
+        # docker version --format json
+        mock_stdout = '{"Client":{"Version":"26.0.0"},"Server":{"Version":"26.0.0"}}'
+        mock_result = MagicMock(returncode=0, stdout=mock_stdout)
+        with patch("subprocess.run", return_value=mock_result):
+            info = VLLMOrchestrator().check_docker()
+        assert info.available is True
+        assert info.server_running is True
+        assert info.version == "26.0.0"
+
+    def test_docker_installed_but_server_down(self):
+        # Client OK, Server missing (Docker Desktop not started)
+        mock_stdout = '{"Client":{"Version":"26.0.0"}}'
+        mock_result = MagicMock(returncode=0, stdout=mock_stdout)
+        with patch("subprocess.run", return_value=mock_result):
+            info = VLLMOrchestrator().check_docker()
+        assert info.available is True
+        assert info.server_running is False
+
+    def test_docker_cli_missing(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            info = VLLMOrchestrator().check_docker()
+        assert info.available is False
+        assert info.server_running is False
+
+    def test_docker_cmd_fails(self):
+        mock_result = MagicMock(returncode=1, stdout="", stderr="daemon not running")
+        with patch("subprocess.run", return_value=mock_result):
+            info = VLLMOrchestrator().check_docker()
+        assert info.available is True  # CLI exists
+        assert info.server_running is False
+
+    def test_state_updated(self):
+        mock_stdout = '{"Client":{"Version":"26.0.0"},"Server":{"Version":"26.0.0"}}'
+        orch = VLLMOrchestrator()
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=mock_stdout)):
+            orch.check_docker()
+        assert orch.state.docker_ok is True
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py::TestCheckDocker -v
+```
+Expected: `AttributeError: check_docker`
+
+- [ ] **Step 3: Implement `check_docker()`**
+
+Add method to `VLLMOrchestrator`:
+
+```python
+import json as _json
+
+
+def check_docker(self) -> DockerInfo:
+    """Detect Docker Desktop. Never raises — returns DockerInfo with flags."""
+    try:
+        result = subprocess.run(
+            ["docker", "version", "--format", "json"],
+            capture_output=True, text=True, timeout=10,
+        )
+    except FileNotFoundError:
+        info = DockerInfo(available=False)
+        self.state.docker_ok = False
+        self.state.docker_info = info
+        return info
+    except subprocess.TimeoutExpired:
+        info = DockerInfo(available=True, server_running=False)
+        self.state.docker_ok = False
+        self.state.docker_info = info
+        return info
+
+    if result.returncode != 0:
+        info = DockerInfo(available=True, server_running=False)
+        self.state.docker_ok = False
+        self.state.docker_info = info
+        return info
+
+    try:
+        parsed = _json.loads(result.stdout)
+    except _json.JSONDecodeError:
+        info = DockerInfo(available=True, server_running=False)
+        self.state.docker_ok = False
+        self.state.docker_info = info
+        return info
+
+    server = parsed.get("Server")
+    version = (server or parsed.get("Client", {})).get("Version", "")
+    info = DockerInfo(
+        available=True,
+        version=version,
+        server_running=server is not None,
+    )
+    self.state.docker_ok = info.server_running
+    self.state.docker_info = info
+    return info
+```
+
+Add `import json as _json` to module imports.
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py::TestCheckDocker -v
+```
+Expected: `5 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py && python -m ruff format --check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git add src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git commit -m "feat(vllm): orchestrator check_docker() non-throwing detection"
+```
+
+---
+
+## Task 8: Orchestrator `recommend_model()` + `filter_registry()`
+
+**Files:**
+- Modify: `src/cognithor/core/vllm_orchestrator.py`
+- Create: `tests/test_core/test_vllm_recommend_model.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_core/test_vllm_recommend_model.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cognithor.core.vllm_orchestrator import (
+    HardwareInfo,
+    ModelEntry,
+    VLLMOrchestrator,
+)
+
+
+REGISTRY_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "src" / "cognithor" / "cli" / "model_registry.json"
+)
+
+
+@pytest.fixture
+def registry() -> list[ModelEntry]:
+    data = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+    return [ModelEntry.from_dict(m) for m in data["providers"]["vllm"]["models"]]
+
+
+@pytest.fixture
+def orch() -> VLLMOrchestrator:
+    return VLLMOrchestrator()
+
+
+class TestRecommendModel:
+    def test_blackwell_32gb_picks_nvfp4(self, orch, registry):
+        hw = HardwareInfo(gpu_name="RTX 5090", vram_gb=32, compute_capability=(12, 0))
+        best = orch.recommend_model(hw, registry, prefer="vision")
+        assert best.quantization == "NVFP4"
+        assert "Qwen3.6-27B" in best.base_model
+
+    def test_ada_24gb_falls_back_to_qwen25(self, orch, registry):
+        # All Qwen3.6 entries have min_vllm_version="pending" → tested=false.
+        # Until one is tested, the only tested entry (Qwen2.5-VL-7B) wins.
+        hw = HardwareInfo(gpu_name="RTX 4090", vram_gb=24, compute_capability=(8, 9))
+        best = orch.recommend_model(hw, registry, prefer="vision")
+        assert best.tested is True
+        assert "Qwen2.5-VL" in best.id
+
+    def test_ampere_24gb_falls_back_to_qwen25(self, orch, registry):
+        hw = HardwareInfo(gpu_name="RTX 3090", vram_gb=24, compute_capability=(8, 0))
+        best = orch.recommend_model(hw, registry, prefer="vision")
+        assert best.tested is True
+
+    def test_turing_16gb_falls_back_to_qwen25(self, orch, registry):
+        hw = HardwareInfo(gpu_name="RTX 2080 Ti", vram_gb=11, compute_capability=(7, 5))
+        # 11 GB < 16 GB → fails all entries. Returns None.
+        best = orch.recommend_model(hw, registry, prefer="vision")
+        assert best is None
+
+    def test_no_vision_text_preference_returns_none_when_none_curated(self, orch, registry):
+        hw = HardwareInfo(gpu_name="RTX 5090", vram_gb=32, compute_capability=(12, 0))
+        best = orch.recommend_model(hw, registry, prefer="text")
+        # Registry has NO text-capability entries
+        assert best is None
+
+    def test_ignores_entries_exceeding_vram(self, orch, registry):
+        hw = HardwareInfo(gpu_name="RTX 4080", vram_gb=16, compute_capability=(8, 9))
+        results = orch.filter_registry(hw, registry)
+        for m in results:
+            assert m.vram_gb_min <= 16
+
+    def test_ignores_entries_requiring_newer_compute_capability(self, orch, registry):
+        hw = HardwareInfo(gpu_name="RTX 4090", vram_gb=24, compute_capability=(8, 9))
+        results = orch.filter_registry(hw, registry)
+        # NVFP4 (12.0) must NOT pass
+        for m in results:
+            assert m.min_cc_tuple <= (8, 9)
+
+
+class TestRecommendationAfterQwen36Support:
+    """Scenario: vLLM ships Qwen3.6 support, we flip tested=True on the FP8 entry."""
+
+    def test_tested_nvfp4_beats_tested_fallback_on_blackwell(self, orch):
+        # Synthetic registry — NVFP4 marked tested=true (simulating future release)
+        entries = [
+            ModelEntry.from_dict({
+                "id": "mmangkad/Qwen3.6-27B-NVFP4",
+                "display_name": "Qwen3.6-27B NVFP4",
+                "base_model": "Qwen/Qwen3.6-27B",
+                "quantization": "NVFP4",
+                "vram_gb_min": 14,
+                "min_compute_capability": "12.0",
+                "min_vllm_version": "0.20.0",
+                "capability": "vision",
+                "priority": "premium",
+                "tested": True,
+                "notes": "",
+            }),
+            ModelEntry.from_dict({
+                "id": "Qwen/Qwen2.5-VL-7B-Instruct",
+                "display_name": "Qwen2.5-VL-7B",
+                "base_model": "Qwen/Qwen2.5-VL-7B-Instruct",
+                "quantization": "bf16",
+                "vram_gb_min": 16,
+                "min_compute_capability": "7.5",
+                "min_vllm_version": "0.7.0",
+                "capability": "vision",
+                "priority": "fallback",
+                "tested": True,
+                "notes": "",
+            }),
+        ]
+        hw = HardwareInfo(gpu_name="RTX 5090", vram_gb=32, compute_capability=(12, 0))
+        best = orch.recommend_model(hw, entries, prefer="vision")
+        assert best.id == "mmangkad/Qwen3.6-27B-NVFP4"
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_recommend_model.py -v
+```
+Expected: `AttributeError: 'VLLMOrchestrator' object has no attribute 'recommend_model'`
+
+- [ ] **Step 3: Implement `filter_registry()` + `recommend_model()`**
+
+Add to `VLLMOrchestrator`:
+
+```python
+_PRIORITY_ORDER = {"premium": 0, "standard": 1, "fallback": 2}
+
+
+def filter_registry(
+    self,
+    hardware: HardwareInfo,
+    registry: list[ModelEntry],
+) -> list[ModelEntry]:
+    """Returns entries that fit the detected GPU (VRAM + compute capability)."""
+    return [
+        m for m in registry
+        if m.vram_gb_min <= hardware.vram_gb
+        and m.min_cc_tuple <= hardware.compute_capability
+    ]
+
+
+def recommend_model(
+    self,
+    hardware: HardwareInfo,
+    registry: list[ModelEntry],
+    *,
+    prefer: Literal["vision", "text"] = "vision",
+) -> ModelEntry | None:
+    """Pick the best curated model for detected hardware.
+
+    Ranking:
+      1. Matches requested ``capability`` (vision/text)
+      2. ``tested==True`` beats ``tested==False``
+      3. Higher priority (premium > standard > fallback)
+      4. Tie-break: larger VRAM headroom (lower vram_gb_min for same tier)
+
+    Returns None if no entry fits.
+    """
+    candidates = [
+        m for m in self.filter_registry(hardware, registry)
+        if m.capability == prefer
+    ]
+    if not candidates:
+        return None
+
+    def sort_key(m: ModelEntry) -> tuple[int, int, int, int]:
+        return (
+            0 if m.tested else 1,          # tested first
+            self._PRIORITY_ORDER[m.priority],  # then priority tier
+            m.vram_gb_min,                 # then smaller VRAM (more headroom)
+            0 if m.min_vllm_version != "pending" else 1,  # stable before pending
+        )
+
+    candidates.sort(key=sort_key)
+    return candidates[0]
+```
+
+Add `from typing import Literal` to imports if not present.
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_recommend_model.py -v
+```
+Expected: `8 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_recommend_model.py && python -m ruff format --check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_recommend_model.py
+git add src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_recommend_model.py
+git commit -m "feat(vllm): orchestrator recommend_model() + filter_registry() with GPU-aware ranking"
+```
+
+---
+
+## Task 9: Orchestrator `pull_image()`
+
+**Files:**
+- Modify: `src/cognithor/core/vllm_orchestrator.py`
+- Modify: `tests/test_core/test_vllm_orchestrator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestPullImage:
+    def test_pull_emits_progress_events(self):
+        """docker pull --progress=auto outputs JSON lines when TTY-off."""
+        # Simulate streaming stdout from docker
+        json_lines = [
+            '{"status":"Pulling from vllm/vllm-openai","id":"latest"}\n',
+            '{"status":"Downloading","progressDetail":{"current":1000000,"total":10000000},"id":"abc123"}\n',
+            '{"status":"Download complete","id":"abc123"}\n',
+            '{"status":"Status: Downloaded newer image for vllm/vllm-openai:v0.19.1"}\n',
+        ]
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter(json_lines)
+        mock_proc.wait.return_value = 0
+        mock_proc.returncode = 0
+
+        events: list[dict] = []
+        def cb(ev): events.append(ev)
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            VLLMOrchestrator().pull_image("vllm/vllm-openai:v0.19.1", progress_callback=cb)
+
+        # Expect at least one "Downloading" event with progressDetail
+        assert any(e.get("status") == "Downloading" for e in events)
+        assert any("current" in (e.get("progressDetail") or {}) for e in events)
+
+    def test_pull_failure_raises(self):
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter(['{"status":"error"}\n'])
+        mock_proc.wait.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            with pytest.raises(Exception):
+                VLLMOrchestrator().pull_image("bad/image:tag", progress_callback=None)
+
+    def test_pull_sets_image_pulled_flag(self):
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter(['{"status":"Pulling"}\n'])
+        mock_proc.wait.return_value = 0
+        mock_proc.returncode = 0
+        orch = VLLMOrchestrator()
+        with patch("subprocess.Popen", return_value=mock_proc):
+            orch.pull_image(orch.docker_image, progress_callback=None)
+        assert orch.state.image_pulled is True
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py::TestPullImage -v
+```
+Expected: `AttributeError: pull_image`
+
+- [ ] **Step 3: Implement `pull_image()`**
+
+Add to `VLLMOrchestrator`:
+
+```python
+from collections.abc import Callable
+
+
+ProgressCallback = Callable[[dict[str, Any]], None] | None
+
+
+def pull_image(
+    self,
+    tag: str,
+    *,
+    progress_callback: ProgressCallback = None,
+) -> None:
+    """Run ``docker pull`` streaming JSON progress to the callback.
+
+    Raises:
+        DockerError: if the pull exits non-zero.
+    """
+    cmd = ["docker", "pull", "--progress=auto", tag]
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+    )
+    try:
+        for line in proc.stdout or []:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = _json.loads(line)
+            except _json.JSONDecodeError:
+                # Docker's --progress=auto sometimes mixes plain text with JSON
+                event = {"status": line}
+            if progress_callback is not None:
+                progress_callback(event)
+    finally:
+        proc.wait()
+
+    if proc.returncode != 0:
+        raise DockerError(
+            f"docker pull {tag} failed with exit {proc.returncode}",
+            recovery_hint="Check Docker Desktop is running and you have network access.",
+        )
+
+    self.state.image_pulled = True
+```
+
+Import `DockerError` at module top:
+
+```python
+from cognithor.core.llm_backend import DockerError, VLLMHardwareError
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py::TestPullImage -v
+```
+Expected: `3 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py && python -m ruff format --check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git add src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git commit -m "feat(vllm): orchestrator pull_image() with streaming JSON progress"
+```
+
+---
+
+## Task 10: Orchestrator `start_container()`
+
+**Files:**
+- Modify: `src/cognithor/core/vllm_orchestrator.py`
+- Modify: `tests/test_core/test_vllm_orchestrator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestStartContainer:
+    def test_constructs_docker_run_command(self):
+        # Mock: port-check OK, docker run OK, health-check OK
+        with patch.object(VLLMOrchestrator, "_port_available", return_value=True), \
+             patch("subprocess.run") as run_mock, \
+             patch.object(VLLMOrchestrator, "_wait_for_health", return_value=True):
+
+            run_mock.return_value = MagicMock(returncode=0, stdout="abc123def456")
+            orch = VLLMOrchestrator(docker_image="vllm/vllm-openai:v0.19.1", port=8000, hf_token="hf_x")
+            info = orch.start_container("Qwen/Qwen3.6-27B-FP8")
+
+        args = run_mock.call_args[0][0]
+        # Verify key flags in the docker run invocation
+        assert "run" in args
+        assert "-d" in args
+        assert "--gpus" in args and "all" in args
+        assert any("HF_TOKEN=hf_x" in a for a in args)
+        assert any("cognithor.managed=true" in a for a in args)
+        assert any("vllm-openai:v0.19.1" in a for a in args)
+        assert "Qwen/Qwen3.6-27B-FP8" in args
+        assert info.port == 8000
+        assert info.model == "Qwen/Qwen3.6-27B-FP8"
+
+    def test_port_fallback_when_busy(self):
+        orch = VLLMOrchestrator(port=8000)
+        # 8000 and 8001 busy, 8002 free
+        with patch.object(orch, "_port_available", side_effect=[False, False, True]), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")), \
+             patch.object(orch, "_wait_for_health", return_value=True):
+            info = orch.start_container("Qwen/Qwen2.5-VL-7B-Instruct")
+        assert info.port == 8002
+
+    def test_raises_when_all_ports_busy(self):
+        orch = VLLMOrchestrator(port=8000)
+        with patch.object(orch, "_port_available", return_value=False):
+            with pytest.raises(VLLMNotReadyError) as exc:
+                orch.start_container("Qwen/Qwen2.5-VL-7B-Instruct")
+            assert "port" in str(exc.value).lower()
+
+    def test_health_timeout_scales_with_model_size(self):
+        """Models with vram >= 20 GB get 300 s timeout instead of 120 s."""
+        orch = VLLMOrchestrator(port=8000)
+        # No registry lookup done here — timeout is passed explicitly
+        with patch.object(orch, "_port_available", return_value=True), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")), \
+             patch.object(orch, "_wait_for_health", return_value=True) as wait_mock:
+            orch.start_container("x", health_timeout=300)
+        # Verify _wait_for_health called with 300
+        assert wait_mock.call_args.kwargs.get("timeout") == 300 \
+            or (wait_mock.call_args.args and wait_mock.call_args.args[-1] == 300)
+
+    def test_default_health_timeout_120(self):
+        orch = VLLMOrchestrator(port=8000)
+        with patch.object(orch, "_port_available", return_value=True), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")), \
+             patch.object(orch, "_wait_for_health", return_value=True) as wait_mock:
+            orch.start_container("x")
+        assert wait_mock.call_args.kwargs.get("timeout", 120) == 120
+```
+
+Add import at top of test file:
+
+```python
+from cognithor.core.llm_backend import VLLMNotReadyError
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py::TestStartContainer -v
+```
+Expected: `AttributeError: start_container`
+
+- [ ] **Step 3: Implement `start_container()`**
+
+Add to `VLLMOrchestrator`:
+
+```python
+import socket
+import time
+import httpx
+
+from cognithor.core.llm_backend import VLLMNotReadyError
+
+_MAX_PORT_FALLBACKS = 10
+
+
+def _port_available(self, port: int) -> bool:
+    """True if nothing is listening on localhost:port."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.5)
+        try:
+            s.bind(("127.0.0.1", port))
+            return True
+        except OSError:
+            return False
+
+
+def _wait_for_health(self, port: int, *, timeout: int = 120) -> bool:
+    """Poll vLLM /health until 200 or timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with httpx.Client(timeout=2.0) as client:
+                r = client.get(f"http://localhost:{port}/health")
+                if r.status_code == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(2.0)
+    return False
+
+
+def start_container(
+    self,
+    model: str,
+    *,
+    health_timeout: int | None = None,
+) -> ContainerInfo:
+    """Start a vLLM container. Auto-falls-back 8000→8009 on port conflict."""
+    # Resolve port
+    port = self.port
+    for offset in range(_MAX_PORT_FALLBACKS):
+        candidate = self.port + offset
+        if self._port_available(candidate):
+            port = candidate
+            break
+    else:
+        raise VLLMNotReadyError(
+            f"All ports {self.port}..{self.port + _MAX_PORT_FALLBACKS - 1} are busy",
+            recovery_hint="Stop other services or change config.vllm.port.",
+        )
+
+    # Construct docker run
+    cmd = [
+        "docker", "run", "-d",
+        "--gpus", "all",
+        "-v", "cognithor-hf-cache:/root/.cache/huggingface",
+        "-e", f"HF_TOKEN={self._hf_token}",
+        "-p", f"{port}:8000",
+        "--label", "cognithor.managed=true",
+        self.docker_image,
+        "--model", model,
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+    if result.returncode != 0:
+        raise VLLMNotReadyError(
+            f"docker run failed: {result.stderr.strip()}",
+            recovery_hint="Check Docker Desktop logs.",
+        )
+
+    container_id = result.stdout.strip().split("\n")[-1][:12]
+
+    # Wait for /health
+    timeout = health_timeout if health_timeout is not None else 120
+    if not self._wait_for_health(port, timeout=timeout):
+        raise VLLMNotReadyError(
+            f"vLLM /health did not respond within {timeout}s",
+            recovery_hint="Check `docker logs <id>` for model-loading errors.",
+        )
+
+    info = ContainerInfo(container_id=container_id, port=port, model=model)
+    self.state.container_running = True
+    self.state.current_model = model
+    return info
+```
+
+Import `socket`, `time`, `httpx` at module top. Import `VLLMNotReadyError` alongside the others.
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py::TestStartContainer -v
+```
+Expected: `5 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py && python -m ruff format --check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git add src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git commit -m "feat(vllm): orchestrator start_container() with port fallback + health wait"
+```
+
+---
+
+## Task 11: Orchestrator `stop_container()` + `reuse_existing()`
+
+**Files:**
+- Modify: `src/cognithor/core/vllm_orchestrator.py`
+- Modify: `tests/test_core/test_vllm_orchestrator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestStopAndReuse:
+    def test_stop_container_via_label(self):
+        # docker ps --filter "label=cognithor.managed=true" --format "{{.ID}}"
+        find_result = MagicMock(returncode=0, stdout="abc123def456\n")
+        stop_result = MagicMock(returncode=0)
+        rm_result = MagicMock(returncode=0)
+
+        orch = VLLMOrchestrator()
+        orch.state.container_running = True
+
+        with patch("subprocess.run", side_effect=[find_result, stop_result, rm_result]):
+            orch.stop_container()
+
+        assert orch.state.container_running is False
+
+    def test_stop_when_no_container_is_noop(self):
+        find_result = MagicMock(returncode=0, stdout="")
+        orch = VLLMOrchestrator()
+        with patch("subprocess.run", return_value=find_result):
+            orch.stop_container()  # must not raise
+
+    def test_reuse_existing_returns_info(self):
+        # ps --filter label=... --format json
+        ps_stdout = '{"ID":"abc123def456","Ports":"0.0.0.0:8000->8000/tcp","Image":"vllm/vllm-openai:v0.19.1","Command":"... --model Qwen/Qwen3.6-27B-FP8 ..."}\n'
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=ps_stdout)):
+            info = VLLMOrchestrator().reuse_existing()
+        assert info is not None
+        assert info.container_id == "abc123def456"
+        assert info.port == 8000
+
+    def test_reuse_existing_returns_none_when_nothing_running(self):
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="")):
+            info = VLLMOrchestrator().reuse_existing()
+        assert info is None
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py::TestStopAndReuse -v
+```
+Expected: `AttributeError: stop_container`
+
+- [ ] **Step 3: Implement both methods**
+
+Add to `VLLMOrchestrator`:
+
+```python
+import re
+
+
+def stop_container(self) -> None:
+    """Stop and remove the cognithor-managed vLLM container. Noop if none."""
+    find = subprocess.run(
+        ["docker", "ps", "-q", "--filter", "label=cognithor.managed=true"],
+        capture_output=True, text=True, timeout=10,
+    )
+    container_id = find.stdout.strip().split("\n")[0] if find.stdout.strip() else ""
+    if not container_id:
+        self.state.container_running = False
+        return
+
+    subprocess.run(["docker", "stop", container_id], capture_output=True, timeout=30)
+    subprocess.run(["docker", "rm", container_id], capture_output=True, timeout=10)
+    self.state.container_running = False
+    self.state.current_model = None
+
+
+def reuse_existing(self) -> ContainerInfo | None:
+    """If a cognithor-managed container is already running, return its info.
+
+    Used at app-start to pick up a container left running across sessions.
+    """
+    result = subprocess.run(
+        [
+            "docker", "ps",
+            "--filter", "label=cognithor.managed=true",
+            "--format", "json",
+        ],
+        capture_output=True, text=True, timeout=10,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+
+    # Docker outputs one JSON object per line
+    first_line = result.stdout.strip().split("\n")[0]
+    try:
+        row = _json.loads(first_line)
+    except _json.JSONDecodeError:
+        return None
+
+    container_id = row.get("ID", "").strip()
+    ports = row.get("Ports", "")
+    cmd = row.get("Command", "")
+
+    port_match = re.search(r"0\.0\.0\.0:(\d+)->8000/tcp", ports)
+    port = int(port_match.group(1)) if port_match else self.port
+
+    model_match = re.search(r"--model\s+(\S+)", cmd)
+    model = model_match.group(1) if model_match else ""
+
+    if not container_id:
+        return None
+
+    info = ContainerInfo(container_id=container_id, port=port, model=model)
+    self.state.container_running = True
+    self.state.current_model = model
+    return info
+```
+
+Add `import re` to imports.
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py::TestStopAndReuse -v
+```
+Expected: `4 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py && python -m ruff format --check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git add src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git commit -m "feat(vllm): orchestrator stop_container() + reuse_existing() via label filter"
+```
+
+---
+
+## Task 12: Orchestrator `status()` Aggregator
+
+**Files:**
+- Modify: `src/cognithor/core/vllm_orchestrator.py`
+- Modify: `tests/test_core/test_vllm_orchestrator.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestStatusAggregator:
+    def test_status_returns_current_state(self):
+        orch = VLLMOrchestrator()
+        orch.state.hardware_ok = True
+        orch.state.docker_ok = True
+        snapshot = orch.status()
+        assert snapshot.hardware_ok is True
+        assert snapshot.docker_ok is True
+        # Must return a copy — mutating the returned object doesn't leak
+        snapshot.hardware_ok = False
+        assert orch.state.hardware_ok is True
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py::TestStatusAggregator -v
+```
+Expected: `AttributeError: status`
+
+- [ ] **Step 3: Implement `status()`**
+
+```python
+import dataclasses
+
+
+def status(self) -> VLLMState:
+    """Return a snapshot copy of the current state (safe to mutate)."""
+    return dataclasses.replace(self.state)
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py -v
+```
+Expected: all orchestrator tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py && python -m ruff format --check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git add src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git commit -m "feat(vllm): orchestrator status() snapshot aggregator"
+```
+
+---
+
+## Task 13: `VLLMBackend` Class Skeleton + `is_available()` + `list_models()` + `close()`
+
+**Files:**
+- Create: `src/cognithor/core/vllm_backend.py` (new)
+- Create: `tests/test_core/test_vllm_backend.py` (new)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_core/test_vllm_backend.py
+from __future__ import annotations
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from cognithor.core.llm_backend import (
+    LLMBackendType,
+    LLMBadRequestError,
+    VLLMNotReadyError,
+)
+from cognithor.core.vllm_backend import VLLMBackend
+
+
+BASE_URL = "http://localhost:8000/v1"
+
+
+@pytest.fixture
+def backend() -> VLLMBackend:
+    return VLLMBackend(base_url=BASE_URL, timeout=5)
+
+
+class TestVLLMBackendBasics:
+    def test_backend_type(self, backend):
+        assert backend.backend_type == LLMBackendType.VLLM
+
+    @pytest.mark.asyncio
+    async def test_is_available_true_on_200(self, backend, httpx_mock: HTTPXMock):
+        httpx_mock.add_response(
+            url="http://localhost:8000/health",
+            status_code=200,
+        )
+        assert await backend.is_available() is True
+
+    @pytest.mark.asyncio
+    async def test_is_available_false_on_connection_refused(self, backend):
+        # No mock registered → httpx gets connection refused
+        assert await backend.is_available() is False
+
+    @pytest.mark.asyncio
+    async def test_list_models_from_openai_endpoint(self, backend, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/models",
+            status_code=200,
+            json={"data": [{"id": "Qwen/Qwen3.6-27B-FP8"}]},
+        )
+        models = await backend.list_models()
+        assert "Qwen/Qwen3.6-27B-FP8" in models
+
+    @pytest.mark.asyncio
+    async def test_close_is_idempotent(self, backend):
+        await backend.close()
+        await backend.close()  # second call must not raise
+```
+
+Install pytest-httpx if not already: check with `pip show pytest-httpx`. If missing, install via `pip install pytest-httpx` and add to dev-dependencies in `pyproject.toml`.
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_backend.py -v
+```
+Expected: `ModuleNotFoundError: No module named 'cognithor.core.vllm_backend'`
+
+- [ ] **Step 3: Create `vllm_backend.py` skeleton**
+
+```python
+"""vLLM backend — OpenAI-compatible LLMBackend adapter.
+
+vLLM serves an OpenAI-compatible ``/v1/chat/completions`` endpoint.
+This class adapts it to Cognithor's LLMBackend ABC with image-payload
+conversion for vision models.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from cognithor.core.llm_backend import (
+    ChatResponse,
+    EmbedResponse,
+    LLMBackend,
+    LLMBackendError,
+    LLMBackendType,
+    LLMBadRequestError,
+    VLLMNotReadyError,
+)
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+log = get_logger(__name__)
+
+
+class VLLMBackend(LLMBackend):
+    """vLLM OpenAI-compat adapter."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "http://localhost:8000/v1",
+        timeout: int = 60,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._client: httpx.AsyncClient | None = None
+
+    @property
+    def backend_type(self) -> LLMBackendType:
+        return LLMBackendType.VLLM
+
+    async def _ensure_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._timeout)
+        return self._client
+
+    async def is_available(self) -> bool:
+        """Ping /health (NOT /v1/health — vLLM exposes /health at server root)."""
+        health_url = self._base_url.rsplit("/v1", 1)[0] + "/health"
+        client = await self._ensure_client()
+        try:
+            r = await client.get(health_url)
+            return r.status_code == 200
+        except Exception:
+            return False
+
+    async def list_models(self) -> list[str]:
+        client = await self._ensure_client()
+        try:
+            r = await client.get(f"{self._base_url}/models")
+            r.raise_for_status()
+            data = r.json()
+            return [m["id"] for m in data.get("data", [])]
+        except httpx.HTTPStatusError as exc:
+            raise LLMBackendError(f"vLLM /models failed: {exc}") from exc
+        except httpx.RequestError as exc:
+            raise VLLMNotReadyError(f"vLLM not reachable: {exc}") from exc
+
+    async def close(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    # chat() / chat_stream() / embed() added in later tasks.
+    async def chat(self, *args: Any, **kwargs: Any) -> ChatResponse:
+        raise NotImplementedError
+
+    async def chat_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[str]:
+        raise NotImplementedError
+        yield  # pragma: no cover
+
+    async def embed(self, *args: Any, **kwargs: Any) -> EmbedResponse:
+        raise NotImplementedError
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_backend.py -v
+```
+Expected: `5 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend.py && python -m ruff format --check src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend.py
+git add src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend.py
+git commit -m "feat(vllm): VLLMBackend skeleton with is_available/list_models/close"
+```
+
+---
+
+## Task 14: `VLLMBackend.chat()` with Image-Payload Conversion
+
+**Files:**
+- Modify: `src/cognithor/core/vllm_backend.py`
+- Modify: `tests/test_core/test_vllm_backend.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestVLLMBackendChat:
+    @pytest.mark.asyncio
+    async def test_chat_sends_openai_payload(self, backend, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=200,
+            json={
+                "choices": [{"message": {"content": "Hello!"}}],
+                "model": "Qwen/Qwen2.5-VL-7B-Instruct",
+                "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+            },
+        )
+        resp = await backend.chat(
+            model="Qwen/Qwen2.5-VL-7B-Instruct",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.7,
+        )
+        assert resp.content == "Hello!"
+        assert resp.model == "Qwen/Qwen2.5-VL-7B-Instruct"
+        assert resp.usage == {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12}
+
+        request = httpx_mock.get_requests()[0]
+        import json as _j
+        body = _j.loads(request.content)
+        assert body["model"] == "Qwen/Qwen2.5-VL-7B-Instruct"
+        assert body["temperature"] == 0.7
+        assert body["messages"] == [{"role": "user", "content": "Hi"}]
+
+    @pytest.mark.asyncio
+    async def test_chat_converts_image_paths_to_openai_vision_format(
+        self, backend, httpx_mock, tmp_path
+    ):
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR")  # minimal PNG-ish bytes
+
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=200,
+            json={"choices": [{"message": {"content": "ok"}}], "model": "x"},
+        )
+        await backend.chat(
+            model="Qwen/Qwen2.5-VL-7B-Instruct",
+            messages=[{"role": "user", "content": "what is this?"}],
+            images=[str(img)],
+        )
+
+        import json as _j
+        body = _j.loads(httpx_mock.get_requests()[0].content)
+        last = body["messages"][-1]
+        assert isinstance(last["content"], list)
+        assert any(c.get("type") == "text" for c in last["content"])
+        assert any(
+            c.get("type") == "image_url" and c["image_url"]["url"].startswith("data:image/png;base64,")
+            for c in last["content"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_chat_raises_bad_request_on_400(self, backend, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=400,
+            json={"error": {"message": "context too long"}},
+        )
+        with pytest.raises(LLMBadRequestError):
+            await backend.chat(model="x", messages=[{"role": "user", "content": "a"}])
+
+    @pytest.mark.asyncio
+    async def test_chat_raises_not_ready_on_5xx(self, backend, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=503,
+            json={"error": "model loading"},
+        )
+        with pytest.raises(VLLMNotReadyError):
+            await backend.chat(model="x", messages=[{"role": "user", "content": "a"}])
+
+    @pytest.mark.asyncio
+    async def test_chat_raises_not_ready_on_connection_refused(self, backend):
+        # No mock → connection refused
+        with pytest.raises(VLLMNotReadyError):
+            await backend.chat(model="x", messages=[{"role": "user", "content": "a"}])
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_backend.py::TestVLLMBackendChat -v
+```
+Expected: `NotImplementedError`
+
+- [ ] **Step 3: Implement `chat()` + image conversion**
+
+Replace the stub `chat` in `VLLMBackend` with:
+
+```python
+import base64
+from pathlib import Path
+
+
+def _encode_image_to_data_url(path: str) -> str | None:
+    """Read an image file, return OpenAI-vision data-URL string. None if unreadable."""
+    try:
+        p = Path(path)
+        if not p.is_file():
+            return None
+        data = p.read_bytes()
+    except OSError:
+        return None
+
+    suffix = p.suffix.lower().lstrip(".")
+    mime_map = {"png": "png", "jpg": "jpeg", "jpeg": "jpeg", "webp": "webp", "gif": "gif", "bmp": "bmp"}
+    mime = mime_map.get(suffix, "png")
+    b64 = base64.b64encode(data).decode("ascii")
+    return f"data:image/{mime};base64,{b64}"
+
+
+def _attach_images_to_last_user(
+    messages: list[dict[str, Any]],
+    images: list[str],
+) -> list[dict[str, Any]]:
+    """Return a NEW messages list with images attached to the last user message in
+    OpenAI-vision format. Never mutates the caller's list."""
+    if not images:
+        return list(messages)
+
+    encoded = [e for e in (_encode_image_to_data_url(p) for p in images) if e]
+    if not encoded:
+        return list(messages)
+
+    new_messages = [dict(m) for m in messages]
+    for i in range(len(new_messages) - 1, -1, -1):
+        if new_messages[i].get("role") == "user":
+            existing = new_messages[i].get("content")
+            text_part = existing if isinstance(existing, str) else ""
+            content_list: list[dict[str, Any]] = []
+            if text_part:
+                content_list.append({"type": "text", "text": text_part})
+            for url in encoded:
+                content_list.append({"type": "image_url", "image_url": {"url": url}})
+            new_messages[i] = {**new_messages[i], "content": content_list}
+            break
+    else:
+        content_list = [{"type": "image_url", "image_url": {"url": u}} for u in encoded]
+        new_messages.append({"role": "user", "content": content_list})
+    return new_messages
+
+
+async def chat(
+    self,
+    model: str,
+    messages: list[dict[str, Any]],
+    *,
+    tools: list[dict[str, Any]] | None = None,
+    temperature: float = 0.7,
+    top_p: float = 0.9,
+    format_json: bool = False,
+    images: list[str] | None = None,
+) -> ChatResponse:
+    """Send a chat-completion request to vLLM. Raises LLMBadRequestError
+    on 400 (excluded from circuit breaker), VLLMNotReadyError on 5xx or
+    connection failure (counts toward breaker)."""
+    if images:
+        messages = _attach_images_to_last_user(messages, images)
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "top_p": top_p,
+    }
+    if tools:
+        payload["tools"] = tools
+    if format_json:
+        payload["response_format"] = {"type": "json_object"}
+
+    client = await self._ensure_client()
+    try:
+        r = await client.post(f"{self._base_url}/chat/completions", json=payload)
+    except httpx.RequestError as exc:
+        raise VLLMNotReadyError(
+            f"vLLM not reachable: {exc}",
+            recovery_hint="Check vLLM container is running.",
+        ) from exc
+
+    if r.status_code == 400:
+        raise LLMBadRequestError(
+            f"vLLM rejected the request: {r.text[:200]}",
+            status_code=400,
+        )
+    if r.status_code >= 500:
+        raise VLLMNotReadyError(
+            f"vLLM returned {r.status_code}: {r.text[:200]}",
+            status_code=r.status_code,
+            recovery_hint="vLLM may still be loading the model.",
+        )
+    if r.status_code >= 400:
+        raise LLMBackendError(
+            f"vLLM returned {r.status_code}: {r.text[:200]}",
+            status_code=r.status_code,
+        )
+
+    data = r.json()
+    first_choice = data.get("choices", [{}])[0]
+    content = first_choice.get("message", {}).get("content", "")
+    tool_calls = first_choice.get("message", {}).get("tool_calls")
+    return ChatResponse(
+        content=content,
+        tool_calls=tool_calls,
+        model=data.get("model", model),
+        usage=data.get("usage"),
+        raw=data,
+    )
+```
+
+Move the helper functions (`_encode_image_to_data_url`, `_attach_images_to_last_user`) to module level. Add `import base64` and `from pathlib import Path` at module top.
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_backend.py::TestVLLMBackendChat -v
+```
+Expected: `5 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend.py && python -m ruff format --check src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend.py
+git add src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend.py
+git commit -m "feat(vllm): VLLMBackend.chat() with OpenAI-vision image payload conversion"
+```
+
+---
+
+## Task 15: `VLLMBackend.chat_stream()`
+
+**Files:**
+- Modify: `src/cognithor/core/vllm_backend.py`
+- Modify: `tests/test_core/test_vllm_backend.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestVLLMBackendChatStream:
+    @pytest.mark.asyncio
+    async def test_stream_yields_content_chunks(self, backend, httpx_mock):
+        # vLLM SSE format: 'data: {"choices":[{"delta":{"content":"..."}}]}\n\n'
+        sse_lines = (
+            b'data: {"choices":[{"delta":{"content":"Hel"}}]}\n\n'
+            b'data: {"choices":[{"delta":{"content":"lo"}}]}\n\n'
+            b'data: [DONE]\n\n'
+        )
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=200,
+            content=sse_lines,
+            headers={"content-type": "text/event-stream"},
+        )
+
+        chunks: list[str] = []
+        async for piece in backend.chat_stream(
+            model="x",
+            messages=[{"role": "user", "content": "hi"}],
+        ):
+            chunks.append(piece)
+
+        assert "".join(chunks) == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_stream_raises_on_5xx(self, backend, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=503,
+        )
+        with pytest.raises(VLLMNotReadyError):
+            async for _ in backend.chat_stream(
+                model="x",
+                messages=[{"role": "user", "content": "hi"}],
+            ):
+                pass
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_backend.py::TestVLLMBackendChatStream -v
+```
+Expected: `NotImplementedError`
+
+- [ ] **Step 3: Implement `chat_stream()`**
+
+Replace the stub with:
+
+```python
+import json as _json
+
+
+async def chat_stream(
+    self,
+    model: str,
+    messages: list[dict[str, Any]],
+    *,
+    temperature: float = 0.7,
+    top_p: float = 0.9,
+    images: list[str] | None = None,
+) -> AsyncIterator[str]:
+    """Stream response tokens from vLLM. Parses OpenAI SSE format."""
+    if images:
+        messages = _attach_images_to_last_user(messages, images)
+
+    payload = {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "top_p": top_p,
+        "stream": True,
+    }
+    client = await self._ensure_client()
+    try:
+        async with client.stream(
+            "POST",
+            f"{self._base_url}/chat/completions",
+            json=payload,
+        ) as r:
+            if r.status_code >= 500:
+                raise VLLMNotReadyError(f"vLLM streaming returned {r.status_code}")
+            if r.status_code == 400:
+                raise LLMBadRequestError(f"vLLM rejected stream request: {r.status_code}")
+            if r.status_code >= 400:
+                raise LLMBackendError(f"vLLM streaming returned {r.status_code}")
+
+            async for line in r.aiter_lines():
+                line = line.strip()
+                if not line or not line.startswith("data:"):
+                    continue
+                payload_str = line[5:].strip()
+                if payload_str == "[DONE]":
+                    return
+                try:
+                    event = _json.loads(payload_str)
+                except _json.JSONDecodeError:
+                    continue
+                choices = event.get("choices", [])
+                if not choices:
+                    continue
+                delta = choices[0].get("delta") or {}
+                piece = delta.get("content")
+                if piece:
+                    yield piece
+    except httpx.RequestError as exc:
+        raise VLLMNotReadyError(f"vLLM stream not reachable: {exc}") from exc
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_backend.py::TestVLLMBackendChatStream -v
+```
+Expected: `2 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend.py && python -m ruff format --check src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend.py
+git add src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend.py
+git commit -m "feat(vllm): VLLMBackend.chat_stream() parsing OpenAI SSE"
+```
+
+---
+
+## Task 16: `VLLMBackend.embed()`
+
+**Files:**
+- Modify: `src/cognithor/core/vllm_backend.py`
+- Modify: `tests/test_core/test_vllm_backend.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestVLLMBackendEmbed:
+    @pytest.mark.asyncio
+    async def test_embed_returns_vector(self, backend, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/embeddings",
+            status_code=200,
+            json={"data": [{"embedding": [0.1, 0.2, 0.3]}], "model": "embed-model"},
+        )
+        resp = await backend.embed(model="embed-model", text="hello")
+        assert resp.embedding == [0.1, 0.2, 0.3]
+        assert resp.model == "embed-model"
+
+    @pytest.mark.asyncio
+    async def test_embed_raises_when_model_doesnt_support(self, backend, httpx_mock):
+        # vLLM returns 400 when the loaded model has no embedding head
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/embeddings",
+            status_code=400,
+            json={"error": "not an embedding model"},
+        )
+        with pytest.raises(LLMBadRequestError):
+            await backend.embed(model="qwen-chat-only", text="hello")
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_backend.py::TestVLLMBackendEmbed -v
+```
+Expected: `NotImplementedError`
+
+- [ ] **Step 3: Implement `embed()`**
+
+```python
+async def embed(self, model: str, text: str) -> EmbedResponse:
+    client = await self._ensure_client()
+    try:
+        r = await client.post(
+            f"{self._base_url}/embeddings",
+            json={"model": model, "input": text},
+        )
+    except httpx.RequestError as exc:
+        raise VLLMNotReadyError(f"vLLM embed not reachable: {exc}") from exc
+
+    if r.status_code == 400:
+        raise LLMBadRequestError(f"vLLM embed rejected: {r.text[:200]}")
+    if r.status_code >= 500:
+        raise VLLMNotReadyError(f"vLLM embed 5xx: {r.status_code}")
+    if r.status_code >= 400:
+        raise LLMBackendError(f"vLLM embed: {r.status_code}")
+
+    data = r.json()
+    items = data.get("data", [])
+    if not items:
+        raise LLMBackendError("vLLM embed returned no data")
+    return EmbedResponse(embedding=items[0].get("embedding", []), model=data.get("model", model))
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_core/test_vllm_backend.py -v
+```
+Expected: all VLLMBackend tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend.py && python -m ruff format --check src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend.py
+git add src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend.py
+git commit -m "feat(vllm): VLLMBackend.embed() for embedding-capable models"
+```
+
+---
+
+## Task 17: Register `VLLMBackend` in `create_backend()` Factory
+
+**Files:**
+- Modify: `src/cognithor/core/llm_backend.py` (add vllm branch to `create_backend()`)
+- Create: `tests/test_core/test_create_backend_vllm.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_core/test_create_backend_vllm.py
+from __future__ import annotations
+
+from cognithor.config import CognithorConfig, VLLMConfig
+from cognithor.core.llm_backend import create_backend
+from cognithor.core.vllm_backend import VLLMBackend
+
+
+class TestCreateVLLMBackend:
+    def test_returns_vllm_backend_when_config_says_vllm(self):
+        cfg = CognithorConfig(
+            llm_backend_type="vllm",
+            vllm=VLLMConfig(enabled=True, port=8000),
+        )
+        backend = create_backend(cfg)
+        assert isinstance(backend, VLLMBackend)
+        assert backend.backend_type.value == "vllm"
+
+    def test_vllm_backend_uses_configured_port(self):
+        cfg = CognithorConfig(
+            llm_backend_type="vllm",
+            vllm=VLLMConfig(enabled=True, port=8042),
+        )
+        backend = create_backend(cfg)
+        assert backend._base_url == "http://localhost:8042/v1"
+
+    def test_vllm_backend_uses_request_timeout(self):
+        cfg = CognithorConfig(
+            llm_backend_type="vllm",
+            vllm=VLLMConfig(enabled=True, request_timeout_seconds=30),
+        )
+        backend = create_backend(cfg)
+        assert backend._timeout == 30
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_core/test_create_backend_vllm.py -v
+```
+Expected: something like `ValueError: Unsupported backend: vllm` — `create_backend()` doesn't know vllm yet.
+
+- [ ] **Step 3: Add vllm branch to `create_backend()`**
+
+Find `create_backend(config)` in `src/cognithor/core/llm_backend.py` (near the bottom). Add a branch:
+
+```python
+def create_backend(config: CognithorConfig) -> LLMBackend:
+    btype = config.llm_backend_type
+    # ... existing branches ...
+    if btype == "vllm":
+        from cognithor.core.vllm_backend import VLLMBackend
+        return VLLMBackend(
+            base_url=f"http://localhost:{config.vllm.port}/v1",
+            timeout=config.vllm.request_timeout_seconds,
+        )
+    # ... fallback / raise ...
+```
+
+Place the branch before the "raise unsupported" tail. Import inside the function (lazy) to avoid circular imports.
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_core/test_create_backend_vllm.py -v
+```
+Expected: `3 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/llm_backend.py tests/test_core/test_create_backend_vllm.py && python -m ruff format --check src/cognithor/core/llm_backend.py tests/test_core/test_create_backend_vllm.py
+git add src/cognithor/core/llm_backend.py tests/test_core/test_create_backend_vllm.py
+git commit -m "feat(llm): wire VLLMBackend into create_backend() factory"
+```
+
+---
+
+## Task 18: `UnifiedLLMClient` — Per-Backend CircuitBreaker + `backend_status`
+
+**Files:**
+- Modify: `src/cognithor/core/unified_llm.py`
+- Create: `tests/test_core/test_unified_llm_circuit_breaker.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_core/test_unified_llm_circuit_breaker.py
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cognithor.core.llm_backend import (
+    ChatResponse,
+    LLMBadRequestError,
+    VLLMNotReadyError,
+)
+from cognithor.core.unified_llm import BackendStatus, UnifiedLLMClient
+from cognithor.utils.circuit_breaker import CircuitState
+
+
+@pytest.fixture
+def mock_vllm_backend() -> AsyncMock:
+    mock = AsyncMock()
+    mock.backend_type = "vllm"
+    return mock
+
+
+@pytest.fixture
+def mock_ollama_client() -> AsyncMock:
+    return AsyncMock()
+
+
+class TestBreakerWiring:
+    @pytest.mark.asyncio
+    async def test_three_consecutive_failures_open_breaker(
+        self, mock_vllm_backend, mock_ollama_client
+    ):
+        mock_vllm_backend.chat.side_effect = VLLMNotReadyError("down")
+        client = UnifiedLLMClient(
+            ollama_client=mock_ollama_client,
+            backend=mock_vllm_backend,
+        )
+        # Reject images → trigger errors
+        for _ in range(3):
+            try:
+                await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+            except Exception:
+                pass
+        assert client.vllm_breaker.state == CircuitState.open
+        assert client.backend_status == BackendStatus.DEGRADED
+
+    @pytest.mark.asyncio
+    async def test_bad_request_error_is_excluded_from_breaker(
+        self, mock_vllm_backend, mock_ollama_client
+    ):
+        mock_vllm_backend.chat.side_effect = LLMBadRequestError("context too long")
+        client = UnifiedLLMClient(
+            ollama_client=mock_ollama_client,
+            backend=mock_vllm_backend,
+        )
+        for _ in range(5):
+            try:
+                await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+            except LLMBadRequestError:
+                pass
+        assert client.vllm_breaker.state == CircuitState.closed
+        assert client.backend_status == BackendStatus.OK
+
+    @pytest.mark.asyncio
+    async def test_half_open_probe_success_closes_breaker(
+        self, mock_vllm_backend, mock_ollama_client
+    ):
+        mock_vllm_backend.chat.side_effect = VLLMNotReadyError("down")
+        client = UnifiedLLMClient(
+            ollama_client=mock_ollama_client,
+            backend=mock_vllm_backend,
+            _breaker_recovery_timeout=0.05,  # fast for test
+        )
+        # Open breaker
+        for _ in range(3):
+            try:
+                await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+            except Exception:
+                pass
+        assert client.vllm_breaker.state == CircuitState.open
+
+        # Wait past recovery_timeout, reset mock to success
+        import asyncio
+        await asyncio.sleep(0.1)
+        mock_vllm_backend.chat.side_effect = None
+        mock_vllm_backend.chat.return_value = ChatResponse(content="ok", model="x")
+
+        await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+        assert client.vllm_breaker.state == CircuitState.closed
+        assert client.backend_status == BackendStatus.OK
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_core/test_unified_llm_circuit_breaker.py -v
+```
+Expected: various attribute errors (`vllm_breaker`, `backend_status`, `BackendStatus`)
+
+- [ ] **Step 3: Extend `UnifiedLLMClient` with breaker + status**
+
+In `src/cognithor/core/unified_llm.py`:
+
+1. Add imports at the top:
+
+```python
+from enum import StrEnum
+
+from cognithor.core.llm_backend import LLMBadRequestError
+from cognithor.utils.circuit_breaker import CircuitBreaker, CircuitBreakerOpen, CircuitState
+```
+
+2. Add enum:
+
+```python
+class BackendStatus(StrEnum):
+    """Public-facing health state surfaced to the UI."""
+
+    OK = "ok"
+    DEGRADED = "degraded"
+```
+
+3. Extend `UnifiedLLMClient.__init__` to accept `_breaker_recovery_timeout` kwarg (test hook) and create per-backend breakers:
+
+```python
+def __init__(
+    self,
+    ollama_client: OllamaClient | None,
+    backend: Any | None = None,
+    config: CognithorConfig | None = None,
+    *,
+    _breaker_recovery_timeout: float = 60.0,
+) -> None:
+    self._ollama = ollama_client
+    self._backend = backend
+    self._config = config
+    self._backend_type: str = "ollama"
+    self._backend_cache: dict[str, Any] = {}
+    # Per-backend circuit breakers
+    self.vllm_breaker = CircuitBreaker(
+        name="llm_backend_vllm",
+        failure_threshold=3,
+        recovery_timeout=_breaker_recovery_timeout,
+        half_open_max_calls=1,
+        excluded_exceptions=(LLMBadRequestError,),
+    )
+    self.ollama_breaker = CircuitBreaker(
+        name="llm_backend_ollama",
+        failure_threshold=3,
+        recovery_timeout=_breaker_recovery_timeout,
+        half_open_max_calls=1,
+        excluded_exceptions=(LLMBadRequestError,),
+    )
+    self.backend_status: BackendStatus = BackendStatus.OK
+    if backend is not None:
+        self._backend_type = getattr(backend, "backend_type", "unknown")
+```
+
+4. Wrap the `chat()` dispatch method to use the relevant breaker AND to update `backend_status`:
+
+```python
+def _breaker_for(self, backend_type: str) -> CircuitBreaker:
+    if backend_type == "vllm":
+        return self.vllm_breaker
+    return self.ollama_breaker
+
+
+def _refresh_status(self) -> None:
+    """Recompute backend_status from breaker state."""
+    breaker = self._breaker_for(self._backend_type)
+    if breaker.state == CircuitState.closed:
+        self.backend_status = BackendStatus.OK
+    else:
+        self.backend_status = BackendStatus.DEGRADED
+
+
+async def chat(self, *args, **kwargs):
+    """Dispatch chat with per-backend circuit breaker protection."""
+    if self._backend is None:
+        # Legacy Ollama path — wrap too
+        breaker = self.ollama_breaker
+        try:
+            result = await breaker.call(self._ollama.chat(*args, **kwargs))
+        finally:
+            self._refresh_status()
+        return result
+
+    breaker = self._breaker_for(self._backend_type)
+    try:
+        result = await breaker.call(self._backend.chat(*args, **kwargs))
+    finally:
+        self._refresh_status()
+    return result
+```
+
+(Update any existing `chat()` implementation to go through the breaker; preserve the existing response-normalization logic if any.)
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_core/test_unified_llm_circuit_breaker.py -v
+```
+Expected: `3 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/unified_llm.py tests/test_core/test_unified_llm_circuit_breaker.py && python -m ruff format --check src/cognithor/core/unified_llm.py tests/test_core/test_unified_llm_circuit_breaker.py
+git add src/cognithor/core/unified_llm.py tests/test_core/test_unified_llm_circuit_breaker.py
+git commit -m "feat(unified-llm): per-backend CircuitBreaker + BackendStatus enum"
+```
+
+---
+
+## Task 19: `UnifiedLLMClient` — Situational Fail-Flow Dispatch
+
+**Files:**
+- Modify: `src/cognithor/core/unified_llm.py`
+- Modify: `tests/test_core/test_unified_llm_circuit_breaker.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestFailFlowDispatch:
+    @pytest.mark.asyncio
+    async def test_text_request_falls_back_to_ollama_when_vllm_degraded(
+        self, mock_vllm_backend, mock_ollama_client
+    ):
+        mock_vllm_backend.chat.side_effect = VLLMNotReadyError("down")
+        # Ollama answers successfully
+        mock_ollama_client.chat = AsyncMock(return_value={"message": {"content": "fallback answer"}})
+
+        client = UnifiedLLMClient(
+            ollama_client=mock_ollama_client,
+            backend=mock_vllm_backend,
+            _breaker_recovery_timeout=60.0,
+        )
+        # Trip the breaker
+        for _ in range(3):
+            try:
+                await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+            except Exception:
+                pass
+
+        # Now a pure text request — no images — must fall back silently
+        result = await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+        # result shape is Ollama-style dict
+        assert "fallback answer" in str(result)
+
+    @pytest.mark.asyncio
+    async def test_image_request_hard_errors_when_vllm_degraded(
+        self, mock_vllm_backend, mock_ollama_client, tmp_path
+    ):
+        mock_vllm_backend.chat.side_effect = VLLMNotReadyError("down")
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG")
+
+        client = UnifiedLLMClient(
+            ollama_client=mock_ollama_client,
+            backend=mock_vllm_backend,
+            _breaker_recovery_timeout=60.0,
+        )
+        # Trip the breaker
+        for _ in range(3):
+            try:
+                await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+            except Exception:
+                pass
+
+        # Image request — Ollama can't do vision → must raise
+        with pytest.raises(VLLMNotReadyError):
+            await client.chat(
+                model="x",
+                messages=[{"role": "user", "content": "what is this?"}],
+                images=[str(img)],
+            )
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_core/test_unified_llm_circuit_breaker.py::TestFailFlowDispatch -v
+```
+Expected: test fails because `chat()` doesn't dispatch between text / image yet
+
+- [ ] **Step 3: Add situational fallback to `chat()`**
+
+Replace the `chat()` method from Task 18 with:
+
+```python
+async def chat(self, *args, images: list[str] | None = None, **kwargs):
+    """Dispatch chat. Text-requests may fall back to Ollama when vLLM is
+    DEGRADED; image-requests raise because Ollama cannot do vision."""
+    is_image_request = bool(images)
+
+    # Try primary backend
+    breaker = self._breaker_for(self._backend_type)
+    try:
+        if self._backend is not None:
+            result = await breaker.call(
+                self._backend.chat(*args, images=images, **kwargs)
+            )
+        else:
+            result = await breaker.call(self._ollama.chat(*args, **kwargs))
+        self._refresh_status()
+        return result
+    except (VLLMNotReadyError, CircuitBreakerOpen) as exc:
+        self._refresh_status()
+        if is_image_request:
+            # No silent fallback — Ollama can't see images
+            if isinstance(exc, CircuitBreakerOpen):
+                raise VLLMNotReadyError(
+                    "vLLM offline — cannot process image",
+                    recovery_hint="Start vLLM from LLM Backends settings.",
+                ) from exc
+            raise
+        if self._backend_type == "vllm" and self._ollama is not None:
+            log.warning("vllm_fallback_to_ollama")
+            return await self._ollama.chat(*args, **kwargs)
+        raise
+```
+
+Import `VLLMNotReadyError` at module top.
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_core/test_unified_llm_circuit_breaker.py -v
+```
+Expected: all circuit-breaker tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/core/unified_llm.py tests/test_core/test_unified_llm_circuit_breaker.py && python -m ruff format --check src/cognithor/core/unified_llm.py tests/test_core/test_unified_llm_circuit_breaker.py
+git add src/cognithor/core/unified_llm.py tests/test_core/test_unified_llm_circuit_breaker.py
+git commit -m "feat(unified-llm): situational fail-flow — text→Ollama, image→hard error"
+```
+
+---
+
+## Task 20: Integration Test — Fake vLLM Server
+
+**Files:**
+- Create: `tests/test_integration/test_vllm_fake_server.py`
+
+- [ ] **Step 1: Write the integration test**
+
+```python
+# tests/test_integration/test_vllm_fake_server.py
+"""End-to-end test: VLLMBackend against a FastAPI impersonating vLLM's OpenAI API.
+
+No GPU, no Docker, no real vLLM. Verifies the full request-response round-trip
+on the HTTP layer with real (mocked-server) sockets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json as _json
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+import uvicorn
+
+from cognithor.core.vllm_backend import VLLMBackend
+
+
+def _build_fake_vllm_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.post("/v1/chat/completions")
+    async def chat(body: dict):
+        if body.get("stream"):
+            async def gen():
+                for chunk in ["Hel", "lo ", "world"]:
+                    payload = _json.dumps({"choices": [{"delta": {"content": chunk}}]})
+                    yield f"data: {payload}\n\n"
+                yield "data: [DONE]\n\n"
+            return StreamingResponse(gen(), media_type="text/event-stream")
+        return {
+            "choices": [{"message": {"content": "echo: " + body["messages"][-1]["content"]}}],
+            "model": body["model"],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+
+    @app.get("/v1/models")
+    async def models():
+        return {"data": [{"id": "fake-model"}]}
+
+    return app
+
+
+@pytest.fixture
+async def fake_server():
+    """Start the fake server on an ephemeral port."""
+    import socket
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+
+    config = uvicorn.Config(
+        _build_fake_vllm_app(),
+        host="127.0.0.1",
+        port=port,
+        log_level="error",
+    )
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve())
+    # Wait for startup
+    for _ in range(50):
+        if server.started:
+            break
+        await asyncio.sleep(0.05)
+    yield port
+    server.should_exit = True
+    await task
+
+
+class TestVLLMBackendEndToEnd:
+    @pytest.mark.asyncio
+    async def test_full_chat_roundtrip(self, fake_server):
+        backend = VLLMBackend(base_url=f"http://127.0.0.1:{fake_server}/v1")
+        try:
+            resp = await backend.chat(
+                model="fake-model",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+            assert resp.content == "echo: hello"
+            assert resp.model == "fake-model"
+        finally:
+            await backend.close()
+
+    @pytest.mark.asyncio
+    async def test_full_stream_roundtrip(self, fake_server):
+        backend = VLLMBackend(base_url=f"http://127.0.0.1:{fake_server}/v1")
+        try:
+            chunks = []
+            async for p in backend.chat_stream(
+                model="fake-model",
+                messages=[{"role": "user", "content": "stream me"}],
+            ):
+                chunks.append(p)
+            assert "".join(chunks) == "Hello world"
+        finally:
+            await backend.close()
+
+    @pytest.mark.asyncio
+    async def test_is_available_roundtrip(self, fake_server):
+        backend = VLLMBackend(base_url=f"http://127.0.0.1:{fake_server}/v1")
+        try:
+            assert await backend.is_available() is True
+        finally:
+            await backend.close()
+
+    @pytest.mark.asyncio
+    async def test_list_models_roundtrip(self, fake_server):
+        backend = VLLMBackend(base_url=f"http://127.0.0.1:{fake_server}/v1")
+        try:
+            models = await backend.list_models()
+            assert "fake-model" in models
+        finally:
+            await backend.close()
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_integration/test_vllm_fake_server.py -v
+```
+Expected: `4 passed` in < 5 seconds
+
+- [ ] **Step 3: Commit**
+
+```bash
+python -m ruff check tests/test_integration/test_vllm_fake_server.py && python -m ruff format --check tests/test_integration/test_vllm_fake_server.py
+git add tests/test_integration/test_vllm_fake_server.py
+git commit -m "test(vllm): integration test against a fake OpenAI-compatible server"
+```
+
+---
+
+## Task 21: FastAPI — `GET /api/backends` + `GET /api/backends/vllm/status`
+
+**Files:**
+- Modify: `src/cognithor/channels/api.py` (add router section for backends)
+- Create: `tests/test_channels/test_api_backends.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_channels/test_api_backends.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client_with_vllm_enabled():
+    """TestClient with a Cognithor API where vLLM is enabled in config."""
+    # Import here to avoid module-level side effects
+    from cognithor.channels.api import build_app
+    from cognithor.config import CognithorConfig, VLLMConfig
+
+    cfg = CognithorConfig(
+        llm_backend_type="ollama",  # Ollama stays default
+        vllm=VLLMConfig(enabled=True),
+    )
+    app = build_app(config=cfg)
+    return TestClient(app), cfg
+
+
+class TestBackendsList:
+    def test_lists_all_backends_with_status(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        r = client.get("/api/backends")
+        assert r.status_code == 200
+        data = r.json()
+        # Response shape: {"active": "ollama", "backends": [...]}
+        assert data["active"] == "ollama"
+        names = {b["name"] for b in data["backends"]}
+        assert "ollama" in names
+        assert "vllm" in names
+
+
+class TestVLLMStatus:
+    def test_status_returns_current_vllm_state(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        # Patch orchestrator.status() to return a known snapshot
+        with patch(
+            "cognithor.core.vllm_orchestrator.VLLMOrchestrator.status"
+        ) as mock:
+            from cognithor.core.vllm_orchestrator import (
+                DockerInfo, HardwareInfo, VLLMState,
+            )
+            mock.return_value = VLLMState(
+                hardware_ok=True,
+                hardware_info=HardwareInfo("RTX 5090", 32, (12, 0)),
+                docker_ok=True,
+                docker_info=DockerInfo(True, "26.0.0", True),
+                image_pulled=False,
+                container_running=False,
+                current_model=None,
+            )
+            r = client.get("/api/backends/vllm/status")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["hardware_ok"] is True
+        assert data["hardware_info"]["gpu_name"] == "RTX 5090"
+        assert data["hardware_info"]["vram_gb"] == 32
+        assert data["hardware_info"]["compute_capability"] == "12.0"
+        assert data["docker_ok"] is True
+        assert data["container_running"] is False
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_channels/test_api_backends.py -v
+```
+Expected: fails — endpoints don't exist.
+
+- [ ] **Step 3: Add endpoints to `src/cognithor/channels/api.py`**
+
+Find where the existing `build_app(config)` function lives. Add a new router:
+
+```python
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+
+
+backends_router = APIRouter(prefix="/api/backends", tags=["backends"])
+_orchestrator: VLLMOrchestrator | None = None
+
+
+def _get_orchestrator(config) -> VLLMOrchestrator:
+    """Lazy-initialized module-level singleton for the vLLM orchestrator."""
+    global _orchestrator
+    if _orchestrator is None:
+        _orchestrator = VLLMOrchestrator(
+            docker_image=config.vllm.docker_image,
+            port=config.vllm.port,
+            hf_token=config.huggingface_api_key,
+        )
+    return _orchestrator
+
+
+@backends_router.get("")
+async def list_backends(request):
+    config = request.app.state.config
+    backends = []
+    # Ollama — assume always available; caller will probe if needed
+    backends.append({
+        "name": "ollama",
+        "enabled": config.llm_backend_type == "ollama",
+        "status": "ready",
+    })
+    # vLLM — read orchestrator state
+    orch = _get_orchestrator(config)
+    st = orch.status()
+    vllm_status = "ready" if st.container_running else (
+        "configured" if config.vllm.enabled else "disabled"
+    )
+    backends.append({
+        "name": "vllm",
+        "enabled": config.vllm.enabled,
+        "status": vllm_status,
+    })
+    return {
+        "active": config.llm_backend_type,
+        "backends": backends,
+    }
+
+
+@backends_router.get("/vllm/status")
+async def vllm_status(request):
+    config = request.app.state.config
+    orch = _get_orchestrator(config)
+    st = orch.status()
+    hw = None
+    if st.hardware_info:
+        hw = {
+            "gpu_name": st.hardware_info.gpu_name,
+            "vram_gb": st.hardware_info.vram_gb,
+            "compute_capability": st.hardware_info.sm_string,
+        }
+    return {
+        "hardware_ok": st.hardware_ok,
+        "hardware_info": hw,
+        "docker_ok": st.docker_ok,
+        "image_pulled": st.image_pulled,
+        "container_running": st.container_running,
+        "current_model": st.current_model,
+        "last_error": st.last_error,
+    }
+```
+
+In `build_app()`, include the router: `app.include_router(backends_router)`. Also store the config on app state: `app.state.config = config`.
+
+The `request` parameter uses FastAPI dependency injection — adjust signatures to the existing style of `channels/api.py` (may need `Request` object import from `fastapi`).
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_channels/test_api_backends.py -v
+```
+Expected: `2 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/channels/api.py tests/test_channels/test_api_backends.py && python -m ruff format --check src/cognithor/channels/api.py tests/test_channels/test_api_backends.py
+git add src/cognithor/channels/api.py tests/test_channels/test_api_backends.py
+git commit -m "feat(api): GET /api/backends + /api/backends/vllm/status"
+```
+
+---
+
+## Task 22: FastAPI — `POST /api/backends/vllm/check-hardware`, `/start`, `/stop`
+
+**Files:**
+- Modify: `src/cognithor/channels/api.py`
+- Modify: `tests/test_channels/test_api_backends.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+class TestVLLMActions:
+    def test_check_hardware_delegates_to_orchestrator(
+        self, client_with_vllm_enabled
+    ):
+        client, _ = client_with_vllm_enabled
+        from cognithor.core.vllm_orchestrator import HardwareInfo
+
+        with patch(
+            "cognithor.core.vllm_orchestrator.VLLMOrchestrator.check_hardware",
+            return_value=HardwareInfo("RTX 5090", 32, (12, 0)),
+        ):
+            r = client.post("/api/backends/vllm/check-hardware")
+        assert r.status_code == 200
+        assert r.json()["gpu_name"] == "RTX 5090"
+        assert r.json()["vram_gb"] == 32
+        assert r.json()["compute_capability"] == "12.0"
+
+    def test_check_hardware_returns_503_on_no_gpu(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        from cognithor.core.llm_backend import VLLMHardwareError
+
+        with patch(
+            "cognithor.core.vllm_orchestrator.VLLMOrchestrator.check_hardware",
+            side_effect=VLLMHardwareError("No GPU", recovery_hint="Install NVIDIA driver"),
+        ):
+            r = client.post("/api/backends/vllm/check-hardware")
+        assert r.status_code == 503
+        body = r.json()
+        assert "No GPU" in body["detail"]["message"]
+        assert body["detail"]["recovery_hint"] == "Install NVIDIA driver"
+
+    def test_start_container_accepts_model(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        from cognithor.core.vllm_orchestrator import ContainerInfo
+
+        with patch(
+            "cognithor.core.vllm_orchestrator.VLLMOrchestrator.start_container",
+            return_value=ContainerInfo("abc123", 8000, "Qwen/Qwen3.6-27B-FP8"),
+        ):
+            r = client.post(
+                "/api/backends/vllm/start",
+                json={"model": "Qwen/Qwen3.6-27B-FP8"},
+            )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["container_id"] == "abc123"
+        assert data["port"] == 8000
+        assert data["model"] == "Qwen/Qwen3.6-27B-FP8"
+
+    def test_stop_container(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        with patch(
+            "cognithor.core.vllm_orchestrator.VLLMOrchestrator.stop_container"
+        ) as stop_mock:
+            r = client.post("/api/backends/vllm/stop")
+        assert r.status_code == 200
+        stop_mock.assert_called_once()
+
+    def test_logs_endpoint(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        with patch(
+            "cognithor.core.vllm_orchestrator.VLLMOrchestrator.get_logs",
+            return_value=["line1", "line2"],
+        ):
+            r = client.get("/api/backends/vllm/logs")
+        assert r.status_code == 200
+        assert r.json()["lines"] == ["line1", "line2"]
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+python -m pytest tests/test_channels/test_api_backends.py::TestVLLMActions -v
+```
+Expected: endpoints missing.
+
+- [ ] **Step 3: Add endpoints**
+
+```python
+class StartRequest(BaseModel):
+    model: str
+
+
+@backends_router.post("/vllm/check-hardware")
+async def check_hardware_endpoint(request):
+    config = request.app.state.config
+    orch = _get_orchestrator(config)
+    try:
+        info = orch.check_hardware()
+    except Exception as exc:
+        from cognithor.core.llm_backend import VLLMHardwareError
+        if isinstance(exc, VLLMHardwareError):
+            raise HTTPException(
+                status_code=503,
+                detail={"message": str(exc), "recovery_hint": exc.recovery_hint},
+            ) from exc
+        raise HTTPException(status_code=500, detail={"message": str(exc)}) from exc
+    return {
+        "gpu_name": info.gpu_name,
+        "vram_gb": info.vram_gb,
+        "compute_capability": info.sm_string,
+    }
+
+
+@backends_router.post("/vllm/start")
+async def vllm_start(request, body: StartRequest):
+    config = request.app.state.config
+    orch = _get_orchestrator(config)
+    try:
+        info = orch.start_container(body.model)
+    except Exception as exc:
+        from cognithor.core.llm_backend import VLLMNotReadyError
+        if isinstance(exc, VLLMNotReadyError):
+            raise HTTPException(
+                status_code=503,
+                detail={"message": str(exc), "recovery_hint": getattr(exc, "recovery_hint", "")},
+            ) from exc
+        raise HTTPException(status_code=500, detail={"message": str(exc)}) from exc
+    return {"container_id": info.container_id, "port": info.port, "model": info.model}
+
+
+@backends_router.post("/vllm/stop")
+async def vllm_stop(request):
+    config = request.app.state.config
+    orch = _get_orchestrator(config)
+    orch.stop_container()
+    return {"status": "stopped"}
+
+
+@backends_router.get("/vllm/logs")
+async def vllm_logs(request):
+    config = request.app.state.config
+    orch = _get_orchestrator(config)
+    return {"lines": orch.get_logs()}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_channels/test_api_backends.py -v
+```
+Expected: all passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/channels/api.py tests/test_channels/test_api_backends.py && python -m ruff format --check src/cognithor/channels/api.py tests/test_channels/test_api_backends.py
+git add src/cognithor/channels/api.py tests/test_channels/test_api_backends.py
+git commit -m "feat(api): vLLM check-hardware / start / stop / logs endpoints"
+```
+
+---
+
+## Task 23: FastAPI — SSE `/api/backends/vllm/pull-image`
+
+**Files:**
+- Modify: `src/cognithor/channels/api.py`
+- Modify: `tests/test_channels/test_api_backends.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestPullImageSSE:
+    def test_pull_image_streams_sse_events(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+
+        # Fake orchestrator.pull_image() — invoke the callback with progress events
+        def fake_pull(tag, progress_callback=None):
+            if progress_callback:
+                progress_callback({"status": "Pulling", "id": "layer1"})
+                progress_callback({"status": "Downloading", "id": "layer1",
+                                   "progressDetail": {"current": 500, "total": 1000}})
+                progress_callback({"status": "Download complete", "id": "layer1"})
+
+        with patch(
+            "cognithor.core.vllm_orchestrator.VLLMOrchestrator.pull_image",
+            side_effect=fake_pull,
+        ):
+            with client.stream("POST", "/api/backends/vllm/pull-image") as r:
+                assert r.status_code == 200
+                assert r.headers["content-type"].startswith("text/event-stream")
+                lines = list(r.iter_lines())
+
+        # SSE format: 'data: {...}\n\n' — blank lines separate events
+        data_lines = [l for l in lines if l.startswith("data:")]
+        assert len(data_lines) >= 3
+        assert any("Downloading" in l for l in data_lines)
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_channels/test_api_backends.py::TestPullImageSSE -v
+```
+Expected: fails — no endpoint.
+
+- [ ] **Step 3: Implement SSE streaming endpoint**
+
+```python
+import asyncio
+from fastapi.responses import StreamingResponse
+
+
+@backends_router.post("/vllm/pull-image")
+async def vllm_pull_image(request):
+    """Stream docker-pull progress to the client as SSE."""
+    config = request.app.state.config
+    orch = _get_orchestrator(config)
+
+    queue: asyncio.Queue[dict | None] = asyncio.Queue()
+
+    def progress_cb(event: dict) -> None:
+        queue.put_nowait(event)
+
+    async def worker() -> None:
+        """Run the blocking pull_image in a thread, enqueue events, sentinel at end."""
+        await asyncio.to_thread(
+            orch.pull_image, config.vllm.docker_image, progress_callback=progress_cb
+        )
+        queue.put_nowait(None)  # sentinel
+
+    async def event_stream():
+        task = asyncio.create_task(worker())
+        try:
+            while True:
+                event = await queue.get()
+                if event is None:
+                    break
+                yield f"data: {_json.dumps(event)}\n\n"
+        finally:
+            await task
+
+    import json as _json
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
+```
+
+Move `import json as _json` and `import asyncio` to module level if not already there.
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_channels/test_api_backends.py::TestPullImageSSE -v
+```
+Expected: passes
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/channels/api.py tests/test_channels/test_api_backends.py && python -m ruff format --check src/cognithor/channels/api.py tests/test_channels/test_api_backends.py
+git add src/cognithor/channels/api.py tests/test_channels/test_api_backends.py
+git commit -m "feat(api): SSE streaming endpoint for docker-pull progress"
+```
+
+---
+
+## Task 24: FastAPI — `POST /api/backends/active` (UnifiedLLMClient re-init)
+
+**Files:**
+- Modify: `src/cognithor/channels/api.py`
+- Modify: `tests/test_channels/test_api_backends.py`
+- Modify: `src/cognithor/gateway/gateway.py:1968+` (extract helper for re-init)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+class TestSetActiveBackend:
+    def test_switch_to_vllm_reinits_unified_client(self, client_with_vllm_enabled):
+        client, cfg = client_with_vllm_enabled
+        # Gateway has a `rebuild_llm_client(new_backend_type)` hook
+        with patch(
+            "cognithor.gateway.gateway.Gateway.rebuild_llm_client"
+        ) as rebuild:
+            r = client.post("/api/backends/active", json={"backend": "vllm"})
+        assert r.status_code == 200
+        rebuild.assert_called_once_with("vllm")
+        assert r.json()["active"] == "vllm"
+
+    def test_rejects_unknown_backend(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        r = client.post("/api/backends/active", json={"backend": "unicorn"})
+        assert r.status_code == 400
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_channels/test_api_backends.py::TestSetActiveBackend -v
+```
+Expected: fails.
+
+- [ ] **Step 3: Extract `rebuild_llm_client` helper on Gateway + add endpoint**
+
+In `src/cognithor/gateway/gateway.py` near line 1968, extract the re-init logic into a method:
+
+```python
+def rebuild_llm_client(self, new_backend_type: str) -> None:
+    """Re-init UnifiedLLMClient for a new backend type. Called from the
+    FastAPI /api/backends/active endpoint when the user switches in UI."""
+    self._config.llm_backend_type = new_backend_type
+    from cognithor.core.unified_llm import UnifiedLLMClient
+    self._llm = UnifiedLLMClient.create(self._config)
+```
+
+In `src/cognithor/channels/api.py`:
+
+```python
+from typing import Literal
+
+
+class SetActiveRequest(BaseModel):
+    backend: Literal["ollama", "vllm", "openai", "anthropic", "gemini", "lmstudio", "claude-code"]
+
+
+@backends_router.post("/active")
+async def set_active_backend(request, body: SetActiveRequest):
+    gateway = request.app.state.gateway
+    gateway.rebuild_llm_client(body.backend)
+    return {"active": body.backend}
+```
+
+Ensure `build_app()` stores the gateway: `app.state.gateway = gateway`.
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_channels/test_api_backends.py -v
+```
+Expected: all passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/channels/api.py src/cognithor/gateway/gateway.py tests/test_channels/test_api_backends.py && python -m ruff format --check src/cognithor/channels/api.py src/cognithor/gateway/gateway.py tests/test_channels/test_api_backends.py
+git add src/cognithor/channels/api.py src/cognithor/gateway/gateway.py tests/test_channels/test_api_backends.py
+git commit -m "feat(api): POST /api/backends/active hot-switches UnifiedLLMClient"
+```
+
+---
+
+## Task 25: Flutter — `LlmBackendProvider` (State + 2s Polling)
+
+**Files:**
+- Create: `flutter_app/lib/providers/llm_backend_provider.dart`
+- Create: `flutter_app/test/providers/llm_backend_provider_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// flutter_app/test/providers/llm_backend_provider_test.dart
+import 'package:cognithor_ui/providers/llm_backend_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LlmBackendProvider', () {
+    test('initial state has empty backends and not polling', () {
+      final p = LlmBackendProvider(apiBaseUrl: 'http://localhost:8741');
+      expect(p.backends, isEmpty);
+      expect(p.vllmStatus, isNull);
+      expect(p.isPolling, isFalse);
+    });
+
+    test('startPolling sets isPolling true', () {
+      final p = LlmBackendProvider(apiBaseUrl: 'http://localhost:8741');
+      p.startPolling();
+      expect(p.isPolling, isTrue);
+      p.stopPolling();
+    });
+
+    test('stopPolling resets', () {
+      final p = LlmBackendProvider(apiBaseUrl: 'http://localhost:8741');
+      p.startPolling();
+      p.stopPolling();
+      expect(p.isPolling, isFalse);
+    });
+
+    test('VLLMStatus.fromJson parses API payload', () {
+      final status = VLLMStatus.fromJson({
+        'hardware_ok': true,
+        'hardware_info': {
+          'gpu_name': 'RTX 5090',
+          'vram_gb': 32,
+          'compute_capability': '12.0',
+        },
+        'docker_ok': true,
+        'image_pulled': false,
+        'container_running': false,
+        'current_model': null,
+        'last_error': null,
+      });
+      expect(status.hardwareOk, isTrue);
+      expect(status.hardwareInfo?.gpuName, 'RTX 5090');
+      expect(status.hardwareInfo?.vramGb, 32);
+      expect(status.hardwareInfo?.computeCapability, '12.0');
+    });
+  });
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+cd flutter_app && flutter test test/providers/llm_backend_provider_test.dart
+```
+Expected: fails — file doesn't exist.
+
+- [ ] **Step 3: Create the provider**
+
+```dart
+// flutter_app/lib/providers/llm_backend_provider.dart
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+class HardwareInfo {
+  final String gpuName;
+  final int vramGb;
+  final String computeCapability;
+
+  HardwareInfo({
+    required this.gpuName,
+    required this.vramGb,
+    required this.computeCapability,
+  });
+
+  factory HardwareInfo.fromJson(Map<String, dynamic> j) => HardwareInfo(
+        gpuName: j['gpu_name'] as String,
+        vramGb: j['vram_gb'] as int,
+        computeCapability: j['compute_capability'] as String,
+      );
+}
+
+class VLLMStatus {
+  final bool hardwareOk;
+  final HardwareInfo? hardwareInfo;
+  final bool dockerOk;
+  final bool imagePulled;
+  final bool containerRunning;
+  final String? currentModel;
+  final String? lastError;
+
+  VLLMStatus({
+    required this.hardwareOk,
+    required this.hardwareInfo,
+    required this.dockerOk,
+    required this.imagePulled,
+    required this.containerRunning,
+    required this.currentModel,
+    required this.lastError,
+  });
+
+  factory VLLMStatus.fromJson(Map<String, dynamic> j) => VLLMStatus(
+        hardwareOk: j['hardware_ok'] as bool,
+        hardwareInfo: j['hardware_info'] == null
+            ? null
+            : HardwareInfo.fromJson(j['hardware_info'] as Map<String, dynamic>),
+        dockerOk: j['docker_ok'] as bool,
+        imagePulled: j['image_pulled'] as bool,
+        containerRunning: j['container_running'] as bool,
+        currentModel: j['current_model'] as String?,
+        lastError: j['last_error'] as String?,
+      );
+}
+
+class BackendEntry {
+  final String name;
+  final bool enabled;
+  final String status;
+  BackendEntry({required this.name, required this.enabled, required this.status});
+  factory BackendEntry.fromJson(Map<String, dynamic> j) => BackendEntry(
+        name: j['name'] as String,
+        enabled: j['enabled'] as bool,
+        status: j['status'] as String,
+      );
+}
+
+class LlmBackendProvider extends ChangeNotifier {
+  final String apiBaseUrl;
+  final http.Client _http;
+  Timer? _pollTimer;
+
+  List<BackendEntry> backends = [];
+  String active = 'ollama';
+  VLLMStatus? vllmStatus;
+  String? error;
+
+  bool get isPolling => _pollTimer != null;
+
+  LlmBackendProvider({required this.apiBaseUrl, http.Client? httpClient})
+      : _http = httpClient ?? http.Client();
+
+  Future<void> refreshList() async {
+    try {
+      final r = await _http.get(Uri.parse('$apiBaseUrl/api/backends'));
+      if (r.statusCode != 200) return;
+      final body = jsonDecode(r.body) as Map<String, dynamic>;
+      active = body['active'] as String;
+      backends = (body['backends'] as List)
+          .map((b) => BackendEntry.fromJson(b as Map<String, dynamic>))
+          .toList();
+      notifyListeners();
+    } catch (e) {
+      error = e.toString();
+      notifyListeners();
+    }
+  }
+
+  Future<void> refreshVllmStatus() async {
+    try {
+      final r = await _http.get(Uri.parse('$apiBaseUrl/api/backends/vllm/status'));
+      if (r.statusCode != 200) return;
+      vllmStatus = VLLMStatus.fromJson(jsonDecode(r.body) as Map<String, dynamic>);
+      notifyListeners();
+    } catch (e) {
+      error = e.toString();
+      notifyListeners();
+    }
+  }
+
+  /// Start polling `/api/backends/vllm/status` every 2 seconds.
+  /// Call from VllmSetupScreen.initState, stop in dispose.
+  void startPolling() {
+    stopPolling();
+    refreshVllmStatus();
+    _pollTimer = Timer.periodic(const Duration(seconds: 2), (_) => refreshVllmStatus());
+  }
+
+  void stopPolling() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+  }
+
+  @override
+  void dispose() {
+    stopPolling();
+    _http.close();
+    super.dispose();
+  }
+
+  Future<void> setActive(String backend) async {
+    final r = await _http.post(
+      Uri.parse('$apiBaseUrl/api/backends/active'),
+      headers: {'content-type': 'application/json'},
+      body: jsonEncode({'backend': backend}),
+    );
+    if (r.statusCode == 200) {
+      active = backend;
+      notifyListeners();
+    } else {
+      throw Exception('Backend switch failed: ${r.statusCode}');
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+cd flutter_app && flutter test test/providers/llm_backend_provider_test.dart
+```
+Expected: `All tests passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd flutter_app && flutter analyze lib/providers/llm_backend_provider.dart test/providers/llm_backend_provider_test.dart
+cd ..
+git add flutter_app/lib/providers/llm_backend_provider.dart flutter_app/test/providers/llm_backend_provider_test.dart
+git commit -m "feat(flutter): LlmBackendProvider with 2s polling + VLLMStatus model"
+```
+
+---
+
+## Task 26: Flutter — `LlmBackendsScreen` (List View)
+
+**Files:**
+- Create: `flutter_app/lib/screens/llm_backends_screen.dart`
+- Create: `flutter_app/test/widgets/llm_backends_screen_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// flutter_app/test/widgets/llm_backends_screen_test.dart
+import 'package:cognithor_ui/providers/llm_backend_provider.dart';
+import 'package:cognithor_ui/screens/llm_backends_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+LlmBackendProvider _mkProvider(List<BackendEntry> backends, String active) {
+  final p = LlmBackendProvider(apiBaseUrl: 'http://test');
+  p.backends = backends;
+  p.active = active;
+  return p;
+}
+
+void main() {
+  testWidgets('renders all backends with status dots', (tester) async {
+    final provider = _mkProvider([
+      BackendEntry(name: 'ollama', enabled: true, status: 'ready'),
+      BackendEntry(name: 'vllm', enabled: false, status: 'disabled'),
+    ], 'ollama');
+
+    await tester.pumpWidget(MaterialApp(
+      home: ChangeNotifierProvider<LlmBackendProvider>.value(
+        value: provider,
+        child: const LlmBackendsScreen(),
+      ),
+    ));
+
+    expect(find.text('Ollama'), findsOneWidget);
+    expect(find.text('vLLM'), findsOneWidget);
+  });
+
+  testWidgets('active backend has a visual marker', (tester) async {
+    final provider = _mkProvider([
+      BackendEntry(name: 'ollama', enabled: true, status: 'ready'),
+      BackendEntry(name: 'vllm', enabled: true, status: 'ready'),
+    ], 'vllm');
+
+    await tester.pumpWidget(MaterialApp(
+      home: ChangeNotifierProvider<LlmBackendProvider>.value(
+        value: provider,
+        child: const LlmBackendsScreen(),
+      ),
+    ));
+
+    // "Active" label near the vllm row
+    expect(find.byKey(const ValueKey('backend-vllm-active')), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+cd flutter_app && flutter test test/widgets/llm_backends_screen_test.dart
+```
+Expected: fails — screen doesn't exist.
+
+- [ ] **Step 3: Create the screen**
+
+```dart
+// flutter_app/lib/screens/llm_backends_screen.dart
+import 'package:cognithor_ui/providers/llm_backend_provider.dart';
+import 'package:cognithor_ui/screens/vllm_setup_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class LlmBackendsScreen extends StatefulWidget {
+  const LlmBackendsScreen({super.key});
+
+  @override
+  State<LlmBackendsScreen> createState() => _LlmBackendsScreenState();
+}
+
+class _LlmBackendsScreenState extends State<LlmBackendsScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<LlmBackendProvider>().refreshList();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final p = context.watch<LlmBackendProvider>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('LLM Backends')),
+      body: ListView.builder(
+        itemCount: p.backends.length,
+        itemBuilder: (ctx, i) {
+          final b = p.backends[i];
+          final isActive = p.active == b.name;
+          return ListTile(
+            leading: Icon(
+              b.status == 'ready' ? Icons.circle : Icons.circle_outlined,
+              color: b.status == 'ready' ? Colors.green : Colors.grey,
+              size: 14,
+            ),
+            title: Text(_displayName(b.name)),
+            subtitle: Text(_statusLine(b)),
+            trailing: isActive
+                ? Container(
+                    key: ValueKey('backend-${b.name}-active'),
+                    padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                    decoration: BoxDecoration(
+                      color: Theme.of(ctx).colorScheme.primary.withValues(alpha: 0.2),
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: const Text('Active', style: TextStyle(fontSize: 11)),
+                  )
+                : const Icon(Icons.chevron_right),
+            onTap: () {
+              if (b.name == 'vllm') {
+                Navigator.of(ctx).push(MaterialPageRoute(
+                  builder: (_) => const VllmSetupScreen(),
+                ));
+              }
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  static String _displayName(String name) {
+    switch (name) {
+      case 'ollama':
+        return 'Ollama';
+      case 'vllm':
+        return 'vLLM';
+      case 'openai':
+        return 'OpenAI';
+      case 'anthropic':
+        return 'Anthropic';
+      default:
+        return name;
+    }
+  }
+
+  static String _statusLine(BackendEntry b) {
+    if (!b.enabled) return 'Disabled';
+    return b.status;
+  }
+}
+```
+
+Note: this file imports `vllm_setup_screen.dart` which is created in the next task. To avoid a broken tree, use a placeholder:
+
+```dart
+// flutter_app/lib/screens/vllm_setup_screen.dart (temporary stub)
+import 'package:flutter/material.dart';
+
+class VllmSetupScreen extends StatelessWidget {
+  const VllmSetupScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('vLLM setup — stub')));
+  }
+}
+```
+
+This stub satisfies the import; it gets fully implemented in Task 27.
+
+- [ ] **Step 4: Run test**
+
+```bash
+cd flutter_app && flutter test test/widgets/llm_backends_screen_test.dart
+```
+Expected: passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd flutter_app && flutter analyze lib/screens/llm_backends_screen.dart lib/screens/vllm_setup_screen.dart test/widgets/llm_backends_screen_test.dart
+cd ..
+git add flutter_app/lib/screens/llm_backends_screen.dart flutter_app/lib/screens/vllm_setup_screen.dart flutter_app/test/widgets/llm_backends_screen_test.dart
+git commit -m "feat(flutter): LlmBackendsScreen list view + VllmSetupScreen stub"
+```
+
+---
+
+## Task 27: Flutter — `VllmSetupScreen` (Status Cards)
+
+**Files:**
+- Modify: `flutter_app/lib/screens/vllm_setup_screen.dart` (replace stub)
+- Create: `flutter_app/test/widgets/vllm_setup_screen_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// flutter_app/test/widgets/vllm_setup_screen_test.dart
+import 'package:cognithor_ui/providers/llm_backend_provider.dart';
+import 'package:cognithor_ui/screens/vllm_setup_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+LlmBackendProvider _mkProvider(VLLMStatus? s) {
+  final p = LlmBackendProvider(apiBaseUrl: 'http://test');
+  p.vllmStatus = s;
+  return p;
+}
+
+void main() {
+  testWidgets('all four status cards are rendered', (tester) async {
+    final provider = _mkProvider(VLLMStatus(
+      hardwareOk: false,
+      hardwareInfo: null,
+      dockerOk: false,
+      imagePulled: false,
+      containerRunning: false,
+      currentModel: null,
+      lastError: null,
+    ));
+
+    await tester.pumpWidget(MaterialApp(
+      home: ChangeNotifierProvider<LlmBackendProvider>.value(
+        value: provider,
+        child: const VllmSetupScreen(),
+      ),
+    ));
+
+    expect(find.byKey(const ValueKey('card-hardware')), findsOneWidget);
+    expect(find.byKey(const ValueKey('card-docker')), findsOneWidget);
+    expect(find.byKey(const ValueKey('card-image')), findsOneWidget);
+    expect(find.byKey(const ValueKey('card-model')), findsOneWidget);
+  });
+
+  testWidgets('hardware card shows GPU name when detected', (tester) async {
+    final provider = _mkProvider(VLLMStatus(
+      hardwareOk: true,
+      hardwareInfo: HardwareInfo(gpuName: 'RTX 5090', vramGb: 32, computeCapability: '12.0'),
+      dockerOk: true,
+      imagePulled: false,
+      containerRunning: false,
+      currentModel: null,
+      lastError: null,
+    ));
+
+    await tester.pumpWidget(MaterialApp(
+      home: ChangeNotifierProvider<LlmBackendProvider>.value(
+        value: provider,
+        child: const VllmSetupScreen(),
+      ),
+    ));
+
+    expect(find.textContaining('RTX 5090'), findsOneWidget);
+    expect(find.textContaining('32 GB'), findsOneWidget);
+  });
+
+  testWidgets('image card shows pull button when pending', (tester) async {
+    final provider = _mkProvider(VLLMStatus(
+      hardwareOk: true,
+      hardwareInfo: HardwareInfo(gpuName: 'RTX 5090', vramGb: 32, computeCapability: '12.0'),
+      dockerOk: true,
+      imagePulled: false,
+      containerRunning: false,
+      currentModel: null,
+      lastError: null,
+    ));
+
+    await tester.pumpWidget(MaterialApp(
+      home: ChangeNotifierProvider<LlmBackendProvider>.value(
+        value: provider,
+        child: const VllmSetupScreen(),
+      ),
+    ));
+
+    expect(find.text('Pull image'), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+cd flutter_app && flutter test test/widgets/vllm_setup_screen_test.dart
+```
+Expected: fails (stub doesn't have keys).
+
+- [ ] **Step 3: Implement VllmSetupScreen**
+
+Replace the content of `flutter_app/lib/screens/vllm_setup_screen.dart`:
+
+```dart
+import 'package:cognithor_ui/providers/llm_backend_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class VllmSetupScreen extends StatefulWidget {
+  const VllmSetupScreen({super.key});
+
+  @override
+  State<VllmSetupScreen> createState() => _VllmSetupScreenState();
+}
+
+class _VllmSetupScreenState extends State<VllmSetupScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<LlmBackendProvider>().startPolling();
+    });
+  }
+
+  @override
+  void dispose() {
+    context.read<LlmBackendProvider>().stopPolling();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final p = context.watch<LlmBackendProvider>();
+    final s = p.vllmStatus;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Configure vLLM')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _HardwareCard(status: s),
+          const SizedBox(height: 12),
+          _DockerCard(status: s),
+          const SizedBox(height: 12),
+          _ImageCard(status: s),
+          const SizedBox(height: 12),
+          _ModelCard(status: s),
+        ],
+      ),
+    );
+  }
+}
+
+enum _CardState { ok, todo, pending, error }
+
+Color _colorFor(_CardState st, BuildContext ctx) {
+  switch (st) {
+    case _CardState.ok:
+      return Colors.green;
+    case _CardState.todo:
+      return Colors.orange;
+    case _CardState.pending:
+      return Theme.of(ctx).colorScheme.outline;
+    case _CardState.error:
+      return Colors.red;
+  }
+}
+
+IconData _iconFor(_CardState st) {
+  switch (st) {
+    case _CardState.ok:
+      return Icons.check_circle;
+    case _CardState.todo:
+      return Icons.radio_button_unchecked;
+    case _CardState.pending:
+      return Icons.more_horiz;
+    case _CardState.error:
+      return Icons.error;
+  }
+}
+
+class _StatusCard extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final _CardState state;
+  final Widget? action;
+  final ValueKey cardKey;
+
+  const _StatusCard({
+    required this.title,
+    required this.subtitle,
+    required this.state,
+    required this.cardKey,
+    this.action,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: cardKey,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: BorderSide(color: _colorFor(state, context), width: 1),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: [
+            Icon(_iconFor(state), color: _colorFor(state, context)),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(title, style: const TextStyle(fontWeight: FontWeight.w600)),
+                  const SizedBox(height: 2),
+                  Text(subtitle, style: const TextStyle(fontSize: 12, color: Colors.grey)),
+                ],
+              ),
+            ),
+            if (action != null) action!,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HardwareCard extends StatelessWidget {
+  final VLLMStatus? status;
+  const _HardwareCard({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final hw = status?.hardwareInfo;
+    final ok = status?.hardwareOk ?? false;
+    return _StatusCard(
+      cardKey: const ValueKey('card-hardware'),
+      title: 'NVIDIA GPU',
+      subtitle: hw == null
+          ? 'Not detected'
+          : '${hw.gpuName}, ${hw.vramGb} GB, SM ${hw.computeCapability}',
+      state: ok ? _CardState.ok : _CardState.error,
+    );
+  }
+}
+
+class _DockerCard extends StatelessWidget {
+  final VLLMStatus? status;
+  const _DockerCard({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final ok = status?.dockerOk ?? false;
+    return _StatusCard(
+      cardKey: const ValueKey('card-docker'),
+      title: 'Docker Desktop',
+      subtitle: ok ? 'Running' : 'Not running — start Docker Desktop',
+      state: ok ? _CardState.ok : _CardState.todo,
+    );
+  }
+}
+
+class _ImageCard extends StatelessWidget {
+  final VLLMStatus? status;
+  const _ImageCard({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final pulled = status?.imagePulled ?? false;
+    return _StatusCard(
+      cardKey: const ValueKey('card-image'),
+      title: 'vLLM Docker image',
+      subtitle: pulled
+          ? 'vllm/vllm-openai:v0.19.1 ready'
+          : 'Pull required (~10 GB, one-time)',
+      state: pulled ? _CardState.ok : _CardState.todo,
+      action: pulled
+          ? null
+          : FilledButton.tonal(
+              onPressed: () {},  // wired up in Task 28 (SSE progress)
+              child: const Text('Pull image'),
+            ),
+    );
+  }
+}
+
+class _ModelCard extends StatelessWidget {
+  final VLLMStatus? status;
+  const _ModelCard({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final running = status?.containerRunning ?? false;
+    final model = status?.currentModel;
+    return _StatusCard(
+      cardKey: const ValueKey('card-model'),
+      title: 'Model',
+      subtitle: running
+          ? 'Running: ${model ?? 'unknown'}'
+          : 'Pick a model to start',
+      state: running
+          ? _CardState.ok
+          : (status?.imagePulled ?? false)
+              ? _CardState.todo
+              : _CardState.pending,
+    );
+  }
+}
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+cd flutter_app && flutter test test/widgets/vllm_setup_screen_test.dart
+```
+Expected: passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd flutter_app && flutter analyze lib/screens/vllm_setup_screen.dart test/widgets/vllm_setup_screen_test.dart
+cd ..
+git add flutter_app/lib/screens/vllm_setup_screen.dart flutter_app/test/widgets/vllm_setup_screen_test.dart
+git commit -m "feat(flutter): VllmSetupScreen with 4 status cards"
+```
+
+---
+
+## Task 28: Flutter — SSE Pull-Image Progress + Model Dropdown with Recommendation
+
+**Files:**
+- Modify: `flutter_app/lib/providers/llm_backend_provider.dart` (add `pullImage` stream)
+- Modify: `flutter_app/lib/screens/vllm_setup_screen.dart` (wire Pull-button + model picker)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `flutter_app/test/providers/llm_backend_provider_test.dart`:
+
+```dart
+test('pullImage yields progress events from SSE stream', () async {
+  // Use a stub http client that returns an SSE response
+  final provider = LlmBackendProvider(apiBaseUrl: 'http://test');
+  // This test verifies the public API surface only — actual SSE integration
+  // is verified manually and by integration tests on the Python side.
+  expect(provider.pullImage, isA<Function>());
+});
+```
+
+The real SSE integration test lives on the Python side (Task 23). Flutter side only verifies the wiring.
+
+- [ ] **Step 2: Run test**
+
+```bash
+cd flutter_app && flutter test test/providers/llm_backend_provider_test.dart
+```
+Expected: fails — `pullImage` method missing.
+
+- [ ] **Step 3: Add SSE streaming method to provider**
+
+Append to `LlmBackendProvider`:
+
+```dart
+/// Kick off docker-pull and yield progress events as parsed maps.
+/// Events: {"status":"Downloading","progressDetail":{"current":N,"total":M},"id":"layer..."}
+Stream<Map<String, dynamic>> pullImage() async* {
+  final uri = Uri.parse('$apiBaseUrl/api/backends/vllm/pull-image');
+  final request = http.Request('POST', uri);
+  final streamed = await _http.send(request);
+  if (streamed.statusCode != 200) {
+    throw Exception('Pull failed: HTTP ${streamed.statusCode}');
+  }
+  String buffer = '';
+  await for (final chunk in streamed.stream.transform(utf8.decoder)) {
+    buffer += chunk;
+    while (true) {
+      final sep = buffer.indexOf('\n\n');
+      if (sep == -1) break;
+      final block = buffer.substring(0, sep);
+      buffer = buffer.substring(sep + 2);
+      for (final line in block.split('\n')) {
+        if (line.startsWith('data:')) {
+          final payload = line.substring(5).trim();
+          if (payload.isEmpty) continue;
+          try {
+            yield jsonDecode(payload) as Map<String, dynamic>;
+          } catch (_) {
+            // Ignore malformed events
+          }
+        }
+      }
+    }
+  }
+  // Refresh full status after pull completes
+  await refreshVllmStatus();
+}
+
+/// POST /api/backends/vllm/start — start a container for the given model.
+Future<void> startContainer(String model) async {
+  final r = await _http.post(
+    Uri.parse('$apiBaseUrl/api/backends/vllm/start'),
+    headers: {'content-type': 'application/json'},
+    body: jsonEncode({'model': model}),
+  );
+  if (r.statusCode != 200) {
+    final body = jsonDecode(r.body);
+    throw Exception(body['detail']?['message'] ?? 'Start failed');
+  }
+  await refreshVllmStatus();
+}
+```
+
+Wire the Pull-button in `VllmSetupScreen._ImageCard` — replace the `onPressed: () {}` with a handler that renders a `LinearProgressIndicator` while the SSE stream runs:
+
+```dart
+class _ImageCard extends StatefulWidget {
+  final VLLMStatus? status;
+  const _ImageCard({required this.status});
+
+  @override
+  State<_ImageCard> createState() => _ImageCardState();
+}
+
+class _ImageCardState extends State<_ImageCard> {
+  double? _progress;
+  String? _layer;
+  bool _pulling = false;
+
+  Future<void> _pull() async {
+    setState(() {
+      _pulling = true;
+      _progress = null;
+      _layer = null;
+    });
+    try {
+      final p = context.read<LlmBackendProvider>();
+      await for (final ev in p.pullImage()) {
+        final detail = ev['progressDetail'] as Map<String, dynamic>?;
+        final current = detail?['current'] as int?;
+        final total = detail?['total'] as int?;
+        if (current != null && total != null && total > 0) {
+          setState(() {
+            _progress = current / total;
+            _layer = ev['id'] as String?;
+          });
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Pull failed: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => _pulling = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pulled = widget.status?.imagePulled ?? false;
+    return _StatusCard(
+      cardKey: const ValueKey('card-image'),
+      title: 'vLLM Docker image',
+      subtitle: pulled
+          ? 'vllm/vllm-openai:v0.19.1 ready'
+          : _pulling
+              ? 'Downloading${_layer != null ? " layer ${_layer!.substring(0, 12)}..." : "…"}'
+              : 'Pull required (~10 GB, one-time)',
+      state: pulled
+          ? _CardState.ok
+          : _pulling
+              ? _CardState.pending
+              : _CardState.todo,
+      action: pulled
+          ? null
+          : _pulling
+              ? SizedBox(
+                  width: 100,
+                  child: LinearProgressIndicator(value: _progress),
+                )
+              : FilledButton.tonal(
+                  onPressed: _pull,
+                  child: const Text('Pull image'),
+                ),
+    );
+  }
+}
+```
+
+Model dropdown wiring for `_ModelCard`: fetch recommended model + full filter_registry via a new endpoint OR inline; simplest v1 — hardcode the display of the dropdown that POSTs to `/start`:
+
+Extend the `_ModelCard` similarly to show a dropdown once the image is pulled (but no hardware-filtering on the client; the Python side already filters via `filter_registry()` — Task 29 adds an endpoint for the full list).
+
+- [ ] **Step 4: Run test**
+
+```bash
+cd flutter_app && flutter test
+```
+Expected: all widget and provider tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd flutter_app && flutter analyze lib/providers/llm_backend_provider.dart lib/screens/vllm_setup_screen.dart
+cd ..
+git add flutter_app/lib/providers/llm_backend_provider.dart flutter_app/lib/screens/vllm_setup_screen.dart flutter_app/test/providers/llm_backend_provider_test.dart
+git commit -m "feat(flutter): SSE pull-image progress + start-container wiring"
+```
+
+---
+
+## Task 29: Flutter — Model Dropdown with Recommendation Badge
+
+**Files:**
+- Modify: `src/cognithor/channels/api.py` — add `/api/backends/vllm/available-models` endpoint
+- Modify: `flutter_app/lib/providers/llm_backend_provider.dart` — fetch available-models
+- Modify: `flutter_app/lib/screens/vllm_setup_screen.dart` — render dropdown with recommendation
+
+- [ ] **Step 1: Write the failing test (Python side)**
+
+```python
+class TestAvailableModels:
+    def test_returns_filtered_registry_with_recommendation_flag(
+        self, client_with_vllm_enabled
+    ):
+        client, _ = client_with_vllm_enabled
+        from cognithor.core.vllm_orchestrator import HardwareInfo, ModelEntry
+
+        with patch(
+            "cognithor.core.vllm_orchestrator.VLLMOrchestrator.check_hardware",
+            return_value=HardwareInfo("RTX 5090", 32, (12, 0)),
+        ):
+            r = client.get("/api/backends/vllm/available-models")
+        assert r.status_code == 200
+        data = r.json()
+        # Shape: {"recommended_id": "...", "models": [{...entry..., "fits": bool}]}
+        assert "recommended_id" in data
+        assert "models" in data
+        assert len(data["models"]) >= 1
+        for m in data["models"]:
+            assert "id" in m
+            assert "fits" in m
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_channels/test_api_backends.py::TestAvailableModels -v
+```
+Expected: fails.
+
+- [ ] **Step 3: Implement endpoint (Python side)**
+
+```python
+@backends_router.get("/vllm/available-models")
+async def vllm_available_models(request):
+    config = request.app.state.config
+    orch = _get_orchestrator(config)
+
+    # Load registry
+    import json as _json
+    from pathlib import Path
+    from cognithor.core.vllm_orchestrator import ModelEntry
+
+    registry_path = (
+        Path(__file__).resolve().parents[1]
+        / "cli" / "model_registry.json"
+    )
+    registry_data = _json.loads(registry_path.read_text(encoding="utf-8"))
+    entries = [
+        ModelEntry.from_dict(m)
+        for m in registry_data["providers"]["vllm"]["models"]
+    ]
+
+    # Detect hardware (cache on orchestrator state if already detected)
+    hw = orch.state.hardware_info
+    if hw is None:
+        try:
+            hw = orch.check_hardware()
+        except Exception:
+            hw = None
+
+    recommended_id: str | None = None
+    if hw is not None:
+        best = orch.recommend_model(hw, entries)
+        recommended_id = best.id if best else None
+
+    # Build response
+    fits_ids: set[str] = set()
+    if hw is not None:
+        fits_ids = {m.id for m in orch.filter_registry(hw, entries)}
+
+    return {
+        "recommended_id": recommended_id,
+        "models": [
+            {
+                "id": e.id,
+                "display_name": e.display_name,
+                "quantization": e.quantization,
+                "vram_gb_min": e.vram_gb_min,
+                "min_compute_capability": e.min_compute_capability,
+                "priority": e.priority,
+                "tested": e.tested,
+                "notes": e.notes,
+                "fits": e.id in fits_ids,
+            }
+            for e in entries
+        ],
+    }
+```
+
+- [ ] **Step 4: Run Python test**
+
+```bash
+python -m pytest tests/test_channels/test_api_backends.py::TestAvailableModels -v
+```
+Expected: passed
+
+- [ ] **Step 5: Flutter-side model dropdown**
+
+Add to `LlmBackendProvider`:
+
+```dart
+List<Map<String, dynamic>> availableModels = [];
+String? recommendedModelId;
+
+Future<void> fetchAvailableModels() async {
+  final r = await _http.get(Uri.parse('$apiBaseUrl/api/backends/vllm/available-models'));
+  if (r.statusCode != 200) return;
+  final body = jsonDecode(r.body) as Map<String, dynamic>;
+  recommendedModelId = body['recommended_id'] as String?;
+  availableModels = (body['models'] as List).cast<Map<String, dynamic>>();
+  notifyListeners();
+}
+```
+
+Update `_ModelCard` to show a dropdown when the image is pulled:
+
+```dart
+class _ModelCard extends StatefulWidget {
+  final VLLMStatus? status;
+  const _ModelCard({required this.status});
+  @override
+  State<_ModelCard> createState() => _ModelCardState();
+}
+
+class _ModelCardState extends State<_ModelCard> {
+  String? _selected;
+  bool _starting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<LlmBackendProvider>().fetchAvailableModels();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final p = context.watch<LlmBackendProvider>();
+    final running = widget.status?.containerRunning ?? false;
+    final pulled = widget.status?.imagePulled ?? false;
+
+    if (running) {
+      return _StatusCard(
+        cardKey: const ValueKey('card-model'),
+        title: 'Model',
+        subtitle: 'Running: ${widget.status?.currentModel ?? "unknown"}',
+        state: _CardState.ok,
+      );
+    }
+
+    if (!pulled) {
+      return const _StatusCard(
+        cardKey: ValueKey('card-model'),
+        title: 'Model',
+        subtitle: 'Available after image pull',
+        state: _CardState.pending,
+      );
+    }
+
+    final models = p.availableModels;
+    final recommendedId = p.recommendedModelId;
+    _selected ??= recommendedId ?? (models.isNotEmpty ? models[0]['id'] as String : null);
+
+    return Card(
+      key: const ValueKey('card-model'),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text('Model', style: TextStyle(fontWeight: FontWeight.w600)),
+            const SizedBox(height: 8),
+            DropdownButton<String>(
+              value: _selected,
+              isExpanded: true,
+              onChanged: (v) => setState(() => _selected = v),
+              items: [
+                for (final m in models)
+                  DropdownMenuItem(
+                    value: m['id'] as String,
+                    enabled: m['fits'] as bool,
+                    child: Row(
+                      children: [
+                        if (m['id'] == recommendedId)
+                          const Padding(
+                            padding: EdgeInsets.only(right: 6),
+                            child: Icon(Icons.star, size: 14, color: Colors.amber),
+                          ),
+                        Expanded(child: Text(m['display_name'] as String)),
+                        Text(
+                          '${m['vram_gb_min']} GB',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: (m['fits'] as bool) ? Colors.grey : Colors.red,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            FilledButton(
+              onPressed: _starting || _selected == null
+                  ? null
+                  : () async {
+                      setState(() => _starting = true);
+                      try {
+                        await p.startContainer(_selected!);
+                      } catch (e) {
+                        if (mounted) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            SnackBar(content: Text('Start failed: $e')),
+                          );
+                        }
+                      } finally {
+                        if (mounted) setState(() => _starting = false);
+                      }
+                    },
+              child: Text(_starting ? 'Starting…' : 'Start vLLM'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+- [ ] **Step 6: Run full Flutter test suite**
+
+```bash
+cd flutter_app && flutter test && flutter analyze
+```
+Expected: all pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+python -m ruff check src/cognithor/channels/api.py tests/test_channels/test_api_backends.py && python -m ruff format --check src/cognithor/channels/api.py tests/test_channels/test_api_backends.py
+git add src/cognithor/channels/api.py tests/test_channels/test_api_backends.py flutter_app/lib/providers/llm_backend_provider.dart flutter_app/lib/screens/vllm_setup_screen.dart
+git commit -m "feat(vllm): GPU-aware model dropdown with recommendation badge + start button"
+```
+
+---
+
+## Task 30: Gateway — Shutdown Hook + `reuse_existing()` on Startup
+
+**Files:**
+- Modify: `src/cognithor/gateway/gateway.py` (add vLLM lifecycle hooks)
+- Create: `tests/test_gateway/test_gateway_vllm_lifecycle.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_gateway/test_gateway_vllm_lifecycle.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cognithor.config import CognithorConfig, VLLMConfig
+
+
+class TestGatewayVLLMLifecycle:
+    def test_shutdown_stops_container_when_toggle_on(self):
+        cfg = CognithorConfig(vllm=VLLMConfig(enabled=True, auto_stop_on_close=True))
+        from cognithor.gateway.gateway import Gateway
+        gw = Gateway.__new__(Gateway)
+        gw._config = cfg
+        gw._vllm_orchestrator = MagicMock()
+        gw.on_shutdown_vllm()
+        gw._vllm_orchestrator.stop_container.assert_called_once()
+
+    def test_shutdown_leaves_container_running_when_toggle_off(self):
+        cfg = CognithorConfig(vllm=VLLMConfig(enabled=True, auto_stop_on_close=False))
+        from cognithor.gateway.gateway import Gateway
+        gw = Gateway.__new__(Gateway)
+        gw._config = cfg
+        gw._vllm_orchestrator = MagicMock()
+        gw.on_shutdown_vllm()
+        gw._vllm_orchestrator.stop_container.assert_not_called()
+
+    def test_startup_picks_up_existing_container(self):
+        cfg = CognithorConfig(vllm=VLLMConfig(enabled=True))
+        from cognithor.gateway.gateway import Gateway
+        from cognithor.core.vllm_orchestrator import ContainerInfo
+        gw = Gateway.__new__(Gateway)
+        gw._config = cfg
+        gw._vllm_orchestrator = MagicMock()
+        gw._vllm_orchestrator.reuse_existing.return_value = ContainerInfo(
+            container_id="abc", port=8000, model="Qwen/Qwen2.5-VL-7B-Instruct"
+        )
+        result = gw.on_startup_vllm()
+        assert result is not None
+        assert result.model == "Qwen/Qwen2.5-VL-7B-Instruct"
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_gateway/test_gateway_vllm_lifecycle.py -v
+```
+Expected: fails — `on_shutdown_vllm` / `on_startup_vllm` missing.
+
+- [ ] **Step 3: Add lifecycle hooks to Gateway**
+
+In `src/cognithor/gateway/gateway.py`, add two methods to the `Gateway` class:
+
+```python
+def on_startup_vllm(self):
+    """Called during 6-phase init. If a cognithor-managed vLLM container
+    is already running, reuse it. Otherwise do nothing — user starts via UI."""
+    if not self._config.vllm.enabled:
+        return None
+    try:
+        return self._vllm_orchestrator.reuse_existing()
+    except Exception as exc:
+        log.warning("vllm_reuse_existing_failed", error=str(exc))
+        return None
+
+
+def on_shutdown_vllm(self) -> None:
+    """Called on Gateway.shutdown(). Stops the container only if the
+    user has opted in via `auto_stop_on_close`."""
+    if not self._config.vllm.enabled:
+        return
+    if self._config.vllm.auto_stop_on_close:
+        try:
+            self._vllm_orchestrator.stop_container()
+        except Exception as exc:
+            log.warning("vllm_shutdown_failed", error=str(exc))
+```
+
+Wire the hooks into the Gateway init (call `on_startup_vllm()` during the 6-phase init) and shutdown (`shutdown()` calls `on_shutdown_vllm()`). Also lazy-instantiate `self._vllm_orchestrator` in Gateway init when `config.vllm.enabled` is True:
+
+```python
+# In Gateway.__init__ or _init_llm phase
+if self._config.vllm.enabled:
+    from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+    self._vllm_orchestrator = VLLMOrchestrator(
+        docker_image=self._config.vllm.docker_image,
+        port=self._config.vllm.port,
+        hf_token=self._config.huggingface_api_key,
+    )
+else:
+    self._vllm_orchestrator = None
+```
+
+- [ ] **Step 4: Run test**
+
+```bash
+python -m pytest tests/test_gateway/test_gateway_vllm_lifecycle.py -v
+```
+Expected: `3 passed`
+
+- [ ] **Step 5: Commit**
+
+```bash
+python -m ruff check src/cognithor/gateway/gateway.py tests/test_gateway/test_gateway_vllm_lifecycle.py && python -m ruff format --check src/cognithor/gateway/gateway.py tests/test_gateway/test_gateway_vllm_lifecycle.py
+git add src/cognithor/gateway/gateway.py tests/test_gateway/test_gateway_vllm_lifecycle.py
+git commit -m "feat(gateway): vLLM shutdown hook + reuse_existing on startup"
+```
+
+---
+
+## Task 31: Cross-Repo Registry-Sync Guard
+
+**Files:**
+- Create: `tests/test_vllm_registry_sync.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# tests/test_vllm_registry_sync.py
+"""Guard test: the vLLM model registry entries must stay self-consistent
+and load cleanly into ModelEntry. Prevents silent drift when someone
+edits model_registry.json but forgets a field.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from cognithor.core.vllm_orchestrator import ModelEntry
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = REPO_ROOT / "src" / "cognithor" / "cli" / "model_registry.json"
+
+
+class TestVLLMRegistryLoads:
+    def test_every_entry_parses_into_ModelEntry(self):
+        data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        for m in data["providers"]["vllm"]["models"]:
+            # Must not raise
+            ModelEntry.from_dict(m)
+
+    def test_compute_capability_tuples_are_valid(self):
+        data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        for m in data["providers"]["vllm"]["models"]:
+            entry = ModelEntry.from_dict(m)
+            cc = entry.min_cc_tuple
+            assert 7 <= cc[0] <= 20
+            assert 0 <= cc[1] <= 9
+
+    def test_min_vllm_version_is_valid(self):
+        data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        for m in data["providers"]["vllm"]["models"]:
+            v = m["min_vllm_version"]
+            # "pending" or semver-ish
+            assert v == "pending" or re.match(r"^\d+\.\d+(\.\d+)?$", v)
+
+    def test_priority_is_enum(self):
+        data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        for m in data["providers"]["vllm"]["models"]:
+            assert m["priority"] in ("premium", "standard", "fallback")
+
+    def test_capability_is_enum(self):
+        data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        for m in data["providers"]["vllm"]["models"]:
+            assert m["capability"] in ("vision", "text")
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+python -m pytest tests/test_vllm_registry_sync.py -v
+```
+Expected: `5 passed` (assuming Tasks 4 & 5 done)
+
+- [ ] **Step 3: Commit**
+
+```bash
+python -m ruff check tests/test_vllm_registry_sync.py && python -m ruff format --check tests/test_vllm_registry_sync.py
+git add tests/test_vllm_registry_sync.py
+git commit -m "test(vllm): registry-sync guard cross-validates every entry with ModelEntry"
+```
+
+---
+
+## Task 32: User-Facing Guide `docs/vllm-user-guide.md`
+
+**Files:**
+- Create: `docs/vllm-user-guide.md`
+
+- [ ] **Step 1: Write the guide**
+
+Create `docs/vllm-user-guide.md` with this content:
+
+```markdown
+# Enabling the vLLM Backend
+
+Cognithor ships with Ollama as the default local LLM backend — it "just works"
+on any Windows/macOS/Linux machine without further setup. vLLM is an **opt-in**
+alternative for users with an NVIDIA GPU who want faster inference, native FP4
+support (Blackwell / RTX 50xx), or access to models not in the Ollama library.
+
+## Prerequisites
+
+You need:
+
+1. **NVIDIA GPU** with at least 16 GB VRAM. For the best experience:
+   - **RTX 5090 (32 GB)** — unlocks NVFP4 quantization, the fastest option
+   - **RTX 4090 (24 GB)** — runs FP8 quantization
+   - **RTX 4080 / 3090 / 4070 Ti Super (16 GB)** — runs AWQ-INT4 quantization
+2. **NVIDIA driver** installed (any modern version from the last 2 years works)
+3. **Docker Desktop** installed and running. Download from
+   [docker.com](https://www.docker.com/products/docker-desktop). Cognithor will
+   not install it for you — the installer needs admin rights and a reboot,
+   which Cognithor does not handle.
+
+## Enabling vLLM
+
+1. Start Cognithor normally.
+2. Open **Settings → LLM Backends**.
+3. Tap **vLLM**. You will see four status cards:
+   - **NVIDIA GPU** — detected automatically
+   - **Docker Desktop** — detected automatically
+   - **vLLM Docker image** — needs a one-time ~10 GB pull
+   - **Model** — which model to load
+4. If any card is red, fix the underlying issue first (install the missing
+   driver, start Docker Desktop, etc.).
+5. Tap **Pull image** on Card 3. Progress streams live.
+6. Pick a model from Card 4. The star badge (⭐) marks the recommendation for
+   your GPU. Models that don't fit your VRAM or require a newer GPU
+   architecture are disabled with a tooltip explaining why.
+7. Tap **Start vLLM**. First start takes 30–300 seconds depending on model
+   size (weights download from HuggingFace).
+8. Back in the list view, tap your vLLM row and select **Make active** to
+   switch all future chat turns through vLLM.
+
+## Switching Back to Ollama
+
+Settings → LLM Backends → Ollama → **Make active**. The switch is live — no
+restart required. vLLM keeps running in the background unless you enable
+"Stop vLLM on app close" in settings.
+
+## Troubleshooting
+
+**"Version Mismatch" overlay on launch**: the installer bundled a stale
+Flutter build. Install the newer Cognithor release.
+
+**vLLM status card stays red with "No GPU detected"**: run `nvidia-smi` in a
+terminal to confirm your driver works. On WSL2 you need the NVIDIA WSL driver
+bundle from nvidia.com/drivers — not just the standard Windows driver.
+
+**Docker card stays red**: open Docker Desktop, wait for the whale icon to
+stop pulsing (that's the "ready" state).
+
+**Pull fails mid-download**: partial layers are cached. Retry the pull —
+Docker will resume from where it stopped.
+
+**Container starts but /health never answers**: the model is probably still
+loading. Qwen3.6-27B at FP8 takes ~60 s on an RTX 5090, up to 5 minutes on
+slower cards. The setup page shows container logs below the status cards.
+
+**Banner "vLLM offline — fallback to Ollama active"** appears mid-chat: vLLM
+has crashed or become unresponsive for 3 consecutive requests. Text chats
+transparently route through Ollama; image requests will error out until vLLM
+recovers. Check `docker logs <container-id>` for the cause.
+
+**I have a Qwen3.6 model selected but it fails to start**: vLLM stable
+(v0.19.1) does not yet support the Qwen3.6 architecture. Workaround: set
+`config.vllm.docker_image` to `vllm/vllm-openai:nightly` and restart. Cognithor
+will adopt the new image on the next container start.
+
+## Advanced Configuration
+
+`~/.cognithor/config.yaml` section `vllm`:
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `enabled` | `false` | Master on/off |
+| `model` | `""` (auto) | HF repo id. Empty → orchestrator picks best per GPU |
+| `docker_image` | `vllm/vllm-openai:v0.19.1` | Override to bleed-edge |
+| `port` | `8000` | Host port (falls back 8001..8009 if busy) |
+| `auto_stop_on_close` | `false` | Stop container when Cognithor quits |
+| `skip_hardware_check` | `false` | Override for unusual setups |
+| `request_timeout_seconds` | `60` | Per-request timeout |
+
+HF token for gated models: set `huggingface_api_key` at the top level of
+`config.yaml` (or via the OS keyring) — Cognithor passes it to the container
+automatically as `HF_TOKEN`.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/vllm-user-guide.md
+git commit -m "docs(vllm): user-facing enable + troubleshooting guide"
+```
+
+---
+
+## Task 33: Manual Smoke-Test Recipe `docs/vllm-manual-test.md`
+
+**Files:**
+- Create: `docs/vllm-manual-test.md`
+
+- [ ] **Step 1: Write the recipe**
+
+Create `docs/vllm-manual-test.md`:
+
+```markdown
+# vLLM Backend — Manual Smoke Test
+
+The Python + Flutter unit tests and the fake-server integration test cover
+everything except the real-hardware path. Before cutting a release that
+touches the vLLM backend, run this recipe once on a dev machine with a real
+NVIDIA GPU and Docker Desktop.
+
+**Time:** ~30 minutes end-to-end.
+
+## Test Matrix
+
+Pick the row matching your dev hardware and run those steps:
+
+| GPU | VRAM | Expected recommended model | Test sections |
+|-----|------|----------------------------|---------------|
+| RTX 5090 | 32 GB | `mmangkad/Qwen3.6-27B-NVFP4` | All |
+| RTX 4090 | 24 GB | `cyankiwi/Qwen3.6-27B-AWQ-INT4` or fallback | 1–5 |
+| RTX 4080 / 4070 Ti Super | 16 GB | `Qwen/Qwen2.5-VL-7B-Instruct` (tested fallback) | 1–4 |
+
+## 1. Fresh install
+
+- Uninstall any previous Cognithor.
+- Wipe `~/.cognithor/config.yaml` (or rename it as backup).
+- Run the new installer.
+- Launch Cognithor. Expect: Flutter UI reaches the main screen. No version-
+  mismatch overlay, no config crash.
+
+## 2. Hardware + Docker detection
+
+- Settings → LLM Backends → tap **vLLM**.
+- Expect: Cards 1 and 2 turn green within 2 seconds (the polling interval).
+  Card 1 shows the correct GPU name, VRAM, and compute capability string.
+- If Docker Desktop is not running, start it and wait — Card 2 turns green
+  when ready.
+
+## 3. Image pull
+
+- Tap **Pull image**.
+- Expect: progress bar advances steadily. Total download ~10 GB.
+- Expect: after completion, Card 3 turns green; Card 4 enables.
+
+## 4. Model picker + start (quick path — Qwen2.5-VL-7B)
+
+- Card 4: expect the model dropdown to populate. Qwen2.5-VL-7B is always
+  marked "tested" and should show the star badge for any non-Blackwell GPU.
+- Select it. Tap **Start vLLM**.
+- Expect: within 120 seconds, Card 4 turns green with "Running: Qwen/
+  Qwen2.5-VL-7B-Instruct".
+- Back in the list view, tap vLLM, tap **Make active**.
+
+## 5. End-to-end chat with vision
+
+- Open the chat screen.
+- Attach an image (any PNG) via the paperclip button.
+- Ask: "What do you see in this image?"
+- Expect: answer comes back within 5–10 seconds, describing the image.
+- Close the chat screen and reopen — state persists.
+
+## 6. Fail-flow verification
+
+- In a terminal: `docker stop $(docker ps -q --filter label=cognithor.managed=true)`
+- In Cognithor chat, send a text-only message: "hello"
+  - Expect: within 2–3 requests, the "⚠ vLLM offline — fallback to Ollama
+    active" banner appears. Reply comes from Ollama.
+- Send an image request.
+  - Expect: red error bubble "vLLM offline — cannot process image".
+- In terminal: `docker start <container-id>`
+  - Expect: within ~60 seconds (the CircuitBreaker `recovery_timeout`), the
+    next text request goes through vLLM again; banner dismisses.
+
+## 7. Lifecycle toggles
+
+- Settings → LLM Backends → vLLM → enable "Keep vLLM running after app close"
+- Close Cognithor entirely.
+- Verify: `docker ps | grep cognithor.managed` — container still running.
+- Reopen Cognithor → status shows "Running" immediately (no restart).
+- Disable the toggle. Close Cognithor.
+- Verify: `docker ps | grep cognithor.managed` — no result (container was
+  stopped on shutdown).
+
+## 8. Blackwell-specific (RTX 5090 only)
+
+- Edit `~/.cognithor/config.yaml` → set `vllm.docker_image: "vllm/vllm-openai:nightly"`.
+- Back in the setup screen, pull the nightly image (replaces the old one).
+- Pick `mmangkad/Qwen3.6-27B-NVFP4` (star-badged on Blackwell).
+- Start. Expect: model loads in ~30–60 seconds.
+- Chat with vision. Expect: tokens stream noticeably faster than FP8 on the
+  same hardware (NVFP4 uses native tensor cores).
+
+## Reporting
+
+If any step fails, capture:
+- Contents of `~/.cognithor/log/cognithor.log` (last 200 lines)
+- Output of `docker logs <container-id>`
+- Screenshot of the relevant Flutter screen
+
+File bugs against the `vllm-backend` label on GitHub.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/vllm-manual-test.md
+git commit -m "docs(vllm): manual smoke-test recipe for release-gate validation"
+```
+
+---
+
+## Task 34: CHANGELOG + Final Integration Run
+
+**Files:**
+- Modify: `CHANGELOG.md` (add [Unreleased] entry)
+
+- [ ] **Step 1: Add CHANGELOG entry**
+
+Add to the top of `CHANGELOG.md` under `## [Unreleased]` (create section if missing):
+
+```markdown
+## [Unreleased]
+
+### Added
+- **vLLM as opt-in LLM backend** with full Flutter-driven lifecycle (install,
+  pull-image, start, stop, hot-switch) — spec at
+  `docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md`,
+  plan at `docs/superpowers/plans/2026-04-22-vllm-opt-in-backend.md`. Ollama
+  remains the default — vLLM is purely additive. Unlocks native FP4 on
+  Blackwell GPUs (RTX 50xx), FP8 on Ada, AWQ-INT4 on Ampere. Model registry
+  carries per-quantization entries with `min_compute_capability` and
+  `vram_gb_min` so the UI can disable models that don't fit the detected GPU
+  and auto-recommend the best fit. New `LlmBackendsScreen` and
+  `VllmSetupScreen` in Flutter. New FastAPI endpoints under
+  `/api/backends/vllm/*` including SSE-streamed pull progress. User guide
+  at `docs/vllm-user-guide.md`, manual test recipe at
+  `docs/vllm-manual-test.md`.
+```
+
+- [ ] **Step 2: Run the full regression locally**
+
+```bash
+python -m pytest tests/ -x -q --ignore=tests/test_integration/test_live_ollama.py
+cd flutter_app && flutter analyze && flutter test
+cd ..
+```
+Expected: every test green, zero analyze warnings.
+
+- [ ] **Step 3: Final ruff sweep across the vLLM touch surface**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_orchestrator.py \
+                    src/cognithor/core/vllm_backend.py \
+                    src/cognithor/core/unified_llm.py \
+                    src/cognithor/core/llm_backend.py \
+                    src/cognithor/channels/api.py \
+                    src/cognithor/config.py \
+                    src/cognithor/gateway/gateway.py \
+                    tests/
+python -m ruff format --check src/cognithor/ tests/
+```
+Expected: `All checks passed!` + `X files already formatted`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "chore(changelog): document vLLM opt-in backend feature"
+```
+
+- [ ] **Step 5: Open PR**
+
+```bash
+git push -u origin feat/vllm-opt-in-backend
+```
+Then open a PR with the title `feat(vllm): opt-in LLM backend with Flutter-driven lifecycle` and the body pulling from `docs/vllm-user-guide.md` summary + reference to spec + plan.
+
+After CI is green, run the **manual smoke test from Task 33** before merging.
+
+---
+
+## Self-Review Checklist
+
+After completing all tasks:
+
+- [ ] All unit tests pass (`pytest tests/test_core/test_vllm_* tests/test_channels/test_api_backends.py tests/test_gateway/test_gateway_vllm_lifecycle.py tests/test_vllm_registry_sync.py tests/test_integration/test_vllm_fake_server.py -v`)
+- [ ] `flutter test` green across `llm_backend_provider_test.dart`, `llm_backends_screen_test.dart`, `vllm_setup_screen_test.dart`
+- [ ] `ruff check src/ tests/` clean
+- [ ] `ruff format --check src/ tests/` clean (remember PR #135 lesson)
+- [ ] `flutter analyze` clean
+- [ ] Manual smoke test from Task 33 completed on real NVIDIA hardware
+- [ ] CHANGELOG entry written
+- [ ] No backward-incompatible changes to existing backends (Ollama/OpenAI/Anthropic paths unchanged)
+- [ ] `config.vllm.enabled: false` path — verify Cognithor behaves identically to before this feature

--- a/docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
+++ b/docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
@@ -53,7 +53,7 @@ Backend switching is live — the existing `gateway.py:1968+` re-init path for `
   - `check_hardware() -> HardwareInfo` — parses `nvidia-smi --query-gpu=name,memory.total,compute_cap --format=csv,noheader,nounits`. Returns name, VRAM GB, and compute capability as `(major, minor)` tuple for model-compatibility filtering (Blackwell SM 12.0, Ada SM 8.9, Ampere SM 8.x)
   - `check_docker() -> DockerInfo` — `docker version --format json`
   - `pull_image(tag, progress_callback) -> None` — streams `docker pull --progress=auto` stdout, parses layer-progress JSON. Typical image size ~10.5 GB (vllm/vllm-openai includes CUDA runtime + torch + vllm wheels).
-  - `start_container(model, port=8000) -> ContainerInfo` — constructs `docker run` with `--gpus all`, `-v cognithor-hf-cache:/root/.cache/huggingface`, `-e HF_TOKEN=$token`, label `cognithor.managed=true`; auto-falls-back 8000→8009 on port conflict
+  - `start_container(model, port=8000, health_timeout=None) -> ContainerInfo` — constructs `docker run` with `--gpus all`, `-v cognithor-hf-cache:/root/.cache/huggingface`, `-e HF_TOKEN=$token`, label `cognithor.managed=true`; auto-falls-back 8000→8009 on port conflict. `health_timeout` defaults to **120 s** for models under 20 GB weights, **300 s** for larger models — first-load includes HF download + vLLM weight-mapping which is slow for big models
   - `stop_container() -> None` — `docker stop` + `docker rm` on labeled container
   - `reuse_existing() -> Optional[ContainerInfo]` — scans `docker ps --filter "label=cognithor.managed=true"`
   - `status() -> VLLMState` — aggregates all above
@@ -220,12 +220,12 @@ New provider section. The registry is **per-quantization**, not per-base-model �
 
 ### Flow C — Fail Flow (vLLM Offline Mid-Chat)
 
-1. `VLLMBackend.chat()` raises `VLLMNotReadyError` (timeout or connection refused)
-2. `UnifiedLLMClient` catches, marks `backend_status = DEGRADED`, notifies Gateway via event
+1. `VLLMBackend.chat()` (wrapped in the vLLM `CircuitBreaker.call()`) raises `VLLMNotReadyError` (timeout or connection refused). After 3 consecutive failures the breaker transitions `CLOSED → OPEN`
+2. `UnifiedLLMClient` catches the `VLLMNotReadyError` / `CircuitBreakerOpen` and marks its own public-facing `backend_status = DEGRADED`, notifies Gateway via event
 3. Gateway sends WebSocket event `backend_status_changed` → Flutter renders banner "⚠ vLLM offline — fallback to Ollama active"
 4. **If text-request** (`working_memory.image_attachments` is empty): `UnifiedLLMClient` transparent-fallback to `OllamaBackend` with the same prompt
-5. **If image-request** (`working_memory.image_attachments` is non-empty — same trigger the Planner uses for vision routing): `VLLMNotReadyError` propagates as error bubble in chat: "vLLM offline — cannot process image". No silent fallback because Ollama cannot do vision
-6. Next request: `VLLMBackend.is_available()` checked → success? → `backend_status = OK`, banner dismisses
+5. **If image-request** (`working_memory.image_attachments` is non-empty — same trigger the Planner uses for vision routing): the error propagates as a red bubble in chat: "vLLM offline — cannot process image". No silent fallback because Ollama cannot do vision
+6. **Recovery is automatic via the breaker**, not via a separate `is_available()` poll: after `recovery_timeout` (60 s) the breaker enters `HALF_OPEN` and lets the next real request through as a probe. Probe success → breaker `CLOSED` → `UnifiedLLMClient` flips `backend_status = OK` → banner dismisses. Probe failure → breaker back to `OPEN`, banner stays
 
 ### Flow D — App Close / Re-Open
 
@@ -240,9 +240,10 @@ New provider section. The registry is **per-quantization**, not per-base-model �
 ### Error Hierarchy (`src/cognithor/core/llm_backend.py`)
 
 - `LLMBackendError` — base (exists)
-- `VLLMNotReadyError` — container not running or model not loaded
-- `VLLMHardwareError` — NVIDIA not detected, VRAM insufficient
-- `DockerError` — Docker Desktop unreachable
+- `LLMBadRequestError(LLMBackendError)` — wraps HTTP 400 responses (context too long, malformed request, unsupported model field). **Marked as `excluded_exceptions` on the `CircuitBreaker`** so these never count toward opening the circuit — they're user/context problems, not backend faults
+- `VLLMNotReadyError(LLMBackendError)` — container not running or model not loaded
+- `VLLMHardwareError(LLMBackendError)` — NVIDIA not detected, VRAM insufficient
+- `DockerError(LLMBackendError)` — Docker Desktop unreachable
 
 All exceptions carry a `recovery_hint: str` field which Flutter renders alongside the error message.
 
@@ -252,14 +253,14 @@ All exceptions carry a `recovery_hint: str` field which Flutter renders alongsid
 - `docker version` return code ≠ 0 → `DockerError("Docker Desktop not running")`, Card 2 shows "Start Docker Desktop" hint
 - `docker pull` timeout (10 min default) → error with retry button; partial layers stay in cache
 - `start_container()` port 8000 busy → automatic fallback 8001 … 8009. Beyond 8010 → error
-- vLLM `/health` doesn't answer within 120 s → last 50 lines of container logs shown in error panel (`docker logs`)
+- vLLM `/health` doesn't answer within `start_container(...)`'s `health_timeout` (120 s for models < 20 GB, 300 s for larger) → last 50 lines of container logs shown in error panel (`docker logs`)
 
 ### Runtime Errors (Request Level)
 
 - `chat()` timeout 60 s default → configurable via `vllm.request_timeout_seconds`
-- HTTP 5xx from vLLM → `VLLMNotReadyError`, triggers fail flow (Flow C)
-- HTTP 400 (e.g. context too long) → `LLMBackendError` propagates directly, **no fallback** (real user error; Ollama wouldn't solve it either)
-- Connection refused → same as 5xx → fail flow
+- HTTP 5xx from vLLM → `VLLMNotReadyError`, triggers fail flow (Flow C) and counts toward the breaker
+- HTTP 400 (e.g. context too long) → `LLMBadRequestError` propagates directly, **no fallback** (real user error; Ollama wouldn't solve it either). Excluded from breaker counting
+- Connection refused → `VLLMNotReadyError` → fail flow
 
 ### Circuit Breaker (reuses existing `cognithor.utils.circuit_breaker.CircuitBreaker`)
 
@@ -297,7 +298,7 @@ No separate health-check thread — the existing breaker heals itself via the HA
 
 ### Constraints
 
-CI runners have no GPU and no way to actually start vLLM. No Docker-in-Docker, no 8 GB image pull. All integration testing uses mocks or fakes.
+CI runners have no GPU and no way to actually start vLLM. No Docker-in-Docker, no ~10.5 GB image pull. All integration testing uses mocks or fakes.
 
 ### Unit Layer (GitHub Actions, free runners)
 
@@ -306,7 +307,7 @@ CI runners have no GPU and no way to actually start vLLM. No Docker-in-Docker, n
   - Image-payload conversion (path → `data:image/…` URL)
   - `chat_stream()` parses SSE chunks correctly
   - `is_available()` against 200-ok and connection-refused
-  - Error propagation (5xx → `VLLMNotReadyError`, 400 → `LLMBackendError`)
+  - Error propagation (5xx → `VLLMNotReadyError`, 400 → `LLMBadRequestError`)
 - **`tests/test_core/test_vllm_orchestrator.py`** — orchestrator with `subprocess.run` mocked
   - `check_hardware()` parses `nvidia-smi` output correctly (real + empty + garbled), extracts compute capability tuple (tested matrix: Blackwell 12.0, Ada 8.9, Ampere 8.6, Turing 7.5)
   - `check_docker()` handles missing Docker gracefully
@@ -322,10 +323,11 @@ CI runners have no GPU and no way to actually start vLLM. No Docker-in-Docker, n
   - Turing SM 7.5 + 16 GB → picks `Qwen2.5-VL-7B-Instruct` (fallback, only tested model that matches)
   - Override: when `prefer="text"` and no text model is curated, returns `None` → UI shows "No curated text model — use Custom path"
   - `filter_registry()` correctly disables entries whose `min_compute_capability` exceeds detected capability
-- **`tests/test_core/test_unified_llm_circuit_breaker.py`** — circuit-breaker state machine
-  - 3 fails in 60 s → `DEGRADED`
-  - Health-ping recovered → `OK`
-  - Fail-flow dispatch (text → Ollama, image → error)
+- **`tests/test_core/test_unified_llm_circuit_breaker.py`** — `UnifiedLLMClient`'s integration of the existing `CircuitBreaker` per backend. Does NOT retest the breaker's state machine itself (that has its own tests in `tests/test_utils/test_circuit_breaker.py`), only the wiring:
+  - 3 consecutive `VLLMNotReadyError` → breaker `OPEN` → `UnifiedLLMClient.backend_status = DEGRADED`
+  - `LLMBadRequestError` thrown by `VLLMBackend.chat()` → breaker counter does NOT increment (excluded_exception), `backend_status` stays `OK`
+  - Breaker `HALF_OPEN` probe succeeds → breaker `CLOSED` → `backend_status = OK`, banner dismisses
+  - Fail-flow dispatch: with `DEGRADED` set, text-request auto-routes to `OllamaBackend`, image-request raises to the caller
 
 ### Integration Layer (GitHub Actions, free runners)
 
@@ -400,7 +402,7 @@ Documented in `docs/vllm-manual-test.md`. Run once on a dev machine with real NV
 
 ## Estimate
 
-**1.5–2 calendar weeks, single engineer.** Breakdown:
+**~2.2 calendar weeks (11 working days), single engineer.** Breakdown:
 
 - `VLLMBackend` class + unit tests: 1 day
 - `vllm_orchestrator.py` + unit tests (including `recommend_model()` + `filter_registry()` GPU-awareness): 2.5 days

--- a/docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
+++ b/docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
@@ -243,14 +243,14 @@ New provider section. The registry is **per-quantization**, not per-base-model �
 - `LLMBadRequestError(LLMBackendError)` — wraps HTTP 400 responses (context too long, malformed request, unsupported model field). **Marked as `excluded_exceptions` on the `CircuitBreaker`** so these never count toward opening the circuit — they're user/context problems, not backend faults
 - `VLLMNotReadyError(LLMBackendError)` — container not running or model not loaded
 - `VLLMHardwareError(LLMBackendError)` — NVIDIA not detected, VRAM insufficient
-- `DockerError(LLMBackendError)` — Docker Desktop unreachable
+- `VLLMDockerError(LLMBackendError)` — Docker Desktop unreachable
 
 All exceptions carry a `recovery_hint: str` field which Flutter renders alongside the error message.
 
 ### Setup-Time Errors (Orchestrator Level)
 
 - `check_hardware()`: `nvidia-smi` returns empty → `VLLMHardwareError("NVIDIA GPU not detected")`, Card 1 stays red, other cards disabled
-- `docker version` return code ≠ 0 → `DockerError("Docker Desktop not running")`, Card 2 shows "Start Docker Desktop" hint
+- `docker version` return code ≠ 0 → `VLLMDockerError("Docker Desktop not running")`, Card 2 shows "Start Docker Desktop" hint
 - `docker pull` timeout (10 min default) → error with retry button; partial layers stay in cache
 - `start_container()` port 8000 busy → automatic fallback 8001 … 8009. Beyond 8010 → error
 - vLLM `/health` doesn't answer within `start_container(...)`'s `health_timeout` (120 s for models < 20 GB, 300 s for larger) → last 50 lines of container logs shown in error panel (`docker logs`)

--- a/docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
+++ b/docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
@@ -15,7 +15,7 @@
 | 1 | **Scope:** Flutter in-app wizard with full container lifecycle (Option B, not point-at-existing) | "Funktional anbieten" requires install + start + stop, not just a config field |
 | 2 | **Install tech:** Docker Desktop + official vLLM image | Cleanest lifecycle, officially supported, fast image pull vs. hour-long `pip install vllm` |
 | 3 | **Docker bootstrap:** Link + detect (Option B) — we don't install Docker Desktop automatically | Docker install needs reboot; silent third-party install is a trust issue |
-| 4 | **Hardware gate:** Strict — NVIDIA vendor + ≥16 GB VRAM (fits the smallest curated VLM, Qwen2.5-VL-7B at FP16) checked before vLLM is selectable | 30-min setup ending in OOM is worse UX than an upfront "not supported" message; override via config flag. Passing the gate only means "can run the smallest curated model." The UI shows a per-model VRAM badge and disables models whose `vram_gb_min` exceeds detected VRAM |
+| 4 | **Hardware gate:** Strict — NVIDIA vendor + ≥16 GB VRAM + detected CUDA compute capability. Each curated model specifies a `min_compute_capability` (SM version) and `vram_gb_min`. The UI disables entries whose requirements exceed the detected GPU | 30-min setup ending in OOM or "no kernel for this arch" is worse UX than upfront "not supported." Blackwell (SM 12.0, RTX 50xx) unlocks NVFP4; Ada (SM 8.9, RTX 40xx) unlocks FP8; Ampere (SM 8.0-8.6, RTX 30xx) falls back to AWQ/INT8. Override via `skip_hardware_check` config flag |
 | 5 | **Model scope:** Hybrid curated + custom (Option Y+Z) | Curated dropdown with tested models, last entry is "Custom (HF repo id…)" text field with disclaimer |
 | 6 | **Flutter UX:** Dedicated sub-screen "LLM Backends" (Option C) | Room for status, metrics, model management per backend; extensible for future backends |
 | 7 | **Setup-page layout:** Status cards on one page (Option B) | All prerequisites visible at once, each card has its own action button, recoverable after partial failure |
@@ -47,16 +47,18 @@ Backend switching is live — the existing `gateway.py:1968+` re-init path for `
 - VLM-aware image-payload conversion: `images: list[str]` path-arg → OpenAI-vision format `{"type":"image_url","image_url":{"url":"data:image/png;base64,..."}}`
 - `httpx.AsyncClient` with connection pooling, configurable timeout (default 60s)
 
-**`vllm_orchestrator.py` — ~400 LOC, no new deps**
-- State: `VLLMState` dataclass — `hardware_ok`, `docker_ok`, `image_pulled`, `container_running`, `current_model`, `last_error`
+**`vllm_orchestrator.py` — ~450 LOC, no new deps**
+- State: `VLLMState` dataclass — `hardware_ok`, `hardware_info` (GPU name, VRAM GB, compute capability as tuple like `(12, 0)`), `docker_ok`, `image_pulled`, `container_running`, `current_model`, `last_error`
 - Methods:
-  - `check_hardware() -> HardwareInfo` — parses `nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits`
+  - `check_hardware() -> HardwareInfo` — parses `nvidia-smi --query-gpu=name,memory.total,compute_cap --format=csv,noheader,nounits`. Returns name, VRAM GB, and compute capability as `(major, minor)` tuple for model-compatibility filtering (Blackwell SM 12.0, Ada SM 8.9, Ampere SM 8.x)
   - `check_docker() -> DockerInfo` — `docker version --format json`
   - `pull_image(tag, progress_callback) -> None` — streams `docker pull --progress=auto` stdout, parses layer-progress JSON. Typical image size ~10.5 GB (vllm/vllm-openai includes CUDA runtime + torch + vllm wheels).
   - `start_container(model, port=8000) -> ContainerInfo` — constructs `docker run` with `--gpus all`, `-v cognithor-hf-cache:/root/.cache/huggingface`, `-e HF_TOKEN=$token`, label `cognithor.managed=true`; auto-falls-back 8000→8009 on port conflict
   - `stop_container() -> None` — `docker stop` + `docker rm` on labeled container
   - `reuse_existing() -> Optional[ContainerInfo]` — scans `docker ps --filter "label=cognithor.managed=true"`
   - `status() -> VLLMState` — aggregates all above
+  - `recommend_model(hardware: HardwareInfo, registry: list[ModelEntry], prefer: Literal["vision","text"]="vision") -> ModelEntry` — returns the best curated model that fits the detected GPU. Ranking: (1) `tested==true` beats `tested==false`, (2) matching capability beats non-matching, (3) higher priority (`premium > standard > fallback`) within VRAM limits, (4) tie-break by lower VRAM-to-weights ratio (headroom for KV cache)
+  - `filter_registry(hardware: HardwareInfo, registry: list[ModelEntry]) -> list[ModelEntry]` — returns all entries that pass the hardware gate, used by the Flutter dropdown to show enabled/disabled state
 - Ring-buffer last 500 lines of container stdout/stderr for diagnostics
 
 ### API Layer (`src/cognithor/channels/api.py` — existing FastAPI)
@@ -86,11 +88,11 @@ New Pydantic sub-model:
 class VLLMConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
     enabled: bool = False
-    model: str = "Qwen/Qwen2.5-VL-7B-Instruct"  # see model-registry note below
-    docker_image: str = "vllm/vllm-openai:v0.19.1"  # stable at brainstorm time
+    model: str = ""  # empty → orchestrator.recommend_model() picks the best fit for detected hardware on first start
+    docker_image: str = "vllm/vllm-openai:v0.19.1"  # stable at brainstorm time; set to ":nightly" for bleed-edge Qwen3.6
     port: int = 8000
     auto_stop_on_close: bool = False  # default: stop on close; user opts in to persistent
-    skip_hardware_check: bool = False  # override for edge cases (wrong detection, smaller models)
+    skip_hardware_check: bool = False  # override for edge cases (wrong detection, smaller models, unlisted GPUs)
     request_timeout_seconds: int = 60
     # HF token is NOT stored here — it's read from the top-level
     # `config.huggingface_api_key` which the existing SecretStore keyring-backs
@@ -98,27 +100,100 @@ class VLLMConfig(BaseModel):
     # container as `-e HF_TOKEN=$value`.
 ```
 
+**Recommendation flow on empty `model`:** orchestrator calls `recommend_model(hardware_info, registry)` and caches the result back to `config.vllm.model` so subsequent starts are deterministic. User can override via the Flutter dropdown at any time.
+
 Embedded in existing `LLMBackendsConfig`. Loaded via the existing legacy-key-tolerant `load_config()` path. **HF-token handling reuses the existing `config.huggingface_api_key` field (already in `_SECRET_FIELDS`, keyring-backed via `SecretStore`) rather than introducing a new nested secret.**
 
 ### Model Registry (`src/cognithor/cli/model_registry.json`)
 
-New provider section. VRAM values account for model weights at the given quantization **plus** KV cache + vLLM scheduler overhead (~1.3× weight size for typical context lengths):
+New provider section. The registry is **per-quantization**, not per-base-model — different quants of the same base model become separate entries so the orchestrator can pick the best fit per detected GPU. VRAM values account for model weights **plus** KV cache + vLLM scheduler overhead (~1.3× weight size for typical context lengths):
 
 ```json
 "vllm": {
-  "description": "Vision-language models tested against vLLM on consumer NVIDIA GPUs. Focus is on vision — text-only models are supported via the Custom path.",
+  "description": "Vision-language models tested against vLLM. Entries include the quantization format, minimum CUDA compute capability and minimum vLLM version required to load the model.",
   "models": [
-    {"id": "Qwen/Qwen2.5-VL-7B-Instruct", "vram_gb_min": 16, "capability": "vision", "tested": true,  "min_vllm_version": "0.7.0",  "quantization": "bf16", "notes": "Default. Well-supported in vLLM, fits on a 16 GB card."},
-    {"id": "QuantTrio/Qwen3.6-35B-A3B-AWQ", "vram_gb_min": 24, "capability": "vision", "tested": false, "min_vllm_version": "pending", "quantization": "AWQ-4bit", "notes": "Community 4-bit AWQ. Awaiting vLLM Qwen3.6 architecture support."},
-    {"id": "Qwen/Qwen3.6-27B-FP8", "vram_gb_min": 32, "capability": "vision", "tested": false, "min_vllm_version": "pending", "quantization": "FP8", "notes": "Official FP8 weights. Awaiting vLLM Qwen3.6 architecture support."},
-    {"id": "Qwen/Qwen3.6-35B-A3B-FP8", "vram_gb_min": 40, "capability": "vision", "tested": false, "min_vllm_version": "pending", "quantization": "FP8", "notes": "Official FP8 MoE. Awaiting vLLM Qwen3.6 architecture support."}
+    {
+      "id": "mmangkad/Qwen3.6-27B-NVFP4",
+      "display_name": "Qwen3.6-27B · NVFP4 (Blackwell-native)",
+      "base_model": "Qwen/Qwen3.6-27B",
+      "quantization": "NVFP4",
+      "vram_gb_min": 14,
+      "min_compute_capability": "12.0",
+      "min_vllm_version": "pending",
+      "capability": "vision",
+      "priority": "premium",
+      "tested": false,
+      "notes": "Fastest option on RTX 50xx / Blackwell. Uses native FP4 tensor cores (~2× FP8 throughput). Built with NVIDIA's ModelOpt toolkit. Recommended default for RTX 5090."
+    },
+    {
+      "id": "Qwen/Qwen3.6-27B-FP8",
+      "display_name": "Qwen3.6-27B · FP8 (official)",
+      "base_model": "Qwen/Qwen3.6-27B",
+      "quantization": "FP8",
+      "vram_gb_min": 32,
+      "min_compute_capability": "8.9",
+      "min_vllm_version": "pending",
+      "capability": "vision",
+      "priority": "premium",
+      "tested": false,
+      "notes": "Official Qwen FP8 block-128 quantization. Near-identical quality to bf16. Needs RTX 4090 (24 GB) with tight KV budget, RTX 5090 (32 GB), or workstation GPU."
+    },
+    {
+      "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
+      "display_name": "Qwen3.6-27B · AWQ-INT4 (community)",
+      "base_model": "Qwen/Qwen3.6-27B",
+      "quantization": "AWQ-INT4",
+      "vram_gb_min": 16,
+      "min_compute_capability": "8.0",
+      "min_vllm_version": "pending",
+      "capability": "vision",
+      "priority": "standard",
+      "tested": false,
+      "notes": "Community 4-bit AWQ. Runs on RTX 3090, 4070 Ti Super, 4080 (16 GB cards). Quality trade ~3-5% vs. bf16."
+    },
+    {
+      "id": "Qwen/Qwen3.6-35B-A3B-FP8",
+      "display_name": "Qwen3.6-35B-A3B · FP8 (MoE, official)",
+      "base_model": "Qwen/Qwen3.6-35B-A3B",
+      "quantization": "FP8",
+      "vram_gb_min": 40,
+      "min_compute_capability": "8.9",
+      "min_vllm_version": "pending",
+      "capability": "vision",
+      "priority": "standard",
+      "tested": false,
+      "notes": "MoE with 3B active params — very fast inference. Needs workstation GPU (A6000, RTX 6000 Ada)."
+    },
+    {
+      "id": "Qwen/Qwen2.5-VL-7B-Instruct",
+      "display_name": "Qwen2.5-VL-7B · BF16 (fallback)",
+      "base_model": "Qwen/Qwen2.5-VL-7B-Instruct",
+      "quantization": "bf16",
+      "vram_gb_min": 16,
+      "min_compute_capability": "7.5",
+      "min_vllm_version": "0.7.0",
+      "capability": "vision",
+      "priority": "fallback",
+      "tested": true,
+      "notes": "Current default until vLLM ships Qwen3.6 architecture support. Well-tested, runs on any 16 GB NVIDIA GPU including RTX 3090 / 4060 Ti 16 GB."
+    }
   ]
 }
 ```
 
-**vLLM-version compatibility**: vLLM v0.19.1 (current stable as of brainstorm) does **not** yet support the Qwen3.6 architecture — Qwen3.6 was released on 2026-04-21, three days after v0.19.1. Until a vLLM release adds `qwen3_6`/`qwen3_5_vl` architecture support (expected v0.19.2 or v0.20.0), Qwen3.6 entries are marked `tested: false` with `min_vllm_version: "pending"`. The Flutter dropdown surfaces them as disabled with a tooltip "Requires vLLM ≥X — pull image first". Users who want to bleed-edge can set `docker_image: "vllm/vllm-openai:latest"` or `:nightly` manually via config.
+**Field semantics:**
+- `priority`: `premium` > `standard` > `fallback`. Orchestrator's `recommend_model()` prefers higher priority within hardware limits. `premium` marks the expected-best choice for each GPU class.
+- `min_compute_capability`: CUDA SM version as `"major.minor"`. `12.0` = Blackwell, `8.9` = Ada, `8.0` = Ampere-A100, `7.5` = Turing. The orchestrator converts `nvidia-smi`'s reported capability to a tuple and compares.
+- `tested: true` means we've verified the model actually loads and produces sensible output on real hardware. `false` = included based on registry-level research but not yet smoke-tested.
+- `min_vllm_version: "pending"` = Qwen3.6 architecture is not yet supported by vLLM stable (v0.19.1 as of 2026-04-22). Will be flipped to the actual version when support lands.
 
-Flutter reads this list for the curated dropdown; the last option is always a "Custom (HF repo id…)" text field with a disclaimer. The registry's `min_vllm_version` is used at implementation time to gate curated entries against the resolved Docker image.
+**Qwen3.6 architecture status (as of 2026-04-22):** vLLM v0.19.1 (released 2026-04-18) predates Qwen3.6 (released 2026-04-21). Qwen3.6 NVFP4/FP8/AWQ weights have already been uploaded to HF by Qwen and the community, but the `qwen3_5_vl` / `qwen3_6` architecture loader is not yet in vLLM's main branch. Curated Qwen3.6 entries stay `tested: false` until a vLLM release lands — expected v0.19.2 or v0.20.0. Users can set `docker_image: "vllm/vllm-openai:nightly"` to bleed-edge it now.
+
+**Flutter behavior:**
+- Dropdown groups entries by `base_model`, shows quant as the differentiator
+- Orchestrator's `recommend_model()` output is rendered with a "⭐ Recommended for your GPU" badge
+- Entries failing `min_compute_capability` or `vram_gb_min` render disabled with a tooltip showing *why* ("Requires Blackwell GPU" / "Needs 32 GB VRAM, you have 16 GB" / "Requires vLLM ≥ 0.20.0")
+- The last dropdown slot is always "Custom (HF repo id…)" with a disclaimer about untested models
 
 ---
 
@@ -130,8 +205,8 @@ Flutter reads this list for the curated dropdown; the last option is always a "C
 2. `vllm_setup_screen.dart` mounts, `LlmBackendProvider` begins polling `GET /api/backends/vllm/status`
 3. Backend runs `orchestrator.check_hardware()` + `check_docker()` synchronously → Cards 1 + 2 render immediately (✓ or ✗)
 4. User clicks "Pull image now" on Card 3 → `POST /api/backends/vllm/pull-image` (SSE stream) → Flutter renders progress bar from layer events
-5. After successful pull, Card 4 "Select & load model" enables → dropdown from `model_registry.json.providers.vllm.models` + Custom text field
-6. User picks a model, clicks "Start vLLM" → `POST /api/backends/vllm/start {model}` → `orchestrator.start_container()` → waits for vLLM `/health` ping (timeout 120 s) → response
+5. After successful pull, Card 4 "Select & load model" enables → dropdown sourced from `orchestrator.filter_registry(hardware, registry)` (entries failing `min_compute_capability` or `vram_gb_min` render disabled with a "why" tooltip). The entry matching `orchestrator.recommend_model(hardware)` is marked with a "⭐ Recommended for your GPU" badge. Last dropdown slot is always "Custom (HF repo id…)"
+6. User picks a model (or accepts the recommendation), clicks "Start vLLM" → `POST /api/backends/vllm/start {model}` → `orchestrator.start_container()` → waits for vLLM `/health` ping (timeout 120 s, bumped to 300 s for first-load of models ≥ 20 GB since HF download + vLLM weight loading is slow) → response
 7. User clicks "Make active" → `POST /api/backends/active {backend:"vllm"}` → `UnifiedLLMClient` re-init → hot-switch without app restart
 
 ### Flow B — Chat Request with Vision
@@ -233,12 +308,20 @@ CI runners have no GPU and no way to actually start vLLM. No Docker-in-Docker, n
   - `is_available()` against 200-ok and connection-refused
   - Error propagation (5xx → `VLLMNotReadyError`, 400 → `LLMBackendError`)
 - **`tests/test_core/test_vllm_orchestrator.py`** — orchestrator with `subprocess.run` mocked
-  - `check_hardware()` parses `nvidia-smi` output correctly (real + empty + garbled)
+  - `check_hardware()` parses `nvidia-smi` output correctly (real + empty + garbled), extracts compute capability tuple (tested matrix: Blackwell 12.0, Ada 8.9, Ampere 8.6, Turing 7.5)
   - `check_docker()` handles missing Docker gracefully
   - `pull_image()` parses Docker-progress JSON
   - `start_container()` constructs the `docker run` command correctly (including `--gpus all`, volume, label, HF token env)
   - `reuse_existing()` filters by label
   - Port-fallback logic (8000 busy → 8001)
+- **`tests/test_core/test_vllm_recommend_model.py`** — model-recommendation logic against the full registry
+  - Blackwell SM 12.0 + 32 GB → picks `mmangkad/Qwen3.6-27B-NVFP4` (premium, native FP4)
+  - Ada SM 8.9 + 24 GB → picks `Qwen/Qwen3.6-27B-FP8` (premium, fits)
+  - Ada SM 8.9 + 16 GB → picks `cyankiwi/Qwen3.6-27B-AWQ-INT4` (fits budget, drops to standard tier)
+  - Ampere SM 8.0 + 24 GB → picks AWQ-INT4 (no FP8 tensor cores on Ampere, vLLM emulates badly)
+  - Turing SM 7.5 + 16 GB → picks `Qwen2.5-VL-7B-Instruct` (fallback, only tested model that matches)
+  - Override: when `prefer="text"` and no text model is curated, returns `None` → UI shows "No curated text model — use Custom path"
+  - `filter_registry()` correctly disables entries whose `min_compute_capability` exceeds detected capability
 - **`tests/test_core/test_unified_llm_circuit_breaker.py`** — circuit-breaker state machine
   - 3 fails in 60 s → `DEGRADED`
   - Health-ping recovered → `OK`
@@ -320,16 +403,16 @@ Documented in `docs/vllm-manual-test.md`. Run once on a dev machine with real NV
 **1.5–2 calendar weeks, single engineer.** Breakdown:
 
 - `VLLMBackend` class + unit tests: 1 day
-- `vllm_orchestrator.py` + unit tests: 2 days
+- `vllm_orchestrator.py` + unit tests (including `recommend_model()` + `filter_registry()` GPU-awareness): 2.5 days
 - FastAPI endpoints including SSE streaming for pull progress: 1 day (was underestimated at 0.5 day — SSE server-side + client-side `EventSource` in Flutter is not trivial)
-- Flutter screens + widget tests + SSE progress consumption: 2 days (was underestimated at 1.5 days)
+- Flutter screens + widget tests + SSE progress consumption + per-model enable/disable logic + "⭐ Recommended" badge rendering: 2.5 days
 - Config extension + `VLLMConfig` + `huggingface_api_key` env-var wiring: 0.5 day
 - Wiring existing `CircuitBreaker` into `UnifiedLLMClient` per-backend + tests: 0.5 day (lighter than "new circuit breaker" because code is reused)
 - User-facing guide (`docs/vllm-user-guide.md`) + manual-test doc: 1 day
 - Manual smoke test on real NVIDIA hardware + bug fixes from it: 1 day
 - Buffer / polish / PR cycle / spec-reviewer loops: 1 day
 
-**Total: ~10 working days = 2 calendar weeks** if everything lines up. Best-case 1.5 weeks if the SSE and Flutter widget work goes smoothly. Revised upward from the original 1-week estimate because of (a) SSE non-triviality on both ends, (b) user-docs budgeted explicitly, (c) real-hardware smoke test typically surfaces 1-2 bugs worth a day.
+**Total: ~11 working days = 2.2 calendar weeks** if everything lines up. Revised upward from the original 1-week estimate because of (a) SSE non-triviality on both ends, (b) user-docs budgeted explicitly, (c) real-hardware smoke test typically surfaces 1-2 bugs worth a day, (d) added `recommend_model()` + `filter_registry()` hardware-awareness (0.5 day orchestrator + 0.5 day Flutter).
 
 ---
 
@@ -345,4 +428,5 @@ Documented in `docs/vllm-manual-test.md`. Run once on a dev machine with real NV
 - ~~HF-token storage~~ → reuse existing top-level `config.huggingface_api_key` (already keyring-backed via `SecretStore._SECRET_FIELDS`), no new nested secret field
 - ~~Circuit breaker implementation~~ → reuse existing `cognithor.utils.circuit_breaker.CircuitBreaker`, per-backend instance, do not reinvent
 - ~~Model-registry VRAM math~~ → original draft used bf16 sizes which fail on consumer hardware; curated list now uses FP8/AWQ quantized variants with realistic per-model VRAM minima
-- ~~Qwen3.6 vLLM support status~~ → vLLM v0.19.1 does **not** yet support the Qwen3.6 architecture (Qwen3.6 released 3 days after v0.19.1). Curated Qwen3.6 entries ship with `tested: false` and `min_vllm_version: "pending"`. Default curated model is Qwen2.5-VL-7B until vLLM ships Qwen3.6 support
+- ~~Qwen3.6 vLLM support status~~ → vLLM v0.19.1 does **not** yet support the Qwen3.6 architecture (Qwen3.6 released 3 days after v0.19.1). Curated Qwen3.6 entries ship with `tested: false` and `min_vllm_version: "pending"`. Until support lands, orchestrator's `recommend_model()` falls back to Qwen2.5-VL-7B-Instruct (the only `tested: true` entry)
+- ~~Hardware-aware model recommendation~~ → registry entries now include `min_compute_capability` (CUDA SM version) and `priority` tier. `orchestrator.recommend_model()` picks the best entry per detected GPU — Blackwell users get NVFP4 as default, Ada users get FP8, Ampere users get AWQ-INT4, Turing falls back to Qwen2.5-VL-7B. Flutter dropdown shows "⭐ Recommended for your GPU" badge on the top pick and disables entries failing the detected GPU's capabilities with actionable tooltips. Unblocks RTX 5090 users to hit native NVFP4 throughput (~2× FP8) on day one

--- a/docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
+++ b/docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
@@ -15,7 +15,7 @@
 | 1 | **Scope:** Flutter in-app wizard with full container lifecycle (Option B, not point-at-existing) | "Funktional anbieten" requires install + start + stop, not just a config field |
 | 2 | **Install tech:** Docker Desktop + official vLLM image | Cleanest lifecycle, officially supported, fast image pull vs. hour-long `pip install vllm` |
 | 3 | **Docker bootstrap:** Link + detect (Option B) — we don't install Docker Desktop automatically | Docker install needs reboot; silent third-party install is a trust issue |
-| 4 | **Hardware gate:** Strict — NVIDIA vendor + ≥16 GB VRAM (the minimum for *any* curated model) checked before vLLM is selectable | 30-min setup ending in OOM is worse UX than an upfront "not supported" message; override via config flag. Note: passing the gate only means "can run the smallest curated model." The UI shows a per-model VRAM badge and disables models whose `vram_gb_min` exceeds detected VRAM |
+| 4 | **Hardware gate:** Strict — NVIDIA vendor + ≥16 GB VRAM (fits the smallest curated VLM, Qwen2.5-VL-7B at FP16) checked before vLLM is selectable | 30-min setup ending in OOM is worse UX than an upfront "not supported" message; override via config flag. Passing the gate only means "can run the smallest curated model." The UI shows a per-model VRAM badge and disables models whose `vram_gb_min` exceeds detected VRAM |
 | 5 | **Model scope:** Hybrid curated + custom (Option Y+Z) | Curated dropdown with tested models, last entry is "Custom (HF repo id…)" text field with disclaimer |
 | 6 | **Flutter UX:** Dedicated sub-screen "LLM Backends" (Option C) | Room for status, metrics, model management per backend; extensible for future backends |
 | 7 | **Setup-page layout:** Status cards on one page (Option B) | All prerequisites visible at once, each card has its own action button, recoverable after partial failure |
@@ -52,7 +52,7 @@ Backend switching is live — the existing `gateway.py:1968+` re-init path for `
 - Methods:
   - `check_hardware() -> HardwareInfo` — parses `nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits`
   - `check_docker() -> DockerInfo` — `docker version --format json`
-  - `pull_image(tag, progress_callback) -> None` — streams `docker pull --progress=auto`, emits layer-progress events
+  - `pull_image(tag, progress_callback) -> None` — streams `docker pull --progress=auto` stdout, parses layer-progress JSON. Typical image size ~10.5 GB (vllm/vllm-openai includes CUDA runtime + torch + vllm wheels).
   - `start_container(model, port=8000) -> ContainerInfo` — constructs `docker run` with `--gpus all`, `-v cognithor-hf-cache:/root/.cache/huggingface`, `-e HF_TOKEN=$token`, label `cognithor.managed=true`; auto-falls-back 8000→8009 on port conflict
   - `stop_container() -> None` — `docker stop` + `docker rm` on labeled container
   - `reuse_existing() -> Optional[ContainerInfo]` — scans `docker ps --filter "label=cognithor.managed=true"`
@@ -66,7 +66,7 @@ Backend switching is live — the existing `gateway.py:1968+` re-init path for `
 | `/api/backends` | GET | List all backends with status |
 | `/api/backends/vllm/status` | GET | `VLLMState` as JSON |
 | `/api/backends/vllm/check-hardware` | POST | Trigger hardware detection |
-| `/api/backends/vllm/pull-image` | POST | SSE-stream for pull progress |
+| `/api/backends/vllm/pull-image` | POST | SSE-stream (FastAPI `StreamingResponse` with `text/event-stream`) for pull progress. Flutter consumes via `EventSource`-equivalent. Line format: `data: {"layer":"sha256:...","current":1234567,"total":10000000}\n\n` |
 | `/api/backends/vllm/start` | POST | Body: `{model: str}` — starts container |
 | `/api/backends/vllm/stop` | POST | Stops container |
 | `/api/backends/vllm/logs` | GET | Ring-buffer of last container logs |
@@ -86,34 +86,39 @@ New Pydantic sub-model:
 class VLLMConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
     enabled: bool = False
-    model: str = "Qwen/Qwen3.6-27B"
-    docker_image: str = "vllm/vllm-openai:v0.6.3"
+    model: str = "Qwen/Qwen2.5-VL-7B-Instruct"  # see model-registry note below
+    docker_image: str = "vllm/vllm-openai:v0.19.1"  # stable at brainstorm time
     port: int = 8000
     auto_stop_on_close: bool = False  # default: stop on close; user opts in to persistent
     skip_hardware_check: bool = False  # override for edge cases (wrong detection, smaller models)
     request_timeout_seconds: int = 60
-    hf_token: str = ""  # for gated models, falls back to HF_TOKEN env var
+    # HF token is NOT stored here — it's read from the top-level
+    # `config.huggingface_api_key` which the existing SecretStore keyring-backs
+    # via `_SECRET_FIELDS` in config.py. The orchestrator passes it to the
+    # container as `-e HF_TOKEN=$value`.
 ```
 
-Embedded in existing `LLMBackendsConfig`. Loaded via the existing legacy-key-tolerant `load_config()` path.
+Embedded in existing `LLMBackendsConfig`. Loaded via the existing legacy-key-tolerant `load_config()` path. **HF-token handling reuses the existing `config.huggingface_api_key` field (already in `_SECRET_FIELDS`, keyring-backed via `SecretStore`) rather than introducing a new nested secret.**
 
 ### Model Registry (`src/cognithor/cli/model_registry.json`)
 
-New provider section:
+New provider section. VRAM values account for model weights at the given quantization **plus** KV cache + vLLM scheduler overhead (~1.3× weight size for typical context lengths):
 
 ```json
 "vllm": {
-  "description": "Models tested against vLLM backend on NVIDIA GPUs.",
+  "description": "Vision-language models tested against vLLM on consumer NVIDIA GPUs. Focus is on vision — text-only models are supported via the Custom path.",
   "models": [
-    {"id": "Qwen/Qwen3.6-27B",        "vram_gb_min": 16, "capability": "vision", "tested": true},
-    {"id": "Qwen/Qwen3.6-35B-A3B",    "vram_gb_min": 20, "capability": "vision", "tested": true},
-    {"id": "Qwen/Qwen3-32B",          "vram_gb_min": 20, "capability": "text",   "tested": true},
-    {"id": "meta-llama/Llama-3.3-70B-Instruct", "vram_gb_min": 40, "capability": "text", "tested": true}
+    {"id": "Qwen/Qwen2.5-VL-7B-Instruct", "vram_gb_min": 16, "capability": "vision", "tested": true,  "min_vllm_version": "0.7.0",  "quantization": "bf16", "notes": "Default. Well-supported in vLLM, fits on a 16 GB card."},
+    {"id": "QuantTrio/Qwen3.6-35B-A3B-AWQ", "vram_gb_min": 24, "capability": "vision", "tested": false, "min_vllm_version": "pending", "quantization": "AWQ-4bit", "notes": "Community 4-bit AWQ. Awaiting vLLM Qwen3.6 architecture support."},
+    {"id": "Qwen/Qwen3.6-27B-FP8", "vram_gb_min": 32, "capability": "vision", "tested": false, "min_vllm_version": "pending", "quantization": "FP8", "notes": "Official FP8 weights. Awaiting vLLM Qwen3.6 architecture support."},
+    {"id": "Qwen/Qwen3.6-35B-A3B-FP8", "vram_gb_min": 40, "capability": "vision", "tested": false, "min_vllm_version": "pending", "quantization": "FP8", "notes": "Official FP8 MoE. Awaiting vLLM Qwen3.6 architecture support."}
   ]
 }
 ```
 
-Flutter reads this list for the curated dropdown; the last option is always a "Custom (HF repo id…)" text field with a disclaimer.
+**vLLM-version compatibility**: vLLM v0.19.1 (current stable as of brainstorm) does **not** yet support the Qwen3.6 architecture — Qwen3.6 was released on 2026-04-21, three days after v0.19.1. Until a vLLM release adds `qwen3_6`/`qwen3_5_vl` architecture support (expected v0.19.2 or v0.20.0), Qwen3.6 entries are marked `tested: false` with `min_vllm_version: "pending"`. The Flutter dropdown surfaces them as disabled with a tooltip "Requires vLLM ≥X — pull image first". Users who want to bleed-edge can set `docker_image: "vllm/vllm-openai:latest"` or `:nightly` manually via config.
+
+Flutter reads this list for the curated dropdown; the last option is always a "Custom (HF repo id…)" text field with a disclaimer. The registry's `min_vllm_version` is used at implementation time to gate curated entries against the resolved Docker image.
 
 ---
 
@@ -133,7 +138,7 @@ Flutter reads this list for the curated dropdown; the last option is always a "C
 
 1. User types prompt + attaches image → Flutter sends via WebSocket to Gateway
 2. Gateway → Planner → `working_memory.image_attachments = [path]`
-3. Planner selects model: `config.vision_model_detail` (e.g., `Qwen/Qwen3.6-27B`) → `unified_llm.chat(images=[path])`
+3. Planner selects model: `config.vision_model_detail` (e.g., `Qwen/Qwen2.5-VL-7B-Instruct` — the curated default; `Qwen/Qwen3.6-27B-FP8` once vLLM ships Qwen3.6 support) → `unified_llm.chat(images=[path])`
 4. `UnifiedLLMClient` dispatches to `VLLMBackend` (active backend)
 5. `VLLMBackend.chat()` converts image paths to OpenAI-vision format (`data:image/png;base64,...`), POSTs to `http://localhost:8000/v1/chat/completions`
 6. vLLM container processes, streams response back → Planner → Gateway → WebSocket → Flutter
@@ -181,10 +186,25 @@ All exceptions carry a `recovery_hint: str` field which Flutter renders alongsid
 - HTTP 400 (e.g. context too long) → `LLMBackendError` propagates directly, **no fallback** (real user error; Ollama wouldn't solve it either)
 - Connection refused → same as 5xx → fail flow
 
-### Circuit Breaker (new, in `UnifiedLLMClient`)
+### Circuit Breaker (reuses existing `cognithor.utils.circuit_breaker.CircuitBreaker`)
 
-- After 3 consecutive failures in 60 s: vLLM backend marked `DEGRADED`, **not dispatched**. Auto-fallback to Ollama for every request until health-check heals. Prevents every user turn from hitting the 60 s timeout while vLLM is down.
-- Health-check thread pings every 30 s in the background → once green, `DEGRADED → OK`, banner dismisses.
+The repo already has a production-grade async circuit breaker with a full `CLOSED → OPEN → HALF_OPEN → CLOSED` state machine (`src/cognithor/utils/circuit_breaker.py`). We reuse it — do not reinvent.
+
+**Integration:** `UnifiedLLMClient` owns one `CircuitBreaker` instance **per backend** (`vllm_breaker`, `ollama_breaker`, …). Per-backend scope prevents a flaky vLLM from tripping Ollama's breaker.
+
+**Parameters** for the vLLM breaker:
+- `name="llm_backend_vllm"`
+- `failure_threshold=3` — three consecutive failures open the circuit
+- `recovery_timeout=60.0` — 60 s in OPEN, then HALF_OPEN for a probe request
+- `half_open_max_calls=1` — one probe at a time in HALF_OPEN
+- `excluded_exceptions=(LLMBadRequestError,)` — HTTP 400 errors are user/context problems, **not** backend faults, so they never count toward the breaker threshold
+
+**Behavior:**
+- `CLOSED` (healthy): normal dispatch
+- `OPEN` (after 3 fails): `CircuitBreakerOpen` raised immediately → `UnifiedLLMClient` treats this as DEGRADED, routes per the fail-flow rules (text → Ollama, image → error). Banner shows.
+- `HALF_OPEN` (after recovery_timeout): next request goes through as a probe. Success → `CLOSED`, banner dismisses. Failure → back to `OPEN` with fresh 60 s countdown.
+
+No separate health-check thread — the existing breaker heals itself via the HALF_OPEN probe on the next real request. Saves a timer thread + 30 s polling cost.
 
 ### Logging
 
@@ -245,7 +265,7 @@ CI runners have no GPU and no way to actually start vLLM. No Docker-in-Docker, n
 
 Documented in `docs/vllm-manual-test.md`. Run once on a dev machine with real NVIDIA GPU + Docker Desktop:
 
-- Full setup flow (click through cards, pull image, start Qwen3.6-27B)
+- Full setup flow (click through cards, pull image, start Qwen2.5-VL-7B-Instruct as the curated default)
 - Chat with text + image
 - App close with/without auto-stop toggle
 - Manually stop vLLM container mid-session → verify fail flow
@@ -276,12 +296,14 @@ Documented in `docs/vllm-manual-test.md`. Run once on a dev machine with real NV
 **In scope:**
 - `VLLMBackend` class implementing `LLMBackend` ABC
 - `vllm_orchestrator.py` for container lifecycle
-- FastAPI endpoints for the Flutter UI
+- FastAPI endpoints for the Flutter UI, including SSE streaming for pull progress
 - New Flutter screens (`LlmBackendsScreen`, `VllmSetupScreen`)
 - Config extension (`VLLMConfig` Pydantic model)
-- Model registry additions
-- Circuit breaker in `UnifiedLLMClient`
+- Model registry additions (curated VLMs + per-model vLLM-version gating)
+- `UnifiedLLMClient` integration of the existing `cognithor.utils.circuit_breaker.CircuitBreaker` per backend
 - Banner + situational fallback in the fail flow
+- **User-facing documentation** at `docs/vllm-user-guide.md` — install prerequisites, enable-vLLM walkthrough, troubleshooting
+- Manual smoke-test instructions at `docs/vllm-manual-test.md`
 - Tests per the testing strategy above
 
 **Out of scope (tracked separately):**
@@ -295,21 +317,32 @@ Documented in `docs/vllm-manual-test.md`. Run once on a dev machine with real NV
 
 ## Estimate
 
-**1 calendar week, single engineer.** Breakdown:
+**1.5–2 calendar weeks, single engineer.** Breakdown:
 
 - `VLLMBackend` class + unit tests: 1 day
 - `vllm_orchestrator.py` + unit tests: 2 days
-- FastAPI endpoints + integration fake-server test: 0.5 day
-- Flutter screens + widget tests: 1.5 days
-- Config extension + migration handling: 0.5 day
-- Manual smoke test on real hardware + docs: 0.5 day
-- Circuit breaker extension in `UnifiedLLMClient` + tests: 0.5 day
-- Buffer / polish / PR cycle: 0.5 day
+- FastAPI endpoints including SSE streaming for pull progress: 1 day (was underestimated at 0.5 day — SSE server-side + client-side `EventSource` in Flutter is not trivial)
+- Flutter screens + widget tests + SSE progress consumption: 2 days (was underestimated at 1.5 days)
+- Config extension + `VLLMConfig` + `huggingface_api_key` env-var wiring: 0.5 day
+- Wiring existing `CircuitBreaker` into `UnifiedLLMClient` per-backend + tests: 0.5 day (lighter than "new circuit breaker" because code is reused)
+- User-facing guide (`docs/vllm-user-guide.md`) + manual-test doc: 1 day
+- Manual smoke test on real NVIDIA hardware + bug fixes from it: 1 day
+- Buffer / polish / PR cycle / spec-reviewer loops: 1 day
+
+**Total: ~10 working days = 2 calendar weeks** if everything lines up. Best-case 1.5 weeks if the SSE and Flutter widget work goes smoothly. Revised upward from the original 1-week estimate because of (a) SSE non-triviality on both ends, (b) user-docs budgeted explicitly, (c) real-hardware smoke test typically surfaces 1-2 bugs worth a day.
 
 ---
 
 ## Open Questions Deferred to Plan
 
-- Exact default for `request_timeout_seconds` — needs one benchmark on Qwen3.6-27B first turn
-- HF-token handling for gated models: environment variable `HF_TOKEN` fallback chain vs. dedicated config field — both listed above, final precedence decided at plan time
+- Exact default for `request_timeout_seconds` — needs one benchmark run on Qwen2.5-VL-7B first turn with a modest prompt + image on the target hardware
 - Whether to ship a Dart-side constant mirror of `model_registry.json` or fetch at runtime from the backend — affects `test_vllm_registry_sync.py` but not user-visible behavior
+- When Qwen3.6 architecture support lands in vLLM: do we bump the default `docker_image` pin, default the `model` to `Qwen/Qwen3.6-27B-FP8`, and retire Qwen2.5-VL-7B from the curated default? Probably yes, but needs one more release cycle to evaluate stability
+
+## Resolved During Research (2026-04-22)
+
+- ~~vLLM Docker image tag to pin~~ → `vllm/vllm-openai:v0.19.1` at brainstorm time, user-overridable via `VLLMConfig.docker_image`
+- ~~HF-token storage~~ → reuse existing top-level `config.huggingface_api_key` (already keyring-backed via `SecretStore._SECRET_FIELDS`), no new nested secret field
+- ~~Circuit breaker implementation~~ → reuse existing `cognithor.utils.circuit_breaker.CircuitBreaker`, per-backend instance, do not reinvent
+- ~~Model-registry VRAM math~~ → original draft used bf16 sizes which fail on consumer hardware; curated list now uses FP8/AWQ quantized variants with realistic per-model VRAM minima
+- ~~Qwen3.6 vLLM support status~~ → vLLM v0.19.1 does **not** yet support the Qwen3.6 architecture (Qwen3.6 released 3 days after v0.19.1). Curated Qwen3.6 entries ship with `tested: false` and `min_vllm_version: "pending"`. Default curated model is Qwen2.5-VL-7B until vLLM ships Qwen3.6 support

--- a/docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
+++ b/docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
@@ -1,0 +1,315 @@
+# vLLM as Opt-In Backend (Windows-functional) — Design Spec
+
+**Status:** Brainstorming approved 2026-04-22, ready for implementation plan.
+
+**Goal:** Add vLLM as a first-class opt-in LLM backend alongside the existing Ollama default. Users with an NVIDIA GPU (≥16 GB VRAM) can install, start, stop, and switch to vLLM entirely from the Flutter UI, without leaving Cognithor. Ollama remains the default — vLLM is purely additive.
+
+**Non-goal for this spec:** Replacing Ollama. Video-input end-to-end (unlocked by vLLM but tracked separately in `project_video_input_deferred.md`). Linux/macOS installer integration (vLLM runs fine there natively; users who install via `pip` and start manually are handled via the Custom-HF-repo path, but no dedicated wizard).
+
+---
+
+## Approved Decisions (Brainstorming Outcomes)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | **Scope:** Flutter in-app wizard with full container lifecycle (Option B, not point-at-existing) | "Funktional anbieten" requires install + start + stop, not just a config field |
+| 2 | **Install tech:** Docker Desktop + official vLLM image | Cleanest lifecycle, officially supported, fast image pull vs. hour-long `pip install vllm` |
+| 3 | **Docker bootstrap:** Link + detect (Option B) — we don't install Docker Desktop automatically | Docker install needs reboot; silent third-party install is a trust issue |
+| 4 | **Hardware gate:** Strict — NVIDIA vendor + ≥16 GB VRAM (the minimum for *any* curated model) checked before vLLM is selectable | 30-min setup ending in OOM is worse UX than an upfront "not supported" message; override via config flag. Note: passing the gate only means "can run the smallest curated model." The UI shows a per-model VRAM badge and disables models whose `vram_gb_min` exceeds detected VRAM |
+| 5 | **Model scope:** Hybrid curated + custom (Option Y+Z) | Curated dropdown with tested models, last entry is "Custom (HF repo id…)" text field with disclaimer |
+| 6 | **Flutter UX:** Dedicated sub-screen "LLM Backends" (Option C) | Room for status, metrics, model management per backend; extensible for future backends |
+| 7 | **Setup-page layout:** Status cards on one page (Option B) | All prerequisites visible at once, each card has its own action button, recoverable after partial failure |
+| 8 | **Fail-mode:** Banner + situational fallback (Option Z) | Text-requests fall back to Ollama silently-with-banner; vision-requests hard-error because Ollama can't do vision |
+| 9 | **Container lifecycle:** Smart with toggle (Option Z) | Default: stop on app close (no VRAM leak). Toggle: "keep running" for power users. Always: reuse existing container on app start if present |
+
+---
+
+## Architecture
+
+vLLM integrates as a second local backend alongside Ollama via the existing `LLMBackend` ABC in `src/cognithor/core/llm_backend.py`. Both share the `UnifiedLLMClient` dispatch layer. No changes to Planner/Gatekeeper/Executor — they already go through `UnifiedLLMClient.chat()`.
+
+Three new modules:
+
+- **`VLLMBackend(LLMBackend)`** — protocol adapter. Talks OpenAI-compatible `/v1/chat/completions` via `httpx.AsyncClient`. Handles VLM image-payload conversion.
+- **`vllm_orchestrator.py`** — stateful lifecycle manager. Wraps `docker`/`nvidia-smi` CLIs via `subprocess`. No Docker-SDK dependency.
+- **Flutter `LlmBackendsScreen` + `VllmSetupScreen`** — the user-facing opt-in surface.
+
+Backend switching is live — the existing `gateway.py:1968+` re-init path for `UnifiedLLMClient` already handles `llm_backend_type` changes and just needs a FastAPI endpoint to trigger it.
+
+---
+
+## Components
+
+### Backend Layer (`src/cognithor/core/`)
+
+**`VLLMBackend(LLMBackend)` — ~250 LOC, template: `OpenAIBackend`**
+- `chat()`, `chat_stream()`, `embed()`, `is_available()`, `list_models()`, `close()`
+- VLM-aware image-payload conversion: `images: list[str]` path-arg → OpenAI-vision format `{"type":"image_url","image_url":{"url":"data:image/png;base64,..."}}`
+- `httpx.AsyncClient` with connection pooling, configurable timeout (default 60s)
+
+**`vllm_orchestrator.py` — ~400 LOC, no new deps**
+- State: `VLLMState` dataclass — `hardware_ok`, `docker_ok`, `image_pulled`, `container_running`, `current_model`, `last_error`
+- Methods:
+  - `check_hardware() -> HardwareInfo` — parses `nvidia-smi --query-gpu=name,memory.total --format=csv,noheader,nounits`
+  - `check_docker() -> DockerInfo` — `docker version --format json`
+  - `pull_image(tag, progress_callback) -> None` — streams `docker pull --progress=auto`, emits layer-progress events
+  - `start_container(model, port=8000) -> ContainerInfo` — constructs `docker run` with `--gpus all`, `-v cognithor-hf-cache:/root/.cache/huggingface`, `-e HF_TOKEN=$token`, label `cognithor.managed=true`; auto-falls-back 8000→8009 on port conflict
+  - `stop_container() -> None` — `docker stop` + `docker rm` on labeled container
+  - `reuse_existing() -> Optional[ContainerInfo]` — scans `docker ps --filter "label=cognithor.managed=true"`
+  - `status() -> VLLMState` — aggregates all above
+- Ring-buffer last 500 lines of container stdout/stderr for diagnostics
+
+### API Layer (`src/cognithor/channels/api.py` — existing FastAPI)
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/backends` | GET | List all backends with status |
+| `/api/backends/vllm/status` | GET | `VLLMState` as JSON |
+| `/api/backends/vllm/check-hardware` | POST | Trigger hardware detection |
+| `/api/backends/vllm/pull-image` | POST | SSE-stream for pull progress |
+| `/api/backends/vllm/start` | POST | Body: `{model: str}` — starts container |
+| `/api/backends/vllm/stop` | POST | Stops container |
+| `/api/backends/vllm/logs` | GET | Ring-buffer of last container logs |
+| `/api/backends/active` | POST | Body: `{backend: "vllm"}` — triggers `UnifiedLLMClient` re-init |
+
+### Flutter Layer (`flutter_app/lib/screens/`)
+
+- **`llm_backends_screen.dart`** — list view of all backends with status dots (Settings → LLM Backends)
+- **`vllm_setup_screen.dart`** — status-card page: Hardware · Docker · Image · Model. Each card has its own action button when the step is pending.
+- **`llm_backend_provider.dart`** — `ChangeNotifier` with 2-second polling of `/api/backends/vllm/status` while the detail page is mounted. No polling from the list view.
+
+### Config Layer (`src/cognithor/config.py`)
+
+New Pydantic sub-model:
+
+```python
+class VLLMConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+    enabled: bool = False
+    model: str = "Qwen/Qwen3.6-27B"
+    docker_image: str = "vllm/vllm-openai:v0.6.3"
+    port: int = 8000
+    auto_stop_on_close: bool = False  # default: stop on close; user opts in to persistent
+    skip_hardware_check: bool = False  # override for edge cases (wrong detection, smaller models)
+    request_timeout_seconds: int = 60
+    hf_token: str = ""  # for gated models, falls back to HF_TOKEN env var
+```
+
+Embedded in existing `LLMBackendsConfig`. Loaded via the existing legacy-key-tolerant `load_config()` path.
+
+### Model Registry (`src/cognithor/cli/model_registry.json`)
+
+New provider section:
+
+```json
+"vllm": {
+  "description": "Models tested against vLLM backend on NVIDIA GPUs.",
+  "models": [
+    {"id": "Qwen/Qwen3.6-27B",        "vram_gb_min": 16, "capability": "vision", "tested": true},
+    {"id": "Qwen/Qwen3.6-35B-A3B",    "vram_gb_min": 20, "capability": "vision", "tested": true},
+    {"id": "Qwen/Qwen3-32B",          "vram_gb_min": 20, "capability": "text",   "tested": true},
+    {"id": "meta-llama/Llama-3.3-70B-Instruct", "vram_gb_min": 40, "capability": "text", "tested": true}
+  ]
+}
+```
+
+Flutter reads this list for the curated dropdown; the last option is always a "Custom (HF repo id…)" text field with a disclaimer.
+
+---
+
+## Data Flows
+
+### Flow A — First-Time Setup (Cold Start)
+
+1. User opens Flutter → Settings → LLM Backends → clicks "vLLM"
+2. `vllm_setup_screen.dart` mounts, `LlmBackendProvider` begins polling `GET /api/backends/vllm/status`
+3. Backend runs `orchestrator.check_hardware()` + `check_docker()` synchronously → Cards 1 + 2 render immediately (✓ or ✗)
+4. User clicks "Pull image now" on Card 3 → `POST /api/backends/vllm/pull-image` (SSE stream) → Flutter renders progress bar from layer events
+5. After successful pull, Card 4 "Select & load model" enables → dropdown from `model_registry.json.providers.vllm.models` + Custom text field
+6. User picks a model, clicks "Start vLLM" → `POST /api/backends/vllm/start {model}` → `orchestrator.start_container()` → waits for vLLM `/health` ping (timeout 120 s) → response
+7. User clicks "Make active" → `POST /api/backends/active {backend:"vllm"}` → `UnifiedLLMClient` re-init → hot-switch without app restart
+
+### Flow B — Chat Request with Vision
+
+1. User types prompt + attaches image → Flutter sends via WebSocket to Gateway
+2. Gateway → Planner → `working_memory.image_attachments = [path]`
+3. Planner selects model: `config.vision_model_detail` (e.g., `Qwen/Qwen3.6-27B`) → `unified_llm.chat(images=[path])`
+4. `UnifiedLLMClient` dispatches to `VLLMBackend` (active backend)
+5. `VLLMBackend.chat()` converts image paths to OpenAI-vision format (`data:image/png;base64,...`), POSTs to `http://localhost:8000/v1/chat/completions`
+6. vLLM container processes, streams response back → Planner → Gateway → WebSocket → Flutter
+
+### Flow C — Fail Flow (vLLM Offline Mid-Chat)
+
+1. `VLLMBackend.chat()` raises `VLLMNotReadyError` (timeout or connection refused)
+2. `UnifiedLLMClient` catches, marks `backend_status = DEGRADED`, notifies Gateway via event
+3. Gateway sends WebSocket event `backend_status_changed` → Flutter renders banner "⚠ vLLM offline — fallback to Ollama active"
+4. **If text-request** (`working_memory.image_attachments` is empty): `UnifiedLLMClient` transparent-fallback to `OllamaBackend` with the same prompt
+5. **If image-request** (`working_memory.image_attachments` is non-empty — same trigger the Planner uses for vision routing): `VLLMNotReadyError` propagates as error bubble in chat: "vLLM offline — cannot process image". No silent fallback because Ollama cannot do vision
+6. Next request: `VLLMBackend.is_available()` checked → success? → `backend_status = OK`, banner dismisses
+
+### Flow D — App Close / Re-Open
+
+1. Flutter app closes → Python backend receives SIGTERM from launcher
+2. Shutdown hook in backend: `config.vllm.auto_stop_on_close == true` → `orchestrator.stop_container()`. Otherwise: do nothing.
+3. Next app start: backend init calls `orchestrator.reuse_existing()` → if a container with label `cognithor.managed=true` is running, mark as `ready` directly, no restart sequence
+
+---
+
+## Error Handling
+
+### Error Hierarchy (`src/cognithor/core/llm_backend.py`)
+
+- `LLMBackendError` — base (exists)
+- `VLLMNotReadyError` — container not running or model not loaded
+- `VLLMHardwareError` — NVIDIA not detected, VRAM insufficient
+- `DockerError` — Docker Desktop unreachable
+
+All exceptions carry a `recovery_hint: str` field which Flutter renders alongside the error message.
+
+### Setup-Time Errors (Orchestrator Level)
+
+- `check_hardware()`: `nvidia-smi` returns empty → `VLLMHardwareError("NVIDIA GPU not detected")`, Card 1 stays red, other cards disabled
+- `docker version` return code ≠ 0 → `DockerError("Docker Desktop not running")`, Card 2 shows "Start Docker Desktop" hint
+- `docker pull` timeout (10 min default) → error with retry button; partial layers stay in cache
+- `start_container()` port 8000 busy → automatic fallback 8001 … 8009. Beyond 8010 → error
+- vLLM `/health` doesn't answer within 120 s → last 50 lines of container logs shown in error panel (`docker logs`)
+
+### Runtime Errors (Request Level)
+
+- `chat()` timeout 60 s default → configurable via `vllm.request_timeout_seconds`
+- HTTP 5xx from vLLM → `VLLMNotReadyError`, triggers fail flow (Flow C)
+- HTTP 400 (e.g. context too long) → `LLMBackendError` propagates directly, **no fallback** (real user error; Ollama wouldn't solve it either)
+- Connection refused → same as 5xx → fail flow
+
+### Circuit Breaker (new, in `UnifiedLLMClient`)
+
+- After 3 consecutive failures in 60 s: vLLM backend marked `DEGRADED`, **not dispatched**. Auto-fallback to Ollama for every request until health-check heals. Prevents every user turn from hitting the 60 s timeout while vLLM is down.
+- Health-check thread pings every 30 s in the background → once green, `DEGRADED → OK`, banner dismisses.
+
+### Logging
+
+- All orchestrator actions log structured: `{"component":"vllm_orchestrator","action":"start_container","model":"...","duration_ms":...,"outcome":"ok|error"}`
+- Container stdout/stderr kept in ring buffer of last 500 lines (in memory), retrievable via `GET /api/backends/vllm/logs` → Flutter can show a "Show logs" button on the setup page when things stall.
+
+### No Backwards-Compatibility Traps
+
+- If vLLM config is absent or disabled → `VLLMBackend` is never instantiated, zero overhead
+- Existing non-vLLM users notice nothing about this module
+
+---
+
+## Testing Strategy
+
+### Constraints
+
+CI runners have no GPU and no way to actually start vLLM. No Docker-in-Docker, no 8 GB image pull. All integration testing uses mocks or fakes.
+
+### Unit Layer (GitHub Actions, free runners)
+
+- **`tests/test_core/test_vllm_backend.py`** — `VLLMBackend` against `httpx_mock`
+  - `chat()` formats OpenAI-compatible payload correctly
+  - Image-payload conversion (path → `data:image/…` URL)
+  - `chat_stream()` parses SSE chunks correctly
+  - `is_available()` against 200-ok and connection-refused
+  - Error propagation (5xx → `VLLMNotReadyError`, 400 → `LLMBackendError`)
+- **`tests/test_core/test_vllm_orchestrator.py`** — orchestrator with `subprocess.run` mocked
+  - `check_hardware()` parses `nvidia-smi` output correctly (real + empty + garbled)
+  - `check_docker()` handles missing Docker gracefully
+  - `pull_image()` parses Docker-progress JSON
+  - `start_container()` constructs the `docker run` command correctly (including `--gpus all`, volume, label, HF token env)
+  - `reuse_existing()` filters by label
+  - Port-fallback logic (8000 busy → 8001)
+- **`tests/test_core/test_unified_llm_circuit_breaker.py`** — circuit-breaker state machine
+  - 3 fails in 60 s → `DEGRADED`
+  - Health-ping recovered → `OK`
+  - Fail-flow dispatch (text → Ollama, image → error)
+
+### Integration Layer (GitHub Actions, free runners)
+
+- **`tests/test_integration/test_vllm_fake_server.py`** — a mini FastAPI app that impersonates vLLM's OpenAI API (started in an `asyncio` fixture, not via Docker). `VLLMBackend` communicates end-to-end with it.
+  - Sends real request, receives real response
+  - Tests streaming, image payloads, error responses
+  - No GPU, no Docker, runs in < 1 second
+
+### Flutter Layer (`flutter test`, already in CI)
+
+- **`test/widgets/llm_backends_screen_test.dart`** — widget test with `LlmBackendProvider` mock. Status cards render correctly for every state.
+- **`test/widgets/vllm_setup_screen_test.dart`** — buttons trigger correct API calls (with `http_mock_adapter`).
+- Goldens: optional, only for the status-card page (clear visual layout, worth it).
+
+### Cross-Repo Guard
+
+- **`tests/test_vllm_registry_sync.py`** — cross-check that `model_registry.json.providers.vllm.models` and Flutter's curated list (if mirrored as a Dart constant) stay in sync. Prevents drift on model-list updates. Same pattern as `test_flutter_version_sync.py`.
+
+### Manual Smoke Tests
+
+Documented in `docs/vllm-manual-test.md`. Run once on a dev machine with real NVIDIA GPU + Docker Desktop:
+
+- Full setup flow (click through cards, pull image, start Qwen3.6-27B)
+- Chat with text + image
+- App close with/without auto-stop toggle
+- Manually stop vLLM container mid-session → verify fail flow
+
+### Coverage Target
+
+≥ 90 % on `vllm_backend.py` and `vllm_orchestrator.py` via unit + integration. Flutter coverage analogous to existing screens (~70 %).
+
+---
+
+## Dependencies & Prerequisites
+
+**Python (in-repo):**
+- No new packages — uses existing `httpx`, `pydantic`, `structlog`, stdlib `subprocess`
+- `huggingface_hub` (already optional for the community-GGUF path from PR #132) is **not** required for vLLM itself — vLLM downloads HF models internally when it starts
+
+**User environment (documented, not installed by us):**
+- Docker Desktop (user installs manually per Decision 3)
+- NVIDIA driver with CUDA runtime (any modern driver from the last 2 years works)
+- NVIDIA GPU with ≥ 16 GB VRAM (enforced by the hardware gate)
+
+**CI environment:** unchanged — no GPU runners, no Docker-in-Docker. All tests use mocks.
+
+---
+
+## Scope Boundaries
+
+**In scope:**
+- `VLLMBackend` class implementing `LLMBackend` ABC
+- `vllm_orchestrator.py` for container lifecycle
+- FastAPI endpoints for the Flutter UI
+- New Flutter screens (`LlmBackendsScreen`, `VllmSetupScreen`)
+- Config extension (`VLLMConfig` Pydantic model)
+- Model registry additions
+- Circuit breaker in `UnifiedLLMClient`
+- Banner + situational fallback in the fail flow
+- Tests per the testing strategy above
+
+**Out of scope (tracked separately):**
+- Video-frame end-to-end support (unlocked by vLLM but needs its own prompt-engineering work) — stays in `project_video_input_deferred.md`
+- Migration from Ollama to vLLM as *default* — Ollama stays default forever
+- Embedding-endpoint parity with Ollama (vLLM's embedding support is model-specific; we accept that `embed()` on vLLM may only work for models that explicitly support it)
+- Multi-GPU / tensor-parallel setups (single-GPU only; flag `--tensor-parallel-size` not exposed in v1)
+- Windows-native vLLM builds (we commit to the Docker Desktop path only)
+
+---
+
+## Estimate
+
+**1 calendar week, single engineer.** Breakdown:
+
+- `VLLMBackend` class + unit tests: 1 day
+- `vllm_orchestrator.py` + unit tests: 2 days
+- FastAPI endpoints + integration fake-server test: 0.5 day
+- Flutter screens + widget tests: 1.5 days
+- Config extension + migration handling: 0.5 day
+- Manual smoke test on real hardware + docs: 0.5 day
+- Circuit breaker extension in `UnifiedLLMClient` + tests: 0.5 day
+- Buffer / polish / PR cycle: 0.5 day
+
+---
+
+## Open Questions Deferred to Plan
+
+- Exact default for `request_timeout_seconds` — needs one benchmark on Qwen3.6-27B first turn
+- HF-token handling for gated models: environment variable `HF_TOKEN` fallback chain vs. dedicated config field — both listed above, final precedence decided at plan time
+- Whether to ship a Dart-side constant mirror of `model_registry.json` or fetch at runtime from the backend — affects `test_vllm_registry_sync.py` but not user-visible behavior

--- a/docs/vllm-manual-test.md
+++ b/docs/vllm-manual-test.md
@@ -1,0 +1,97 @@
+# vLLM Backend — Manual Smoke Test
+
+The Python + Flutter unit tests and the fake-server integration test cover
+everything except the real-hardware path. Before cutting a release that
+touches the vLLM backend, run this recipe once on a dev machine with a real
+NVIDIA GPU and Docker Desktop.
+
+**Time:** ~30 minutes end-to-end.
+
+## Test Matrix
+
+Pick the row matching your dev hardware and run those steps:
+
+| GPU | VRAM | Expected recommended model | Test sections |
+|-----|------|----------------------------|---------------|
+| RTX 5090 | 32 GB | `mmangkad/Qwen3.6-27B-NVFP4` | All |
+| RTX 4090 | 24 GB | `cyankiwi/Qwen3.6-27B-AWQ-INT4` or fallback | 1–5 |
+| RTX 4080 / 4070 Ti Super | 16 GB | `Qwen/Qwen2.5-VL-7B-Instruct` (tested fallback) | 1–4 |
+
+## 1. Fresh install
+
+- Uninstall any previous Cognithor.
+- Wipe `~/.cognithor/config.yaml` (or rename it as backup).
+- Run the new installer.
+- Launch Cognithor. Expect: Flutter UI reaches the main screen. No version-
+  mismatch overlay, no config crash.
+
+## 2. Hardware + Docker detection
+
+- Settings → LLM Backends → tap **vLLM**.
+- Expect: Cards 1 and 2 turn green within 2 seconds (the polling interval).
+  Card 1 shows the correct GPU name, VRAM, and compute capability string.
+- If Docker Desktop is not running, start it and wait — Card 2 turns green
+  when ready.
+
+## 3. Image pull
+
+- Tap **Pull image**.
+- Expect: progress bar advances steadily. Total download ~10 GB.
+- Expect: after completion, Card 3 turns green; Card 4 enables.
+
+## 4. Model picker + start (quick path — Qwen2.5-VL-7B)
+
+- Card 4: expect the model dropdown to populate. Qwen2.5-VL-7B is always
+  marked "tested" and should show the star badge for any non-Blackwell GPU.
+- Select it. Tap **Start vLLM**.
+- Expect: within 120 seconds, Card 4 turns green with "Running: Qwen/
+  Qwen2.5-VL-7B-Instruct".
+- Back in the list view, tap vLLM, tap **Make active**.
+
+## 5. End-to-end chat with vision
+
+- Open the chat screen.
+- Attach an image (any PNG) via the paperclip button.
+- Ask: "What do you see in this image?"
+- Expect: answer comes back within 5–10 seconds, describing the image.
+- Close the chat screen and reopen — state persists.
+
+## 6. Fail-flow verification
+
+- In a terminal: `docker stop $(docker ps -q --filter label=cognithor.managed=true)`
+- In Cognithor chat, send a text-only message: "hello"
+  - Expect: within 2–3 requests, the "⚠ vLLM offline — fallback to Ollama
+    active" banner appears. Reply comes from Ollama.
+- Send an image request.
+  - Expect: red error bubble "vLLM offline — cannot process image".
+- In terminal: `docker start <container-id>`
+  - Expect: within ~60 seconds (the CircuitBreaker `recovery_timeout`), the
+    next text request goes through vLLM again; banner dismisses.
+
+## 7. Lifecycle toggles
+
+- Settings → LLM Backends → vLLM → enable "Keep vLLM running after app close"
+- Close Cognithor entirely.
+- Verify: `docker ps | grep cognithor.managed` — container still running.
+- Reopen Cognithor → status shows "Running" immediately (no restart).
+- Disable the toggle. Close Cognithor.
+- Verify: `docker ps | grep cognithor.managed` — no result (container was
+  stopped on shutdown).
+
+## 8. Blackwell-specific (RTX 5090 only)
+
+- Edit `~/.cognithor/config.yaml` → set `vllm.docker_image: "vllm/vllm-openai:nightly"`.
+- Back in the setup screen, pull the nightly image (replaces the old one).
+- Pick `mmangkad/Qwen3.6-27B-NVFP4` (star-badged on Blackwell).
+- Start. Expect: model loads in ~30–60 seconds.
+- Chat with vision. Expect: tokens stream noticeably faster than FP8 on the
+  same hardware (NVFP4 uses native tensor cores).
+
+## Reporting
+
+If any step fails, capture:
+- Contents of `~/.cognithor/log/cognithor.log` (last 200 lines)
+- Output of `docker logs <container-id>`
+- Screenshot of the relevant Flutter screen
+
+File bugs against the `vllm-backend` label on GitHub.

--- a/docs/vllm-user-guide.md
+++ b/docs/vllm-user-guide.md
@@ -1,0 +1,93 @@
+# Enabling the vLLM Backend
+
+Cognithor ships with Ollama as the default local LLM backend — it "just works"
+on any Windows/macOS/Linux machine without further setup. vLLM is an **opt-in**
+alternative for users with an NVIDIA GPU who want faster inference, native FP4
+support (Blackwell / RTX 50xx), or access to models not in the Ollama library.
+
+## Prerequisites
+
+You need:
+
+1. **NVIDIA GPU** with at least 16 GB VRAM. For the best experience:
+   - **RTX 5090 (32 GB)** — unlocks NVFP4 quantization, the fastest option
+   - **RTX 4090 (24 GB)** — runs FP8 quantization
+   - **RTX 4080 / 3090 / 4070 Ti Super (16 GB)** — runs AWQ-INT4 quantization
+2. **NVIDIA driver** installed (any modern version from the last 2 years works)
+3. **Docker Desktop** installed and running. Download from
+   [docker.com](https://www.docker.com/products/docker-desktop). Cognithor will
+   not install it for you — the installer needs admin rights and a reboot,
+   which Cognithor does not handle.
+
+## Enabling vLLM
+
+1. Start Cognithor normally.
+2. Open **Settings → LLM Backends**.
+3. Tap **vLLM**. You will see four status cards:
+   - **NVIDIA GPU** — detected automatically
+   - **Docker Desktop** — detected automatically
+   - **vLLM Docker image** — needs a one-time ~10 GB pull
+   - **Model** — which model to load
+4. If any card is red, fix the underlying issue first (install the missing
+   driver, start Docker Desktop, etc.).
+5. Tap **Pull image** on Card 3. Progress streams live.
+6. Pick a model from Card 4. The star badge (⭐) marks the recommendation for
+   your GPU. Models that don't fit your VRAM or require a newer GPU
+   architecture are disabled with a tooltip explaining why.
+7. Tap **Start vLLM**. First start takes 30–300 seconds depending on model
+   size (weights download from HuggingFace).
+8. Back in the list view, tap your vLLM row and select **Make active** to
+   switch all future chat turns through vLLM.
+
+## Switching Back to Ollama
+
+Settings → LLM Backends → Ollama → **Make active**. The switch is live — no
+restart required. vLLM keeps running in the background unless you enable
+"Stop vLLM on app close" in settings.
+
+## Troubleshooting
+
+**"Version Mismatch" overlay on launch**: the installer bundled a stale
+Flutter build. Install the newer Cognithor release.
+
+**vLLM status card stays red with "No GPU detected"**: run `nvidia-smi` in a
+terminal to confirm your driver works. On WSL2 you need the NVIDIA WSL driver
+bundle from nvidia.com/drivers — not just the standard Windows driver.
+
+**Docker card stays red**: open Docker Desktop, wait for the whale icon to
+stop pulsing (that's the "ready" state).
+
+**Pull fails mid-download**: partial layers are cached. Retry the pull —
+Docker will resume from where it stopped.
+
+**Container starts but /health never answers**: the model is probably still
+loading. Qwen3.6-27B at FP8 takes ~60 s on an RTX 5090, up to 5 minutes on
+slower cards. The setup page shows container logs below the status cards.
+
+**Banner "vLLM offline — fallback to Ollama active"** appears mid-chat: vLLM
+has crashed or become unresponsive for 3 consecutive requests. Text chats
+transparently route through Ollama; image requests will error out until vLLM
+recovers. Check `docker logs <container-id>` for the cause.
+
+**I have a Qwen3.6 model selected but it fails to start**: vLLM stable
+(v0.19.1) does not yet support the Qwen3.6 architecture. Workaround: set
+`config.vllm.docker_image` to `vllm/vllm-openai:nightly` and restart. Cognithor
+will adopt the new image on the next container start.
+
+## Advanced Configuration
+
+`~/.cognithor/config.yaml` section `vllm`:
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `enabled` | `false` | Master on/off |
+| `model` | `""` (auto) | HF repo id. Empty → orchestrator picks best per GPU |
+| `docker_image` | `vllm/vllm-openai:v0.19.1` | Override to bleed-edge |
+| `port` | `8000` | Host port (falls back 8001..8009 if busy) |
+| `auto_stop_on_close` | `false` | Stop container when Cognithor quits |
+| `skip_hardware_check` | `false` | Override for unusual setups |
+| `request_timeout_seconds` | `60` | Per-request timeout |
+
+HF token for gated models: set `huggingface_api_key` at the top level of
+`config.yaml` (or via the OS keyring) — Cognithor passes it to the container
+automatically as `HF_TOKEN`.

--- a/flutter_app/lib/providers/llm_backend_provider.dart
+++ b/flutter_app/lib/providers/llm_backend_provider.dart
@@ -82,6 +82,8 @@ class LlmBackendProvider extends ChangeNotifier {
   String active = 'ollama';
   VLLMStatus? vllmStatus;
   String? error;
+  List<Map<String, dynamic>> availableModels = [];
+  String? recommendedModelId;
 
   bool get isPolling => _pollTimer != null;
 
@@ -201,5 +203,16 @@ class LlmBackendProvider extends ChangeNotifier {
     } else {
       throw Exception('Backend switch failed: ${r.statusCode}');
     }
+  }
+
+  Future<void> fetchAvailableModels() async {
+    final r = await _http.get(
+      Uri.parse('$apiBaseUrl/api/backends/vllm/available-models'),
+    );
+    if (r.statusCode != 200) return;
+    final body = jsonDecode(r.body) as Map<String, dynamic>;
+    recommendedModelId = body['recommended_id'] as String?;
+    availableModels = (body['models'] as List).cast<Map<String, dynamic>>();
+    notifyListeners();
   }
 }

--- a/flutter_app/lib/providers/llm_backend_provider.dart
+++ b/flutter_app/lib/providers/llm_backend_provider.dart
@@ -1,0 +1,157 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+class HardwareInfo {
+  final String gpuName;
+  final int vramGb;
+  final String computeCapability;
+
+  HardwareInfo({
+    required this.gpuName,
+    required this.vramGb,
+    required this.computeCapability,
+  });
+
+  factory HardwareInfo.fromJson(Map<String, dynamic> j) => HardwareInfo(
+        gpuName: j['gpu_name'] as String,
+        vramGb: j['vram_gb'] as int,
+        computeCapability: j['compute_capability'] as String,
+      );
+}
+
+class VLLMStatus {
+  final bool hardwareOk;
+  final HardwareInfo? hardwareInfo;
+  final bool dockerOk;
+  final bool imagePulled;
+  final bool containerRunning;
+  final String? currentModel;
+  final String? lastError;
+
+  VLLMStatus({
+    required this.hardwareOk,
+    required this.hardwareInfo,
+    required this.dockerOk,
+    required this.imagePulled,
+    required this.containerRunning,
+    required this.currentModel,
+    required this.lastError,
+  });
+
+  factory VLLMStatus.fromJson(Map<String, dynamic> j) => VLLMStatus(
+        hardwareOk: j['hardware_ok'] as bool,
+        hardwareInfo: j['hardware_info'] == null
+            ? null
+            : HardwareInfo.fromJson(
+                j['hardware_info'] as Map<String, dynamic>),
+        dockerOk: j['docker_ok'] as bool,
+        imagePulled: j['image_pulled'] as bool,
+        containerRunning: j['container_running'] as bool,
+        currentModel: j['current_model'] as String?,
+        lastError: j['last_error'] as String?,
+      );
+}
+
+class BackendEntry {
+  final String name;
+  final bool enabled;
+  final String status;
+
+  BackendEntry({
+    required this.name,
+    required this.enabled,
+    required this.status,
+  });
+
+  factory BackendEntry.fromJson(Map<String, dynamic> j) => BackendEntry(
+        name: j['name'] as String,
+        enabled: j['enabled'] as bool,
+        status: j['status'] as String,
+      );
+}
+
+class LlmBackendProvider extends ChangeNotifier {
+  final String apiBaseUrl;
+  final http.Client _http;
+  Timer? _pollTimer;
+
+  List<BackendEntry> backends = [];
+  String active = 'ollama';
+  VLLMStatus? vllmStatus;
+  String? error;
+
+  bool get isPolling => _pollTimer != null;
+
+  LlmBackendProvider({required this.apiBaseUrl, http.Client? httpClient})
+      : _http = httpClient ?? http.Client();
+
+  Future<void> refreshList() async {
+    try {
+      final r = await _http.get(Uri.parse('$apiBaseUrl/api/backends'));
+      if (r.statusCode != 200) return;
+      final body = jsonDecode(r.body) as Map<String, dynamic>;
+      active = body['active'] as String;
+      backends = (body['backends'] as List)
+          .map((b) => BackendEntry.fromJson(b as Map<String, dynamic>))
+          .toList();
+      notifyListeners();
+    } catch (e) {
+      error = e.toString();
+      notifyListeners();
+    }
+  }
+
+  Future<void> refreshVllmStatus() async {
+    try {
+      final r =
+          await _http.get(Uri.parse('$apiBaseUrl/api/backends/vllm/status'));
+      if (r.statusCode != 200) return;
+      vllmStatus =
+          VLLMStatus.fromJson(jsonDecode(r.body) as Map<String, dynamic>);
+      notifyListeners();
+    } catch (e) {
+      error = e.toString();
+      notifyListeners();
+    }
+  }
+
+  /// Start polling `/api/backends/vllm/status` every 2 seconds.
+  /// Call from VllmSetupScreen.initState, stop in dispose.
+  void startPolling() {
+    stopPolling();
+    refreshVllmStatus();
+    _pollTimer = Timer.periodic(
+      const Duration(seconds: 2),
+      (_) => refreshVllmStatus(),
+    );
+  }
+
+  void stopPolling() {
+    _pollTimer?.cancel();
+    _pollTimer = null;
+  }
+
+  @override
+  void dispose() {
+    stopPolling();
+    _http.close();
+    super.dispose();
+  }
+
+  Future<void> setActive(String backend) async {
+    final r = await _http.post(
+      Uri.parse('$apiBaseUrl/api/backends/active'),
+      headers: {'content-type': 'application/json'},
+      body: jsonEncode({'backend': backend}),
+    );
+    if (r.statusCode == 200) {
+      active = backend;
+      notifyListeners();
+    } else {
+      throw Exception('Backend switch failed: ${r.statusCode}');
+    }
+  }
+}

--- a/flutter_app/lib/providers/llm_backend_provider.dart
+++ b/flutter_app/lib/providers/llm_backend_provider.dart
@@ -141,6 +141,54 @@ class LlmBackendProvider extends ChangeNotifier {
     super.dispose();
   }
 
+  /// Kick off docker-pull and yield progress events as parsed maps.
+  /// Events: {"status":"Downloading","progressDetail":{"current":N,"total":M},"id":"layer..."}
+  Stream<Map<String, dynamic>> pullImage() async* {
+    final uri = Uri.parse('$apiBaseUrl/api/backends/vllm/pull-image');
+    final request = http.Request('POST', uri);
+    final streamed = await _http.send(request);
+    if (streamed.statusCode != 200) {
+      throw Exception('Pull failed: HTTP ${streamed.statusCode}');
+    }
+    String buffer = '';
+    await for (final chunk in streamed.stream.transform(utf8.decoder)) {
+      buffer += chunk;
+      while (true) {
+        final sep = buffer.indexOf('\n\n');
+        if (sep == -1) break;
+        final block = buffer.substring(0, sep);
+        buffer = buffer.substring(sep + 2);
+        for (final line in block.split('\n')) {
+          if (line.startsWith('data:')) {
+            final payload = line.substring(5).trim();
+            if (payload.isEmpty) continue;
+            try {
+              yield jsonDecode(payload) as Map<String, dynamic>;
+            } catch (_) {
+              // Ignore malformed events
+            }
+          }
+        }
+      }
+    }
+    // Refresh full status after pull completes
+    await refreshVllmStatus();
+  }
+
+  /// POST /api/backends/vllm/start — start a container for the given model.
+  Future<void> startContainer(String model) async {
+    final r = await _http.post(
+      Uri.parse('$apiBaseUrl/api/backends/vllm/start'),
+      headers: {'content-type': 'application/json'},
+      body: jsonEncode({'model': model}),
+    );
+    if (r.statusCode != 200) {
+      final body = jsonDecode(r.body);
+      throw Exception(body['detail']?['message'] ?? 'Start failed');
+    }
+    await refreshVllmStatus();
+  }
+
   Future<void> setActive(String backend) async {
     final r = await _http.post(
       Uri.parse('$apiBaseUrl/api/backends/active'),

--- a/flutter_app/lib/screens/llm_backends_screen.dart
+++ b/flutter_app/lib/screens/llm_backends_screen.dart
@@ -1,0 +1,89 @@
+import 'package:cognithor_ui/providers/llm_backend_provider.dart';
+import 'package:cognithor_ui/screens/vllm_setup_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+class LlmBackendsScreen extends StatefulWidget {
+  const LlmBackendsScreen({super.key});
+
+  @override
+  State<LlmBackendsScreen> createState() => _LlmBackendsScreenState();
+}
+
+class _LlmBackendsScreenState extends State<LlmBackendsScreen> {
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      context.read<LlmBackendProvider>().refreshList();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final p = context.watch<LlmBackendProvider>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('LLM Backends')),
+      body: ListView.builder(
+        itemCount: p.backends.length,
+        itemBuilder: (ctx, i) {
+          final b = p.backends[i];
+          final isActive = p.active == b.name;
+          return ListTile(
+            leading: Icon(
+              b.status == 'ready' ? Icons.circle : Icons.circle_outlined,
+              color: b.status == 'ready' ? Colors.green : Colors.grey,
+              size: 14,
+            ),
+            title: Text(_displayName(b.name)),
+            subtitle: Text(_statusLine(b)),
+            trailing: isActive
+                ? Container(
+                    key: ValueKey('backend-${b.name}-active'),
+                    padding: const EdgeInsets.symmetric(
+                      horizontal: 8,
+                      vertical: 4,
+                    ),
+                    decoration: BoxDecoration(
+                      color: Theme.of(ctx)
+                          .colorScheme
+                          .primary
+                          .withValues(alpha: 0.2),
+                      borderRadius: BorderRadius.circular(4),
+                    ),
+                    child: const Text('Active', style: TextStyle(fontSize: 11)),
+                  )
+                : const Icon(Icons.chevron_right),
+            onTap: () {
+              if (b.name == 'vllm') {
+                Navigator.of(ctx).push(MaterialPageRoute(
+                  builder: (_) => const VllmSetupScreen(),
+                ));
+              }
+            },
+          );
+        },
+      ),
+    );
+  }
+
+  static String _displayName(String name) {
+    switch (name) {
+      case 'ollama':
+        return 'Ollama';
+      case 'vllm':
+        return 'vLLM';
+      case 'openai':
+        return 'OpenAI';
+      case 'anthropic':
+        return 'Anthropic';
+      default:
+        return name;
+    }
+  }
+
+  static String _statusLine(BackendEntry b) {
+    if (!b.enabled) return 'Disabled';
+    return b.status;
+  }
+}

--- a/flutter_app/lib/screens/vllm_setup_screen.dart
+++ b/flutter_app/lib/screens/vllm_setup_screen.dart
@@ -1,0 +1,10 @@
+import 'package:flutter/material.dart';
+
+class VllmSetupScreen extends StatelessWidget {
+  const VllmSetupScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(body: Center(child: Text('vLLM setup — stub')));
+  }
+}

--- a/flutter_app/lib/screens/vllm_setup_screen.dart
+++ b/flutter_app/lib/screens/vllm_setup_screen.dart
@@ -1,10 +1,213 @@
+import 'package:cognithor_ui/providers/llm_backend_provider.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-class VllmSetupScreen extends StatelessWidget {
+class VllmSetupScreen extends StatefulWidget {
   const VllmSetupScreen({super.key});
 
   @override
+  State<VllmSetupScreen> createState() => _VllmSetupScreenState();
+}
+
+class _VllmSetupScreenState extends State<VllmSetupScreen> {
+  LlmBackendProvider? _provider;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      _provider = context.read<LlmBackendProvider>();
+      _provider!.startPolling();
+    });
+  }
+
+  @override
+  void dispose() {
+    _provider?.stopPolling();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const Scaffold(body: Center(child: Text('vLLM setup — stub')));
+    final p = context.watch<LlmBackendProvider>();
+    final s = p.vllmStatus;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Configure vLLM')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _HardwareCard(status: s),
+          const SizedBox(height: 12),
+          _DockerCard(status: s),
+          const SizedBox(height: 12),
+          _ImageCard(status: s),
+          const SizedBox(height: 12),
+          _ModelCard(status: s),
+        ],
+      ),
+    );
+  }
+}
+
+enum _CardState { ok, todo, pending, error }
+
+Color _colorFor(_CardState st, BuildContext ctx) {
+  switch (st) {
+    case _CardState.ok:
+      return Colors.green;
+    case _CardState.todo:
+      return Colors.orange;
+    case _CardState.pending:
+      return Theme.of(ctx).colorScheme.outline;
+    case _CardState.error:
+      return Colors.red;
+  }
+}
+
+IconData _iconFor(_CardState st) {
+  switch (st) {
+    case _CardState.ok:
+      return Icons.check_circle;
+    case _CardState.todo:
+      return Icons.radio_button_unchecked;
+    case _CardState.pending:
+      return Icons.more_horiz;
+    case _CardState.error:
+      return Icons.error;
+  }
+}
+
+class _StatusCard extends StatelessWidget {
+  final String title;
+  final String subtitle;
+  final _CardState state;
+  final Widget? action;
+  final ValueKey<String> cardKey;
+
+  const _StatusCard({
+    required this.title,
+    required this.subtitle,
+    required this.state,
+    required this.cardKey,
+    this.action,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      key: cardKey,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(8),
+        side: BorderSide(color: _colorFor(state, context), width: 1),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Row(
+          children: [
+            Icon(_iconFor(state), color: _colorFor(state, context)),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(title,
+                      style: const TextStyle(fontWeight: FontWeight.w600)),
+                  const SizedBox(height: 2),
+                  Text(
+                    subtitle,
+                    style:
+                        const TextStyle(fontSize: 12, color: Colors.grey),
+                  ),
+                ],
+              ),
+            ),
+            if (action != null) action!,
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _HardwareCard extends StatelessWidget {
+  final VLLMStatus? status;
+  const _HardwareCard({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final hw = status?.hardwareInfo;
+    final ok = status?.hardwareOk ?? false;
+    return _StatusCard(
+      cardKey: const ValueKey('card-hardware'),
+      title: 'NVIDIA GPU',
+      subtitle: hw == null
+          ? 'Not detected'
+          : '${hw.gpuName}, ${hw.vramGb} GB, SM ${hw.computeCapability}',
+      state: ok ? _CardState.ok : _CardState.error,
+    );
+  }
+}
+
+class _DockerCard extends StatelessWidget {
+  final VLLMStatus? status;
+  const _DockerCard({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final ok = status?.dockerOk ?? false;
+    return _StatusCard(
+      cardKey: const ValueKey('card-docker'),
+      title: 'Docker Desktop',
+      subtitle: ok ? 'Running' : 'Not running — start Docker Desktop',
+      state: ok ? _CardState.ok : _CardState.todo,
+    );
+  }
+}
+
+class _ImageCard extends StatelessWidget {
+  final VLLMStatus? status;
+  const _ImageCard({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final pulled = status?.imagePulled ?? false;
+    return _StatusCard(
+      cardKey: const ValueKey('card-image'),
+      title: 'vLLM Docker image',
+      subtitle: pulled
+          ? 'vllm/vllm-openai:v0.19.1 ready'
+          : 'Pull required (~10 GB, one-time)',
+      state: pulled ? _CardState.ok : _CardState.todo,
+      action: pulled
+          ? null
+          : FilledButton.tonal(
+              onPressed: () {}, // wired up in Task 28 (SSE progress)
+              child: const Text('Pull image'),
+            ),
+    );
+  }
+}
+
+class _ModelCard extends StatelessWidget {
+  final VLLMStatus? status;
+  const _ModelCard({required this.status});
+
+  @override
+  Widget build(BuildContext context) {
+    final running = status?.containerRunning ?? false;
+    final model = status?.currentModel;
+    final imagePulled = status?.imagePulled ?? false;
+    return _StatusCard(
+      cardKey: const ValueKey('card-model'),
+      title: 'Model',
+      subtitle: running
+          ? 'Running: ${model ?? 'unknown'}'
+          : 'Pick a model to start',
+      state: running
+          ? _CardState.ok
+          : (imagePulled ? _CardState.todo : _CardState.pending),
+    );
   }
 }

--- a/flutter_app/lib/screens/vllm_setup_screen.dart
+++ b/flutter_app/lib/screens/vllm_setup_screen.dart
@@ -239,24 +239,126 @@ class _ImageCardState extends State<_ImageCard> {
   }
 }
 
-class _ModelCard extends StatelessWidget {
+class _ModelCard extends StatefulWidget {
   final VLLMStatus? status;
   const _ModelCard({required this.status});
 
   @override
+  State<_ModelCard> createState() => _ModelCardState();
+}
+
+class _ModelCardState extends State<_ModelCard> {
+  String? _selected;
+  bool _starting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (mounted) context.read<LlmBackendProvider>().fetchAvailableModels();
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final running = status?.containerRunning ?? false;
-    final model = status?.currentModel;
-    final imagePulled = status?.imagePulled ?? false;
-    return _StatusCard(
-      cardKey: const ValueKey('card-model'),
-      title: 'Model',
-      subtitle: running
-          ? 'Running: ${model ?? 'unknown'}'
-          : 'Pick a model to start',
-      state: running
-          ? _CardState.ok
-          : (imagePulled ? _CardState.todo : _CardState.pending),
+    final p = context.watch<LlmBackendProvider>();
+    final running = widget.status?.containerRunning ?? false;
+    final pulled = widget.status?.imagePulled ?? false;
+
+    if (running) {
+      return _StatusCard(
+        cardKey: const ValueKey('card-model'),
+        title: 'Model',
+        subtitle: 'Running: ${widget.status?.currentModel ?? "unknown"}',
+        state: _CardState.ok,
+      );
+    }
+
+    if (!pulled) {
+      return const _StatusCard(
+        cardKey: ValueKey('card-model'),
+        title: 'Model',
+        subtitle: 'Available after image pull',
+        state: _CardState.pending,
+      );
+    }
+
+    final models = p.availableModels;
+    final recommendedId = p.recommendedModelId;
+    _selected ??=
+        recommendedId ?? (models.isNotEmpty ? models[0]['id'] as String : null);
+
+    return Card(
+      key: const ValueKey('card-model'),
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Model',
+              style: TextStyle(fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 8),
+            DropdownButton<String>(
+              value: _selected,
+              isExpanded: true,
+              onChanged: (v) => setState(() => _selected = v),
+              items: [
+                for (final m in models)
+                  DropdownMenuItem<String>(
+                    value: m['id'] as String,
+                    enabled: m['fits'] as bool,
+                    child: Row(
+                      children: [
+                        if (m['id'] == recommendedId)
+                          const Padding(
+                            padding: EdgeInsets.only(right: 6),
+                            child: Icon(
+                              Icons.star,
+                              size: 14,
+                              color: Colors.amber,
+                            ),
+                          ),
+                        Expanded(child: Text(m['display_name'] as String)),
+                        Text(
+                          '${m['vram_gb_min']} GB',
+                          style: TextStyle(
+                            fontSize: 11,
+                            color: (m['fits'] as bool)
+                                ? Colors.grey
+                                : Colors.red,
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            FilledButton(
+              onPressed: _starting || _selected == null
+                  ? null
+                  : () async {
+                      setState(() => _starting = true);
+                      final messenger = ScaffoldMessenger.of(context);
+                      try {
+                        await p.startContainer(_selected!);
+                      } catch (e) {
+                        if (mounted) {
+                          messenger.showSnackBar(
+                            SnackBar(content: Text('Start failed: $e')),
+                          );
+                        }
+                      } finally {
+                        if (mounted) setState(() => _starting = false);
+                      }
+                    },
+              child: Text(_starting ? 'Starting\u2026' : 'Start vLLM'),
+            ),
+          ],
+        ),
+      ),
     );
   }
 }

--- a/flutter_app/lib/screens/vllm_setup_screen.dart
+++ b/flutter_app/lib/screens/vllm_setup_screen.dart
@@ -166,26 +166,75 @@ class _DockerCard extends StatelessWidget {
   }
 }
 
-class _ImageCard extends StatelessWidget {
+class _ImageCard extends StatefulWidget {
   final VLLMStatus? status;
   const _ImageCard({required this.status});
 
   @override
+  State<_ImageCard> createState() => _ImageCardState();
+}
+
+class _ImageCardState extends State<_ImageCard> {
+  double? _progress;
+  String? _layer;
+  bool _pulling = false;
+
+  Future<void> _pull() async {
+    setState(() {
+      _pulling = true;
+      _progress = null;
+      _layer = null;
+    });
+    try {
+      final p = context.read<LlmBackendProvider>();
+      await for (final ev in p.pullImage()) {
+        final detail = ev['progressDetail'] as Map<String, dynamic>?;
+        final current = detail?['current'] as int?;
+        final total = detail?['total'] as int?;
+        if (current != null && total != null && total > 0) {
+          setState(() {
+            _progress = current / total;
+            _layer = ev['id'] as String?;
+          });
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Pull failed: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => _pulling = false);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final pulled = status?.imagePulled ?? false;
+    final pulled = widget.status?.imagePulled ?? false;
     return _StatusCard(
       cardKey: const ValueKey('card-image'),
       title: 'vLLM Docker image',
       subtitle: pulled
           ? 'vllm/vllm-openai:v0.19.1 ready'
-          : 'Pull required (~10 GB, one-time)',
-      state: pulled ? _CardState.ok : _CardState.todo,
+          : _pulling
+              ? 'Downloading${_layer != null ? " layer ${_layer!.length >= 12 ? _layer!.substring(0, 12) : _layer!}..." : "…"}'
+              : 'Pull required (~10 GB, one-time)',
+      state: pulled
+          ? _CardState.ok
+          : _pulling
+              ? _CardState.pending
+              : _CardState.todo,
       action: pulled
           ? null
-          : FilledButton.tonal(
-              onPressed: () {}, // wired up in Task 28 (SSE progress)
-              child: const Text('Pull image'),
-            ),
+          : _pulling
+              ? SizedBox(
+                  width: 100,
+                  child: LinearProgressIndicator(value: _progress),
+                )
+              : FilledButton.tonal(
+                  onPressed: _pull,
+                  child: const Text('Pull image'),
+                ),
     );
   }
 }

--- a/flutter_app/test/providers/llm_backend_provider_test.dart
+++ b/flutter_app/test/providers/llm_backend_provider_test.dart
@@ -1,0 +1,47 @@
+import 'package:cognithor_ui/providers/llm_backend_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('LlmBackendProvider', () {
+    test('initial state has empty backends and not polling', () {
+      final p = LlmBackendProvider(apiBaseUrl: 'http://localhost:8741');
+      expect(p.backends, isEmpty);
+      expect(p.vllmStatus, isNull);
+      expect(p.isPolling, isFalse);
+    });
+
+    test('startPolling sets isPolling true', () {
+      final p = LlmBackendProvider(apiBaseUrl: 'http://localhost:8741');
+      p.startPolling();
+      expect(p.isPolling, isTrue);
+      p.stopPolling();
+    });
+
+    test('stopPolling resets', () {
+      final p = LlmBackendProvider(apiBaseUrl: 'http://localhost:8741');
+      p.startPolling();
+      p.stopPolling();
+      expect(p.isPolling, isFalse);
+    });
+
+    test('VLLMStatus.fromJson parses API payload', () {
+      final status = VLLMStatus.fromJson({
+        'hardware_ok': true,
+        'hardware_info': {
+          'gpu_name': 'RTX 5090',
+          'vram_gb': 32,
+          'compute_capability': '12.0',
+        },
+        'docker_ok': true,
+        'image_pulled': false,
+        'container_running': false,
+        'current_model': null,
+        'last_error': null,
+      });
+      expect(status.hardwareOk, isTrue);
+      expect(status.hardwareInfo?.gpuName, 'RTX 5090');
+      expect(status.hardwareInfo?.vramGb, 32);
+      expect(status.hardwareInfo?.computeCapability, '12.0');
+    });
+  });
+}

--- a/flutter_app/test/providers/llm_backend_provider_test.dart
+++ b/flutter_app/test/providers/llm_backend_provider_test.dart
@@ -43,5 +43,17 @@ void main() {
       expect(status.hardwareInfo?.vramGb, 32);
       expect(status.hardwareInfo?.computeCapability, '12.0');
     });
+
+    test('pullImage method exists on provider', () {
+      final p = LlmBackendProvider(apiBaseUrl: 'http://test');
+      // Real SSE integration is covered server-side (Python test_vllm_fake_server.py).
+      // Flutter side only verifies the surface: method is callable and returns a Stream.
+      expect(p.pullImage, isA<Function>());
+    });
+
+    test('startContainer method exists on provider', () {
+      final p = LlmBackendProvider(apiBaseUrl: 'http://test');
+      expect(p.startContainer, isA<Function>());
+    });
   });
 }

--- a/flutter_app/test/widgets/llm_backends_screen_test.dart
+++ b/flutter_app/test/widgets/llm_backends_screen_test.dart
@@ -1,0 +1,47 @@
+import 'package:cognithor_ui/providers/llm_backend_provider.dart';
+import 'package:cognithor_ui/screens/llm_backends_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+LlmBackendProvider _mkProvider(List<BackendEntry> backends, String active) {
+  final p = LlmBackendProvider(apiBaseUrl: 'http://test');
+  p.backends = backends;
+  p.active = active;
+  return p;
+}
+
+void main() {
+  testWidgets('renders all backends with status dots', (tester) async {
+    final provider = _mkProvider([
+      BackendEntry(name: 'ollama', enabled: true, status: 'ready'),
+      BackendEntry(name: 'vllm', enabled: false, status: 'disabled'),
+    ], 'ollama');
+
+    await tester.pumpWidget(MaterialApp(
+      home: ChangeNotifierProvider<LlmBackendProvider>.value(
+        value: provider,
+        child: const LlmBackendsScreen(),
+      ),
+    ));
+
+    expect(find.text('Ollama'), findsOneWidget);
+    expect(find.text('vLLM'), findsOneWidget);
+  });
+
+  testWidgets('active backend has a visual marker', (tester) async {
+    final provider = _mkProvider([
+      BackendEntry(name: 'ollama', enabled: true, status: 'ready'),
+      BackendEntry(name: 'vllm', enabled: true, status: 'ready'),
+    ], 'vllm');
+
+    await tester.pumpWidget(MaterialApp(
+      home: ChangeNotifierProvider<LlmBackendProvider>.value(
+        value: provider,
+        child: const LlmBackendsScreen(),
+      ),
+    ));
+
+    expect(find.byKey(const ValueKey('backend-vllm-active')), findsOneWidget);
+  });
+}

--- a/flutter_app/test/widgets/vllm_setup_screen_test.dart
+++ b/flutter_app/test/widgets/vllm_setup_screen_test.dart
@@ -1,0 +1,88 @@
+import 'package:cognithor_ui/providers/llm_backend_provider.dart';
+import 'package:cognithor_ui/screens/vllm_setup_screen.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+LlmBackendProvider _mkProvider(VLLMStatus? s) {
+  final p = LlmBackendProvider(apiBaseUrl: 'http://test');
+  p.vllmStatus = s;
+  return p;
+}
+
+void main() {
+  testWidgets('all four status cards are rendered', (tester) async {
+    final provider = _mkProvider(VLLMStatus(
+      hardwareOk: false,
+      hardwareInfo: null,
+      dockerOk: false,
+      imagePulled: false,
+      containerRunning: false,
+      currentModel: null,
+      lastError: null,
+    ));
+
+    await tester.pumpWidget(MaterialApp(
+      home: ChangeNotifierProvider<LlmBackendProvider>.value(
+        value: provider,
+        child: const VllmSetupScreen(),
+      ),
+    ));
+
+    expect(find.byKey(const ValueKey('card-hardware')), findsOneWidget);
+    expect(find.byKey(const ValueKey('card-docker')), findsOneWidget);
+    expect(find.byKey(const ValueKey('card-image')), findsOneWidget);
+    expect(find.byKey(const ValueKey('card-model')), findsOneWidget);
+  });
+
+  testWidgets('hardware card shows GPU name when detected', (tester) async {
+    final provider = _mkProvider(VLLMStatus(
+      hardwareOk: true,
+      hardwareInfo: HardwareInfo(
+        gpuName: 'RTX 5090',
+        vramGb: 32,
+        computeCapability: '12.0',
+      ),
+      dockerOk: true,
+      imagePulled: false,
+      containerRunning: false,
+      currentModel: null,
+      lastError: null,
+    ));
+
+    await tester.pumpWidget(MaterialApp(
+      home: ChangeNotifierProvider<LlmBackendProvider>.value(
+        value: provider,
+        child: const VllmSetupScreen(),
+      ),
+    ));
+
+    expect(find.textContaining('RTX 5090'), findsOneWidget);
+    expect(find.textContaining('32 GB'), findsOneWidget);
+  });
+
+  testWidgets('image card shows pull button when pending', (tester) async {
+    final provider = _mkProvider(VLLMStatus(
+      hardwareOk: true,
+      hardwareInfo: HardwareInfo(
+        gpuName: 'RTX 5090',
+        vramGb: 32,
+        computeCapability: '12.0',
+      ),
+      dockerOk: true,
+      imagePulled: false,
+      containerRunning: false,
+      currentModel: null,
+      lastError: null,
+    ));
+
+    await tester.pumpWidget(MaterialApp(
+      home: ChangeNotifierProvider<LlmBackendProvider>.value(
+        value: provider,
+        child: const VllmSetupScreen(),
+      ),
+    ));
+
+    expect(find.text('Pull image'), findsOneWidget);
+  });
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dev = [
     "pytest>=8.0,<9",
     "pytest-asyncio>=0.24,<1",
     "pytest-cov>=6.0,<7",
+    "pytest-httpx>=0.30",
     "hypothesis>=6.0,<7",
     "ruff>=0.9,<1",
     "mypy>=1.14,<2",

--- a/src/cognithor/channels/api.py
+++ b/src/cognithor/channels/api.py
@@ -331,6 +331,15 @@ class APIChannel(Channel):
                 future.set_result(resp.approved)
             return {"status": "processed"}
 
+        # Include the backends router for LLM-backend management endpoints
+        try:
+            from cognithor.channels.backends_api import backends_router as _backends_router
+
+            app.include_router(_backends_router)
+            app.state.config = self._config if hasattr(self, "_config") else None
+        except Exception as exc:
+            log.warning("backends_router_include_failed", error=str(exc))
+
         return app
 
     @property

--- a/src/cognithor/channels/backends_api.py
+++ b/src/cognithor/channels/backends_api.py
@@ -1,0 +1,102 @@
+"""FastAPI router for LLM-backend management endpoints.
+
+Exposes GET /api/backends, GET /api/backends/vllm/status and related routes
+used by the Flutter "LLM Backends" settings screen. Separated from the
+main APIChannel app so it can be included or tested independently.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, FastAPI, Request
+
+if TYPE_CHECKING:
+    from cognithor.config import CognithorConfig
+    from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+
+
+backends_router = APIRouter(prefix="/api/backends", tags=["backends"])
+
+# Module-level orchestrator singleton. Reset across app builds by wiring
+# through app.state.config → build_backends_app().
+_orchestrator_cache: dict[int, VLLMOrchestrator] = {}
+
+
+def _get_orchestrator(config: CognithorConfig) -> VLLMOrchestrator:
+    """Lazy-initialized singleton keyed by config id. Same config → same orchestrator."""
+    from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+
+    key = id(config)
+    if key not in _orchestrator_cache:
+        _orchestrator_cache[key] = VLLMOrchestrator(
+            docker_image=config.vllm.docker_image,
+            port=config.vllm.port,
+            hf_token=config.huggingface_api_key,
+        )
+    return _orchestrator_cache[key]
+
+
+@backends_router.get("")
+async def list_backends(request: Request) -> dict:
+    """Return every configured backend with its current readiness."""
+    config: CognithorConfig = request.app.state.config
+    backends = [
+        {
+            "name": "ollama",
+            "enabled": config.llm_backend_type == "ollama",
+            "status": "ready",
+        }
+    ]
+    orch = _get_orchestrator(config)
+    st = orch.status()
+    if st.container_running:
+        vllm_status = "ready"
+    elif config.vllm.enabled:
+        vllm_status = "configured"
+    else:
+        vllm_status = "disabled"
+    backends.append(
+        {
+            "name": "vllm",
+            "enabled": config.vllm.enabled,
+            "status": vllm_status,
+        }
+    )
+    return {"active": config.llm_backend_type, "backends": backends}
+
+
+@backends_router.get("/vllm/status")
+async def vllm_status(request: Request) -> dict:
+    """Return the current VLLMState as JSON for the Flutter setup page."""
+    config: CognithorConfig = request.app.state.config
+    orch = _get_orchestrator(config)
+    st = orch.status()
+    hw = None
+    if st.hardware_info:
+        hw = {
+            "gpu_name": st.hardware_info.gpu_name,
+            "vram_gb": st.hardware_info.vram_gb,
+            "compute_capability": st.hardware_info.sm_string,
+        }
+    return {
+        "hardware_ok": st.hardware_ok,
+        "hardware_info": hw,
+        "docker_ok": st.docker_ok,
+        "image_pulled": st.image_pulled,
+        "container_running": st.container_running,
+        "current_model": st.current_model,
+        "last_error": st.last_error,
+    }
+
+
+def build_backends_app(*, config: CognithorConfig) -> FastAPI:
+    """Minimal FastAPI app exposing just the backends router.
+
+    Used by tests. In production the router is included directly in the
+    APIChannel's main app.
+    """
+    app = FastAPI()
+    app.state.config = config
+    app.include_router(backends_router)
+    return app

--- a/src/cognithor/channels/backends_api.py
+++ b/src/cognithor/channels/backends_api.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from fastapi import APIRouter, FastAPI, Request
+from fastapi import APIRouter, FastAPI, HTTPException, Request
+from pydantic import BaseModel
 
 if TYPE_CHECKING:
     from cognithor.config import CognithorConfig
@@ -17,6 +18,11 @@ if TYPE_CHECKING:
 
 
 backends_router = APIRouter(prefix="/api/backends", tags=["backends"])
+
+
+class StartRequest(BaseModel):
+    model: str
+
 
 # Module-level orchestrator singleton. Reset across app builds by wiring
 # through app.state.config → build_backends_app().
@@ -88,6 +94,71 @@ async def vllm_status(request: Request) -> dict:
         "current_model": st.current_model,
         "last_error": st.last_error,
     }
+
+
+@backends_router.post("/vllm/check-hardware")
+async def check_hardware_endpoint(request: Request) -> dict:
+    config: CognithorConfig = request.app.state.config
+    orch = _get_orchestrator(config)
+    try:
+        info = orch.check_hardware()
+    except Exception as exc:
+        from cognithor.core.llm_backend import VLLMHardwareError
+
+        if isinstance(exc, VLLMHardwareError):
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "message": str(exc),
+                    "recovery_hint": exc.recovery_hint,
+                },
+            ) from exc
+        raise HTTPException(status_code=500, detail={"message": str(exc)}) from exc
+    return {
+        "gpu_name": info.gpu_name,
+        "vram_gb": info.vram_gb,
+        "compute_capability": info.sm_string,
+    }
+
+
+@backends_router.post("/vllm/start")
+async def vllm_start(request: Request, body: StartRequest) -> dict:
+    config: CognithorConfig = request.app.state.config
+    orch = _get_orchestrator(config)
+    try:
+        info = orch.start_container(body.model)
+    except Exception as exc:
+        from cognithor.core.llm_backend import VLLMNotReadyError
+
+        if isinstance(exc, VLLMNotReadyError):
+            raise HTTPException(
+                status_code=503,
+                detail={
+                    "message": str(exc),
+                    "recovery_hint": getattr(exc, "recovery_hint", ""),
+                },
+            ) from exc
+        raise HTTPException(status_code=500, detail={"message": str(exc)}) from exc
+    return {
+        "container_id": info.container_id,
+        "port": info.port,
+        "model": info.model,
+    }
+
+
+@backends_router.post("/vllm/stop")
+async def vllm_stop(request: Request) -> dict:
+    config: CognithorConfig = request.app.state.config
+    orch = _get_orchestrator(config)
+    orch.stop_container()
+    return {"status": "stopped"}
+
+
+@backends_router.get("/vllm/logs")
+async def vllm_logs(request: Request) -> dict:
+    config: CognithorConfig = request.app.state.config
+    orch = _get_orchestrator(config)
+    return {"lines": orch.get_logs()}
 
 
 def build_backends_app(*, config: CognithorConfig) -> FastAPI:

--- a/src/cognithor/channels/backends_api.py
+++ b/src/cognithor/channels/backends_api.py
@@ -201,6 +201,61 @@ async def vllm_logs(request: Request) -> dict:
     return {"lines": orch.get_logs()}
 
 
+@backends_router.get("/vllm/available-models")
+async def vllm_available_models(request: Request) -> dict:
+    """Return the curated vLLM model registry filtered against detected hardware.
+
+    Response shape:
+        {
+          "recommended_id": "<model id or null>",
+          "models": [ {<ModelEntry fields>, "fits": bool}, ... ]
+        }
+    """
+    import json as _json
+    from pathlib import Path
+
+    from cognithor.core.vllm_orchestrator import ModelEntry
+
+    config: CognithorConfig = request.app.state.config
+    orch = _get_orchestrator(config)
+
+    registry_path = Path(__file__).resolve().parents[1] / "cli" / "model_registry.json"
+    registry_data = _json.loads(registry_path.read_text(encoding="utf-8"))
+    entries = [ModelEntry.from_dict(m) for m in registry_data["providers"]["vllm"]["models"]]
+
+    hw = orch.state.hardware_info
+    if hw is None:
+        try:
+            hw = orch.check_hardware()
+        except Exception:
+            hw = None
+
+    recommended_id: str | None = None
+    fits_ids: set[str] = set()
+    if hw is not None:
+        best = orch.recommend_model(hw, entries)
+        recommended_id = best.id if best else None
+        fits_ids = {m.id for m in orch.filter_registry(hw, entries)}
+
+    return {
+        "recommended_id": recommended_id,
+        "models": [
+            {
+                "id": e.id,
+                "display_name": e.display_name,
+                "quantization": e.quantization,
+                "vram_gb_min": e.vram_gb_min,
+                "min_compute_capability": e.min_compute_capability,
+                "priority": e.priority,
+                "tested": e.tested,
+                "notes": e.notes,
+                "fits": e.id in fits_ids,
+            }
+            for e in entries
+        ],
+    }
+
+
 @backends_router.post("/vllm/pull-image")
 async def vllm_pull_image(request: Request) -> StreamingResponse:
     """Stream docker-pull progress to the client as SSE."""

--- a/src/cognithor/channels/backends_api.py
+++ b/src/cognithor/channels/backends_api.py
@@ -7,9 +7,12 @@ main APIChannel app so it can be included or tested independently.
 
 from __future__ import annotations
 
+import asyncio
+import json as _json
 from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 if TYPE_CHECKING:
@@ -159,6 +162,42 @@ async def vllm_logs(request: Request) -> dict:
     config: CognithorConfig = request.app.state.config
     orch = _get_orchestrator(config)
     return {"lines": orch.get_logs()}
+
+
+@backends_router.post("/vllm/pull-image")
+async def vllm_pull_image(request: Request) -> StreamingResponse:
+    """Stream docker-pull progress to the client as SSE."""
+    config: CognithorConfig = request.app.state.config
+    orch = _get_orchestrator(config)
+
+    queue: asyncio.Queue[dict | None] = asyncio.Queue()
+
+    def progress_cb(event: dict) -> None:
+        queue.put_nowait(event)
+
+    async def worker() -> None:
+        """Run the blocking pull_image in a thread, enqueue events, sentinel at end."""
+        try:
+            await asyncio.to_thread(
+                orch.pull_image,
+                config.vllm.docker_image,
+                progress_callback=progress_cb,
+            )
+        finally:
+            queue.put_nowait(None)
+
+    async def event_stream():
+        task = asyncio.create_task(worker())
+        try:
+            while True:
+                event = await queue.get()
+                if event is None:
+                    break
+                yield f"data: {_json.dumps(event)}\n\n"
+        finally:
+            await task
+
+    return StreamingResponse(event_stream(), media_type="text/event-stream")
 
 
 def build_backends_app(*, config: CognithorConfig) -> FastAPI:

--- a/src/cognithor/channels/backends_api.py
+++ b/src/cognithor/channels/backends_api.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json as _json
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from fastapi import APIRouter, FastAPI, HTTPException, Request
 from fastapi.responses import StreamingResponse
@@ -25,6 +25,30 @@ backends_router = APIRouter(prefix="/api/backends", tags=["backends"])
 
 class StartRequest(BaseModel):
     model: str
+
+
+class SetActiveRequest(BaseModel):
+    backend: Literal[
+        "ollama",
+        "openai",
+        "anthropic",
+        "gemini",
+        "groq",
+        "deepseek",
+        "mistral",
+        "together",
+        "openrouter",
+        "xai",
+        "cerebras",
+        "github",
+        "bedrock",
+        "huggingface",
+        "moonshot",
+        "lmstudio",
+        "vllm",
+        "llama_cpp",
+        "claude-code",
+    ]
 
 
 # Module-level orchestrator singleton. Reset across app builds by wiring
@@ -157,6 +181,19 @@ async def vllm_stop(request: Request) -> dict:
     return {"status": "stopped"}
 
 
+@backends_router.post("/active")
+async def set_active_backend(request: Request, body: SetActiveRequest) -> dict:
+    """Switch the active LLM backend and re-init UnifiedLLMClient."""
+    gateway = request.app.state.gateway
+    if gateway is None:
+        raise HTTPException(
+            status_code=503,
+            detail={"message": "Gateway not wired — backend switching not available"},
+        )
+    gateway.rebuild_llm_client(body.backend)
+    return {"active": body.backend}
+
+
 @backends_router.get("/vllm/logs")
 async def vllm_logs(request: Request) -> dict:
     config: CognithorConfig = request.app.state.config
@@ -200,7 +237,11 @@ async def vllm_pull_image(request: Request) -> StreamingResponse:
     return StreamingResponse(event_stream(), media_type="text/event-stream")
 
 
-def build_backends_app(*, config: CognithorConfig) -> FastAPI:
+def build_backends_app(
+    *,
+    config: CognithorConfig,
+    gateway: object | None = None,
+) -> FastAPI:
     """Minimal FastAPI app exposing just the backends router.
 
     Used by tests. In production the router is included directly in the
@@ -208,5 +249,6 @@ def build_backends_app(*, config: CognithorConfig) -> FastAPI:
     """
     app = FastAPI()
     app.state.config = config
+    app.state.gateway = gateway
     app.include_router(backends_router)
     return app

--- a/src/cognithor/cli/model_registry.json
+++ b/src/cognithor/cli/model_registry.json
@@ -75,6 +75,76 @@
       "models": [
         "claude-sonnet-4"
       ]
+    },
+    "vllm": {
+      "description": "Vision-language models tested against vLLM. Entries include quantization format, min CUDA compute capability, and min vLLM version required.",
+      "models": [
+        {
+          "id": "mmangkad/Qwen3.6-27B-NVFP4",
+          "display_name": "Qwen3.6-27B · NVFP4 (Blackwell-native)",
+          "base_model": "Qwen/Qwen3.6-27B",
+          "quantization": "NVFP4",
+          "vram_gb_min": 14,
+          "min_compute_capability": "12.0",
+          "min_vllm_version": "pending",
+          "capability": "vision",
+          "priority": "premium",
+          "tested": false,
+          "notes": "Fastest option on RTX 50xx / Blackwell. Uses native FP4 tensor cores (~2x FP8 throughput). Built with NVIDIA ModelOpt toolkit. Recommended default for RTX 5090."
+        },
+        {
+          "id": "Qwen/Qwen3.6-27B-FP8",
+          "display_name": "Qwen3.6-27B · FP8 (official)",
+          "base_model": "Qwen/Qwen3.6-27B",
+          "quantization": "FP8",
+          "vram_gb_min": 32,
+          "min_compute_capability": "8.9",
+          "min_vllm_version": "pending",
+          "capability": "vision",
+          "priority": "premium",
+          "tested": false,
+          "notes": "Official Qwen FP8 block-128 quantization. Near-identical quality to bf16. Needs RTX 4090 (24 GB) with tight KV budget, RTX 5090 (32 GB), or workstation GPU."
+        },
+        {
+          "id": "cyankiwi/Qwen3.6-27B-AWQ-INT4",
+          "display_name": "Qwen3.6-27B · AWQ-INT4 (community)",
+          "base_model": "Qwen/Qwen3.6-27B",
+          "quantization": "AWQ-INT4",
+          "vram_gb_min": 16,
+          "min_compute_capability": "8.0",
+          "min_vllm_version": "pending",
+          "capability": "vision",
+          "priority": "standard",
+          "tested": false,
+          "notes": "Community 4-bit AWQ. Runs on RTX 3090, 4070 Ti Super, 4080 (16 GB cards). Quality trade ~3-5% vs. bf16."
+        },
+        {
+          "id": "Qwen/Qwen3.6-35B-A3B-FP8",
+          "display_name": "Qwen3.6-35B-A3B · FP8 (MoE, official)",
+          "base_model": "Qwen/Qwen3.6-35B-A3B",
+          "quantization": "FP8",
+          "vram_gb_min": 40,
+          "min_compute_capability": "8.9",
+          "min_vllm_version": "pending",
+          "capability": "vision",
+          "priority": "standard",
+          "tested": false,
+          "notes": "MoE with 3B active params — very fast inference. Needs workstation GPU (A6000, RTX 6000 Ada)."
+        },
+        {
+          "id": "Qwen/Qwen2.5-VL-7B-Instruct",
+          "display_name": "Qwen2.5-VL-7B · BF16 (fallback)",
+          "base_model": "Qwen/Qwen2.5-VL-7B-Instruct",
+          "quantization": "bf16",
+          "vram_gb_min": 16,
+          "min_compute_capability": "7.5",
+          "min_vllm_version": "0.7.0",
+          "capability": "vision",
+          "priority": "fallback",
+          "tested": true,
+          "notes": "Current default until vLLM ships Qwen3.6 architecture support. Well-tested, runs on any 16 GB NVIDIA GPU including RTX 3090 / 4060 Ti 16 GB."
+        }
+      ]
     }
   }
 }

--- a/src/cognithor/config.py
+++ b/src/cognithor/config.py
@@ -2546,6 +2546,26 @@ class SocialConfig(BaseModel):
         )
 
 
+class VLLMConfig(BaseModel):
+    """Configuration for the optional vLLM backend.
+
+    HF token is NOT stored here — read from the top-level
+    ``config.huggingface_api_key`` which is keyring-backed via
+    ``SecretStore._SECRET_FIELDS``. The orchestrator passes it to
+    the container as ``-e HF_TOKEN=$value``.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    enabled: bool = Field(default=False)
+    model: str = Field(default="")
+    docker_image: str = Field(default="vllm/vllm-openai:v0.19.1")
+    port: int = Field(default=8000, ge=1024, le=65535)
+    auto_stop_on_close: bool = Field(default=False)
+    skip_hardware_check: bool = Field(default=False)
+    request_timeout_seconds: int = Field(default=60, ge=5, le=600)
+
+
 # ============================================================================
 # Haupt-Konfiguration
 # ============================================================================
@@ -2648,6 +2668,7 @@ class CognithorConfig(BaseModel):
         default="http://localhost:8000/v1",
         description="vLLM server URL",
     )
+    vllm: VLLMConfig = Field(default_factory=VLLMConfig)
     llama_cpp_api_key: str = Field(
         default="",
         description="llama-cpp-python API key (usually empty for local)",

--- a/src/cognithor/core/llm_backend.py
+++ b/src/cognithor/core/llm_backend.py
@@ -103,7 +103,7 @@ class VLLMHardwareError(LLMBackendError):
     """NVIDIA GPU not detected, VRAM insufficient, or unsupported compute capability."""
 
 
-class DockerError(LLMBackendError):
+class VLLMDockerError(LLMBackendError):
     """Docker Desktop unreachable or wrong version."""
 
 

--- a/src/cognithor/core/llm_backend.py
+++ b/src/cognithor/core/llm_backend.py
@@ -43,6 +43,7 @@ class LLMBackendType(StrEnum):
     GEMINI = "gemini"
     LMSTUDIO = "lmstudio"
     CLAUDE_CODE = "claude-code"
+    VLLM = "vllm"
 
 
 @dataclass

--- a/src/cognithor/core/llm_backend.py
+++ b/src/cognithor/core/llm_backend.py
@@ -75,9 +75,36 @@ class EmbedResponse:
 class LLMBackendError(Exception):
     """Error communicating with the LLM backend."""
 
-    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int | None = None,
+        recovery_hint: str = "",
+    ) -> None:
         super().__init__(message)
         self.status_code = status_code
+        self.recovery_hint = recovery_hint
+
+
+class LLMBadRequestError(LLMBackendError):
+    """Wraps HTTP 400 responses — user/context problem, not a backend fault.
+
+    Excluded from circuit-breaker failure counting via ``excluded_exceptions``
+    when the breaker is wired in ``UnifiedLLMClient``.
+    """
+
+
+class VLLMNotReadyError(LLMBackendError):
+    """vLLM container not running or model not loaded."""
+
+
+class VLLMHardwareError(LLMBackendError):
+    """NVIDIA GPU not detected, VRAM insufficient, or unsupported compute capability."""
+
+
+class DockerError(LLMBackendError):
+    """Docker Desktop unreachable or wrong version."""
 
 
 # ============================================================================

--- a/src/cognithor/core/llm_backend.py
+++ b/src/cognithor/core/llm_backend.py
@@ -1480,10 +1480,11 @@ def create_backend(config: CognithorConfig) -> LLMBackend:
                 timeout=config.ollama.timeout_seconds,
             )
         case "vllm":
-            return OpenAIBackend(
-                api_key=getattr(config, "vllm_api_key", "") or "vllm",
-                base_url=getattr(config, "vllm_base_url", "http://localhost:8000/v1"),
-                timeout=config.ollama.timeout_seconds,
+            from cognithor.core.vllm_backend import VLLMBackend
+
+            return VLLMBackend(
+                base_url=f"http://localhost:{config.vllm.port}/v1",
+                timeout=config.vllm.request_timeout_seconds,
             )
         case "llama_cpp":
             return OpenAIBackend(

--- a/src/cognithor/core/unified_llm.py
+++ b/src/cognithor/core/unified_llm.py
@@ -16,10 +16,12 @@ Usage:
 
 from __future__ import annotations
 
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
-from cognithor.core.llm_backend import LLMBackendError
+from cognithor.core.llm_backend import LLMBackendError, LLMBadRequestError
 from cognithor.core.model_router import OllamaClient, OllamaError
+from cognithor.utils.circuit_breaker import CircuitBreaker, CircuitState
 from cognithor.utils.logging import get_logger
 
 if TYPE_CHECKING:
@@ -28,6 +30,13 @@ if TYPE_CHECKING:
     from cognithor.config import CognithorConfig
 
 log = get_logger(__name__)
+
+
+class BackendStatus(StrEnum):
+    """Public-facing health state surfaced to the UI."""
+
+    OK = "ok"
+    DEGRADED = "degraded"
 
 
 class UnifiedLLMClient:
@@ -44,6 +53,8 @@ class UnifiedLLMClient:
         ollama_client: OllamaClient | None,
         backend: Any | None = None,
         config: CognithorConfig | None = None,
+        *,
+        _breaker_recovery_timeout: float = 60.0,
     ) -> None:
         """Erstellt den unified Client.
 
@@ -52,6 +63,7 @@ class UnifiedLLMClient:
             backend: Optionales LLMBackend aus llm_backend.py.
                      Wenn None und ollama_client vorhanden, wird direkt OllamaClient genutzt.
             config: CognithorConfig for on-demand per-task backend creation.
+            _breaker_recovery_timeout: Seconds until the circuit moves from OPEN to HALF_OPEN.
         """
         self._ollama = ollama_client
         self._backend = backend
@@ -63,6 +75,22 @@ class UnifiedLLMClient:
             self._backend_type = getattr(backend, "backend_type", "unknown")
             if hasattr(self._backend_type, "value"):
                 self._backend_type = self._backend_type.value
+
+        self.vllm_breaker = CircuitBreaker(
+            name="llm_backend_vllm",
+            failure_threshold=3,
+            recovery_timeout=_breaker_recovery_timeout,
+            half_open_max_calls=1,
+            excluded_exceptions=(LLMBadRequestError,),
+        )
+        self.ollama_breaker = CircuitBreaker(
+            name="llm_backend_ollama",
+            failure_threshold=3,
+            recovery_timeout=_breaker_recovery_timeout,
+            half_open_max_calls=1,
+            excluded_exceptions=(LLMBadRequestError,),
+        )
+        self.backend_status: BackendStatus = BackendStatus.OK
 
     @classmethod
     def create(cls, config: CognithorConfig) -> UnifiedLLMClient:
@@ -159,6 +187,18 @@ class UnifiedLLMClient:
             )
             return self._backend
 
+    def _breaker_for(self, backend_type: str) -> CircuitBreaker:
+        if backend_type == "vllm":
+            return self.vllm_breaker
+        return self.ollama_breaker
+
+    def _refresh_status(self) -> None:
+        breaker = self._breaker_for(self._backend_type)
+        if breaker.state == CircuitState.closed:
+            self.backend_status = BackendStatus.OK
+        else:
+            self.backend_status = BackendStatus.DEGRADED
+
     # ========================================================================
     # Chat (Hauptmethode -- von Planner/Reflector aufgerufen)
     # ========================================================================
@@ -251,50 +291,45 @@ class UnifiedLLMClient:
                     f"Backend-Typ: '{_cfg_backend}', Modell: '{model}'. "
                     f"Bitte Backend-Konfiguration und API-Key pruefen."
                 )
-            return await self._ollama.chat(
-                model=model,
-                messages=messages,
-                tools=tools,
-                temperature=temperature,
-                top_p=top_p,
-                stream=stream,
-                format_json=format_json,
-                options=options,
-            )
-
-        # Via LLMBackend
-        try:
-            response = await effective_backend.chat(
-                model=model,
-                messages=messages,
-                tools=tools,
-                temperature=temperature,
-                top_p=top_p,
-                format_json=format_json,
-            )
-
-            # ChatResponse → Ollama-Dict konvertieren
-            result: dict[str, Any] = {
-                "message": {
-                    "role": "assistant",
-                    "content": response.content,
-                },
-                "model": response.model or model,
-                "done": True,
-            }
-
-            # Transfer tool calls
-            if response.tool_calls:
-                result["message"]["tool_calls"] = response.tool_calls
-
-            # Transfer usage info
-            if response.usage:
-                result["prompt_eval_count"] = response.usage.get("prompt_tokens", 0)
-                result["eval_count"] = response.usage.get("completion_tokens", 0)
-
+            breaker = self.ollama_breaker
+            try:
+                result = await breaker.call(
+                    self._ollama.chat(
+                        model=model,
+                        messages=messages,
+                        tools=tools,
+                        temperature=temperature,
+                        top_p=top_p,
+                        stream=stream,
+                        format_json=format_json,
+                        options=options,
+                    )
+                )
+            finally:
+                self._refresh_status()
             return result
 
+        # Via LLMBackend
+        effective_backend_type = getattr(effective_backend, "backend_type", self._backend_type)
+        if hasattr(effective_backend_type, "value"):
+            effective_backend_type = effective_backend_type.value
+        breaker = self._breaker_for(str(effective_backend_type))
+        try:
+            response = await breaker.call(
+                effective_backend.chat(
+                    model=model,
+                    messages=messages,
+                    tools=tools,
+                    temperature=temperature,
+                    top_p=top_p,
+                    format_json=format_json,
+                )
+            )
+        except LLMBadRequestError:
+            self._refresh_status()
+            raise
         except Exception as exc:
+            self._refresh_status()
             # Alle Backend-Fehler als OllamaError wrappen
             # so Planner/Reflector catch blocks keep working
             bt = backend_override or self._backend_type
@@ -302,6 +337,29 @@ class UnifiedLLMClient:
                 f"LLM-Backend-Fehler ({bt}): {exc}",
                 status_code=getattr(exc, "status_code", None),
             ) from exc
+        else:
+            self._refresh_status()
+
+        # ChatResponse → Ollama-Dict konvertieren
+        result_dict: dict[str, Any] = {
+            "message": {
+                "role": "assistant",
+                "content": response.content,
+            },
+            "model": response.model or model,
+            "done": True,
+        }
+
+        # Transfer tool calls
+        if response.tool_calls:
+            result_dict["message"]["tool_calls"] = response.tool_calls
+
+        # Transfer usage info
+        if response.usage:
+            result_dict["prompt_eval_count"] = response.usage.get("prompt_tokens", 0)
+            result_dict["eval_count"] = response.usage.get("completion_tokens", 0)
+
+        return result_dict
 
     # ========================================================================
     # Chat-Streaming

--- a/src/cognithor/core/unified_llm.py
+++ b/src/cognithor/core/unified_llm.py
@@ -19,9 +19,9 @@ from __future__ import annotations
 from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 
-from cognithor.core.llm_backend import LLMBackendError, LLMBadRequestError
+from cognithor.core.llm_backend import LLMBackendError, LLMBadRequestError, VLLMNotReadyError
 from cognithor.core.model_router import OllamaClient, OllamaError
-from cognithor.utils.circuit_breaker import CircuitBreaker, CircuitState
+from cognithor.utils.circuit_breaker import CircuitBreaker, CircuitBreakerOpen, CircuitState
 from cognithor.utils.logging import get_logger
 
 if TYPE_CHECKING:
@@ -215,6 +215,7 @@ class UnifiedLLMClient:
         format_json: bool = False,
         options: dict[str, Any] | None = None,
         backend_override: str = "",
+        images: list[str] | None = None,
     ) -> dict[str, Any]:
         """Chat-Completion im Ollama-Response-Format.
 
@@ -310,27 +311,59 @@ class UnifiedLLMClient:
             return result
 
         # Via LLMBackend
+        is_image_request = bool(images)
         effective_backend_type = getattr(effective_backend, "backend_type", self._backend_type)
         if hasattr(effective_backend_type, "value"):
             effective_backend_type = effective_backend_type.value
         breaker = self._breaker_for(str(effective_backend_type))
         try:
-            response = await breaker.call(
-                effective_backend.chat(
+            backend_call_kwargs: dict[str, Any] = {
+                "model": model,
+                "messages": messages,
+                "tools": tools,
+                "temperature": temperature,
+                "top_p": top_p,
+                "format_json": format_json,
+            }
+            if images is not None:
+                backend_call_kwargs["images"] = images
+            response = await breaker.call(effective_backend.chat(**backend_call_kwargs))
+        except LLMBadRequestError:
+            self._refresh_status()
+            raise
+        except (VLLMNotReadyError, CircuitBreakerOpen) as exc:
+            self._refresh_status()
+            if is_image_request:
+                # Images cannot be processed by Ollama fallback — hard error
+                if isinstance(exc, CircuitBreakerOpen):
+                    raise VLLMNotReadyError(
+                        "vLLM offline — cannot process image",
+                        recovery_hint="Start vLLM from LLM Backends settings.",
+                    ) from exc
+                raise
+            # Text-only: transparent fallback to Ollama
+            if self._ollama is not None:
+                log.warning("vllm_fallback_to_ollama", error=str(exc))
+                self._refresh_status()
+                return await self._ollama.chat(
                     model=model,
                     messages=messages,
                     tools=tools,
                     temperature=temperature,
                     top_p=top_p,
+                    stream=stream,
                     format_json=format_json,
+                    options=options,
                 )
-            )
-        except LLMBadRequestError:
-            self._refresh_status()
-            raise
+            # No Ollama available — wrap and raise
+            bt = backend_override or self._backend_type
+            raise OllamaError(
+                f"LLM-Backend-Fehler ({bt}): {exc}",
+                status_code=getattr(exc, "status_code", None),
+            ) from exc
         except Exception as exc:
             self._refresh_status()
-            # Alle Backend-Fehler als OllamaError wrappen
+            # Alle anderen Backend-Fehler als OllamaError wrappen
             # so Planner/Reflector catch blocks keep working
             bt = backend_override or self._backend_type
             raise OllamaError(

--- a/src/cognithor/core/vllm_backend.py
+++ b/src/cognithor/core/vllm_backend.py
@@ -9,6 +9,8 @@ See spec: docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
 
 from __future__ import annotations
 
+import base64
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -19,6 +21,7 @@ from cognithor.core.llm_backend import (
     LLMBackend,
     LLMBackendError,
     LLMBackendType,
+    LLMBadRequestError,
     VLLMNotReadyError,
 )
 from cognithor.utils.logging import get_logger
@@ -27,6 +30,61 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
 log = get_logger(__name__)
+
+
+def _encode_image_to_data_url(path: str) -> str | None:
+    """Read an image file, return OpenAI-vision data-URL string. None if unreadable."""
+    try:
+        p = Path(path)
+        if not p.is_file():
+            return None
+        data = p.read_bytes()
+    except OSError:
+        return None
+
+    suffix = p.suffix.lower().lstrip(".")
+    mime_map = {
+        "png": "png",
+        "jpg": "jpeg",
+        "jpeg": "jpeg",
+        "webp": "webp",
+        "gif": "gif",
+        "bmp": "bmp",
+    }
+    mime = mime_map.get(suffix, "png")
+    b64 = base64.b64encode(data).decode("ascii")
+    return f"data:image/{mime};base64,{b64}"
+
+
+def _attach_images_to_last_user(
+    messages: list[dict[str, Any]],
+    images: list[str],
+) -> list[dict[str, Any]]:
+    """Return a NEW messages list with images attached to the last user message
+    in OpenAI-vision format. Never mutates the caller's list."""
+    if not images:
+        return list(messages)
+
+    encoded = [e for e in (_encode_image_to_data_url(p) for p in images) if e]
+    if not encoded:
+        return list(messages)
+
+    new_messages = [dict(m) for m in messages]
+    for i in range(len(new_messages) - 1, -1, -1):
+        if new_messages[i].get("role") == "user":
+            existing = new_messages[i].get("content")
+            text_part = existing if isinstance(existing, str) else ""
+            content_list: list[dict[str, Any]] = []
+            if text_part:
+                content_list.append({"type": "text", "text": text_part})
+            for url in encoded:
+                content_list.append({"type": "image_url", "image_url": {"url": url}})
+            new_messages[i] = {**new_messages[i], "content": content_list}
+            break
+    else:
+        content_list = [{"type": "image_url", "image_url": {"url": u}} for u in encoded]
+        new_messages.append({"role": "user", "content": content_list})
+    return new_messages
 
 
 class VLLMBackend(LLMBackend):
@@ -78,9 +136,76 @@ class VLLMBackend(LLMBackend):
             await self._client.aclose()
             self._client = None
 
-    # Stubs — implemented in Tasks 14-16
-    async def chat(self, *args: Any, **kwargs: Any) -> ChatResponse:
-        raise NotImplementedError
+    # chat() implemented in Task 14; chat_stream/embed in Tasks 15-16
+    async def chat(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        format_json: bool = False,
+        images: list[str] | None = None,
+    ) -> ChatResponse:
+        """Send a chat-completion request to vLLM.
+
+        Raises:
+            LLMBadRequestError: on HTTP 400 (excluded from circuit breaker).
+            VLLMNotReadyError: on HTTP 5xx or connection failure (counts toward breaker).
+            LLMBackendError: on HTTP 4xx (other than 400).
+        """
+        if images:
+            messages = _attach_images_to_last_user(messages, images)
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+            "top_p": top_p,
+        }
+        if tools:
+            payload["tools"] = tools
+        if format_json:
+            payload["response_format"] = {"type": "json_object"}
+
+        client = await self._ensure_client()
+        try:
+            r = await client.post(f"{self._base_url}/chat/completions", json=payload)
+        except httpx.RequestError as exc:
+            raise VLLMNotReadyError(
+                f"vLLM not reachable: {exc}",
+                recovery_hint="Check vLLM container is running.",
+            ) from exc
+
+        if r.status_code == 400:
+            raise LLMBadRequestError(
+                f"vLLM rejected the request: {r.text[:200]}",
+                status_code=400,
+            )
+        if r.status_code >= 500:
+            raise VLLMNotReadyError(
+                f"vLLM returned {r.status_code}: {r.text[:200]}",
+                status_code=r.status_code,
+                recovery_hint="vLLM may still be loading the model.",
+            )
+        if r.status_code >= 400:
+            raise LLMBackendError(
+                f"vLLM returned {r.status_code}: {r.text[:200]}",
+                status_code=r.status_code,
+            )
+
+        data = r.json()
+        first_choice = data.get("choices", [{}])[0]
+        content = first_choice.get("message", {}).get("content", "")
+        tool_calls = first_choice.get("message", {}).get("tool_calls")
+        return ChatResponse(
+            content=content,
+            tool_calls=tool_calls,
+            model=data.get("model", model),
+            usage=data.get("usage"),
+            raw=data,
+        )
 
     async def chat_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[str]:
         raise NotImplementedError

--- a/src/cognithor/core/vllm_backend.py
+++ b/src/cognithor/core/vllm_backend.py
@@ -10,6 +10,7 @@ See spec: docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
 from __future__ import annotations
 
 import base64
+import json as _json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -207,9 +208,60 @@ class VLLMBackend(LLMBackend):
             raw=data,
         )
 
-    async def chat_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[str]:
-        raise NotImplementedError
-        yield  # pragma: no cover
+    async def chat_stream(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        *,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        images: list[str] | None = None,
+    ) -> AsyncIterator[str]:
+        """Stream response tokens from vLLM. Parses OpenAI SSE format."""
+        if images:
+            messages = _attach_images_to_last_user(messages, images)
+
+        payload = {
+            "model": model,
+            "messages": messages,
+            "temperature": temperature,
+            "top_p": top_p,
+            "stream": True,
+        }
+        client = await self._ensure_client()
+        try:
+            async with client.stream(
+                "POST",
+                f"{self._base_url}/chat/completions",
+                json=payload,
+            ) as r:
+                if r.status_code >= 500:
+                    raise VLLMNotReadyError(f"vLLM streaming returned {r.status_code}")
+                if r.status_code == 400:
+                    raise LLMBadRequestError(f"vLLM rejected stream request: {r.status_code}")
+                if r.status_code >= 400:
+                    raise LLMBackendError(f"vLLM streaming returned {r.status_code}")
+
+                async for line in r.aiter_lines():
+                    line = line.strip()
+                    if not line or not line.startswith("data:"):
+                        continue
+                    payload_str = line[5:].strip()
+                    if payload_str == "[DONE]":
+                        return
+                    try:
+                        event = _json.loads(payload_str)
+                    except _json.JSONDecodeError:
+                        continue
+                    choices = event.get("choices", [])
+                    if not choices:
+                        continue
+                    delta = choices[0].get("delta") or {}
+                    piece = delta.get("content")
+                    if piece:
+                        yield piece
+        except httpx.RequestError as exc:
+            raise VLLMNotReadyError(f"vLLM stream not reachable: {exc}") from exc
 
     async def embed(self, *args: Any, **kwargs: Any) -> EmbedResponse:
         raise NotImplementedError

--- a/src/cognithor/core/vllm_backend.py
+++ b/src/cognithor/core/vllm_backend.py
@@ -263,5 +263,35 @@ class VLLMBackend(LLMBackend):
         except httpx.RequestError as exc:
             raise VLLMNotReadyError(f"vLLM stream not reachable: {exc}") from exc
 
-    async def embed(self, *args: Any, **kwargs: Any) -> EmbedResponse:
-        raise NotImplementedError
+    async def embed(self, model: str, text: str) -> EmbedResponse:
+        """Send an embedding request to vLLM.
+
+        Raises:
+            LLMBadRequestError: on HTTP 400 (excluded from circuit breaker).
+            VLLMNotReadyError: on HTTP 5xx or connection failure (counts toward breaker).
+            LLMBackendError: on HTTP 4xx (other than 400) or missing data.
+        """
+        client = await self._ensure_client()
+        try:
+            r = await client.post(
+                f"{self._base_url}/embeddings",
+                json={"model": model, "input": text},
+            )
+        except httpx.RequestError as exc:
+            raise VLLMNotReadyError(f"vLLM embed not reachable: {exc}") from exc
+
+        if r.status_code == 400:
+            raise LLMBadRequestError(f"vLLM embed rejected: {r.text[:200]}")
+        if r.status_code >= 500:
+            raise VLLMNotReadyError(f"vLLM embed 5xx: {r.status_code}")
+        if r.status_code >= 400:
+            raise LLMBackendError(f"vLLM embed: {r.status_code}")
+
+        data = r.json()
+        items = data.get("data", [])
+        if not items:
+            raise LLMBackendError("vLLM embed returned no data")
+        return EmbedResponse(
+            embedding=items[0].get("embedding", []),
+            model=data.get("model", model),
+        )

--- a/src/cognithor/core/vllm_backend.py
+++ b/src/cognithor/core/vllm_backend.py
@@ -1,0 +1,90 @@
+"""vLLM backend — OpenAI-compatible LLMBackend adapter.
+
+vLLM serves an OpenAI-compatible ``/v1/chat/completions`` endpoint.
+This class adapts it to Cognithor's LLMBackend ABC with image-payload
+conversion for vision models.
+
+See spec: docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import httpx
+
+from cognithor.core.llm_backend import (
+    ChatResponse,
+    EmbedResponse,
+    LLMBackend,
+    LLMBackendError,
+    LLMBackendType,
+    VLLMNotReadyError,
+)
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+log = get_logger(__name__)
+
+
+class VLLMBackend(LLMBackend):
+    """vLLM OpenAI-compat adapter."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "http://localhost:8000/v1",
+        timeout: int = 60,
+    ) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._timeout = timeout
+        self._client: httpx.AsyncClient | None = None
+
+    @property
+    def backend_type(self) -> LLMBackendType:
+        return LLMBackendType.VLLM
+
+    async def _ensure_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._timeout)
+        return self._client
+
+    async def is_available(self) -> bool:
+        """Ping /health (NOT /v1/health — vLLM exposes /health at server root)."""
+        health_url = self._base_url.rsplit("/v1", 1)[0] + "/health"
+        client = await self._ensure_client()
+        try:
+            r = await client.get(health_url)
+            return r.status_code == 200
+        except Exception:
+            return False
+
+    async def list_models(self) -> list[str]:
+        client = await self._ensure_client()
+        try:
+            r = await client.get(f"{self._base_url}/models")
+            r.raise_for_status()
+            data = r.json()
+            return [m["id"] for m in data.get("data", [])]
+        except httpx.HTTPStatusError as exc:
+            raise LLMBackendError(f"vLLM /models failed: {exc}") from exc
+        except httpx.RequestError as exc:
+            raise VLLMNotReadyError(f"vLLM not reachable: {exc}") from exc
+
+    async def close(self) -> None:
+        if self._client is not None:
+            await self._client.aclose()
+            self._client = None
+
+    # Stubs — implemented in Tasks 14-16
+    async def chat(self, *args: Any, **kwargs: Any) -> ChatResponse:
+        raise NotImplementedError
+
+    async def chat_stream(self, *args: Any, **kwargs: Any) -> AsyncIterator[str]:
+        raise NotImplementedError
+        yield  # pragma: no cover
+
+    async def embed(self, *args: Any, **kwargs: Any) -> EmbedResponse:
+        raise NotImplementedError

--- a/src/cognithor/core/vllm_orchestrator.py
+++ b/src/cognithor/core/vllm_orchestrator.py
@@ -10,6 +10,7 @@ See spec: docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
 from __future__ import annotations
 
 import collections
+import json as _json
 import subprocess
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -177,4 +178,49 @@ class VLLMOrchestrator:
         )
         self.state.hardware_info = info
         self.state.hardware_ok = True
+        return info
+
+    def check_docker(self) -> DockerInfo:
+        """Detect Docker Desktop. Never raises — returns DockerInfo with flags."""
+        try:
+            result = subprocess.run(
+                ["docker", "version", "--format", "json"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except FileNotFoundError:
+            info = DockerInfo(available=False)
+            self.state.docker_ok = False
+            self.state.docker_info = info
+            return info
+        except subprocess.TimeoutExpired:
+            info = DockerInfo(available=True, server_running=False)
+            self.state.docker_ok = False
+            self.state.docker_info = info
+            return info
+
+        if result.returncode != 0:
+            info = DockerInfo(available=True, server_running=False)
+            self.state.docker_ok = False
+            self.state.docker_info = info
+            return info
+
+        try:
+            parsed = _json.loads(result.stdout)
+        except _json.JSONDecodeError:
+            info = DockerInfo(available=True, server_running=False)
+            self.state.docker_ok = False
+            self.state.docker_info = info
+            return info
+
+        server = parsed.get("Server")
+        version = (server or parsed.get("Client", {})).get("Version", "")
+        info = DockerInfo(
+            available=True,
+            version=version,
+            server_running=server is not None,
+        )
+        self.state.docker_ok = info.server_running
+        self.state.docker_info = info
         return info

--- a/src/cognithor/core/vllm_orchestrator.py
+++ b/src/cognithor/core/vllm_orchestrator.py
@@ -12,13 +12,16 @@ from __future__ import annotations
 import collections
 import json as _json
 import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from cognithor.core.llm_backend import VLLMHardwareError
+from cognithor.core.llm_backend import VLLMDockerError, VLLMHardwareError
 from cognithor.utils.logging import get_logger
 
 log = get_logger(__name__)
+
+ProgressCallback = Callable[[dict[str, Any]], None] | None
 
 Priority = Literal["premium", "standard", "fallback"]
 Capability = Literal["vision", "text"]
@@ -131,6 +134,47 @@ class VLLMOrchestrator:
     def get_logs(self) -> list[str]:
         """Snapshot of the container-log ring buffer."""
         return list(self._log_ring)
+
+    def pull_image(
+        self,
+        tag: str,
+        *,
+        progress_callback: ProgressCallback = None,
+    ) -> None:
+        """Run ``docker pull`` streaming JSON progress to the callback.
+
+        Raises:
+            VLLMDockerError: if the pull exits non-zero.
+        """
+        cmd = ["docker", "pull", "--progress=auto", tag]
+        proc = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        try:
+            for line in proc.stdout or []:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = _json.loads(line)
+                except _json.JSONDecodeError:
+                    event = {"status": line}
+                if progress_callback is not None:
+                    progress_callback(event)
+        finally:
+            proc.wait()
+
+        if proc.returncode != 0:
+            raise VLLMDockerError(
+                f"docker pull {tag} failed with exit {proc.returncode}",
+                recovery_hint="Check Docker Desktop is running and you have network access.",
+            )
+
+        self.state.image_pulled = True
 
     def check_hardware(self) -> HardwareInfo:
         """Detect NVIDIA GPU. Raises VLLMHardwareError on any failure."""

--- a/src/cognithor/core/vllm_orchestrator.py
+++ b/src/cognithor/core/vllm_orchestrator.py
@@ -10,9 +10,11 @@ See spec: docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
 from __future__ import annotations
 
 import collections
+import subprocess
 from dataclasses import dataclass
 from typing import Any, Literal
 
+from cognithor.core.llm_backend import VLLMHardwareError
 from cognithor.utils.logging import get_logger
 
 log = get_logger(__name__)
@@ -126,3 +128,53 @@ class VLLMOrchestrator:
     def get_logs(self) -> list[str]:
         """Snapshot of the container-log ring buffer."""
         return list(self._log_ring)
+
+    def check_hardware(self) -> HardwareInfo:
+        """Detect NVIDIA GPU. Raises VLLMHardwareError on any failure."""
+        cmd = [
+            "nvidia-smi",
+            "--query-gpu=name,memory.total,compute_cap",
+            "--format=csv,noheader,nounits",
+        ]
+        try:
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=10)
+        except FileNotFoundError as exc:
+            raise VLLMHardwareError(
+                "nvidia-smi not found — NVIDIA driver not installed?",
+                recovery_hint="Install the NVIDIA GPU driver from nvidia.com.",
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise VLLMHardwareError(
+                "nvidia-smi timed out",
+                recovery_hint="Check GPU driver health.",
+            ) from exc
+
+        if result.returncode != 0:
+            raise VLLMHardwareError(
+                f"nvidia-smi failed: {result.stderr.strip() or 'unknown error'}",
+            )
+
+        first_line = result.stdout.strip().split("\n")[0] if result.stdout.strip() else ""
+        if not first_line:
+            raise VLLMHardwareError("No NVIDIA GPU detected")
+
+        parts = [p.strip() for p in first_line.split(",")]
+        if len(parts) < 3:
+            raise VLLMHardwareError(f"Unexpected nvidia-smi output: {first_line!r}")
+
+        gpu_name = parts[0]
+        try:
+            vram_mib = int(parts[1])
+            cc_parts = parts[2].split(".")
+            compute_capability = (int(cc_parts[0]), int(cc_parts[1]))
+        except (ValueError, IndexError) as exc:
+            raise VLLMHardwareError(f"Cannot parse nvidia-smi output: {first_line!r}") from exc
+
+        info = HardwareInfo(
+            gpu_name=gpu_name,
+            vram_gb=round(vram_mib / 1024),
+            compute_capability=compute_capability,
+        )
+        self.state.hardware_info = info
+        self.state.hardware_ok = True
+        return info

--- a/src/cognithor/core/vllm_orchestrator.py
+++ b/src/cognithor/core/vllm_orchestrator.py
@@ -11,12 +11,16 @@ from __future__ import annotations
 
 import collections
 import json as _json
+import socket
 import subprocess
+import time
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from cognithor.core.llm_backend import VLLMDockerError, VLLMHardwareError
+import httpx
+
+from cognithor.core.llm_backend import VLLMDockerError, VLLMHardwareError, VLLMNotReadyError
 from cognithor.utils.logging import get_logger
 
 log = get_logger(__name__)
@@ -116,6 +120,7 @@ class VLLMOrchestrator:
     """Stateful vLLM lifecycle manager. Methods added in later tasks."""
 
     _PRIORITY_ORDER: dict[str, int] = {"premium": 0, "standard": 1, "fallback": 2}
+    _MAX_PORT_FALLBACKS = 10
 
     def __init__(
         self,
@@ -313,3 +318,85 @@ class VLLMOrchestrator:
 
         candidates.sort(key=sort_key)
         return candidates[0]
+
+    def _port_available(self, port: int) -> bool:
+        """True if nothing is listening on localhost:port."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.settimeout(0.5)
+            try:
+                s.bind(("127.0.0.1", port))
+                return True
+            except OSError:
+                return False
+
+    def _wait_for_health(self, port: int, *, timeout: int = 120) -> bool:
+        """Poll vLLM /health until 200 or timeout."""
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            try:
+                with httpx.Client(timeout=2.0) as client:
+                    r = client.get(f"http://localhost:{port}/health")
+                    if r.status_code == 200:
+                        return True
+            except Exception:
+                pass
+            time.sleep(2.0)
+        return False
+
+    def start_container(
+        self,
+        model: str,
+        *,
+        health_timeout: int | None = None,
+    ) -> ContainerInfo:
+        """Start a vLLM container. Auto-falls-back self.port → self.port+N on port conflict."""
+        port = self.port
+        for offset in range(self._MAX_PORT_FALLBACKS):
+            candidate = self.port + offset
+            if self._port_available(candidate):
+                port = candidate
+                break
+        else:
+            raise VLLMNotReadyError(
+                f"All ports {self.port}..{self.port + self._MAX_PORT_FALLBACKS - 1} are busy",
+                recovery_hint="Stop other services or change config.vllm.port.",
+            )
+
+        cmd = [
+            "docker",
+            "run",
+            "-d",
+            "--gpus",
+            "all",
+            "-v",
+            "cognithor-hf-cache:/root/.cache/huggingface",
+            "-e",
+            f"HF_TOKEN={self._hf_token}",
+            "-p",
+            f"{port}:8000",
+            "--label",
+            "cognithor.managed=true",
+            self.docker_image,
+            "--model",
+            model,
+        ]
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
+        if result.returncode != 0:
+            raise VLLMNotReadyError(
+                f"docker run failed: {result.stderr.strip()}",
+                recovery_hint="Check Docker Desktop logs.",
+            )
+
+        container_id = result.stdout.strip().split("\n")[-1][:12]
+
+        timeout = health_timeout if health_timeout is not None else 120
+        if not self._wait_for_health(port, timeout=timeout):
+            raise VLLMNotReadyError(
+                f"vLLM /health did not respond within {timeout}s",
+                recovery_hint="Check `docker logs <id>` for model-loading errors.",
+            )
+
+        info = ContainerInfo(container_id=container_id, port=port, model=model)
+        self.state.container_running = True
+        self.state.current_model = model
+        return info

--- a/src/cognithor/core/vllm_orchestrator.py
+++ b/src/cognithor/core/vllm_orchestrator.py
@@ -10,6 +10,7 @@ See spec: docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
 from __future__ import annotations
 
 import collections
+import dataclasses
 import json as _json
 import re
 import socket
@@ -140,6 +141,10 @@ class VLLMOrchestrator:
     def get_logs(self) -> list[str]:
         """Snapshot of the container-log ring buffer."""
         return list(self._log_ring)
+
+    def status(self) -> VLLMState:
+        """Return a snapshot copy of the current state (safe to mutate)."""
+        return dataclasses.replace(self.state)
 
     def pull_image(
         self,

--- a/src/cognithor/core/vllm_orchestrator.py
+++ b/src/cognithor/core/vllm_orchestrator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import collections
 import json as _json
+import re
 import socket
 import subprocess
 import time
@@ -395,6 +396,66 @@ class VLLMOrchestrator:
                 f"vLLM /health did not respond within {timeout}s",
                 recovery_hint="Check `docker logs <id>` for model-loading errors.",
             )
+
+        info = ContainerInfo(container_id=container_id, port=port, model=model)
+        self.state.container_running = True
+        self.state.current_model = model
+        return info
+
+    def stop_container(self) -> None:
+        """Stop and remove the cognithor-managed vLLM container. Noop if none."""
+        find = subprocess.run(
+            ["docker", "ps", "-q", "--filter", "label=cognithor.managed=true"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        container_id = find.stdout.strip().split("\n")[0] if find.stdout.strip() else ""
+        if not container_id:
+            self.state.container_running = False
+            return
+
+        subprocess.run(["docker", "stop", container_id], capture_output=True, timeout=30)
+        subprocess.run(["docker", "rm", container_id], capture_output=True, timeout=10)
+        self.state.container_running = False
+        self.state.current_model = None
+
+    def reuse_existing(self) -> ContainerInfo | None:
+        """If a cognithor-managed container is already running, return its info."""
+        result = subprocess.run(
+            [
+                "docker",
+                "ps",
+                "--filter",
+                "label=cognithor.managed=true",
+                "--format",
+                "json",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0 or not result.stdout.strip():
+            return None
+
+        first_line = result.stdout.strip().split("\n")[0]
+        try:
+            row = _json.loads(first_line)
+        except _json.JSONDecodeError:
+            return None
+
+        container_id = row.get("ID", "").strip()
+        ports = row.get("Ports", "")
+        cmd = row.get("Command", "")
+
+        port_match = re.search(r"0\.0\.0\.0:(\d+)->8000/tcp", ports)
+        port = int(port_match.group(1)) if port_match else self.port
+
+        model_match = re.search(r"--model\s+(\S+)", cmd)
+        model = model_match.group(1) if model_match else ""
+
+        if not container_id:
+            return None
 
         info = ContainerInfo(container_id=container_id, port=port, model=model)
         self.state.container_running = True

--- a/src/cognithor/core/vllm_orchestrator.py
+++ b/src/cognithor/core/vllm_orchestrator.py
@@ -112,6 +112,8 @@ class VLLMState:
 class VLLMOrchestrator:
     """Stateful vLLM lifecycle manager. Methods added in later tasks."""
 
+    _PRIORITY_ORDER: dict[str, int] = {"premium": 0, "standard": 1, "fallback": 2}
+
     def __init__(
         self,
         *,
@@ -224,3 +226,46 @@ class VLLMOrchestrator:
         self.state.docker_ok = info.server_running
         self.state.docker_info = info
         return info
+
+    def filter_registry(
+        self,
+        hardware: HardwareInfo,
+        registry: list[ModelEntry],
+    ) -> list[ModelEntry]:
+        """Returns entries that fit the detected GPU (VRAM + compute capability)."""
+        return [
+            m
+            for m in registry
+            if m.vram_gb_min <= hardware.vram_gb and m.min_cc_tuple <= hardware.compute_capability
+        ]
+
+    def recommend_model(
+        self,
+        hardware: HardwareInfo,
+        registry: list[ModelEntry],
+        *,
+        prefer: Literal["vision", "text"] = "vision",
+    ) -> ModelEntry | None:
+        """Pick the best curated model for detected hardware.
+
+        Ranking:
+          1. Matches requested capability (vision/text)
+          2. tested==True beats tested==False
+          3. Higher priority (premium > standard > fallback)
+          4. Tie-break: smaller vram_gb_min (more headroom for KV cache)
+          5. Stable min_vllm_version before "pending"
+        """
+        candidates = [m for m in self.filter_registry(hardware, registry) if m.capability == prefer]
+        if not candidates:
+            return None
+
+        def sort_key(m: ModelEntry) -> tuple[int, int, int, int]:
+            return (
+                0 if m.tested else 1,
+                self._PRIORITY_ORDER[m.priority],
+                m.vram_gb_min,
+                0 if m.min_vllm_version != "pending" else 1,
+            )
+
+        candidates.sort(key=sort_key)
+        return candidates[0]

--- a/src/cognithor/core/vllm_orchestrator.py
+++ b/src/cognithor/core/vllm_orchestrator.py
@@ -1,0 +1,128 @@
+"""vLLM lifecycle orchestrator — wraps docker/nvidia-smi subprocesses.
+
+Stateful manager: hardware detection, Docker readiness, image pull,
+container start/stop, model recommendation. No Docker-SDK dependency —
+pure `subprocess` calls.
+
+See spec: docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md
+"""
+
+from __future__ import annotations
+
+import collections
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from cognithor.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+Priority = Literal["premium", "standard", "fallback"]
+Capability = Literal["vision", "text"]
+
+
+@dataclass
+class HardwareInfo:
+    """NVIDIA GPU detection result."""
+
+    gpu_name: str
+    vram_gb: int
+    compute_capability: tuple[int, int]
+
+    @property
+    def sm_string(self) -> str:
+        """Returns the compute capability as 'major.minor' string."""
+        return f"{self.compute_capability[0]}.{self.compute_capability[1]}"
+
+
+@dataclass
+class DockerInfo:
+    """Docker Desktop readiness."""
+
+    available: bool
+    version: str = ""
+    server_running: bool = False
+
+
+@dataclass
+class ContainerInfo:
+    """A running/started vLLM container."""
+
+    container_id: str
+    port: int
+    model: str
+
+
+@dataclass
+class ModelEntry:
+    """One row from the model_registry.json vllm provider section."""
+
+    id: str
+    display_name: str
+    base_model: str
+    quantization: str
+    vram_gb_min: int
+    min_compute_capability: str
+    min_vllm_version: str
+    capability: Capability
+    priority: Priority
+    tested: bool
+    notes: str = ""
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> ModelEntry:
+        return cls(
+            id=data["id"],
+            display_name=data["display_name"],
+            base_model=data["base_model"],
+            quantization=data["quantization"],
+            vram_gb_min=int(data["vram_gb_min"]),
+            min_compute_capability=data["min_compute_capability"],
+            min_vllm_version=data["min_vllm_version"],
+            capability=data["capability"],
+            priority=data["priority"],
+            tested=bool(data["tested"]),
+            notes=data.get("notes", ""),
+        )
+
+    @property
+    def min_cc_tuple(self) -> tuple[int, int]:
+        """Returns min_compute_capability as (major, minor) tuple."""
+        parts = self.min_compute_capability.split(".")
+        return (int(parts[0]), int(parts[1]))
+
+
+@dataclass
+class VLLMState:
+    """Aggregate state snapshot for UI rendering."""
+
+    hardware_ok: bool = False
+    hardware_info: HardwareInfo | None = None
+    docker_ok: bool = False
+    docker_info: DockerInfo | None = None
+    image_pulled: bool = False
+    container_running: bool = False
+    current_model: str | None = None
+    last_error: str | None = None
+
+
+class VLLMOrchestrator:
+    """Stateful vLLM lifecycle manager. Methods added in later tasks."""
+
+    def __init__(
+        self,
+        *,
+        docker_image: str = "vllm/vllm-openai:v0.19.1",
+        port: int = 8000,
+        hf_token: str = "",
+        log_ring_size: int = 500,
+    ) -> None:
+        self.docker_image = docker_image
+        self.port = port
+        self._hf_token = hf_token
+        self.state = VLLMState()
+        self._log_ring: collections.deque[str] = collections.deque(maxlen=log_ring_size)
+
+    def get_logs(self) -> list[str]:
+        """Snapshot of the container-log ring buffer."""
+        return list(self._log_ring)

--- a/src/cognithor/gateway/gateway.py
+++ b/src/cognithor/gateway/gateway.py
@@ -1819,6 +1819,17 @@ class Gateway:
 
         log.info("gateway_shutdown_complete")
 
+    def rebuild_llm_client(self, new_backend_type: str) -> None:
+        """Re-init UnifiedLLMClient for a new backend type.
+
+        Called from the FastAPI /api/backends/active endpoint when the user
+        switches backends from the Flutter UI. No app restart needed.
+        """
+        from cognithor.core.unified_llm import UnifiedLLMClient
+
+        self._config.llm_backend_type = new_backend_type
+        self._llm = UnifiedLLMClient.create(self._config)
+
     async def execute_workflow(self, workflow_yaml: str) -> dict[str, Any]:
         """Execute a workflow via the DAG WorkflowEngine.
 

--- a/src/cognithor/gateway/gateway.py
+++ b/src/cognithor/gateway/gateway.py
@@ -181,6 +181,18 @@ class Gateway:
         self._background_tasks: set[asyncio.Task[Any]] = set()
         self._pattern_record_timestamps: list[float] = []
 
+        # vLLM orchestrator — created lazily if enabled; lifecycle hooks use this
+        if self._config.vllm.enabled:
+            from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+
+            self._vllm_orchestrator = VLLMOrchestrator(
+                docker_image=self._config.vllm.docker_image,
+                port=self._config.vllm.port,
+                hf_token=self._config.huggingface_api_key,
+            )
+        else:
+            self._vllm_orchestrator = None
+
         # Declare all subsystem attributes via phase modules
         apply_phase(self, declare_core_attrs(self._config))
         apply_phase(self, declare_security_attrs(self._config))
@@ -1682,6 +1694,29 @@ class Gateway:
             except Exception as exc:
                 log.debug("auto_update_skipped", reason=str(exc))
             await asyncio.sleep(86400)  # Daily
+
+    def on_startup_vllm(self):
+        """Called during init. If a cognithor-managed vLLM container is
+        already running (from a previous session with auto_stop_on_close=False,
+        or because the user ran the container manually), adopt it — no restart."""
+        if not self._config.vllm.enabled or self._vllm_orchestrator is None:
+            return None
+        try:
+            return self._vllm_orchestrator.reuse_existing()
+        except Exception as exc:
+            log.warning("vllm_reuse_existing_failed", error=str(exc))
+            return None
+
+    def on_shutdown_vllm(self) -> None:
+        """Called on Gateway.shutdown(). Stops the container only if the user
+        has opted in via config.vllm.auto_stop_on_close."""
+        if not self._config.vllm.enabled or self._vllm_orchestrator is None:
+            return
+        if self._config.vllm.auto_stop_on_close:
+            try:
+                self._vllm_orchestrator.stop_container()
+            except Exception as exc:
+                log.warning("vllm_shutdown_failed", error=str(exc))
 
     async def shutdown(self) -> None:
         """Faehrt den Gateway sauber herunter mit Session-Persistierung."""

--- a/tests/config/test_vllm_config.py
+++ b/tests/config/test_vllm_config.py
@@ -1,0 +1,33 @@
+# tests/config/test_vllm_config.py
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from cognithor.config import CognithorConfig, VLLMConfig
+
+
+class TestVLLMConfig:
+    def test_defaults(self):
+        c = VLLMConfig()
+        assert c.enabled is False
+        assert c.model == ""
+        assert c.docker_image == "vllm/vllm-openai:v0.19.1"
+        assert c.port == 8000
+        assert c.auto_stop_on_close is False
+        assert c.skip_hardware_check is False
+        assert c.request_timeout_seconds == 60
+
+    def test_rejects_unknown_fields(self):
+        with pytest.raises(ValidationError):
+            VLLMConfig(unknown_field=1)
+
+    def test_cognithor_config_has_vllm_sub_model(self):
+        c = CognithorConfig()
+        assert hasattr(c, "vllm")
+        assert isinstance(c.vllm, VLLMConfig)
+
+    def test_vllm_override(self):
+        c = CognithorConfig(vllm={"enabled": True, "port": 8042})
+        assert c.vllm.enabled is True
+        assert c.vllm.port == 8042

--- a/tests/test_channels/test_api_backends.py
+++ b/tests/test_channels/test_api_backends.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cognithor.channels.backends_api import build_backends_app
+from cognithor.config import CognithorConfig, VLLMConfig
+
+
+@pytest.fixture
+def client_with_vllm_enabled():
+    cfg = CognithorConfig(
+        llm_backend_type="ollama",
+        vllm=VLLMConfig(enabled=True),
+    )
+    app = build_backends_app(config=cfg)
+    return TestClient(app), cfg
+
+
+class TestBackendsList:
+    def test_lists_all_backends_with_status(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        r = client.get("/api/backends")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["active"] == "ollama"
+        names = {b["name"] for b in data["backends"]}
+        assert "ollama" in names
+        assert "vllm" in names
+
+
+class TestVLLMStatus:
+    def test_status_returns_current_vllm_state(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        from cognithor.core.vllm_orchestrator import (
+            DockerInfo,
+            HardwareInfo,
+            VLLMState,
+        )
+
+        with patch("cognithor.core.vllm_orchestrator.VLLMOrchestrator.status") as mock:
+            mock.return_value = VLLMState(
+                hardware_ok=True,
+                hardware_info=HardwareInfo("RTX 5090", 32, (12, 0)),
+                docker_ok=True,
+                docker_info=DockerInfo(True, "26.0.0", True),
+                image_pulled=False,
+                container_running=False,
+                current_model=None,
+            )
+            r = client.get("/api/backends/vllm/status")
+        assert r.status_code == 200
+        data = r.json()
+        assert data["hardware_ok"] is True
+        assert data["hardware_info"]["gpu_name"] == "RTX 5090"
+        assert data["hardware_info"]["vram_gb"] == 32
+        assert data["hardware_info"]["compute_capability"] == "12.0"
+        assert data["docker_ok"] is True
+        assert data["container_running"] is False

--- a/tests/test_channels/test_api_backends.py
+++ b/tests/test_channels/test_api_backends.py
@@ -59,3 +59,68 @@ class TestVLLMStatus:
         assert data["hardware_info"]["compute_capability"] == "12.0"
         assert data["docker_ok"] is True
         assert data["container_running"] is False
+
+
+class TestVLLMActions:
+    def test_check_hardware_delegates_to_orchestrator(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        from cognithor.core.vllm_orchestrator import HardwareInfo
+
+        with patch(
+            "cognithor.core.vllm_orchestrator.VLLMOrchestrator.check_hardware",
+            return_value=HardwareInfo("RTX 5090", 32, (12, 0)),
+        ):
+            r = client.post("/api/backends/vllm/check-hardware")
+        assert r.status_code == 200
+        assert r.json()["gpu_name"] == "RTX 5090"
+        assert r.json()["vram_gb"] == 32
+        assert r.json()["compute_capability"] == "12.0"
+
+    def test_check_hardware_returns_503_on_no_gpu(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        from cognithor.core.llm_backend import VLLMHardwareError
+
+        with patch(
+            "cognithor.core.vllm_orchestrator.VLLMOrchestrator.check_hardware",
+            side_effect=VLLMHardwareError("No GPU", recovery_hint="Install NVIDIA driver"),
+        ):
+            r = client.post("/api/backends/vllm/check-hardware")
+        assert r.status_code == 503
+        body = r.json()
+        assert "No GPU" in body["detail"]["message"]
+        assert body["detail"]["recovery_hint"] == "Install NVIDIA driver"
+
+    def test_start_container_accepts_model(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        from cognithor.core.vllm_orchestrator import ContainerInfo
+
+        with patch(
+            "cognithor.core.vllm_orchestrator.VLLMOrchestrator.start_container",
+            return_value=ContainerInfo("abc123", 8000, "Qwen/Qwen3.6-27B-FP8"),
+        ):
+            r = client.post(
+                "/api/backends/vllm/start",
+                json={"model": "Qwen/Qwen3.6-27B-FP8"},
+            )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["container_id"] == "abc123"
+        assert data["port"] == 8000
+        assert data["model"] == "Qwen/Qwen3.6-27B-FP8"
+
+    def test_stop_container(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        with patch("cognithor.core.vllm_orchestrator.VLLMOrchestrator.stop_container") as stop_mock:
+            r = client.post("/api/backends/vllm/stop")
+        assert r.status_code == 200
+        stop_mock.assert_called_once()
+
+    def test_logs_endpoint(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        with patch(
+            "cognithor.core.vllm_orchestrator.VLLMOrchestrator.get_logs",
+            return_value=["line1", "line2"],
+        ):
+            r = client.get("/api/backends/vllm/logs")
+        assert r.status_code == 200
+        assert r.json()["lines"] == ["line1", "line2"]

--- a/tests/test_channels/test_api_backends.py
+++ b/tests/test_channels/test_api_backends.py
@@ -124,3 +124,33 @@ class TestVLLMActions:
             r = client.get("/api/backends/vllm/logs")
         assert r.status_code == 200
         assert r.json()["lines"] == ["line1", "line2"]
+
+
+class TestPullImageSSE:
+    def test_pull_image_streams_sse_events(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+
+        def fake_pull(tag, progress_callback=None):
+            if progress_callback:
+                progress_callback({"status": "Pulling", "id": "layer1"})
+                progress_callback(
+                    {
+                        "status": "Downloading",
+                        "id": "layer1",
+                        "progressDetail": {"current": 500, "total": 1000},
+                    }
+                )
+                progress_callback({"status": "Download complete", "id": "layer1"})
+
+        with patch(
+            "cognithor.core.vllm_orchestrator.VLLMOrchestrator.pull_image",
+            side_effect=fake_pull,
+        ):
+            with client.stream("POST", "/api/backends/vllm/pull-image") as r:
+                assert r.status_code == 200
+                assert r.headers["content-type"].startswith("text/event-stream")
+                lines = list(r.iter_lines())
+
+        data_lines = [l for l in lines if l.startswith("data:")]
+        assert len(data_lines) >= 3
+        assert any("Downloading" in l for l in data_lines)

--- a/tests/test_channels/test_api_backends.py
+++ b/tests/test_channels/test_api_backends.py
@@ -154,3 +154,35 @@ class TestPullImageSSE:
         data_lines = [l for l in lines if l.startswith("data:")]
         assert len(data_lines) >= 3
         assert any("Downloading" in l for l in data_lines)
+
+
+class TestSetActiveBackend:
+    def _client_with_gateway(self, cfg, gateway):
+        from cognithor.channels.backends_api import build_backends_app
+
+        app = build_backends_app(config=cfg, gateway=gateway)
+        return TestClient(app)
+
+    def test_switch_to_vllm_reinits_unified_client(self):
+        from unittest.mock import MagicMock
+
+        from cognithor.config import CognithorConfig, VLLMConfig
+
+        cfg = CognithorConfig(vllm=VLLMConfig(enabled=True))
+        gateway = MagicMock()
+        client = self._client_with_gateway(cfg, gateway)
+        r = client.post("/api/backends/active", json={"backend": "vllm"})
+        assert r.status_code == 200
+        gateway.rebuild_llm_client.assert_called_once_with("vllm")
+        assert r.json()["active"] == "vllm"
+
+    def test_rejects_unknown_backend(self):
+        from unittest.mock import MagicMock
+
+        from cognithor.config import CognithorConfig, VLLMConfig
+
+        cfg = CognithorConfig(vllm=VLLMConfig(enabled=True))
+        gateway = MagicMock()
+        client = self._client_with_gateway(cfg, gateway)
+        r = client.post("/api/backends/active", json={"backend": "unicorn"})
+        assert r.status_code == 422  # Pydantic Literal rejects invalid value

--- a/tests/test_channels/test_api_backends.py
+++ b/tests/test_channels/test_api_backends.py
@@ -186,3 +186,23 @@ class TestSetActiveBackend:
         client = self._client_with_gateway(cfg, gateway)
         r = client.post("/api/backends/active", json={"backend": "unicorn"})
         assert r.status_code == 422  # Pydantic Literal rejects invalid value
+
+
+class TestAvailableModels:
+    def test_returns_filtered_registry_with_recommendation_flag(self, client_with_vllm_enabled):
+        client, _ = client_with_vllm_enabled
+        from cognithor.core.vllm_orchestrator import HardwareInfo
+
+        with patch(
+            "cognithor.core.vllm_orchestrator.VLLMOrchestrator.check_hardware",
+            return_value=HardwareInfo("RTX 5090", 32, (12, 0)),
+        ):
+            r = client.get("/api/backends/vllm/available-models")
+        assert r.status_code == 200
+        data = r.json()
+        assert "recommended_id" in data
+        assert "models" in data
+        assert len(data["models"]) >= 1
+        for m in data["models"]:
+            assert "id" in m
+            assert "fits" in m

--- a/tests/test_core/test_create_backend_vllm.py
+++ b/tests/test_core/test_create_backend_vllm.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from cognithor.config import CognithorConfig, VLLMConfig
+from cognithor.core.llm_backend import create_backend
+from cognithor.core.vllm_backend import VLLMBackend
+
+
+class TestCreateVLLMBackend:
+    def test_returns_vllm_backend_when_config_says_vllm(self):
+        cfg = CognithorConfig(
+            llm_backend_type="vllm",
+            vllm=VLLMConfig(enabled=True, port=8000),
+        )
+        backend = create_backend(cfg)
+        assert isinstance(backend, VLLMBackend)
+        assert backend.backend_type.value == "vllm"
+
+    def test_vllm_backend_uses_configured_port(self):
+        cfg = CognithorConfig(
+            llm_backend_type="vllm",
+            vllm=VLLMConfig(enabled=True, port=8042),
+        )
+        backend = create_backend(cfg)
+        assert backend._base_url == "http://localhost:8042/v1"
+
+    def test_vllm_backend_uses_request_timeout(self):
+        cfg = CognithorConfig(
+            llm_backend_type="vllm",
+            vllm=VLLMConfig(enabled=True, request_timeout_seconds=30),
+        )
+        backend = create_backend(cfg)
+        assert backend._timeout == 30

--- a/tests/test_core/test_llm_backend_errors.py
+++ b/tests/test_core/test_llm_backend_errors.py
@@ -28,3 +28,17 @@ class TestErrorHierarchy:
     def test_status_code_preserved_from_base(self):
         err = LLMBadRequestError("context too long", status_code=400)
         assert err.status_code == 400
+
+
+class TestBackendTypeEnum:
+    def test_vllm_is_a_backend_type(self):
+        from cognithor.core.llm_backend import LLMBackendType
+
+        assert LLMBackendType.VLLM == "vllm"
+        assert LLMBackendType.VLLM.value == "vllm"
+
+    def test_vllm_value_matches_config_literal(self):
+        """config.CognithorConfig.llm_backend_type accepts "vllm" — keep enum aligned."""
+        from cognithor.core.llm_backend import LLMBackendType
+
+        assert "vllm" in {t.value for t in LLMBackendType}

--- a/tests/test_core/test_llm_backend_errors.py
+++ b/tests/test_core/test_llm_backend_errors.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from cognithor.core.llm_backend import (
+    DockerError,
+    LLMBackendError,
+    LLMBadRequestError,
+    VLLMHardwareError,
+    VLLMNotReadyError,
+)
+
+
+class TestErrorHierarchy:
+    def test_all_vllm_errors_inherit_from_llm_backend_error(self):
+        assert issubclass(LLMBadRequestError, LLMBackendError)
+        assert issubclass(VLLMNotReadyError, LLMBackendError)
+        assert issubclass(VLLMHardwareError, LLMBackendError)
+        assert issubclass(DockerError, LLMBackendError)
+
+    def test_errors_carry_recovery_hint(self):
+        err = VLLMNotReadyError("container down", recovery_hint="Run: docker start vllm")
+        assert err.recovery_hint == "Run: docker start vllm"
+        assert str(err) == "container down"
+
+    def test_recovery_hint_defaults_to_empty(self):
+        err = DockerError("Docker not found")
+        assert err.recovery_hint == ""
+
+    def test_status_code_preserved_from_base(self):
+        err = LLMBadRequestError("context too long", status_code=400)
+        assert err.status_code == 400

--- a/tests/test_core/test_llm_backend_errors.py
+++ b/tests/test_core/test_llm_backend_errors.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from cognithor.core.llm_backend import (
-    DockerError,
     LLMBackendError,
     LLMBadRequestError,
+    VLLMDockerError,
     VLLMHardwareError,
     VLLMNotReadyError,
 )
@@ -14,7 +14,7 @@ class TestErrorHierarchy:
         assert issubclass(LLMBadRequestError, LLMBackendError)
         assert issubclass(VLLMNotReadyError, LLMBackendError)
         assert issubclass(VLLMHardwareError, LLMBackendError)
-        assert issubclass(DockerError, LLMBackendError)
+        assert issubclass(VLLMDockerError, LLMBackendError)
 
     def test_errors_carry_recovery_hint(self):
         err = VLLMNotReadyError("container down", recovery_hint="Run: docker start vllm")
@@ -22,7 +22,7 @@ class TestErrorHierarchy:
         assert str(err) == "container down"
 
     def test_recovery_hint_defaults_to_empty(self):
-        err = DockerError("Docker not found")
+        err = VLLMDockerError("Docker not found")
         assert err.recovery_hint == ""
 
     def test_status_code_preserved_from_base(self):

--- a/tests/test_core/test_model_registry_vllm.py
+++ b/tests/test_core/test_model_registry_vllm.py
@@ -1,0 +1,64 @@
+# tests/test_core/test_model_registry_vllm.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REGISTRY_PATH = (
+    Path(__file__).resolve().parents[2] / "src" / "cognithor" / "cli" / "model_registry.json"
+)
+
+
+class TestVLLMRegistrySection:
+    def setup_method(self):
+        with open(REGISTRY_PATH, encoding="utf-8") as f:
+            self.registry = json.load(f)
+
+    def test_vllm_provider_exists(self):
+        assert "vllm" in self.registry["providers"]
+
+    def test_vllm_has_curated_models(self):
+        models = self.registry["providers"]["vllm"]["models"]
+        assert len(models) >= 5
+
+    def test_each_model_has_required_fields(self):
+        models = self.registry["providers"]["vllm"]["models"]
+        required = {
+            "id",
+            "display_name",
+            "base_model",
+            "quantization",
+            "vram_gb_min",
+            "min_compute_capability",
+            "min_vllm_version",
+            "capability",
+            "priority",
+            "tested",
+            "notes",
+        }
+        for m in models:
+            missing = required - set(m.keys())
+            assert not missing, f"Model {m.get('id')} missing fields: {missing}"
+
+    def test_priority_values_are_valid(self):
+        models = self.registry["providers"]["vllm"]["models"]
+        for m in models:
+            assert m["priority"] in ("premium", "standard", "fallback")
+
+    def test_compute_capability_is_parseable(self):
+        models = self.registry["providers"]["vllm"]["models"]
+        for m in models:
+            parts = m["min_compute_capability"].split(".")
+            assert len(parts) == 2
+            assert int(parts[0]) >= 7
+            assert int(parts[1]) >= 0
+
+    def test_vram_is_positive_integer(self):
+        models = self.registry["providers"]["vllm"]["models"]
+        for m in models:
+            assert isinstance(m["vram_gb_min"], int)
+            assert m["vram_gb_min"] > 0
+
+    def test_at_least_one_tested_model(self):
+        models = self.registry["providers"]["vllm"]["models"]
+        assert any(m["tested"] for m in models)

--- a/tests/test_core/test_unified_llm_circuit_breaker.py
+++ b/tests/test_core/test_unified_llm_circuit_breaker.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from unittest.mock import AsyncMock
+
+import pytest
+
+from cognithor.core.llm_backend import (
+    ChatResponse,
+    LLMBadRequestError,
+    VLLMNotReadyError,
+)
+from cognithor.core.unified_llm import BackendStatus, UnifiedLLMClient
+from cognithor.utils.circuit_breaker import CircuitState
+
+
+@pytest.fixture
+def mock_vllm_backend() -> AsyncMock:
+    mock = AsyncMock()
+    mock.backend_type = "vllm"
+    return mock
+
+
+@pytest.fixture
+def mock_ollama_client() -> AsyncMock:
+    return AsyncMock()
+
+
+class TestBreakerWiring:
+    @pytest.mark.asyncio
+    async def test_three_consecutive_failures_open_breaker(
+        self, mock_vllm_backend, mock_ollama_client
+    ):
+        mock_vllm_backend.chat.side_effect = VLLMNotReadyError("down")
+        client = UnifiedLLMClient(
+            ollama_client=mock_ollama_client,
+            backend=mock_vllm_backend,
+        )
+        for _ in range(3):
+            with contextlib.suppress(Exception):
+                await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+        assert client.vllm_breaker.state == CircuitState.open
+        assert client.backend_status == BackendStatus.DEGRADED
+
+    @pytest.mark.asyncio
+    async def test_bad_request_error_is_excluded_from_breaker(
+        self, mock_vllm_backend, mock_ollama_client
+    ):
+        mock_vllm_backend.chat.side_effect = LLMBadRequestError("context too long")
+        client = UnifiedLLMClient(
+            ollama_client=mock_ollama_client,
+            backend=mock_vllm_backend,
+        )
+        for _ in range(5):
+            with contextlib.suppress(LLMBadRequestError):
+                await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+        assert client.vllm_breaker.state == CircuitState.closed
+        assert client.backend_status == BackendStatus.OK
+
+    @pytest.mark.asyncio
+    async def test_half_open_probe_success_closes_breaker(
+        self, mock_vllm_backend, mock_ollama_client
+    ):
+        mock_vllm_backend.chat.side_effect = VLLMNotReadyError("down")
+        client = UnifiedLLMClient(
+            ollama_client=mock_ollama_client,
+            backend=mock_vllm_backend,
+            _breaker_recovery_timeout=0.05,
+        )
+        for _ in range(3):
+            with contextlib.suppress(Exception):
+                await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+        assert client.vllm_breaker.state == CircuitState.open
+
+        await asyncio.sleep(0.1)
+        mock_vllm_backend.chat.side_effect = None
+        mock_vllm_backend.chat.return_value = ChatResponse(content="ok", model="x")
+
+        await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+        assert client.vllm_breaker.state == CircuitState.closed
+        assert client.backend_status == BackendStatus.OK

--- a/tests/test_core/test_unified_llm_circuit_breaker.py
+++ b/tests/test_core/test_unified_llm_circuit_breaker.py
@@ -80,3 +80,50 @@ class TestBreakerWiring:
         await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
         assert client.vllm_breaker.state == CircuitState.closed
         assert client.backend_status == BackendStatus.OK
+
+
+class TestFailFlowDispatch:
+    @pytest.mark.asyncio
+    async def test_text_request_falls_back_to_ollama_when_vllm_degraded(
+        self, mock_vllm_backend, mock_ollama_client
+    ):
+        mock_vllm_backend.chat.side_effect = VLLMNotReadyError("down")
+        mock_ollama_client.chat = AsyncMock(
+            return_value={"message": {"content": "fallback answer"}}
+        )
+
+        client = UnifiedLLMClient(
+            ollama_client=mock_ollama_client,
+            backend=mock_vllm_backend,
+            _breaker_recovery_timeout=60.0,
+        )
+        for _ in range(3):
+            with contextlib.suppress(Exception):
+                await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+
+        result = await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+        assert "fallback answer" in str(result)
+
+    @pytest.mark.asyncio
+    async def test_image_request_hard_errors_when_vllm_degraded(
+        self, mock_vllm_backend, mock_ollama_client, tmp_path
+    ):
+        mock_vllm_backend.chat.side_effect = VLLMNotReadyError("down")
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG")
+
+        client = UnifiedLLMClient(
+            ollama_client=mock_ollama_client,
+            backend=mock_vllm_backend,
+            _breaker_recovery_timeout=60.0,
+        )
+        for _ in range(3):
+            with contextlib.suppress(Exception):
+                await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+
+        with pytest.raises(VLLMNotReadyError):
+            await client.chat(
+                model="x",
+                messages=[{"role": "user", "content": "what is this?"}],
+                images=[str(img)],
+            )

--- a/tests/test_core/test_vllm_backend.py
+++ b/tests/test_core/test_vllm_backend.py
@@ -172,3 +172,26 @@ class TestVLLMBackendChatStream:
                 messages=[{"role": "user", "content": "hi"}],
             ):
                 pass
+
+
+class TestVLLMBackendEmbed:
+    @pytest.mark.asyncio
+    async def test_embed_returns_vector(self, backend, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/embeddings",
+            status_code=200,
+            json={"data": [{"embedding": [0.1, 0.2, 0.3]}], "model": "embed-model"},
+        )
+        resp = await backend.embed(model="embed-model", text="hello")
+        assert resp.embedding == [0.1, 0.2, 0.3]
+        assert resp.model == "embed-model"
+
+    @pytest.mark.asyncio
+    async def test_embed_raises_when_model_doesnt_support(self, backend, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/embeddings",
+            status_code=400,
+            json={"error": "not an embedding model"},
+        )
+        with pytest.raises(LLMBadRequestError):
+            await backend.embed(model="qwen-chat-only", text="hello")

--- a/tests/test_core/test_vllm_backend.py
+++ b/tests/test_core/test_vllm_backend.py
@@ -6,8 +6,9 @@ import pytest
 
 from cognithor.core.llm_backend import (
     LLMBackendType,
+    LLMBadRequestError,
 )
-from cognithor.core.vllm_backend import VLLMBackend
+from cognithor.core.vllm_backend import VLLMBackend, VLLMNotReadyError
 
 if TYPE_CHECKING:
     from pytest_httpx import HTTPXMock
@@ -50,3 +51,88 @@ class TestVLLMBackendBasics:
     async def test_close_is_idempotent(self, backend):
         await backend.close()
         await backend.close()
+
+
+class TestVLLMBackendChat:
+    @pytest.mark.asyncio
+    async def test_chat_sends_openai_payload(self, backend, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=200,
+            json={
+                "choices": [{"message": {"content": "Hello!"}}],
+                "model": "Qwen/Qwen2.5-VL-7B-Instruct",
+                "usage": {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+            },
+        )
+        resp = await backend.chat(
+            model="Qwen/Qwen2.5-VL-7B-Instruct",
+            messages=[{"role": "user", "content": "Hi"}],
+            temperature=0.7,
+        )
+        assert resp.content == "Hello!"
+        assert resp.model == "Qwen/Qwen2.5-VL-7B-Instruct"
+        assert resp.usage == {"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12}
+
+        request = httpx_mock.get_requests()[0]
+        import json as _j
+
+        body = _j.loads(request.content)
+        assert body["model"] == "Qwen/Qwen2.5-VL-7B-Instruct"
+        assert body["temperature"] == 0.7
+        assert body["messages"] == [{"role": "user", "content": "Hi"}]
+
+    @pytest.mark.asyncio
+    async def test_chat_converts_image_paths_to_openai_vision_format(
+        self, backend, httpx_mock, tmp_path
+    ):
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR")
+
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=200,
+            json={"choices": [{"message": {"content": "ok"}}], "model": "x"},
+        )
+        await backend.chat(
+            model="Qwen/Qwen2.5-VL-7B-Instruct",
+            messages=[{"role": "user", "content": "what is this?"}],
+            images=[str(img)],
+        )
+
+        import json as _j
+
+        body = _j.loads(httpx_mock.get_requests()[0].content)
+        last = body["messages"][-1]
+        assert isinstance(last["content"], list)
+        assert any(c.get("type") == "text" for c in last["content"])
+        prefix = "data:image/png;base64,"
+        assert any(
+            c.get("type") == "image_url" and c["image_url"]["url"].startswith(prefix)
+            for c in last["content"]
+        )
+
+    @pytest.mark.asyncio
+    async def test_chat_raises_bad_request_on_400(self, backend, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=400,
+            json={"error": {"message": "context too long"}},
+        )
+        with pytest.raises(LLMBadRequestError):
+            await backend.chat(model="x", messages=[{"role": "user", "content": "a"}])
+
+    @pytest.mark.asyncio
+    async def test_chat_raises_not_ready_on_5xx(self, backend, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=503,
+            json={"error": "model loading"},
+        )
+        with pytest.raises(VLLMNotReadyError):
+            await backend.chat(model="x", messages=[{"role": "user", "content": "a"}])
+
+    @pytest.mark.asyncio
+    async def test_chat_raises_not_ready_on_connection_refused(self, backend):
+        with pytest.raises(VLLMNotReadyError):
+            await backend.chat(model="x", messages=[{"role": "user", "content": "a"}])

--- a/tests/test_core/test_vllm_backend.py
+++ b/tests/test_core/test_vllm_backend.py
@@ -136,3 +136,39 @@ class TestVLLMBackendChat:
     async def test_chat_raises_not_ready_on_connection_refused(self, backend):
         with pytest.raises(VLLMNotReadyError):
             await backend.chat(model="x", messages=[{"role": "user", "content": "a"}])
+
+
+class TestVLLMBackendChatStream:
+    @pytest.mark.asyncio
+    async def test_stream_yields_content_chunks(self, backend, httpx_mock):
+        sse_lines = (
+            b'data: {"choices":[{"delta":{"content":"Hel"}}]}\n\n'
+            b'data: {"choices":[{"delta":{"content":"lo"}}]}\n\n'
+            b"data: [DONE]\n\n"
+        )
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=200,
+            content=sse_lines,
+            headers={"content-type": "text/event-stream"},
+        )
+        chunks: list[str] = []
+        async for piece in backend.chat_stream(
+            model="x",
+            messages=[{"role": "user", "content": "hi"}],
+        ):
+            chunks.append(piece)
+        assert "".join(chunks) == "Hello"
+
+    @pytest.mark.asyncio
+    async def test_stream_raises_on_5xx(self, backend, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=503,
+        )
+        with pytest.raises(VLLMNotReadyError):
+            async for _ in backend.chat_stream(
+                model="x",
+                messages=[{"role": "user", "content": "hi"}],
+            ):
+                pass

--- a/tests/test_core/test_vllm_backend.py
+++ b/tests/test_core/test_vllm_backend.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cognithor.core.llm_backend import (
+    LLMBackendType,
+)
+from cognithor.core.vllm_backend import VLLMBackend
+
+if TYPE_CHECKING:
+    from pytest_httpx import HTTPXMock
+
+BASE_URL = "http://localhost:8000/v1"
+
+
+@pytest.fixture
+def backend() -> VLLMBackend:
+    return VLLMBackend(base_url=BASE_URL, timeout=5)
+
+
+class TestVLLMBackendBasics:
+    def test_backend_type(self, backend):
+        assert backend.backend_type == LLMBackendType.VLLM
+
+    @pytest.mark.asyncio
+    async def test_is_available_true_on_200(self, backend, httpx_mock: HTTPXMock):
+        httpx_mock.add_response(
+            url="http://localhost:8000/health",
+            status_code=200,
+        )
+        assert await backend.is_available() is True
+
+    @pytest.mark.asyncio
+    async def test_is_available_false_on_connection_refused(self, backend):
+        assert await backend.is_available() is False
+
+    @pytest.mark.asyncio
+    async def test_list_models_from_openai_endpoint(self, backend, httpx_mock):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/models",
+            status_code=200,
+            json={"data": [{"id": "Qwen/Qwen3.6-27B-FP8"}]},
+        )
+        models = await backend.list_models()
+        assert "Qwen/Qwen3.6-27B-FP8" in models
+
+    @pytest.mark.asyncio
+    async def test_close_is_idempotent(self, backend):
+        await backend.close()
+        await backend.close()

--- a/tests/test_core/test_vllm_orchestrator.py
+++ b/tests/test_core/test_vllm_orchestrator.py
@@ -288,3 +288,39 @@ class TestStartContainer:
         call = wait_mock.call_args
         got_timeout = call.kwargs.get("timeout", 120) if call.kwargs else 120
         assert got_timeout == 120
+
+
+class TestStopAndReuse:
+    def test_stop_container_via_label(self):
+        find_result = MagicMock(returncode=0, stdout="abc123def456\n")
+        stop_result = MagicMock(returncode=0)
+        rm_result = MagicMock(returncode=0)
+        orch = VLLMOrchestrator()
+        orch.state.container_running = True
+
+        with patch("subprocess.run", side_effect=[find_result, stop_result, rm_result]):
+            orch.stop_container()
+
+        assert orch.state.container_running is False
+
+    def test_stop_when_no_container_is_noop(self):
+        find_result = MagicMock(returncode=0, stdout="")
+        orch = VLLMOrchestrator()
+        with patch("subprocess.run", return_value=find_result):
+            orch.stop_container()
+
+    def test_reuse_existing_returns_info(self):
+        ps_stdout = (
+            '{"ID":"abc123def456","Ports":"0.0.0.0:8000->8000/tcp",'
+            '"Image":"vllm/vllm-openai:v0.19.1","Command":"... --model Qwen/Qwen3.6-27B-FP8 ..."}\n'
+        )
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=ps_stdout)):
+            info = VLLMOrchestrator().reuse_existing()
+        assert info is not None
+        assert info.container_id == "abc123def456"
+        assert info.port == 8000
+
+    def test_reuse_existing_returns_none_when_nothing_running(self):
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="")):
+            info = VLLMOrchestrator().reuse_existing()
+        assert info is None

--- a/tests/test_core/test_vllm_orchestrator.py
+++ b/tests/test_core/test_vllm_orchestrator.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cognithor.core.llm_backend import VLLMHardwareError
+from cognithor.core.llm_backend import VLLMHardwareError, VLLMNotReadyError
 from cognithor.core.vllm_orchestrator import (
     ContainerInfo,
     DockerInfo,
@@ -220,3 +220,71 @@ class TestPullImage:
         with patch("subprocess.Popen", return_value=mock_proc):
             orch.pull_image(orch.docker_image, progress_callback=None)
         assert orch.state.image_pulled is True
+
+
+class TestStartContainer:
+    def test_constructs_docker_run_command(self):
+        with (
+            patch.object(VLLMOrchestrator, "_port_available", return_value=True),
+            patch("subprocess.run") as run_mock,
+            patch.object(VLLMOrchestrator, "_wait_for_health", return_value=True),
+        ):
+            run_mock.return_value = MagicMock(returncode=0, stdout="abc123def456")
+            orch = VLLMOrchestrator(
+                docker_image="vllm/vllm-openai:v0.19.1", port=8000, hf_token="hf_x"
+            )
+            info = orch.start_container("Qwen/Qwen3.6-27B-FP8")
+
+        args = run_mock.call_args[0][0]
+        assert "run" in args
+        assert "-d" in args
+        assert "--gpus" in args and "all" in args
+        assert any("HF_TOKEN=hf_x" in a for a in args)
+        assert any("cognithor.managed=true" in a for a in args)
+        assert any("vllm-openai:v0.19.1" in a for a in args)
+        assert "Qwen/Qwen3.6-27B-FP8" in args
+        assert info.port == 8000
+        assert info.model == "Qwen/Qwen3.6-27B-FP8"
+
+    def test_port_fallback_when_busy(self):
+        orch = VLLMOrchestrator(port=8000)
+        with (
+            patch.object(orch, "_port_available", side_effect=[False, False, True]),
+            patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")),
+            patch.object(orch, "_wait_for_health", return_value=True),
+        ):
+            info = orch.start_container("Qwen/Qwen2.5-VL-7B-Instruct")
+        assert info.port == 8002
+
+    def test_raises_when_all_ports_busy(self):
+        orch = VLLMOrchestrator(port=8000)
+        with patch.object(orch, "_port_available", return_value=False):
+            with pytest.raises(VLLMNotReadyError) as exc:
+                orch.start_container("Qwen/Qwen2.5-VL-7B-Instruct")
+            assert "port" in str(exc.value).lower()
+
+    def test_health_timeout_scales_with_explicit_argument(self):
+        orch = VLLMOrchestrator(port=8000)
+        with (
+            patch.object(orch, "_port_available", return_value=True),
+            patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")),
+            patch.object(orch, "_wait_for_health", return_value=True) as wait_mock,
+        ):
+            orch.start_container("x", health_timeout=300)
+        call = wait_mock.call_args
+        got_timeout = call.kwargs.get("timeout") if call.kwargs else None
+        if got_timeout is None and call.args:
+            got_timeout = call.args[-1] if len(call.args) > 1 else None
+        assert got_timeout == 300
+
+    def test_default_health_timeout_is_120(self):
+        orch = VLLMOrchestrator(port=8000)
+        with (
+            patch.object(orch, "_port_available", return_value=True),
+            patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")),
+            patch.object(orch, "_wait_for_health", return_value=True) as wait_mock,
+        ):
+            orch.start_container("x")
+        call = wait_mock.call_args
+        got_timeout = call.kwargs.get("timeout", 120) if call.kwargs else 120
+        assert got_timeout == 120

--- a/tests/test_core/test_vllm_orchestrator.py
+++ b/tests/test_core/test_vllm_orchestrator.py
@@ -1,5 +1,10 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cognithor.core.llm_backend import VLLMHardwareError
 from cognithor.core.vllm_orchestrator import (
     ContainerInfo,
     DockerInfo,
@@ -72,3 +77,60 @@ class TestOrchestratorInit:
         assert orch.port == 8000
         assert orch._hf_token == "hf_test"
         assert orch.state.hardware_ok is False
+
+
+class TestCheckHardware:
+    def _mk_orch(self):
+        return VLLMOrchestrator()
+
+    def test_detects_rtx_5090(self):
+        mock_result = MagicMock(returncode=0, stdout="NVIDIA GeForce RTX 5090, 32768, 12.0\n")
+        with patch("subprocess.run", return_value=mock_result):
+            info = self._mk_orch().check_hardware()
+        assert info.gpu_name == "NVIDIA GeForce RTX 5090"
+        assert info.vram_gb == 32
+        assert info.compute_capability == (12, 0)
+
+    def test_detects_rtx_4090(self):
+        mock_result = MagicMock(returncode=0, stdout="NVIDIA GeForce RTX 4090, 24564, 8.9\n")
+        with patch("subprocess.run", return_value=mock_result):
+            info = self._mk_orch().check_hardware()
+        assert info.gpu_name == "NVIDIA GeForce RTX 4090"
+        assert info.vram_gb == 24
+        assert info.compute_capability == (8, 9)
+
+    def test_raises_when_nvidia_smi_missing(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(VLLMHardwareError) as exc:
+                self._mk_orch().check_hardware()
+            assert "nvidia-smi" in str(exc.value).lower()
+
+    def test_raises_when_no_gpu_detected(self):
+        mock_result = MagicMock(returncode=0, stdout="")
+        with patch("subprocess.run", return_value=mock_result):
+            with pytest.raises(VLLMHardwareError):
+                self._mk_orch().check_hardware()
+
+    def test_raises_when_nvidia_smi_fails(self):
+        mock_result = MagicMock(returncode=9, stdout="", stderr="NVIDIA-SMI has failed")
+        with patch("subprocess.run", return_value=mock_result):
+            with pytest.raises(VLLMHardwareError):
+                self._mk_orch().check_hardware()
+
+    def test_picks_first_gpu_when_multiple(self):
+        mock_result = MagicMock(
+            returncode=0,
+            stdout="NVIDIA GeForce RTX 5090, 32768, 12.0\nNVIDIA GeForce RTX 3060, 12288, 8.6\n",
+        )
+        with patch("subprocess.run", return_value=mock_result):
+            info = self._mk_orch().check_hardware()
+        assert "5090" in info.gpu_name
+
+    def test_state_updated_after_success(self):
+        mock_result = MagicMock(returncode=0, stdout="NVIDIA GeForce RTX 4080, 16380, 8.9\n")
+        orch = self._mk_orch()
+        with patch("subprocess.run", return_value=mock_result):
+            orch.check_hardware()
+        assert orch.state.hardware_ok is True
+        assert orch.state.hardware_info is not None
+        assert orch.state.hardware_info.compute_capability == (8, 9)

--- a/tests/test_core/test_vllm_orchestrator.py
+++ b/tests/test_core/test_vllm_orchestrator.py
@@ -173,3 +173,50 @@ class TestCheckDocker:
         with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=mock_stdout)):
             orch.check_docker()
         assert orch.state.docker_ok is True
+
+
+class TestPullImage:
+    def test_pull_emits_progress_events(self):
+        json_lines = [
+            '{"status":"Pulling from vllm/vllm-openai","id":"latest"}\n',
+            '{"status":"Downloading","progressDetail":{"current":1000000,"total":10000000},"id":"abc123"}\n',
+            '{"status":"Download complete","id":"abc123"}\n',
+            '{"status":"Status: Downloaded newer image for vllm/vllm-openai:v0.19.1"}\n',
+        ]
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter(json_lines)
+        mock_proc.wait.return_value = 0
+        mock_proc.returncode = 0
+
+        events: list[dict] = []
+
+        def cb(ev):
+            events.append(ev)
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            VLLMOrchestrator().pull_image("vllm/vllm-openai:v0.19.1", progress_callback=cb)
+
+        assert any(e.get("status") == "Downloading" for e in events)
+        assert any("current" in (e.get("progressDetail") or {}) for e in events)
+
+    def test_pull_failure_raises(self):
+        from cognithor.core.llm_backend import VLLMDockerError
+
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter(['{"status":"error"}\n'])
+        mock_proc.wait.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("subprocess.Popen", return_value=mock_proc):
+            with pytest.raises(VLLMDockerError):
+                VLLMOrchestrator().pull_image("bad/image:tag", progress_callback=None)
+
+    def test_pull_sets_image_pulled_flag(self):
+        mock_proc = MagicMock()
+        mock_proc.stdout = iter(['{"status":"Pulling"}\n'])
+        mock_proc.wait.return_value = 0
+        mock_proc.returncode = 0
+        orch = VLLMOrchestrator()
+        with patch("subprocess.Popen", return_value=mock_proc):
+            orch.pull_image(orch.docker_image, progress_callback=None)
+        assert orch.state.image_pulled is True

--- a/tests/test_core/test_vllm_orchestrator.py
+++ b/tests/test_core/test_vllm_orchestrator.py
@@ -134,3 +134,42 @@ class TestCheckHardware:
         assert orch.state.hardware_ok is True
         assert orch.state.hardware_info is not None
         assert orch.state.hardware_info.compute_capability == (8, 9)
+
+
+class TestCheckDocker:
+    def test_docker_running(self):
+        mock_stdout = '{"Client":{"Version":"26.0.0"},"Server":{"Version":"26.0.0"}}'
+        mock_result = MagicMock(returncode=0, stdout=mock_stdout)
+        with patch("subprocess.run", return_value=mock_result):
+            info = VLLMOrchestrator().check_docker()
+        assert info.available is True
+        assert info.server_running is True
+        assert info.version == "26.0.0"
+
+    def test_docker_installed_but_server_down(self):
+        mock_stdout = '{"Client":{"Version":"26.0.0"}}'
+        mock_result = MagicMock(returncode=0, stdout=mock_stdout)
+        with patch("subprocess.run", return_value=mock_result):
+            info = VLLMOrchestrator().check_docker()
+        assert info.available is True
+        assert info.server_running is False
+
+    def test_docker_cli_missing(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            info = VLLMOrchestrator().check_docker()
+        assert info.available is False
+        assert info.server_running is False
+
+    def test_docker_cmd_fails(self):
+        mock_result = MagicMock(returncode=1, stdout="", stderr="daemon not running")
+        with patch("subprocess.run", return_value=mock_result):
+            info = VLLMOrchestrator().check_docker()
+        assert info.available is True
+        assert info.server_running is False
+
+    def test_state_updated(self):
+        mock_stdout = '{"Client":{"Version":"26.0.0"},"Server":{"Version":"26.0.0"}}'
+        orch = VLLMOrchestrator()
+        with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=mock_stdout)):
+            orch.check_docker()
+        assert orch.state.docker_ok is True

--- a/tests/test_core/test_vllm_orchestrator.py
+++ b/tests/test_core/test_vllm_orchestrator.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+from cognithor.core.vllm_orchestrator import (
+    ContainerInfo,
+    DockerInfo,
+    HardwareInfo,
+    ModelEntry,
+    VLLMOrchestrator,
+    VLLMState,
+)
+
+
+class TestDataclasses:
+    def test_hardware_info_fields(self):
+        h = HardwareInfo(gpu_name="RTX 5090", vram_gb=32, compute_capability=(12, 0))
+        assert h.gpu_name == "RTX 5090"
+        assert h.vram_gb == 32
+        assert h.compute_capability == (12, 0)
+
+    def test_hardware_info_sm_as_string(self):
+        h = HardwareInfo(gpu_name="RTX 4090", vram_gb=24, compute_capability=(8, 9))
+        assert h.sm_string == "8.9"
+
+    def test_docker_info_fields(self):
+        d = DockerInfo(available=True, version="26.0.0", server_running=True)
+        assert d.available is True
+        assert d.version == "26.0.0"
+
+    def test_model_entry_from_dict(self):
+        m = ModelEntry.from_dict(
+            {
+                "id": "mmangkad/Qwen3.6-27B-NVFP4",
+                "display_name": "Qwen3.6-27B NVFP4",
+                "base_model": "Qwen/Qwen3.6-27B",
+                "quantization": "NVFP4",
+                "vram_gb_min": 14,
+                "min_compute_capability": "12.0",
+                "min_vllm_version": "pending",
+                "capability": "vision",
+                "priority": "premium",
+                "tested": False,
+                "notes": "",
+            }
+        )
+        assert m.id == "mmangkad/Qwen3.6-27B-NVFP4"
+        assert m.min_cc_tuple == (12, 0)
+        assert m.vram_gb_min == 14
+        assert m.priority == "premium"
+
+    def test_vllm_state_initial(self):
+        s = VLLMState()
+        assert s.hardware_ok is False
+        assert s.docker_ok is False
+        assert s.container_running is False
+        assert s.current_model is None
+        assert s.hardware_info is None
+
+    def test_container_info(self):
+        c = ContainerInfo(container_id="abc123", port=8000, model="Qwen/Qwen3.6-27B-FP8")
+        assert c.container_id == "abc123"
+        assert c.port == 8000
+
+
+class TestOrchestratorInit:
+    def test_orchestrator_constructs_with_config(self):
+        orch = VLLMOrchestrator(
+            docker_image="vllm/vllm-openai:v0.19.1",
+            port=8000,
+            hf_token="hf_test",
+        )
+        assert orch.docker_image == "vllm/vllm-openai:v0.19.1"
+        assert orch.port == 8000
+        assert orch._hf_token == "hf_test"
+        assert orch.state.hardware_ok is False

--- a/tests/test_core/test_vllm_orchestrator.py
+++ b/tests/test_core/test_vllm_orchestrator.py
@@ -324,3 +324,16 @@ class TestStopAndReuse:
         with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="")):
             info = VLLMOrchestrator().reuse_existing()
         assert info is None
+
+
+class TestStatusAggregator:
+    def test_status_returns_current_state(self):
+        orch = VLLMOrchestrator()
+        orch.state.hardware_ok = True
+        orch.state.docker_ok = True
+        snapshot = orch.status()
+        assert snapshot.hardware_ok is True
+        assert snapshot.docker_ok is True
+        # Mutating the returned copy must not leak back into orch.state
+        snapshot.hardware_ok = False
+        assert orch.state.hardware_ok is True

--- a/tests/test_core/test_vllm_recommend_model.py
+++ b/tests/test_core/test_vllm_recommend_model.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cognithor.core.vllm_orchestrator import (
+    HardwareInfo,
+    ModelEntry,
+    VLLMOrchestrator,
+)
+
+REGISTRY_PATH = (
+    Path(__file__).resolve().parents[2] / "src" / "cognithor" / "cli" / "model_registry.json"
+)
+
+
+@pytest.fixture
+def registry() -> list[ModelEntry]:
+    data = json.loads(REGISTRY_PATH.read_text(encoding="utf-8"))
+    return [ModelEntry.from_dict(m) for m in data["providers"]["vllm"]["models"]]
+
+
+@pytest.fixture
+def orch() -> VLLMOrchestrator:
+    return VLLMOrchestrator()
+
+
+class TestRecommendModel:
+    def test_blackwell_32gb_picks_nvfp4_when_tested(self, orch):
+        # Use synthetic registry where NVFP4 is marked tested=True (simulates future
+        # vLLM Qwen3.6 support landing). Controller must pick it over fallback.
+        entries = [
+            ModelEntry.from_dict(
+                {
+                    "id": "mmangkad/Qwen3.6-27B-NVFP4",
+                    "display_name": "NVFP4",
+                    "base_model": "Qwen/Qwen3.6-27B",
+                    "quantization": "NVFP4",
+                    "vram_gb_min": 14,
+                    "min_compute_capability": "12.0",
+                    "min_vllm_version": "0.20.0",
+                    "capability": "vision",
+                    "priority": "premium",
+                    "tested": True,
+                    "notes": "",
+                }
+            ),
+            ModelEntry.from_dict(
+                {
+                    "id": "Qwen/Qwen2.5-VL-7B-Instruct",
+                    "display_name": "fallback",
+                    "base_model": "Qwen/Qwen2.5-VL-7B-Instruct",
+                    "quantization": "bf16",
+                    "vram_gb_min": 16,
+                    "min_compute_capability": "7.5",
+                    "min_vllm_version": "0.7.0",
+                    "capability": "vision",
+                    "priority": "fallback",
+                    "tested": True,
+                    "notes": "",
+                }
+            ),
+        ]
+        hw = HardwareInfo(gpu_name="RTX 5090", vram_gb=32, compute_capability=(12, 0))
+        best = orch.recommend_model(hw, entries, prefer="vision")
+        assert best.id == "mmangkad/Qwen3.6-27B-NVFP4"
+
+    def test_current_registry_ada_24gb_falls_back_to_qwen25(self, orch, registry):
+        # All current Qwen3.6 entries have tested=False. Only Qwen2.5-VL-7B is tested.
+        hw = HardwareInfo(gpu_name="RTX 4090", vram_gb=24, compute_capability=(8, 9))
+        best = orch.recommend_model(hw, registry, prefer="vision")
+        assert best.tested is True
+        assert "Qwen2.5-VL" in best.id
+
+    def test_current_registry_ampere_24gb_falls_back_to_qwen25(self, orch, registry):
+        hw = HardwareInfo(gpu_name="RTX 3090", vram_gb=24, compute_capability=(8, 0))
+        best = orch.recommend_model(hw, registry, prefer="vision")
+        assert best.tested is True
+
+    def test_low_vram_returns_none(self, orch, registry):
+        hw = HardwareInfo(gpu_name="RTX 2080 Ti", vram_gb=11, compute_capability=(7, 5))
+        best = orch.recommend_model(hw, registry, prefer="vision")
+        assert best is None
+
+    def test_text_preference_returns_none_when_none_curated(self, orch, registry):
+        # Registry has no text-capability entries in v1
+        hw = HardwareInfo(gpu_name="RTX 5090", vram_gb=32, compute_capability=(12, 0))
+        best = orch.recommend_model(hw, registry, prefer="text")
+        assert best is None
+
+
+class TestFilterRegistry:
+    def test_ignores_entries_exceeding_vram(self, orch, registry):
+        hw = HardwareInfo(gpu_name="RTX 4080", vram_gb=16, compute_capability=(8, 9))
+        results = orch.filter_registry(hw, registry)
+        for m in results:
+            assert m.vram_gb_min <= 16
+
+    def test_ignores_entries_requiring_newer_compute_capability(self, orch, registry):
+        hw = HardwareInfo(gpu_name="RTX 4090", vram_gb=24, compute_capability=(8, 9))
+        results = orch.filter_registry(hw, registry)
+        for m in results:
+            assert m.min_cc_tuple <= (8, 9)

--- a/tests/test_gateway/test_gateway_vllm_lifecycle.py
+++ b/tests/test_gateway/test_gateway_vllm_lifecycle.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from cognithor.config import CognithorConfig, VLLMConfig
+
+
+class TestGatewayVLLMLifecycle:
+    def test_shutdown_stops_container_when_toggle_on(self):
+        cfg = CognithorConfig(vllm=VLLMConfig(enabled=True, auto_stop_on_close=True))
+        from cognithor.gateway.gateway import Gateway
+
+        gw = Gateway.__new__(Gateway)
+        gw._config = cfg
+        gw._vllm_orchestrator = MagicMock()
+        gw.on_shutdown_vllm()
+        gw._vllm_orchestrator.stop_container.assert_called_once()
+
+    def test_shutdown_leaves_container_running_when_toggle_off(self):
+        cfg = CognithorConfig(vllm=VLLMConfig(enabled=True, auto_stop_on_close=False))
+        from cognithor.gateway.gateway import Gateway
+
+        gw = Gateway.__new__(Gateway)
+        gw._config = cfg
+        gw._vllm_orchestrator = MagicMock()
+        gw.on_shutdown_vllm()
+        gw._vllm_orchestrator.stop_container.assert_not_called()
+
+    def test_startup_picks_up_existing_container(self):
+        cfg = CognithorConfig(vllm=VLLMConfig(enabled=True))
+        from cognithor.core.vllm_orchestrator import ContainerInfo
+        from cognithor.gateway.gateway import Gateway
+
+        gw = Gateway.__new__(Gateway)
+        gw._config = cfg
+        gw._vllm_orchestrator = MagicMock()
+        gw._vllm_orchestrator.reuse_existing.return_value = ContainerInfo(
+            container_id="abc", port=8000, model="Qwen/Qwen2.5-VL-7B-Instruct"
+        )
+        result = gw.on_startup_vllm()
+        assert result is not None
+        assert result.model == "Qwen/Qwen2.5-VL-7B-Instruct"
+
+    def test_startup_returns_none_when_vllm_disabled(self):
+        cfg = CognithorConfig(vllm=VLLMConfig(enabled=False))
+        from cognithor.gateway.gateway import Gateway
+
+        gw = Gateway.__new__(Gateway)
+        gw._config = cfg
+        gw._vllm_orchestrator = None
+        result = gw.on_startup_vllm()
+        assert result is None

--- a/tests/test_integration/test_vllm_fake_server.py
+++ b/tests/test_integration/test_vllm_fake_server.py
@@ -1,0 +1,120 @@
+"""End-to-end test: VLLMBackend against a FastAPI impersonating vLLM's OpenAI API.
+
+No GPU, no Docker, no real vLLM. Verifies the full request-response round-trip
+on the HTTP layer with real (mocked-server) sockets.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json as _json
+import socket
+
+import pytest
+import uvicorn
+from fastapi import FastAPI
+from fastapi.responses import StreamingResponse
+
+from cognithor.core.vllm_backend import VLLMBackend
+
+
+def _build_fake_vllm_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.post("/v1/chat/completions")
+    async def chat(body: dict):
+        if body.get("stream"):
+
+            async def gen():
+                for chunk in ["Hel", "lo ", "world"]:
+                    payload = _json.dumps({"choices": [{"delta": {"content": chunk}}]})
+                    yield f"data: {payload}\n\n"
+                yield "data: [DONE]\n\n"
+
+            return StreamingResponse(gen(), media_type="text/event-stream")
+        return {
+            "choices": [{"message": {"content": "echo: " + body["messages"][-1]["content"]}}],
+            "model": body["model"],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        }
+
+    @app.get("/v1/models")
+    async def models():
+        return {"data": [{"id": "fake-model"}]}
+
+    return app
+
+
+@pytest.fixture
+async def fake_server():
+    """Start the fake server on an ephemeral port."""
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+
+    config = uvicorn.Config(
+        _build_fake_vllm_app(),
+        host="127.0.0.1",
+        port=port,
+        log_level="error",
+    )
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve())
+    for _ in range(50):
+        if server.started:
+            break
+        await asyncio.sleep(0.05)
+    yield port
+    server.should_exit = True
+    await task
+
+
+class TestVLLMBackendEndToEnd:
+    @pytest.mark.asyncio
+    async def test_full_chat_roundtrip(self, fake_server):
+        backend = VLLMBackend(base_url=f"http://127.0.0.1:{fake_server}/v1")
+        try:
+            resp = await backend.chat(
+                model="fake-model",
+                messages=[{"role": "user", "content": "hello"}],
+            )
+            assert resp.content == "echo: hello"
+            assert resp.model == "fake-model"
+        finally:
+            await backend.close()
+
+    @pytest.mark.asyncio
+    async def test_full_stream_roundtrip(self, fake_server):
+        backend = VLLMBackend(base_url=f"http://127.0.0.1:{fake_server}/v1")
+        try:
+            chunks = []
+            async for p in backend.chat_stream(
+                model="fake-model",
+                messages=[{"role": "user", "content": "stream me"}],
+            ):
+                chunks.append(p)
+            assert "".join(chunks) == "Hello world"
+        finally:
+            await backend.close()
+
+    @pytest.mark.asyncio
+    async def test_is_available_roundtrip(self, fake_server):
+        backend = VLLMBackend(base_url=f"http://127.0.0.1:{fake_server}/v1")
+        try:
+            assert await backend.is_available() is True
+        finally:
+            await backend.close()
+
+    @pytest.mark.asyncio
+    async def test_list_models_roundtrip(self, fake_server):
+        backend = VLLMBackend(base_url=f"http://127.0.0.1:{fake_server}/v1")
+        try:
+            models = await backend.list_models()
+            assert "fake-model" in models
+        finally:
+            await backend.close()

--- a/tests/test_vllm_registry_sync.py
+++ b/tests/test_vllm_registry_sync.py
@@ -1,0 +1,45 @@
+"""Guard test: the vLLM model registry entries must stay self-consistent
+and load cleanly into ModelEntry.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from cognithor.core.vllm_orchestrator import ModelEntry
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REGISTRY = REPO_ROOT / "src" / "cognithor" / "cli" / "model_registry.json"
+
+
+class TestVLLMRegistryLoads:
+    def test_every_entry_parses_into_ModelEntry(self):
+        data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        for m in data["providers"]["vllm"]["models"]:
+            ModelEntry.from_dict(m)  # must not raise
+
+    def test_compute_capability_tuples_are_valid(self):
+        data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        for m in data["providers"]["vllm"]["models"]:
+            entry = ModelEntry.from_dict(m)
+            cc = entry.min_cc_tuple
+            assert 7 <= cc[0] <= 20
+            assert 0 <= cc[1] <= 9
+
+    def test_min_vllm_version_is_valid(self):
+        data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        for m in data["providers"]["vllm"]["models"]:
+            v = m["min_vllm_version"]
+            assert v == "pending" or re.match(r"^\d+\.\d+(\.\d+)?$", v)
+
+    def test_priority_is_enum(self):
+        data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        for m in data["providers"]["vllm"]["models"]:
+            assert m["priority"] in ("premium", "standard", "fallback")
+
+    def test_capability_is_enum(self):
+        data = json.loads(REGISTRY.read_text(encoding="utf-8"))
+        for m in data["providers"]["vllm"]["models"]:
+            assert m["capability"] in ("vision", "text")


### PR DESCRIPTION
## Summary

Adds **vLLM as a first-class opt-in LLM backend** alongside the existing Ollama default. Users with an NVIDIA GPU can install, start, stop, and hot-switch to vLLM entirely from the Flutter UI. Ollama stays the default — vLLM is purely additive. No existing user behavior changes until the vLLM option is explicitly enabled.

**Why:** Opens the door for faster inference on consumer GPUs (FP8, AWQ-INT4) and unlocks native NVFP4 on Blackwell (RTX 50xx). Also enables end-to-end vision workflows with models not available in the Ollama library (Qwen3.6, Qwen2.5-VL).

**Spec:** `docs/superpowers/specs/2026-04-22-vllm-opt-in-backend-design.md`
**Plan:** `docs/superpowers/plans/2026-04-22-vllm-opt-in-backend.md`

## What's in here

### Python backend

- `src/cognithor/core/vllm_backend.py` (~240 LOC) — `VLLMBackend` implementing `LLMBackend` ABC. OpenAI-compatible `/v1/chat/completions`, streaming via SSE, `/v1/models` listing, `/v1/embeddings`, image-payload conversion (PNG/JPG/WEBP/GIF/BMP → OpenAI-vision data-URLs attached to the last user message).
- `src/cognithor/core/vllm_orchestrator.py` (~450 LOC) — stateful lifecycle manager wrapping `docker` and `nvidia-smi` subprocesses. Methods: `check_hardware`, `check_docker`, `pull_image` (streamed JSON progress), `start_container` (auto-port-fallback 8000→8009, configurable health timeout), `stop_container`, `reuse_existing` (pick up containers labeled `cognithor.managed=true`), `recommend_model` + `filter_registry` (GPU-aware ranking), `status` (snapshot).
- `src/cognithor/core/llm_backend.py` — new `LLMBadRequestError`, `VLLMNotReadyError`, `VLLMHardwareError`, `VLLMDockerError` (renamed during review from `DockerError` to avoid collision with `mcp.docker_tools.DockerError`). New `LLMBackendType.VLLM` enum entry. `create_backend()` factory wired for `vllm`.
- `src/cognithor/core/unified_llm.py` — per-backend `CircuitBreaker` (reuses existing `cognithor.utils.circuit_breaker.CircuitBreaker` — do not reinvent). New `BackendStatus` enum (`OK`/`DEGRADED`). Situational fail-flow: text requests transparently fall back to Ollama when vLLM is DEGRADED, image requests raise `VLLMNotReadyError` because Ollama cannot do vision. `LLMBadRequestError` excluded from breaker counting (it's user/context error, not backend fault).
- `src/cognithor/config.py` — new `VLLMConfig` Pydantic sub-model with `extra="forbid"`. Embedded on `CognithorConfig.vllm`. HF token is NOT stored here — reuses existing `config.huggingface_api_key` (keyring-backed via `SecretStore._SECRET_FIELDS`).
- `src/cognithor/cli/model_registry.json` — new `vllm` provider section with 5 curated entries per-quantization (NVFP4, FP8, AWQ-INT4, MoE-FP8, bf16 fallback), each with `min_compute_capability`, `vram_gb_min`, `priority`, `tested`, `min_vllm_version`.
- `src/cognithor/gateway/gateway.py` — `on_startup_vllm` (reuse running container if present), `on_shutdown_vllm` (respects `auto_stop_on_close` toggle), `rebuild_llm_client` (hot-switch hook called by the /active endpoint).

### FastAPI

- `src/cognithor/channels/backends_api.py` (new) — dedicated `APIRouter` with `_get_orchestrator` singleton and `build_backends_app` test helper:
    - `GET /api/backends` — list all backends + active
    - `GET /api/backends/vllm/status` — current VLLMState
    - `POST /api/backends/vllm/check-hardware` — 503 on no-GPU with `recovery_hint`
    - `POST /api/backends/vllm/pull-image` — **SSE-streamed** docker-pull progress via `asyncio.Queue` + `asyncio.to_thread`
    - `POST /api/backends/vllm/start` — accepts `{model}`, returns ContainerInfo
    - `POST /api/backends/vllm/stop` — idempotent stop+rm on labeled container
    - `GET /api/backends/vllm/logs` — ring-buffer of last 500 lines
    - `GET /api/backends/vllm/available-models` — filtered registry + `recommended_id` for the GPU
    - `POST /api/backends/active` — hot-switch via `gateway.rebuild_llm_client()`
- `src/cognithor/channels/api.py` — existing `APIChannel._create_app()` includes the new router.

### Flutter UI

- `flutter_app/lib/providers/llm_backend_provider.dart` — `ChangeNotifier` with 2-second polling while the detail page is mounted, `pullImage()` async stream parsing SSE chunks, `startContainer()`, `fetchAvailableModels()`, `setActive()`.
- `flutter_app/lib/screens/llm_backends_screen.dart` — list view with status dots + active marker, tap-to-configure navigation.
- `flutter_app/lib/screens/vllm_setup_screen.dart` — 4 status cards (Hardware · Docker · Image · Model) with live polling. Pull button renders `LinearProgressIndicator` driven by the SSE stream. Model dropdown shows ⭐ badge on the recommended entry, disables entries that don't fit the detected VRAM, flags VRAM ceiling in red.

### Docs

- `docs/vllm-user-guide.md` — prerequisites, 8-step enable flow, 7 troubleshooting scenarios, `~/.cognithor/config.yaml` reference.
- `docs/vllm-manual-test.md` — release-gate checklist to run once per release on real NVIDIA hardware. Covers fresh install, hardware detection, image pull, model start, vision chat, fail-flow, lifecycle toggles, Blackwell-specific NVFP4.
- `CHANGELOG.md` — `[Unreleased] → Added` entry.

## Testing

- **14,027 tests pass, 12 skipped, 0 failures** (full `pytest tests/` — 19 min)
- **Flutter: 12/12 tests pass, `flutter analyze` clean**
- **Ruff check + format --check clean** across `src/` and `tests/`

New test files:
- `tests/test_core/test_llm_backend_errors.py` (6 tests — error hierarchy + enum)
- `tests/config/test_vllm_config.py` (4 tests)
- `tests/test_core/test_model_registry_vllm.py` (7 tests — registry schema)
- `tests/test_core/test_vllm_orchestrator.py` (32 tests — full orchestrator surface)
- `tests/test_core/test_vllm_recommend_model.py` (7 tests — GPU-aware ranking)
- `tests/test_core/test_vllm_backend.py` (14 tests — chat/stream/embed/errors)
- `tests/test_core/test_create_backend_vllm.py` (3 tests — factory)
- `tests/test_core/test_unified_llm_circuit_breaker.py` (5 tests — CB wiring + fail-flow)
- `tests/test_integration/test_vllm_fake_server.py` (4 tests — E2E against a fake OpenAI-compat server)
- `tests/test_channels/test_api_backends.py` (11 tests — all 9 FastAPI endpoints)
- `tests/test_gateway/test_gateway_vllm_lifecycle.py` (4 tests)
- `tests/test_vllm_registry_sync.py` (5 tests — cross-repo guard)
- Flutter: `llm_backend_provider_test.dart` (6 tests), `llm_backends_screen_test.dart` (2 widget tests), `vllm_setup_screen_test.dart` (3 widget tests)

## Known follow-ups (not blockers)

- `Gateway.rebuild_llm_client` omits the old-client async close — flagged during T24 review. Hot-switch works; old client is GC'd eventually. A proper lifecycle-aware close can land as a follow-up PR.
- vLLM v0.19.1 (pinned as default) does **not** yet support the Qwen3.6 architecture. Qwen3.6 registry entries ship with `tested: false` and `min_vllm_version: "pending"`. Users who want to bleed-edge can set `docker_image: "vllm/vllm-openai:nightly"`. Default recommendation on all hardware until vLLM ships Qwen3.6 support: `Qwen/Qwen2.5-VL-7B-Instruct` (only `tested: true` entry).

## Usage (for reviewers)

```yaml
# ~/.cognithor/config.yaml
vllm:
  enabled: true
  # model: ""   # empty → orchestrator recommend_model() picks per GPU
  # docker_image: "vllm/vllm-openai:v0.19.1"
  port: 8000
  auto_stop_on_close: false
```

Launch Cognithor → **Settings → LLM Backends → vLLM** → walk through the 4 status cards → pick a model → **Start vLLM** → **Make active**.

## Plan execution method

Subagent-Driven Development (superpowers skill). 34 tasks, TDD throughout: failing test → red → implement → green → commit. Fresh subagent per task, two-stage review (spec compliance + code quality) for substantive tasks. One code-quality issue caught early (DockerError name collision) and fixed before cascading — renamed to `VLLMDockerError` across spec, plan, code, and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
