### PR TITLE
fix(config): reload planner prompts on language change (closes #136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to Cognithor are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+- **Language change in Settings now actually changes the chat response
+  language** (closes #136). Reported by @PCAssistSoftware: switching
+  Administration → Configuration → Language from German to English still
+  produced German chat replies. Root cause: the config-save handler in
+  `config_routes.py` was calling `gateway.reload_components(config=True)`
+  only — which reloads the config itself but leaves the `Planner`'s cached
+  `_system_prompt_template` untouched. The planner had already built its
+  template from the German i18n preset (or the hardcoded German fallback
+  which literally contains `"Du sprichst Deutsch."`) and continued using
+  it for every subsequent LLM call. Now the handler additionally passes
+  `prompts=True` when the language field is part of the update, which
+  triggers `planner.reload_prompts()` and re-resolves the template from
+  the preset chain for the new language. No restart required.
+
 ## [0.92.5] -- 2026-04-22
 
 ### Added

--- a/src/cognithor/channels/config_routes.py
+++ b/src/cognithor/channels/config_routes.py
@@ -742,9 +742,15 @@ def _register_config_routes(
                 log.error("config_update_key_failed", key=key, error=str(exc))
                 results.append({"key": key, "status": "error", "error": "Ungueltige Konfiguration"})
         config_manager.save()
-        # Trigger live-reload of runtime components
+        # Trigger live-reload of runtime components.
+        # Language changes must also reload the planner's cached system prompts
+        # (issue #136) — otherwise the planner keeps the German preset it
+        # loaded at startup and the LLM keeps answering in German.
         if gateway is not None and hasattr(gateway, "reload_components"):
-            gateway.reload_components(config=True)
+            gateway.reload_components(
+                config=True,
+                prompts="language" in updates,
+            )
         # Sync backend i18n locale when language changes (#33)
         if "language" in updates:
             try:

--- a/tests/test_channels/test_config_routes.py
+++ b/tests/test_channels/test_config_routes.py
@@ -409,6 +409,31 @@ class TestConfigRoutes:
         assert result["results"][0]["status"] == "skipped"
 
     @pytest.mark.asyncio
+    async def test_language_change_triggers_prompt_reload(
+        self, registered_app: FakeApp, gateway: MagicMock
+    ) -> None:
+        """Issue #136: changing language must reload the planner prompts too —
+        otherwise the planner keeps its cached German system prompt and the LLM
+        keeps answering in German even after the user switches to English."""
+        handler = registered_app.routes["PATCH /api/v1/config"]
+        await handler(updates={"language": "en"})
+        gateway.reload_components.assert_called_once()
+        kwargs = gateway.reload_components.call_args.kwargs
+        assert kwargs.get("config") is True
+        assert kwargs.get("prompts") is True
+
+    @pytest.mark.asyncio
+    async def test_non_language_update_does_not_reload_prompts(
+        self, registered_app: FakeApp, gateway: MagicMock
+    ) -> None:
+        """Updates that don't touch `language` must NOT pay the reload_prompts cost."""
+        handler = registered_app.routes["PATCH /api/v1/config"]
+        await handler(updates={"owner_name": "Tester"})
+        gateway.reload_components.assert_called_once()
+        kwargs = gateway.reload_components.call_args.kwargs
+        assert kwargs.get("prompts") is not True
+
+    @pytest.mark.asyncio
     async def test_config_reload(self, registered_app: FakeApp, gateway: MagicMock) -> None:
         handler = registered_app.routes["POST /api/v1/config/reload"]
         result = await handler()


### PR DESCRIPTION
## Summary

Fixes #136 — reported by @PCAssistSoftware. Changing the language in Administration → Configuration → Language from German to English left chat replies still coming back in German.

## Root cause

`config_routes.py` PATCH `/api/v1/config` handler triggered:

```python
gateway.reload_components(config=True)
```

`reload_components(config=True)` reloads the config object itself but does **not** touch the Planner's cached `_system_prompt_template`. The planner had built that template at startup from the German i18n preset (or the hardcoded German `SYSTEM_PROMPT` fallback in `planner.py` — which literally contains `"Du sprichst Deutsch."`). Every subsequent LLM call used that cached German template regardless of `config.language`.

The infrastructure for the real fix was already in place:

- `prompt_presets.py` ships both `de` and `en` system-prompt presets.
- `Planner.reload_prompts()` re-resolves the template through the disk → preset → hardcoded chain.
- `Gateway.reload_components(prompts=True, ...)` calls `Planner.reload_prompts()`.

The save handler just wasn't wiring it.

## Fix

When `"language"` is in the update payload, also pass `prompts=True` to `reload_components()`:

```python
gateway.reload_components(
    config=True,
    prompts="language" in updates,
)
```

That triggers `planner.reload_prompts()` which re-resolves the template through the preset chain using the newly-applied `config.language`. The English `plannerSystem` preset is picked up, replaces the German one, and the next chat turn answers in English. No app restart required.

## Test plan

Two regression tests added to `tests/test_channels/test_config_routes.py`:

- `test_language_change_triggers_prompt_reload` — handler called with `{"language": "en"}` → `reload_components` must be called with `config=True` AND `prompts=True`
- `test_non_language_update_does_not_reload_prompts` — handler called with `{"owner_name": "..."}` → `reload_components` must NOT pass `prompts=True` (we don't pay the reload cost for unrelated updates)

**Result:** 164/164 config_routes tests pass (162 existing + 2 new). Ruff check + format clean.

## User impact

Before: language change in UI → UI labels update, chat replies stay German. User has to restart Cognithor.

After: language change in UI → UI labels update **and** next chat turn honors the new language. No restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
