### PR TITLE
feat(vllm-video): native video input via Qwen3.6-27B + 5 review rounds

### DIFF
--- a/.github/workflows/build-windows-installer.yml
+++ b/.github/workflows/build-windows-installer.yml
@@ -43,6 +43,20 @@ jobs:
         env:
           ISCC_PATH: "C:\\Program Files (x86)\\Inno Setup 6\\ISCC.exe"
 
+      - name: Verify bundled ffmpeg is LGPL (not GPL)
+        shell: pwsh
+        run: |
+          $ffmpeg = Get-ChildItem -Recurse -Filter ffmpeg.exe | Select-Object -First 1
+          if (-not $ffmpeg) { throw "ffmpeg.exe not found in build output" }
+          $version = & $ffmpeg.FullName -version 2>&1 | Out-String
+          if ($version -match '--enable-gpl') {
+            throw "Bundled ffmpeg is a GPL build — Cognithor is Apache-2.0. Use LGPL variant."
+          }
+          if ($version -notmatch '--enable-version3') {
+            Write-Warning "Bundled ffmpeg does not claim LGPL v3 — double-check the build source"
+          }
+          Write-Host "ffmpeg build is LGPL-compatible"
+
       - name: Find installer EXE
         id: find_exe
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,28 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   `/api/backends/vllm/*` including SSE-streamed pull progress. User guide
   at `docs/vllm-user-guide.md`, manual test recipe at
   `docs/vllm-manual-test.md`.
+- **Video input via vLLM** — attach a local video (`.mp4` / `.webm` / `.mov` / `.mkv` /
+  `.avi`) or paste a direct video URL in chat; Qwen3.6-27B (or any vLLM-served
+  video-capable VLM) analyzes it end-to-end. Native vLLM `video_url` content
+  type — no frame-extraction workarounds. Adaptive frame sampling based on
+  duration (fps=3 for clips under 10 s, num_frames=32 for videos over 5 min)
+  via `ffprobe`. Single video per chat turn. Local uploads served to vLLM over
+  a 127.0.0.1-only HTTP file server. Videos are cleaned up when the chat
+  session closes and auto-expire after 24 h. Video requests on a DEGRADED vLLM
+  produce a hard error — no silent fallback to Ollama (Ollama has no vision).
+  Windows installer now bundles an LGPL-licensed ffmpeg build. See
+  `docs/vllm-user-guide.md` and `docs/superpowers/specs/2026-04-23-video-input-vllm-design.md`.
+
+### Changed
+- Cognithor now requires Docker Engine ≥ 20.10 when using vLLM on Linux
+  (host-gateway flag for `--add-host` was added in 20.10). Docker Desktop
+  versions are all fine.
+- Flutter paperclip in the chat input is now a popup menu with explicit
+  entries for Image / Video / File / URL instead of a single file picker.
+- Default `vllm/vllm-openai` image flipped from `v0.19.1` to `cu130-nightly`
+  because the tagged release crashes Qwen3.6-27B-NVFP4 at warmup on SM120;
+  the nightly ships the `FlashInferCutlassNvFp4LinearKernel` fix. See
+  `docs/superpowers/spikes/2026-04-23-video-input-vllm-spike-findings.md`.
 
 ### Fixed
 - **Language change in Settings now actually changes the chat response

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,105 @@ All notable changes to Cognithor are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/).
 
+## [0.92.7] -- 2026-04-23
+
+### Added
+- **Video input via vLLM** — attach a local video (`.mp4` / `.webm` / `.mov` / `.mkv` /
+  `.avi`) or paste a direct video URL in chat; Qwen3.6-27B (or any vLLM-served
+  video-capable VLM) analyzes it end-to-end. Native vLLM `video_url` content
+  type — no frame-extraction workarounds. Adaptive frame sampling based on
+  duration (fps=3 for clips under 10 s, num_frames=32 for videos over 5 min)
+  via `ffprobe`. Single video per chat turn. Local uploads served to vLLM over
+  a 127.0.0.1-only HTTP file server. Videos are cleaned up when the chat
+  session closes and auto-expire after 24 h. Video requests on a DEGRADED vLLM
+  produce a hard error — no silent fallback to Ollama (Ollama has no vision).
+  Windows installer now bundles an LGPL-licensed ffmpeg build. See
+  `docs/vllm-user-guide.md` and `docs/superpowers/specs/2026-04-23-video-input-vllm-design.md`.
+- **Flutter URL-einfügen dialog** — paperclip → "URL einfügen" opens an
+  AlertDialog for a direct video URL (adds to Decision 1 of the video-input
+  spec). Delegates validation to `ChatProvider.handlePastedTextForVideoUrl`.
+- **Structured logging for docker run** — `VLLMOrchestrator.start_container`
+  emits `log.info("vllm_docker_run_starting", cmd=..., model=..., port=...)`
+  before `subprocess.run` and `log.error("vllm_docker_run_failed", ...)` on
+  non-zero exit. HF_TOKEN values are redacted. Makes fragile-startup
+  debugging possible without a local debugger.
+
+### Changed
+- Cognithor now requires Docker Engine ≥ 20.10 when using vLLM on Linux
+  (host-gateway flag for `--add-host` was added in 20.10). Docker Desktop
+  versions are all fine.
+- Flutter paperclip in the chat input is now a popup menu with explicit
+  entries for Image / Video / File / URL instead of a single file picker.
+- Default `vllm/vllm-openai` image flipped from `v0.19.1` to `cu130-nightly`
+  because the tagged release crashes Qwen3.6-27B-NVFP4 at warmup on SM120;
+  the nightly ships the `FlashInferCutlassNvFp4LinearKernel` fix. See
+  `docs/superpowers/spikes/2026-04-23-video-input-vllm-spike-findings.md`.
+- `VLLMOrchestrator` now threads the live `VLLMConfig` through both
+  construction sites (`backends_api._get_orchestrator` and
+  `Gateway.__init__`) so user overrides of `max_model_len`,
+  `gpu_memory_utilization`, `cpu_offload_gb`, `enforce_eager` actually
+  reach the `docker run` command. Previously both sites fell back to
+  `VLLMConfig()` defaults silently.
+- Backend code paths unify on a single `VLLMOrchestrator` instance via
+  `app.state.vllm_orchestrator`. Previously `backends_api` had its own
+  cache, and the UI's "Start vLLM" button hit that second instance which
+  never had `media_url` wired — leaving the container unable to fetch
+  uploads. Fallback cache retained for standalone-API mode.
+
+### Fixed
+- **Video helper preserves text on multi-modal turns** — both
+  `_attach_video_to_last_user` and `_attach_images_to_last_user` now
+  handle list-form content (a prior image/video attachment in the same
+  turn). Previously the text was silently dropped to `""` and the
+  model received only the media with no question.
+- **Flutter send-button race during upload** — `_pickVideo` now tracks
+  `_isUploading`, the Send button becomes a progress indicator, and
+  `_submit` short-circuits until the multipart POST completes. Also
+  defers the `_isUploading = false` reset to a `WidgetsBinding`
+  post-frame callback so the Send tree has rebuilt before the guard
+  lifts.
+- **ffprobe / ffmpeg no longer block the event loop** — the FastAPI
+  `/api/media/upload` handler and the Gateway per-turn handler both
+  offload the blocking `subprocess.run` calls via `asyncio.to_thread`.
+  Concurrent uploads stop serialising on the uvicorn worker.
+- **Path-traversal guard hardened** — `/media/{filename}` endpoints on
+  both the Flutter-facing `/api/media/thumb` and the vLLM-facing
+  MediaUploadServer now verify `resolved.is_relative_to(media_dir)`
+  instead of substring-checking `"/" in filename or ".." in filename`.
+  The old guard let `C:%5CWindows%5Csystem32%5Ccmd.exe` through on
+  Windows because `pathlib` resolves absolute paths as replacements.
+- **Quota TOCTOU** — `MediaUploadServer.save_upload` is now protected by
+  a `threading.Lock` over the evict-and-write critical section. Two
+  concurrent uploads can no longer both pass the quota check
+  independently, leave the dir above quota, and silently accept a
+  third party's eviction.
+- **Session-close cleanup wired** — `Gateway._cleanup_stale_sessions`
+  now dispatches `VideoCleanupWorker.on_session_close(session_id)`
+  via `loop.create_task` when a running loop is available. Previously
+  the 24 h TTL sweep was the only deletion path; videos from closed
+  sessions persisted until then.
+- **VideoCleanupWorker.start() is idempotent** — second calls without
+  an intervening `stop()` no longer orphan the first sweep task.
+- **URL paste filename strips query + fragment** — `clip.mp4?token=abc`
+  now derives `filename="clip.mp4"` while the full URL (including
+  query/fragment for fetching) remains intact in the pending
+  attachment. The regex also now accepts URLs with `?` or `#` after
+  the extension — previously it rejected them entirely.
+- **chat_stream accepts video kwarg** — `VLLMBackend.chat_stream` now
+  threads `video=` through the same way `chat()` does. A future caller
+  routing video through the streaming path no longer silently drops
+  the attachment.
+- **URL-dialog TextEditingController lifecycle** — moved into a
+  `_UrlInputDialog` StatefulWidget so its `dispose` runs after the
+  dialog's exit animation.
+- **KeyboardListener FocusNode lifecycle** — promoted from inline
+  `FocusNode()` in `build()` (leaked every rebuild) to a `late final`
+  state field initialised in `initState`, disposed in `dispose`.
+- **Quota-exceeded recovery hint** — the 507 response for
+  `MediaUploadQuotaExceededError` now includes `recovery_hint` so the
+  client can surface actionable guidance. Previously the generic
+  `MediaUploadError` branch dropped it.
+
 ## [0.92.6] -- 2026-04-23
 
 ### Added
@@ -21,28 +120,6 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   `/api/backends/vllm/*` including SSE-streamed pull progress. User guide
   at `docs/vllm-user-guide.md`, manual test recipe at
   `docs/vllm-manual-test.md`.
-- **Video input via vLLM** — attach a local video (`.mp4` / `.webm` / `.mov` / `.mkv` /
-  `.avi`) or paste a direct video URL in chat; Qwen3.6-27B (or any vLLM-served
-  video-capable VLM) analyzes it end-to-end. Native vLLM `video_url` content
-  type — no frame-extraction workarounds. Adaptive frame sampling based on
-  duration (fps=3 for clips under 10 s, num_frames=32 for videos over 5 min)
-  via `ffprobe`. Single video per chat turn. Local uploads served to vLLM over
-  a 127.0.0.1-only HTTP file server. Videos are cleaned up when the chat
-  session closes and auto-expire after 24 h. Video requests on a DEGRADED vLLM
-  produce a hard error — no silent fallback to Ollama (Ollama has no vision).
-  Windows installer now bundles an LGPL-licensed ffmpeg build. See
-  `docs/vllm-user-guide.md` and `docs/superpowers/specs/2026-04-23-video-input-vllm-design.md`.
-
-### Changed
-- Cognithor now requires Docker Engine ≥ 20.10 when using vLLM on Linux
-  (host-gateway flag for `--add-host` was added in 20.10). Docker Desktop
-  versions are all fine.
-- Flutter paperclip in the chat input is now a popup menu with explicit
-  entries for Image / Video / File / URL instead of a single file picker.
-- Default `vllm/vllm-openai` image flipped from `v0.19.1` to `cu130-nightly`
-  because the tagged release crashes Qwen3.6-27B-NVFP4 at warmup on SM120;
-  the nightly ships the `FlashInferCutlassNvFp4LinearKernel` fix. See
-  `docs/superpowers/spikes/2026-04-23-video-input-vllm-spike-findings.md`.
 
 ### Fixed
 - **Language change in Settings now actually changes the chat response

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ What makes it different from other local AI tools is that Cognithor is not just 
 - **Security** — Platform-adaptive sandbox (bubblewrap on Linux, subprocess+timeout fallback), AST-based Python/Shell code analysis (Python `ast.NodeVisitor` + `bashlex` parser), SHA-256 audit chain, credential vault, runtime token encryption (Fernet AES-256), Gatekeeper policy engine with GREEN/YELLOW/ORANGE/RED risk classification (not independently audited — see [Status & Maturity](#status--maturity))
 - **Knowledge Vault** — Obsidian-compatible Markdown vault with YAML frontmatter, tags, `[[backlinks]]`, full-text search
 - **Document Analysis** — LLM-powered structured analysis of PDF/DOCX/HTML (summary, risks, action items, decisions)
+- **Video Input** — Attach local videos (`.mp4` / `.webm` / `.mov` / `.mkv` / `.avi`) or paste direct video URLs; Qwen3.6-27B (or any video-capable VLM) analyzes them end-to-end via vLLM's native `video_url` content type. Adaptive frame sampling (fps=3 for short clips, `num_frames=32` for long) via `ffprobe`. Single video per turn, served from a 127.0.0.1-only HTTP file server, 24h auto-cleanup. Requires vLLM backend — Windows installer bundles LGPL ffmpeg. See [`docs/vllm-user-guide.md`](docs/vllm-user-guide.md).
 - **Model Context Protocol (MCP)** — 145+ tools across 14 modules (filesystem, shell, memory, web, browser, media, vault, synthesis, code, skills, documents, reddit, social, kanban, identity) + A2A delegation
 - **Computer Use** — Complete desktop automation: screenshots, clicking, typing, scrolling, dragging, Windows UI Automation via pywinauto for exact element coordinates, 3-layer security, adaptive wait
 - **ARC-AGI-3 Benchmark Agent** — Compete in ARC Prize 2026: 13/25 games solved (24 levels), 4 solver families (ClusterClick, SequenceClick+SimA*, KeyboardDFS, SmartExplorer), persistent game profiles, multimodal vision (qwen3-vl)
@@ -816,6 +817,12 @@ Copyright 2026 Alexander Soellner
 ---
 
 ## What's New
+
+### v0.92.7 (2026-04-23)
+- **Video input via vLLM** — end-to-end video analysis in chat using Qwen3.6-27B or any vLLM-served VLM. Paperclip → "Video hochladen" or paste a direct `.mp4`/`.webm`/`.mov`/`.mkv`/`.avi` URL. Adaptive frame sampling via `ffprobe` (short clips: `fps=3`, long clips: `num_frames=32`), 500 MB per-file cap + 5 GB quota with LRU eviction, session-lifetime + 24 h TTL cleanup, no silent fallback to Ollama (Ollama has no vision). Windows installer now bundles LGPL ffmpeg + CI verifies the GPL-free build. See [`docs/vllm-user-guide.md`](docs/vllm-user-guide.md).
+- **Default vLLM image flipped to `cu130-nightly`** — the tagged `v0.19.1` crashes Qwen3.6-27B-NVFP4 at warmup on SM120 (Blackwell / RTX 50xx). The nightly ships the `FlashInferCutlassNvFp4LinearKernel` fix. Day-1 spike findings at [`docs/superpowers/spikes/2026-04-23-video-input-vllm-spike-findings.md`](docs/superpowers/spikes/2026-04-23-video-input-vllm-spike-findings.md).
+- **Orchestrator unified** — `backends_api` and `Gateway` now share a single `VLLMOrchestrator` instance via `app.state`, so `media_url` wired after the media server starts actually reaches the `docker run` command.
+- **14,118 Python tests + 31 Flutter tests passing** (+180 new for this release), 0 failures, 0 ruff errors.
 
 ### v0.92.2 (2026-04-19)
 - **Windows Launcher Hardening** — `Cognithor.exe` (the .NET tray app) no longer vanishes silently on startup. All exceptions in the AppShell constructor are now caught, logged to `%LOCALAPPDATA%\Cognithor\launcher-crash.log`, and shown via MessageBox. Previously a missing `python\python.exe` (e.g. AV quarantine) would throw `FileNotFoundException` before `Application.Run()` started the message loop, making the process disappear from Task Manager with no trace.

--- a/docs/superpowers/plans/2026-04-23-video-input-vllm.md
+++ b/docs/superpowers/plans/2026-04-23-video-input-vllm.md
@@ -70,170 +70,22 @@ python -m ruff format --check <files>
 
 ---
 
-## Task 1: Day-1 Spike — Verify vLLM Wire Shape + Media-Domain Policy + ffprobe Timing
+## Task 1: Day-1 Spike — ✅ COMPLETE 2026-04-23
 
-**Files:**
-- Create: `docs/vllm-video-spike-notes.md` (findings doc)
-- No production code in this task. Goal: capture ground truth before any design assumption is turned into code.
+**Findings:** [`docs/superpowers/spikes/2026-04-23-video-input-vllm-spike-findings.md`](../spikes/2026-04-23-video-input-vllm-spike-findings.md)
 
-**Why this task blocks everything else:** if the spike reveals that `extra_body.mm_processor_kwargs.video` has a different shape or that vLLM's fetch allowlist rejects `host.docker.internal`, later task code would need to be rewritten. Spike first, design-adjust if needed, then build.
+**Gate:** 🟢 APPROVED — proceed to Task 2.
 
-- [ ] **Step 1: Start a local vLLM container with Qwen2.5-VL-7B-Instruct for probing**
+**Key outcomes that propagate into later tasks:**
 
-```bash
-# Pull the pinned image from PR #137 (already local if that PR's installer was used)
-docker pull vllm/vllm-openai:v0.19.1
+1. **Base image must be `vllm/vllm-openai:cu130-nightly`** (not `:v0.19.1`). v0.19.1 crashes Qwen3.6-27B-NVFP4 at warmup; the fix is shipped in `cu130-nightly` only. See Task 10 for the full `docker run` line.
+2. **Wire shape** `extra_body.mm_processor_kwargs.video.{fps | num_frames}` is accepted as specced. No change to Task 9.
+3. **Fetch policy** — vLLM has no allowlist; any HTTPS URL works. `--allowed-media-domains` NOT needed. Task 10 keeps `--add-host host.docker.internal:host-gateway`.
+4. **Fetch resilience** — some public CDNs (observed: GCS) return 403 to the container's HTTP client. Spec's local-HTTP-upload path is empirically validated as the safer common case. Task 13's user-facing fail message should include a "try uploading instead" hint when a URL fetch returns 4xx.
+5. **VRAM ceiling on 32 GB GPUs** — the launcher default profile **must** use `--max-model-len 16384 --max-num-seqs 2 --max-num-batched-tokens 2048 --gpu-memory-utilization 0.94 --cpu-offload-gb 4 --enforce-eager`. Larger GPUs relax these — see Task 5 for the config fields and Task 10 for the flag generation.
+6. **ffprobe HTTP timing** — not empirically measured in the spike. Task 3's unit tests + `resolve_sampling()` integration test are the new gate for the 30 s default.
 
-# Start with media-io-kwargs from the spec AND --allowed-media-domains OPEN to start
-docker run --rm -d --name vllm-spike \
-    --gpus all \
-    --add-host host.docker.internal:host-gateway \
-    -v cognithor-hf-cache:/root/.cache/huggingface \
-    -e HF_TOKEN="$HF_TOKEN" \
-    -p 8765:8000 \
-    vllm/vllm-openai:v0.19.1 \
-    --model Qwen/Qwen2.5-VL-7B-Instruct \
-    --media-io-kwargs '{"video": {"num_frames": -1}}'
-
-# Wait for /health (up to 3 minutes for first-time model load)
-for i in $(seq 1 90); do
-  if curl -sf http://localhost:8765/health > /dev/null; then
-    echo "vLLM ready after ${i} tries"
-    break
-  fi
-  sleep 2
-done
-```
-
-Expected: `vLLM ready after N tries` printed. If it fails after 90 tries, first diagnose normally (check `docker logs vllm-spike` for model-load errors) — this is not the spike target.
-
-- [ ] **Step 2: Send a real video-URL request and capture the exact `extra_body` shape**
-
-Use Qwen's own sample URL from the modelcard:
-
-```bash
-curl -X POST http://localhost:8765/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "Qwen/Qwen2.5-VL-7B-Instruct",
-    "messages": [
-      {"role": "user", "content": [
-        {"type": "video_url", "video_url": {"url": "https://qianwen-res.oss-accelerate.aliyuncs.com/Qwen3.5/demo/video/N1cdUjctpG8.mp4"}},
-        {"type": "text", "text": "What is in this video?"}
-      ]}
-    ],
-    "extra_body": {"mm_processor_kwargs": {"video": {"fps": 1}}}
-  }'
-```
-
-Record in `docs/vllm-video-spike-notes.md`:
-- HTTP status
-- Response body (first 500 chars of content field)
-- If 400 or 422: the error message. Then try these alternative shapes one at a time and record which succeeds:
-  - `"extra_body": {"mm_processor_kwargs": {"fps": 1}}` (flat, no "video" nest)
-  - `"extra_body": {"video_kwargs": {"fps": 1}}` (different key)
-  - `"mm_processor_kwargs": {"video": {"fps": 1}}` (no `extra_body` wrapper — top-level)
-
-- [ ] **Step 3: Do the same with `num_frames=32` instead of `fps=1`**
-
-Same request, replace `{"fps": 1}` with `{"num_frames": 32}`. Record the success shape.
-
-- [ ] **Step 4: Verify `host.docker.internal` fetch policy**
-
-Start a tiny HTTP static server on the host:
-
-```bash
-# In a separate shell, at the repo root:
-python -c "
-import http.server, socketserver
-from pathlib import Path
-PORT = 4712
-DIR = Path.home() / 'Downloads'   # any dir with a small mp4
-import os; os.chdir(DIR)
-httpd = socketserver.TCPServer(('127.0.0.1', PORT), http.server.SimpleHTTPRequestHandler)
-print(f'serving {DIR} on http://127.0.0.1:{PORT}')
-httpd.serve_forever()
-"
-```
-
-Put any 10-second MP4 in `~/Downloads/test-clip.mp4`. Now from the container:
-
-```bash
-curl -X POST http://localhost:8765/v1/chat/completions \
-  -H "Content-Type: application/json" \
-  -d '{
-    "model": "Qwen/Qwen2.5-VL-7B-Instruct",
-    "messages": [
-      {"role": "user", "content": [
-        {"type": "video_url", "video_url": {"url": "http://host.docker.internal:4712/test-clip.mp4"}},
-        {"type": "text", "text": "Describe this."}
-      ]}
-    ],
-    "extra_body": {"mm_processor_kwargs": {"video": {"fps": 2}}}
-  }'
-```
-
-Record in spike notes:
-- Success → our transport (B2) works without `--allowed-media-domains`
-- Connection-refused / DNS error → `host.docker.internal` resolution needs the `--add-host` flag we already included. Re-run without the flag to confirm
-- 403 / policy-rejected → vLLM has a fetch allowlist. Find the CLI flag (search `docker exec vllm-spike python -c "import vllm; print(vllm.__file__)"` then grep the installed source for `allowed_media_domains`)
-
-- [ ] **Step 5: Measure ffprobe HTTP timing against three URL classes**
-
-```bash
-# Install ffmpeg if not present: apt install ffmpeg OR winget install ffmpeg
-time ffprobe -v error -show_entries format=duration -of json "https://qianwen-res.oss-accelerate.aliyuncs.com/Qwen3.5/demo/video/N1cdUjctpG8.mp4"
-time ffprobe -v error -show_entries format=duration -of json "http://host.docker.internal:4712/test-clip.mp4"
-# A big remote one — pick any .mp4 > 500 MB you can find, e.g., archive.org
-time ffprobe -v error -show_entries format=duration -of json "<big-remote-mp4-url>"
-```
-
-Record the three `real` times. If any exceeds the spec default (30 s HTTP), update `VLLMConfig.video_ffprobe_http_timeout_seconds` default in Task 8 accordingly. If all three are under 10 s, consider lowering the default to 15 s for faster user-feedback on stuck URLs.
-
-- [ ] **Step 6: Write the findings doc**
-
-Create `docs/vllm-video-spike-notes.md` with this structure:
-
-```markdown
-# vLLM Video-Input Spike (2026-04-23)
-
-## Environment
-- Image: vllm/vllm-openai:v0.19.1 (or whichever is current)
-- Model used: Qwen/Qwen2.5-VL-7B-Instruct
-- GPU: <your dev card>
-- Docker: <docker --version output>
-
-## Finding 1 — extra_body.mm_processor_kwargs.video wire shape
-**Winning shape:** <exact JSON that worked>
-**Shapes that failed:** <list with error messages>
-
-## Finding 2 — vLLM fetch allowlist
-**Default behavior:** <allows host.docker.internal / blocks>
-**CLI flag needed (if any):** <e.g. --allowed-media-domains ...>
-
-## Finding 3 — ffprobe HTTP timings
-| URL class | Real time | Notes |
-|-----------|-----------|-------|
-| Qwen OSS sample | Xs | |
-| host.docker.internal local | Xs | |
-| 500+ MB remote | Xs | |
-
-**Recommended video_ffprobe_http_timeout_seconds default:** <value, ≥ max observed>
-
-## Spec-impact summary
-- <bulleted list of what stays, what must change>
-- <if any design decision is invalidated, STOP and escalate to design>
-```
-
-- [ ] **Step 7: Commit the findings doc**
-
-```bash
-docker rm -f vllm-spike
-git add docs/vllm-video-spike-notes.md
-git commit -m "docs(spike): vLLM video-input wire shape + fetch policy findings"
-```
-
-**🔴 GATE: If Finding 1 or Finding 2 invalidates a spec assumption, STOP here. Update the spec, return for re-review, then resume at Task 2.** If both findings match the spec's assumptions, proceed.
+No production code committed in this task.
 
 ---
 
@@ -748,6 +600,39 @@ class TestVLLMConfigVideoFields:
     def test_upload_mb_upper_bound(self):
         with pytest.raises(ValidationError):
             VLLMConfig(video_max_upload_mb=999999)
+
+
+class TestVLLMConfigLauncherFields:
+    """Flags that the spike identified as required for 32 GB-class GPUs.
+    Defaults match the spike's working RTX 5090 profile."""
+
+    def test_launcher_defaults_match_spike_profile(self):
+        c = VLLMConfig()
+        assert c.max_model_len == 16384
+        assert c.max_num_seqs == 2
+        assert c.max_num_batched_tokens == 2048
+        assert c.gpu_memory_utilization == 0.94
+        assert c.cpu_offload_gb == 4
+        assert c.enforce_eager is True
+
+    def test_gpu_util_must_be_in_open_unit_interval(self):
+        with pytest.raises(ValidationError):
+            VLLMConfig(gpu_memory_utilization=0.0)
+        with pytest.raises(ValidationError):
+            VLLMConfig(gpu_memory_utilization=1.01)
+
+    def test_larger_gpu_profile(self):
+        """User with an A100 loosens the defaults."""
+        c = VLLMConfig(
+            max_model_len=65536,
+            max_num_seqs=8,
+            gpu_memory_utilization=0.90,
+            cpu_offload_gb=0,
+            enforce_eager=False,
+        )
+        assert c.max_model_len == 65536
+        assert c.cpu_offload_gb == 0
+        assert c.enforce_eager is False
 ```
 
 - [ ] **Step 2: Run — expect `AttributeError` on `video_sampling_mode`**
@@ -776,7 +661,18 @@ Inside `VLLMConfig`, after the existing `request_timeout_seconds` field:
     video_max_upload_mb: int = Field(default=500, ge=1, le=5000)
     video_quota_gb: int = Field(default=5, ge=1, le=100)
     video_upload_ttl_hours: int = Field(default=24, ge=1, le=168)
+
+    # Launcher flags for the vLLM `docker run` command (see Day-1 spike findings).
+    # Defaults target a 32 GB-class consumer GPU (RTX 5090) — loosen on larger cards.
+    max_model_len: int = Field(default=16384, ge=2048, le=1_010_000)
+    max_num_seqs: int = Field(default=2, ge=1, le=256)
+    max_num_batched_tokens: int = Field(default=2048, ge=512, le=131072)
+    gpu_memory_utilization: float = Field(default=0.94, gt=0.0, le=1.0)
+    cpu_offload_gb: int = Field(default=4, ge=0, le=128)
+    enforce_eager: bool = Field(default=True)
 ```
+
+**Rationale for the defaults (documented in the field descriptions / user guide):** the spike verified that a 32 GB RTX 5090 running Qwen3.6-27B-NVFP4 stabilizes at exactly these values. On A100/H100 (80 GB), users override `gpu_memory_utilization=0.90`, `cpu_offload_gb=0`, `enforce_eager=False`, `max_model_len=65536+` via the CognithorConfig cascade (config.yaml or `COGNITHOR_VLLM__*` env vars). The installer wizard (Task 21) writes the right profile based on the auto-detected VRAM bucket.
 
 - [ ] **Step 4: Run — expect all pass**
 
@@ -1565,12 +1461,12 @@ class TestChatWithVideo:
             status_code=200,
             json={
                 "choices": [{"message": {"content": "A drone flying over a field."}}],
-                "model": "Qwen/Qwen3.6-27B-FP8",
+                "model": "mmangkad/Qwen3.6-27B-NVFP4",
                 "usage": {"prompt_tokens": 100, "completion_tokens": 10, "total_tokens": 110},
             },
         )
         resp = await backend.chat(
-            model="Qwen/Qwen3.6-27B-FP8",
+            model="mmangkad/Qwen3.6-27B-NVFP4",
             messages=[{"role": "user", "content": "What's in this clip?"}],
             video={"url": "http://host.docker.internal:4711/media/abc.mp4", "sampling": {"fps": 2.0}},
         )
@@ -1731,55 +1627,82 @@ git commit -m "feat(vllm): VLLMBackend.chat(video=...) with mm_processor_kwargs 
 ## Task 10: VLLMOrchestrator — docker run Flags for Video
 
 **Files:**
-- Modify: `src/cognithor/core/vllm_orchestrator.py` (extend `start_container()` with `--media-io-kwargs` + `--add-host`)
+- Modify: `src/cognithor/core/vllm_orchestrator.py` (extend `start_container()` with all spike-required flags)
 - Modify: `tests/test_core/test_vllm_orchestrator.py` (add `TestStartContainerVideoFlags`)
+
+Per the Day-1 spike findings, the `docker run` command must now include the full set of flags that made Qwen3.6-27B-NVFP4 stable on RTX 5090 (32 GB). The image default changes from `v0.19.1` to `cu130-nightly` and the config fields from Task 5 feed most of the values.
 
 - [ ] **Step 1: Append test class**
 
 ```python
 class TestStartContainerVideoFlags:
-    def test_docker_run_includes_media_io_kwargs(self):
+    def _run_start(self, **orch_kwargs):
         from unittest.mock import MagicMock, patch
         from cognithor.core.vllm_orchestrator import VLLMOrchestrator
-
         with patch.object(VLLMOrchestrator, "_port_available", return_value=True), \
              patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")) as run_mock, \
              patch.object(VLLMOrchestrator, "_wait_for_health", return_value=True):
-            orch = VLLMOrchestrator(docker_image="vllm/vllm-openai:v0.19.1", port=8000, hf_token="")
-            orch.start_container("Qwen/Qwen2.5-VL-7B-Instruct")
+            orch = VLLMOrchestrator(**orch_kwargs)
+            orch.start_container("mmangkad/Qwen3.6-27B-NVFP4")
+        return run_mock.call_args[0][0]
 
-        args = run_mock.call_args[0][0]
-        # --media-io-kwargs flag is present with the num_frames=-1 default
+    def test_default_image_is_cu130_nightly(self):
+        args = self._run_start(port=8000)
+        assert "vllm/vllm-openai:cu130-nightly" in args
+
+    def test_docker_run_includes_media_io_kwargs(self):
+        args = self._run_start(port=8000)
         idx = args.index("--media-io-kwargs")
         assert '"video"' in args[idx + 1]
         assert '"num_frames": -1' in args[idx + 1]
 
     def test_docker_run_includes_add_host(self):
-        from unittest.mock import MagicMock, patch
-        from cognithor.core.vllm_orchestrator import VLLMOrchestrator
-
-        with patch.object(VLLMOrchestrator, "_port_available", return_value=True), \
-             patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")) as run_mock, \
-             patch.object(VLLMOrchestrator, "_wait_for_health", return_value=True):
-            orch = VLLMOrchestrator(port=8000)
-            orch.start_container("Qwen/Qwen2.5-VL-7B-Instruct")
-        args = run_mock.call_args[0][0]
+        args = self._run_start(port=8000)
         assert "--add-host" in args
         idx = args.index("--add-host")
         assert args[idx + 1] == "host.docker.internal:host-gateway"
 
+    def test_docker_run_includes_spike_stability_flags(self):
+        args = self._run_start(port=8000)
+        assert "--max-model-len" in args and args[args.index("--max-model-len") + 1] == "16384"
+        assert "--max-num-seqs" in args and args[args.index("--max-num-seqs") + 1] == "2"
+        assert "--max-num-batched-tokens" in args and args[args.index("--max-num-batched-tokens") + 1] == "2048"
+        assert "--gpu-memory-utilization" in args and args[args.index("--gpu-memory-utilization") + 1] == "0.94"
+        assert "--cpu-offload-gb" in args and args[args.index("--cpu-offload-gb") + 1] == "4"
+        assert "--enforce-eager" in args
+        assert "--reasoning-parser" in args and args[args.index("--reasoning-parser") + 1] == "qwen3"
+        assert "--trust-remote-code" in args
+
     def test_docker_run_includes_media_url_env_when_port_given(self):
         from unittest.mock import MagicMock, patch
         from cognithor.core.vllm_orchestrator import VLLMOrchestrator
-
         with patch.object(VLLMOrchestrator, "_port_available", return_value=True), \
              patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")) as run_mock, \
              patch.object(VLLMOrchestrator, "_wait_for_health", return_value=True):
             orch = VLLMOrchestrator(port=8000)
-            orch.media_url = "http://host.docker.internal:4711"  # orchestrator learns this from the media server
-            orch.start_container("Qwen/Qwen2.5-VL-7B-Instruct")
+            orch.media_url = "http://host.docker.internal:4711"
+            orch.start_container("mmangkad/Qwen3.6-27B-NVFP4")
         args = run_mock.call_args[0][0]
         assert any("COGNITHOR_MEDIA_URL=http://host.docker.internal:4711" in a for a in args)
+
+    def test_overrides_from_vllm_config(self):
+        """A 40 GB-class GPU loosens the defaults — orchestrator reads from VLLMConfig."""
+        from cognithor.config import VLLMConfig
+        cfg = VLLMConfig(
+            max_model_len=65536,
+            max_num_seqs=8,
+            max_num_batched_tokens=8192,
+            gpu_memory_utilization=0.90,
+            cpu_offload_gb=0,
+            enforce_eager=False,
+        )
+        args = self._run_start(port=8000, config=cfg)
+        assert args[args.index("--max-model-len") + 1] == "65536"
+        assert args[args.index("--gpu-memory-utilization") + 1] == "0.9"
+        # --cpu-offload-gb must be OMITTED when 0 (vLLM complains if 0 is passed)
+        assert "--cpu-offload-gb" not in args
+        # --enforce-eager must be OMITTED when disabled
+        assert "--enforce-eager" not in args
 ```
 
 - [ ] **Step 2: Run — expect failures**
@@ -1790,12 +1713,13 @@ python -m pytest tests/test_core/test_vllm_orchestrator.py::TestStartContainerVi
 
 - [ ] **Step 3: Extend `VLLMOrchestrator.start_container()` in `src/cognithor/core/vllm_orchestrator.py`**
 
-Add a new attribute `self.media_url: str | None = None` to `__init__`. Modify the `cmd` list in `start_container` to insert the new flags (before `self.docker_image`):
+Update the `__init__` default image to `vllm/vllm-openai:cu130-nightly`. Add `self.media_url: str | None = None`. Accept a `config: VLLMConfig | None = None` parameter with the defaults carried from the config (see Task 5). Build the command:
 
 ```python
 def start_container(self, model: str, *, health_timeout: int | None = None) -> ContainerInfo:
     # ... existing port-resolve logic ...
 
+    cfg = self._config  # VLLMConfig, see Task 5
     cmd = [
         "docker", "run", "-d",
         "--gpus", "all",
@@ -1808,10 +1732,20 @@ def start_container(self, model: str, *, health_timeout: int | None = None) -> C
     if self.media_url:
         cmd.extend(["-e", f"COGNITHOR_MEDIA_URL={self.media_url}"])
     cmd.extend([
-        self.docker_image,
+        self.docker_image,  # defaults to "vllm/vllm-openai:cu130-nightly"
         "--model", model,
+        "--max-model-len", str(cfg.max_model_len),
+        "--max-num-seqs", str(cfg.max_num_seqs),
+        "--max-num-batched-tokens", str(cfg.max_num_batched_tokens),
+        "--gpu-memory-utilization", f"{cfg.gpu_memory_utilization:g}",
+        "--reasoning-parser", "qwen3",
+        "--trust-remote-code",
         "--media-io-kwargs", '{"video": {"num_frames": -1}}',
     ])
+    if cfg.cpu_offload_gb > 0:
+        cmd.extend(["--cpu-offload-gb", str(cfg.cpu_offload_gb)])
+    if cfg.enforce_eager:
+        cmd.append("--enforce-eager")
     # ... rest of existing body (subprocess.run + health wait) ...
 ```
 
@@ -1827,7 +1761,7 @@ python -m pytest tests/test_core/test_vllm_orchestrator.py -v
 python -m ruff check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
 python -m ruff format --check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
 git add src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
-git commit -m "feat(vllm): orchestrator adds --media-io-kwargs + --add-host + COGNITHOR_MEDIA_URL for video"
+git commit -m "feat(vllm): orchestrator switches to cu130-nightly + spike stability flags"
 ```
 
 ---
@@ -1913,7 +1847,7 @@ async def test_video_attachment_also_routes_to_vision_model(
     self, planner_with_mocks
 ):
     from cognithor.models import WorkingMemory
-    planner_with_mocks._config.vision_model_detail = "Qwen/Qwen3.6-27B-FP8"
+    planner_with_mocks._config.vision_model_detail = "mmangkad/Qwen3.6-27B-NVFP4"
     wm = WorkingMemory(session_id="s1")
     wm.video_attachment = {
         "url": "http://host.docker.internal:4711/media/abc.mp4",
@@ -1927,7 +1861,7 @@ async def test_video_attachment_also_routes_to_vision_model(
     )
 
     call = planner_with_mocks._ollama.chat.call_args
-    assert call.kwargs.get("model") == "Qwen/Qwen3.6-27B-FP8"
+    assert call.kwargs.get("model") == "mmangkad/Qwen3.6-27B-NVFP4"
     assert call.kwargs.get("video") is not None
     assert call.kwargs["video"]["url"].endswith("abc.mp4")
 ```

--- a/docs/superpowers/plans/2026-04-23-video-input-vllm.md
+++ b/docs/superpowers/plans/2026-04-23-video-input-vllm.md
@@ -1,0 +1,3335 @@
+# Video Input via vLLM Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let Cognithor users attach a local video file or paste a video URL in the chat and have it analyzed end-to-end by Qwen3.6-27B (or any vLLM-served VLM with video support), with adaptive frame-sampling based on duration, session-lifetime cleanup, and hard-error fail-flow (no Ollama fallback — Ollama has no vision).
+
+**Architecture:** Single-video-per-turn payload adapter on top of the existing `VLLMBackend` from PR #137. Three new modules: `MediaUploadServer` (local HTTP file-server that vLLM fetches from via `host.docker.internal`), `VideoSamplingResolver` (ffprobe + adaptive bucket table), `VideoCleanupWorker` (in-memory session registry + filesystem mtime-based TTL). Existing `VLLMBackend.chat()` gets a new `video: dict | None` kwarg; `WorkingMemory` gets a `video_attachment: dict | None` field; Flutter paperclip becomes a `PopupMenuButton`.
+
+**Tech Stack:** Python 3.12, Pydantic v2, pytest-asyncio, FastAPI (existing), httpx, Flutter 3.41.4, Docker Desktop + vLLM from PR #137, ffmpeg/ffprobe (LGPL build bundled on Windows, expected in `$PATH` elsewhere).
+
+**Spec:** `docs/superpowers/specs/2026-04-23-video-input-vllm-design.md` — read it before starting. Seven decisions are locked, three Day-1 spikes are gated.
+
+---
+
+## ⚠ CRITICAL: Day-1 Spike Gate
+
+**Task 1 is a dedicated spike to verify three risks before any other code is written.** If the spike finding invalidates a spec assumption (especially the `extra_body.mm_processor_kwargs.video` wire shape or the vLLM fetch-allowlist policy), STOP and return to the design table — do not continue with Tasks 2+ on top of a broken premise.
+
+---
+
+## File Structure
+
+**New Python files:**
+- `src/cognithor/core/video_sampling.py` — ~80 LOC — `VideoSampling` dataclass + `resolve_sampling()` + bucket rules
+- `src/cognithor/channels/media_server.py` — ~120 LOC — `MediaUploadServer` (FastAPI static on 127.0.0.1:<ephemeral>)
+- `src/cognithor/gateway/video_cleanup.py` — ~80 LOC — `VideoCleanupWorker` with in-memory session map + filesystem TTL sweep
+- `tests/test_core/test_video_sampling.py`
+- `tests/test_channels/test_media_server.py`
+- `tests/test_gateway/test_video_cleanup.py`
+- `tests/test_core/test_vllm_backend_video.py` — `VLLMBackend.chat(video=...)` payload shape
+- `tests/test_integration/test_vllm_video_fake_server.py` — end-to-end vs. fake OpenAI server
+- `flutter_app/test/widgets/chat_input_video_menu_test.dart`
+- `flutter_app/test/widgets/chat_bubble_video_test.dart`
+- `docs/vllm-video-spike-notes.md` — spike output, ground truth for all later tasks
+
+**Modified Python files:**
+- `src/cognithor/core/llm_backend.py` — `MediaUploadError` + 3 subclasses, added to `CircuitBreaker.excluded_exceptions` wiring in `UnifiedLLMClient`
+- `src/cognithor/core/vllm_backend.py` — `chat(video=...)` kwarg, `_attach_video_to_last_user()` helper
+- `src/cognithor/core/vllm_orchestrator.py` — `docker run` adds `--media-io-kwargs` + `--add-host host.docker.internal:host-gateway` + `-e COGNITHOR_MEDIA_URL`
+- `src/cognithor/core/unified_llm.py` — video+DEGRADED = hard error (no Ollama fallback)
+- `src/cognithor/config.py` — `VLLMConfig` gains 6 video fields
+- `src/cognithor/models.py` — `WorkingMemory.video_attachment: dict | None`
+- `src/cognithor/core/planner.py` — route to `vision_model_detail` when `video_attachment is not None`
+- `src/cognithor/gateway/gateway.py` — extract video attachment per turn, register with cleanup worker
+- `src/cognithor/channels/api.py` — `POST /api/media/upload` + `GET /api/media/thumb/<uuid>.jpg`
+
+**Modified Flutter files:**
+- `flutter_app/lib/widgets/chat_input.dart` — `IconButton` → `PopupMenuButton`
+- `flutter_app/lib/widgets/chat_bubble.dart` — render video-kind metadata with thumbnail
+- `flutter_app/lib/providers/chat_provider.dart` — `sendVideo()`, URL-paste detection
+
+**Modified build/docs:**
+- `installer/build_installer.py` — bundle LGPL ffmpeg under `%LOCALAPPDATA%\Cognithor\ffmpeg\`
+- `.github/workflows/build-windows-installer.yml` — LGPL-vs-GPL verification step
+- `docs/vllm-user-guide.md` — video section
+- `docs/vllm-manual-test.md` — video smoke-test matrix
+- `CHANGELOG.md` — `[Unreleased]` entry
+
+---
+
+## TDD Contract
+
+Same as PR #137: each task follows write failing test → red → implement → green → commit. Ruff check + format --check on every file touched.
+
+**Before EVERY commit** (except Task 1 which has no code):
+```bash
+python -m ruff check <files>
+python -m ruff format --check <files>
+```
+
+---
+
+## Task 1: Day-1 Spike — Verify vLLM Wire Shape + Media-Domain Policy + ffprobe Timing
+
+**Files:**
+- Create: `docs/vllm-video-spike-notes.md` (findings doc)
+- No production code in this task. Goal: capture ground truth before any design assumption is turned into code.
+
+**Why this task blocks everything else:** if the spike reveals that `extra_body.mm_processor_kwargs.video` has a different shape or that vLLM's fetch allowlist rejects `host.docker.internal`, later task code would need to be rewritten. Spike first, design-adjust if needed, then build.
+
+- [ ] **Step 1: Start a local vLLM container with Qwen2.5-VL-7B-Instruct for probing**
+
+```bash
+# Pull the pinned image from PR #137 (already local if that PR's installer was used)
+docker pull vllm/vllm-openai:v0.19.1
+
+# Start with media-io-kwargs from the spec AND --allowed-media-domains OPEN to start
+docker run --rm -d --name vllm-spike \
+    --gpus all \
+    --add-host host.docker.internal:host-gateway \
+    -v cognithor-hf-cache:/root/.cache/huggingface \
+    -e HF_TOKEN="$HF_TOKEN" \
+    -p 8765:8000 \
+    vllm/vllm-openai:v0.19.1 \
+    --model Qwen/Qwen2.5-VL-7B-Instruct \
+    --media-io-kwargs '{"video": {"num_frames": -1}}'
+
+# Wait for /health (up to 3 minutes for first-time model load)
+for i in $(seq 1 90); do
+  if curl -sf http://localhost:8765/health > /dev/null; then
+    echo "vLLM ready after ${i} tries"
+    break
+  fi
+  sleep 2
+done
+```
+
+Expected: `vLLM ready after N tries` printed. If it fails after 90 tries, first diagnose normally (check `docker logs vllm-spike` for model-load errors) — this is not the spike target.
+
+- [ ] **Step 2: Send a real video-URL request and capture the exact `extra_body` shape**
+
+Use Qwen's own sample URL from the modelcard:
+
+```bash
+curl -X POST http://localhost:8765/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen2.5-VL-7B-Instruct",
+    "messages": [
+      {"role": "user", "content": [
+        {"type": "video_url", "video_url": {"url": "https://qianwen-res.oss-accelerate.aliyuncs.com/Qwen3.5/demo/video/N1cdUjctpG8.mp4"}},
+        {"type": "text", "text": "What is in this video?"}
+      ]}
+    ],
+    "extra_body": {"mm_processor_kwargs": {"video": {"fps": 1}}}
+  }'
+```
+
+Record in `docs/vllm-video-spike-notes.md`:
+- HTTP status
+- Response body (first 500 chars of content field)
+- If 400 or 422: the error message. Then try these alternative shapes one at a time and record which succeeds:
+  - `"extra_body": {"mm_processor_kwargs": {"fps": 1}}` (flat, no "video" nest)
+  - `"extra_body": {"video_kwargs": {"fps": 1}}` (different key)
+  - `"mm_processor_kwargs": {"video": {"fps": 1}}` (no `extra_body` wrapper — top-level)
+
+- [ ] **Step 3: Do the same with `num_frames=32` instead of `fps=1`**
+
+Same request, replace `{"fps": 1}` with `{"num_frames": 32}`. Record the success shape.
+
+- [ ] **Step 4: Verify `host.docker.internal` fetch policy**
+
+Start a tiny HTTP static server on the host:
+
+```bash
+# In a separate shell, at the repo root:
+python -c "
+import http.server, socketserver
+from pathlib import Path
+PORT = 4712
+DIR = Path.home() / 'Downloads'   # any dir with a small mp4
+import os; os.chdir(DIR)
+httpd = socketserver.TCPServer(('127.0.0.1', PORT), http.server.SimpleHTTPRequestHandler)
+print(f'serving {DIR} on http://127.0.0.1:{PORT}')
+httpd.serve_forever()
+"
+```
+
+Put any 10-second MP4 in `~/Downloads/test-clip.mp4`. Now from the container:
+
+```bash
+curl -X POST http://localhost:8765/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen2.5-VL-7B-Instruct",
+    "messages": [
+      {"role": "user", "content": [
+        {"type": "video_url", "video_url": {"url": "http://host.docker.internal:4712/test-clip.mp4"}},
+        {"type": "text", "text": "Describe this."}
+      ]}
+    ],
+    "extra_body": {"mm_processor_kwargs": {"video": {"fps": 2}}}
+  }'
+```
+
+Record in spike notes:
+- Success → our transport (B2) works without `--allowed-media-domains`
+- Connection-refused / DNS error → `host.docker.internal` resolution needs the `--add-host` flag we already included. Re-run without the flag to confirm
+- 403 / policy-rejected → vLLM has a fetch allowlist. Find the CLI flag (search `docker exec vllm-spike python -c "import vllm; print(vllm.__file__)"` then grep the installed source for `allowed_media_domains`)
+
+- [ ] **Step 5: Measure ffprobe HTTP timing against three URL classes**
+
+```bash
+# Install ffmpeg if not present: apt install ffmpeg OR winget install ffmpeg
+time ffprobe -v error -show_entries format=duration -of json "https://qianwen-res.oss-accelerate.aliyuncs.com/Qwen3.5/demo/video/N1cdUjctpG8.mp4"
+time ffprobe -v error -show_entries format=duration -of json "http://host.docker.internal:4712/test-clip.mp4"
+# A big remote one — pick any .mp4 > 500 MB you can find, e.g., archive.org
+time ffprobe -v error -show_entries format=duration -of json "<big-remote-mp4-url>"
+```
+
+Record the three `real` times. If any exceeds the spec default (30 s HTTP), update `VLLMConfig.video_ffprobe_http_timeout_seconds` default in Task 8 accordingly. If all three are under 10 s, consider lowering the default to 15 s for faster user-feedback on stuck URLs.
+
+- [ ] **Step 6: Write the findings doc**
+
+Create `docs/vllm-video-spike-notes.md` with this structure:
+
+```markdown
+# vLLM Video-Input Spike (2026-04-23)
+
+## Environment
+- Image: vllm/vllm-openai:v0.19.1 (or whichever is current)
+- Model used: Qwen/Qwen2.5-VL-7B-Instruct
+- GPU: <your dev card>
+- Docker: <docker --version output>
+
+## Finding 1 — extra_body.mm_processor_kwargs.video wire shape
+**Winning shape:** <exact JSON that worked>
+**Shapes that failed:** <list with error messages>
+
+## Finding 2 — vLLM fetch allowlist
+**Default behavior:** <allows host.docker.internal / blocks>
+**CLI flag needed (if any):** <e.g. --allowed-media-domains ...>
+
+## Finding 3 — ffprobe HTTP timings
+| URL class | Real time | Notes |
+|-----------|-----------|-------|
+| Qwen OSS sample | Xs | |
+| host.docker.internal local | Xs | |
+| 500+ MB remote | Xs | |
+
+**Recommended video_ffprobe_http_timeout_seconds default:** <value, ≥ max observed>
+
+## Spec-impact summary
+- <bulleted list of what stays, what must change>
+- <if any design decision is invalidated, STOP and escalate to design>
+```
+
+- [ ] **Step 7: Commit the findings doc**
+
+```bash
+docker rm -f vllm-spike
+git add docs/vllm-video-spike-notes.md
+git commit -m "docs(spike): vLLM video-input wire shape + fetch policy findings"
+```
+
+**🔴 GATE: If Finding 1 or Finding 2 invalidates a spec assumption, STOP here. Update the spec, return for re-review, then resume at Task 2.** If both findings match the spec's assumptions, proceed.
+
+---
+
+## Task 2: VideoSampling Dataclass + Bucket Rules
+
+**Files:**
+- Create: `src/cognithor/core/video_sampling.py`
+- Create: `tests/test_core/test_video_sampling.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_core/test_video_sampling.py
+from __future__ import annotations
+
+import pytest
+
+from cognithor.core.video_sampling import VideoSampling, _bucket_for_duration
+
+
+class TestVideoSamplingDataclass:
+    def test_fps_only(self):
+        s = VideoSampling(fps=2.0, duration_sec=25.0)
+        assert s.fps == 2.0
+        assert s.num_frames is None
+        assert s.duration_sec == 25.0
+
+    def test_num_frames_only(self):
+        s = VideoSampling(num_frames=32, duration_sec=900.0)
+        assert s.num_frames == 32
+        assert s.fps is None
+
+    def test_as_mm_kwargs_fps(self):
+        s = VideoSampling(fps=3.0)
+        assert s.as_mm_kwargs() == {"fps": 3.0}
+
+    def test_as_mm_kwargs_num_frames(self):
+        s = VideoSampling(num_frames=64)
+        assert s.as_mm_kwargs() == {"num_frames": 64}
+
+    def test_as_mm_kwargs_raises_when_neither(self):
+        s = VideoSampling()  # both None
+        with pytest.raises(ValueError):
+            s.as_mm_kwargs()
+
+
+class TestBucketForDuration:
+    # Spec bucket table (see design doc § "Frame Sampling"):
+    # <10s → fps=3; 10-30s → fps=2; 30s-2min → fps=1;
+    # 2-5min → num_frames=64; 5-15min → num_frames=32; >15min → num_frames=32
+    @pytest.mark.parametrize("dur,expected_fps,expected_num", [
+        (5.0,   3.0,  None),
+        (9.99,  3.0,  None),
+        (10.0,  2.0,  None),
+        (29.99, 2.0,  None),
+        (30.0,  1.0,  None),
+        (119.99, 1.0, None),
+        (120.0, None, 64),
+        (299.99, None, 64),
+        (300.0,  None, 32),
+        (899.99, None, 32),
+        (900.0,  None, 32),  # >15min still 32
+        (3600.0, None, 32),
+    ])
+    def test_buckets(self, dur: float, expected_fps: float | None, expected_num: int | None) -> None:
+        s = _bucket_for_duration(dur)
+        assert s.fps == expected_fps
+        assert s.num_frames == expected_num
+
+    def test_zero_or_negative_duration_falls_back(self):
+        # Defensive: upstream feeds us >0 but guard anyway
+        s = _bucket_for_duration(0.0)
+        assert s.num_frames == 32
+        assert s.fps is None
+        s = _bucket_for_duration(-5.0)
+        assert s.num_frames == 32
+```
+
+- [ ] **Step 2: Run — expect `ImportError`**
+
+```bash
+python -m pytest tests/test_core/test_video_sampling.py -v
+```
+Expected: `ModuleNotFoundError: No module named 'cognithor.core.video_sampling'`.
+
+- [ ] **Step 3: Create `src/cognithor/core/video_sampling.py`**
+
+```python
+"""Video sampling: pick fps or num_frames for a vLLM `video_url` request.
+
+Uses ffprobe to detect duration, then maps to the bucket table from the
+spec (docs/superpowers/specs/2026-04-23-video-input-vllm-design.md).
+
+This module is pure-logic-plus-subprocess. `_bucket_for_duration` is
+pure; `resolve_sampling` (added in Task 3) is the I/O entry point.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class VideoSampling:
+    """Resolved per-video sampling spec.
+
+    Exactly one of `fps` or `num_frames` is set when sampling is active.
+    Both None is a default-constructed placeholder and will raise from
+    `as_mm_kwargs()`.
+    """
+
+    fps: float | None = None
+    num_frames: int | None = None
+    duration_sec: float | None = None  # for logging/UI, not sent to vLLM
+
+    def as_mm_kwargs(self) -> dict[str, Any]:
+        """Return the dict suitable for `extra_body.mm_processor_kwargs.video`.
+
+        Shape confirmed by Task-1 spike.
+        """
+        if self.fps is not None:
+            return {"fps": self.fps}
+        if self.num_frames is not None:
+            return {"num_frames": self.num_frames}
+        raise ValueError("VideoSampling has neither fps nor num_frames set")
+
+
+# Bucket thresholds in seconds
+_BUCKET_LT_10 = 10.0
+_BUCKET_LT_30 = 30.0
+_BUCKET_LT_2MIN = 120.0
+_BUCKET_LT_5MIN = 300.0
+_BUCKET_LT_15MIN = 900.0
+
+
+def _bucket_for_duration(duration_sec: float) -> VideoSampling:
+    """Map a duration in seconds to a VideoSampling per the spec's bucket table.
+
+    Defensive default for non-positive durations: `num_frames=32` so callers
+    don't have to special-case ffprobe edge-cases.
+    """
+    if duration_sec <= 0:
+        return VideoSampling(num_frames=32, duration_sec=duration_sec)
+    if duration_sec < _BUCKET_LT_10:
+        return VideoSampling(fps=3.0, duration_sec=duration_sec)
+    if duration_sec < _BUCKET_LT_30:
+        return VideoSampling(fps=2.0, duration_sec=duration_sec)
+    if duration_sec < _BUCKET_LT_2MIN:
+        return VideoSampling(fps=1.0, duration_sec=duration_sec)
+    if duration_sec < _BUCKET_LT_5MIN:
+        return VideoSampling(num_frames=64, duration_sec=duration_sec)
+    # 5 min – 15 min AND > 15 min both use num_frames=32; UI banner is
+    # a display concern not a sampling one.
+    return VideoSampling(num_frames=32, duration_sec=duration_sec)
+```
+
+- [ ] **Step 4: Run — expect all pass**
+
+```bash
+python -m pytest tests/test_core/test_video_sampling.py -v
+```
+Expected: `17 passed`.
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+python -m ruff check src/cognithor/core/video_sampling.py tests/test_core/test_video_sampling.py
+python -m ruff format --check src/cognithor/core/video_sampling.py tests/test_core/test_video_sampling.py
+git add src/cognithor/core/video_sampling.py tests/test_core/test_video_sampling.py
+git commit -m "feat(video): VideoSampling dataclass + duration bucket rules"
+```
+
+---
+
+## Task 3: `resolve_sampling()` — ffprobe Wrapper + Fallback Chain
+
+**Files:**
+- Modify: `src/cognithor/core/video_sampling.py` (add `resolve_sampling`)
+- Modify: `tests/test_core/test_video_sampling.py` (add `TestResolveSampling`)
+
+- [ ] **Step 1: Append to the test file**
+
+```python
+from unittest.mock import MagicMock, patch
+
+from cognithor.core.video_sampling import resolve_sampling
+
+
+class TestResolveSampling:
+    def _mk_probe_stdout(self, duration: float) -> str:
+        import json as _json
+        return _json.dumps({"format": {"duration": str(duration)}})
+
+    def test_adaptive_short_clip(self):
+        mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(5.0))
+        with patch("subprocess.run", return_value=mock):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.fps == 3.0
+        assert s.num_frames is None
+        assert s.duration_sec == 5.0
+
+    def test_adaptive_long_clip(self):
+        mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(1800.0))
+        with patch("subprocess.run", return_value=mock):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.num_frames == 32
+        assert s.duration_sec == 1800.0
+
+    def test_ffprobe_missing_falls_back_to_num_frames_32(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.num_frames == 32
+        assert s.fps is None
+        assert s.duration_sec is None
+
+    def test_ffprobe_timeout_falls_back(self):
+        import subprocess as _sp
+        with patch("subprocess.run", side_effect=_sp.TimeoutExpired(cmd="ffprobe", timeout=5)):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.num_frames == 32
+
+    def test_ffprobe_nonzero_returncode_falls_back(self):
+        mock = MagicMock(returncode=1, stdout="", stderr="file not found")
+        with patch("subprocess.run", return_value=mock):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.num_frames == 32
+
+    def test_ffprobe_unparseable_json_falls_back(self):
+        mock = MagicMock(returncode=0, stdout="not json at all")
+        with patch("subprocess.run", return_value=mock):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.num_frames == 32
+
+    def test_ffprobe_negative_duration_falls_back(self):
+        mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(-1.0))
+        with patch("subprocess.run", return_value=mock):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.num_frames == 32
+
+    def test_ffprobe_duration_over_24h_falls_back(self):
+        mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(100_000.0))
+        with patch("subprocess.run", return_value=mock):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.num_frames == 32
+
+    def test_override_fixed_32_skips_ffprobe(self):
+        with patch("subprocess.run") as run_mock:
+            s = resolve_sampling("/tmp/x.mp4", override="fixed_32")
+        assert s.num_frames == 32
+        assert s.fps is None
+        run_mock.assert_not_called()
+
+    def test_override_fixed_64_skips_ffprobe(self):
+        with patch("subprocess.run") as run_mock:
+            s = resolve_sampling("/tmp/x.mp4", override="fixed_64")
+        assert s.num_frames == 64
+        run_mock.assert_not_called()
+
+    def test_override_fps_1_skips_ffprobe(self):
+        with patch("subprocess.run") as run_mock:
+            s = resolve_sampling("/tmp/x.mp4", override="fps_1")
+        assert s.fps == 1.0
+        run_mock.assert_not_called()
+
+    def test_http_url_uses_http_timeout(self):
+        mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(45.0))
+        with patch("subprocess.run", return_value=mock) as run_mock:
+            resolve_sampling("https://example.com/clip.mp4", timeout_seconds=5, http_timeout_seconds=30)
+        # Verify the timeout kwarg passed to subprocess.run is the HTTP one (30, not 5)
+        assert run_mock.call_args.kwargs["timeout"] == 30
+
+    def test_local_path_uses_local_timeout(self):
+        mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(45.0))
+        with patch("subprocess.run", return_value=mock) as run_mock:
+            resolve_sampling("/tmp/x.mp4", timeout_seconds=5, http_timeout_seconds=30)
+        assert run_mock.call_args.kwargs["timeout"] == 5
+```
+
+- [ ] **Step 2: Run — expect `ImportError: cannot import name 'resolve_sampling'`**
+
+```bash
+python -m pytest tests/test_core/test_video_sampling.py::TestResolveSampling -v
+```
+
+- [ ] **Step 3: Add `resolve_sampling` to `src/cognithor/core/video_sampling.py`**
+
+Imports to add at the top:
+
+```python
+import json as _json
+import subprocess
+from typing import Literal
+
+from cognithor.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+_MAX_PLAUSIBLE_DURATION_SEC = 86400.0  # 24 hours; anything bigger is almost certainly garbage
+```
+
+Then add:
+
+```python
+SamplingOverride = Literal["adaptive", "fixed_32", "fixed_64", "fps_1"]
+
+
+def resolve_sampling(
+    source: str,
+    *,
+    ffprobe_path: str = "ffprobe",
+    timeout_seconds: int = 5,
+    http_timeout_seconds: int = 30,
+    override: SamplingOverride = "adaptive",
+) -> VideoSampling:
+    """Resolve a video source URL or local path to a VideoSampling.
+
+    For `override != "adaptive"`, returns a fixed sampling without touching
+    ffprobe. For adaptive, runs ffprobe with the appropriate timeout
+    (`timeout_seconds` for local paths, `http_timeout_seconds` for URLs) and
+    falls back to `VideoSampling(num_frames=32)` on any failure.
+    """
+    if override == "fixed_32":
+        return VideoSampling(num_frames=32)
+    if override == "fixed_64":
+        return VideoSampling(num_frames=64)
+    if override == "fps_1":
+        return VideoSampling(fps=1.0)
+
+    is_http = source.lower().startswith(("http://", "https://"))
+    timeout = http_timeout_seconds if is_http else timeout_seconds
+
+    cmd = [
+        ffprobe_path, "-v", "error",
+        "-show_entries", "format=duration",
+        "-of", "json",
+        source,
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError:
+        log.warning("video_ffprobe_missing", recovery="fallback to num_frames=32")
+        return VideoSampling(num_frames=32)
+    except subprocess.TimeoutExpired:
+        log.warning("video_duration_detection_timeout", source=_redact_source(source), timeout_seconds=timeout)
+        return VideoSampling(num_frames=32)
+
+    if result.returncode != 0:
+        log.warning("video_ffprobe_failed", returncode=result.returncode, stderr=result.stderr.strip()[:200])
+        return VideoSampling(num_frames=32)
+
+    try:
+        data = _json.loads(result.stdout)
+        duration = float(data["format"]["duration"])
+    except (_json.JSONDecodeError, KeyError, ValueError, TypeError):
+        log.warning("video_ffprobe_unparseable", stdout=result.stdout[:200])
+        return VideoSampling(num_frames=32)
+
+    if duration <= 0 or duration > _MAX_PLAUSIBLE_DURATION_SEC:
+        log.warning("video_duration_implausible", duration=duration)
+        return VideoSampling(num_frames=32)
+
+    return _bucket_for_duration(duration)
+
+
+def _redact_source(source: str) -> str:
+    """Strip query strings from URLs so we don't log credentials / tokens."""
+    if "?" in source:
+        return source.split("?", 1)[0] + "?…"
+    return source
+```
+
+- [ ] **Step 4: Run — expect all pass**
+
+```bash
+python -m pytest tests/test_core/test_video_sampling.py -v
+```
+Expected: `30 passed` (17 from Task 2 + 13 new).
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+python -m ruff check src/cognithor/core/video_sampling.py tests/test_core/test_video_sampling.py
+python -m ruff format --check src/cognithor/core/video_sampling.py tests/test_core/test_video_sampling.py
+git add src/cognithor/core/video_sampling.py tests/test_core/test_video_sampling.py
+git commit -m "feat(video): ffprobe-based resolve_sampling with adaptive + override modes"
+```
+
+---
+
+## Task 4: MediaUploadError Hierarchy
+
+**Files:**
+- Modify: `src/cognithor/core/llm_backend.py` (add 3 error classes after `LLMBadRequestError`)
+- Modify: `tests/test_core/test_llm_backend_errors.py` (add test class)
+
+- [ ] **Step 1: Append to `tests/test_core/test_llm_backend_errors.py`**
+
+```python
+class TestMediaUploadErrors:
+    def test_media_upload_error_is_llm_backend_error(self):
+        from cognithor.core.llm_backend import LLMBackendError, MediaUploadError
+        assert issubclass(MediaUploadError, LLMBackendError)
+
+    def test_too_large_inherits(self):
+        from cognithor.core.llm_backend import MediaUploadError, MediaUploadTooLargeError
+        assert issubclass(MediaUploadTooLargeError, MediaUploadError)
+        err = MediaUploadTooLargeError("file is 600 MB, max is 500 MB", status_code=413)
+        assert err.status_code == 413
+
+    def test_unsupported_format_inherits(self):
+        from cognithor.core.llm_backend import MediaUploadError, MediaUploadUnsupportedFormatError
+        assert issubclass(MediaUploadUnsupportedFormatError, MediaUploadError)
+
+    def test_quota_exceeded_inherits(self):
+        from cognithor.core.llm_backend import MediaUploadError, MediaUploadQuotaExceededError
+        assert issubclass(MediaUploadQuotaExceededError, MediaUploadError)
+
+    def test_all_carry_recovery_hint(self):
+        from cognithor.core.llm_backend import MediaUploadTooLargeError
+        err = MediaUploadTooLargeError(
+            "too big",
+            recovery_hint="Shorten or downscale the clip before uploading.",
+        )
+        assert err.recovery_hint == "Shorten or downscale the clip before uploading."
+```
+
+- [ ] **Step 2: Run — expect `ImportError: cannot import name 'MediaUploadError'`**
+
+```bash
+python -m pytest tests/test_core/test_llm_backend_errors.py::TestMediaUploadErrors -v
+```
+
+- [ ] **Step 3: Add to `src/cognithor/core/llm_backend.py`** (below the existing `LLMBadRequestError` class)
+
+```python
+class MediaUploadError(LLMBackendError):
+    """Upload of a media file (video in v1) could not be accepted by the
+    local media server. User-side problem, not a vLLM/backend fault —
+    excluded from circuit-breaker failure counting in UnifiedLLMClient.
+    """
+
+
+class MediaUploadTooLargeError(MediaUploadError):
+    """Upload exceeds ``config.vllm.video_max_upload_mb``."""
+
+
+class MediaUploadUnsupportedFormatError(MediaUploadError):
+    """File extension not in the allow-list (.mp4, .webm, .mov, .mkv, .avi)."""
+
+
+class MediaUploadQuotaExceededError(MediaUploadError):
+    """Would exceed ``config.vllm.video_quota_gb`` even after LRU eviction.
+
+    This can only happen if the single upload is larger than the entire
+    quota — otherwise LRU eviction always makes room. Practically means
+    the user needs to raise ``video_quota_gb`` or shrink the file.
+    """
+```
+
+- [ ] **Step 4: Run — expect all pass**
+
+```bash
+python -m pytest tests/test_core/test_llm_backend_errors.py -v
+```
+Expected: all passing (count depends on PR #137 baseline).
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+python -m ruff check src/cognithor/core/llm_backend.py tests/test_core/test_llm_backend_errors.py
+python -m ruff format --check src/cognithor/core/llm_backend.py tests/test_core/test_llm_backend_errors.py
+git add src/cognithor/core/llm_backend.py tests/test_core/test_llm_backend_errors.py
+git commit -m "feat(llm): MediaUploadError hierarchy for video upload failures"
+```
+
+---
+
+## Task 5: VLLMConfig Video Fields
+
+**Files:**
+- Modify: `src/cognithor/config.py` (extend existing `VLLMConfig`)
+- Modify: `tests/config/test_vllm_config.py` (add test class)
+
+- [ ] **Step 1: Append to the test file**
+
+```python
+class TestVLLMConfigVideoFields:
+    def test_video_defaults(self):
+        c = VLLMConfig()
+        assert c.video_sampling_mode == "adaptive"
+        assert c.video_ffprobe_path == "ffprobe"
+        assert c.video_ffprobe_timeout_seconds == 5
+        assert c.video_ffprobe_http_timeout_seconds == 30
+        assert c.video_max_upload_mb == 500
+        assert c.video_quota_gb == 5
+        assert c.video_upload_ttl_hours == 24
+
+    def test_video_sampling_mode_literal_rejects_garbage(self):
+        with pytest.raises(ValidationError):
+            VLLMConfig(video_sampling_mode="totally_bogus")
+
+    def test_video_sampling_mode_accepts_all_four(self):
+        for mode in ("adaptive", "fixed_32", "fixed_64", "fps_1"):
+            c = VLLMConfig(video_sampling_mode=mode)
+            assert c.video_sampling_mode == mode
+
+    def test_timeout_lower_bound(self):
+        with pytest.raises(ValidationError):
+            VLLMConfig(video_ffprobe_timeout_seconds=0)
+
+    def test_upload_mb_upper_bound(self):
+        with pytest.raises(ValidationError):
+            VLLMConfig(video_max_upload_mb=999999)
+```
+
+- [ ] **Step 2: Run — expect `AttributeError` on `video_sampling_mode`**
+
+```bash
+python -m pytest tests/config/test_vllm_config.py::TestVLLMConfigVideoFields -v
+```
+
+- [ ] **Step 3: Add fields to `VLLMConfig` in `src/cognithor/config.py`**
+
+At the top of the file (or inside appropriate import block):
+
+```python
+from typing import Literal
+```
+(if not already imported)
+
+Inside `VLLMConfig`, after the existing `request_timeout_seconds` field:
+
+```python
+    # Video-input (from video-input-vllm spec 2026-04-23)
+    video_sampling_mode: Literal["adaptive", "fixed_32", "fixed_64", "fps_1"] = Field(default="adaptive")
+    video_ffprobe_path: str = Field(default="ffprobe")
+    video_ffprobe_timeout_seconds: int = Field(default=5, ge=1, le=30)
+    video_ffprobe_http_timeout_seconds: int = Field(default=30, ge=5, le=120)
+    video_max_upload_mb: int = Field(default=500, ge=1, le=5000)
+    video_quota_gb: int = Field(default=5, ge=1, le=100)
+    video_upload_ttl_hours: int = Field(default=24, ge=1, le=168)
+```
+
+- [ ] **Step 4: Run — expect all pass**
+
+```bash
+python -m pytest tests/config/test_vllm_config.py -v
+```
+Expected: all previous + 5 new tests pass.
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+python -m ruff check src/cognithor/config.py tests/config/test_vllm_config.py
+python -m ruff format --check src/cognithor/config.py tests/config/test_vllm_config.py
+git add src/cognithor/config.py tests/config/test_vllm_config.py
+git commit -m "feat(config): video-related fields on VLLMConfig (sampling mode, quotas, TTL)"
+```
+
+---
+
+## Task 6: MediaUploadServer — save_upload + LRU Eviction
+
+**Files:**
+- Create: `src/cognithor/channels/media_server.py`
+- Create: `tests/test_channels/test_media_server.py`
+
+This task covers only the `save_upload` / `delete` / `public_url` / quota logic. The FastAPI HTTP app is added in Task 7.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_channels/test_media_server.py
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from cognithor.channels.media_server import MediaUploadServer
+from cognithor.config import CognithorConfig, VLLMConfig
+from cognithor.core.llm_backend import (
+    MediaUploadQuotaExceededError,
+    MediaUploadTooLargeError,
+    MediaUploadUnsupportedFormatError,
+)
+
+
+@pytest.fixture
+def server(tmp_path: Path) -> MediaUploadServer:
+    cfg = CognithorConfig(
+        cognithor_home=tmp_path,
+        vllm=VLLMConfig(
+            enabled=True,
+            video_max_upload_mb=10,   # small cap for fast tests
+            video_quota_gb=1,
+        ),
+    )
+    srv = MediaUploadServer(cfg)
+    # Pretend we've bound to port 4711 (real start() is tested in Task 7)
+    srv._port = 4711
+    return srv
+
+
+class TestSaveUpload:
+    def test_saves_bytes_returns_uuid(self, server: MediaUploadServer):
+        data = b"\x00" * 1024  # 1 KB
+        uuid = server.save_upload(data, "mp4")
+        assert uuid
+        path = server._media_dir / f"{uuid}.mp4"
+        assert path.is_file()
+        assert path.read_bytes() == data
+
+    def test_rejects_file_over_per_file_cap(self, server: MediaUploadServer):
+        too_big = b"\x00" * (11 * 1024 * 1024)  # 11 MB > 10 MB cap
+        with pytest.raises(MediaUploadTooLargeError):
+            server.save_upload(too_big, "mp4")
+
+    def test_rejects_unsupported_extension(self, server: MediaUploadServer):
+        with pytest.raises(MediaUploadUnsupportedFormatError):
+            server.save_upload(b"\x00" * 1024, "exe")
+
+    def test_case_insensitive_extension(self, server: MediaUploadServer):
+        uuid = server.save_upload(b"\x00" * 1024, "MP4")
+        assert uuid  # accepts "MP4" / "Mp4"
+
+    def test_public_url_shape(self, server: MediaUploadServer):
+        uuid = server.save_upload(b"\x00" * 1024, "mp4")
+        url = server.public_url(uuid, "mp4")
+        assert url == f"http://host.docker.internal:4711/media/{uuid}.mp4"
+
+    def test_lru_eviction_when_quota_exceeded(self, server: MediaUploadServer, tmp_path: Path):
+        # Quota is 1 GB. Fill up with 3 files of 5 MB each (< cap, close to quota)
+        # Then add a file that would push total over 1 GB if nothing is evicted.
+        # The actual sizes don't need to exceed 1 GB — we monkey-patch the quota to
+        # something small to exercise the eviction path deterministically.
+        server._quota_bytes = 12 * 1024 * 1024  # override quota to 12 MB for this test
+
+        # Save 3 files totaling 9 MB
+        import time
+        u1 = server.save_upload(b"\x00" * (3 * 1024 * 1024), "mp4")
+        time.sleep(0.01)  # ensure distinct mtimes
+        u2 = server.save_upload(b"\x00" * (3 * 1024 * 1024), "mp4")
+        time.sleep(0.01)
+        u3 = server.save_upload(b"\x00" * (3 * 1024 * 1024), "mp4")
+
+        # Now save a 5 MB file — total would be 14 MB > 12 MB quota.
+        # Expected: u1 (oldest) gets evicted.
+        u4 = server.save_upload(b"\x00" * (5 * 1024 * 1024), "mp4")
+        assert not (server._media_dir / f"{u1}.mp4").exists()
+        assert (server._media_dir / f"{u2}.mp4").exists()
+        assert (server._media_dir / f"{u4}.mp4").exists()
+
+
+class TestDelete:
+    def test_delete_removes_file(self, server: MediaUploadServer):
+        uuid = server.save_upload(b"\x00" * 1024, "mp4")
+        path = server._media_dir / f"{uuid}.mp4"
+        assert path.exists()
+        server.delete(uuid, "mp4")
+        assert not path.exists()
+
+    def test_delete_of_missing_is_noop(self, server: MediaUploadServer):
+        server.delete("nonexistent-uuid-abc", "mp4")  # must not raise
+```
+
+- [ ] **Step 2: Run — expect `ModuleNotFoundError`**
+
+```bash
+python -m pytest tests/test_channels/test_media_server.py -v
+```
+
+- [ ] **Step 3: Create `src/cognithor/channels/media_server.py`**
+
+```python
+"""MediaUploadServer — local HTTP file-server for vLLM to fetch user uploads.
+
+vLLM inside the Cognithor-managed Docker container reaches this server via
+``http://host.docker.internal:<port>/media/<uuid>.<ext>``. The server binds
+only on ``127.0.0.1``, so only processes on the host machine can reach it.
+
+This file contains the storage + quota logic. The FastAPI app + port binding
+live in companion methods `start()` / `stop()` added in Task 7.
+"""
+
+from __future__ import annotations
+
+import uuid as _uuid
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from cognithor.core.llm_backend import (
+    MediaUploadQuotaExceededError,
+    MediaUploadTooLargeError,
+    MediaUploadUnsupportedFormatError,
+)
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from cognithor.config import CognithorConfig
+
+log = get_logger(__name__)
+
+_ALLOWED_EXTS = frozenset({"mp4", "webm", "mov", "mkv", "avi"})
+
+
+class MediaUploadServer:
+    """Local-loopback static file server for vLLM media fetches.
+
+    Lifecycle: instantiate with the live CognithorConfig, call `await start()`
+    to bind the ephemeral port (returns the port number), `await stop()` at
+    shutdown. In between, call `save_upload(data, ext) -> uuid` to store
+    bytes and `public_url(uuid, ext) -> str` to get the URL vLLM should fetch.
+    """
+
+    def __init__(self, config: "CognithorConfig") -> None:
+        self._config = config
+        self._media_dir = config.cognithor_home / "media" / "vllm-uploads"
+        self._media_dir.mkdir(parents=True, exist_ok=True)
+        self._max_per_file_bytes = config.vllm.video_max_upload_mb * 1024 * 1024
+        self._quota_bytes = config.vllm.video_quota_gb * 1024 * 1024 * 1024
+        self._port: int | None = None
+        self._server = None  # filled by start() in Task 7
+
+    def save_upload(self, data: bytes, ext: str) -> str:
+        """Store `data` under `<uuid>.<ext>` in the media dir, return uuid.
+
+        Raises MediaUploadTooLargeError / MediaUploadUnsupportedFormatError /
+        MediaUploadQuotaExceededError on the respective failure modes. LRU-
+        evicts older files if the new upload would push total size over quota.
+        """
+        ext_lower = ext.lower().lstrip(".")
+        if ext_lower not in _ALLOWED_EXTS:
+            raise MediaUploadUnsupportedFormatError(
+                f"Unsupported extension: {ext!r}. Allowed: {sorted(_ALLOWED_EXTS)}",
+                status_code=400,
+            )
+        if len(data) > self._max_per_file_bytes:
+            mb = len(data) / 1024 / 1024
+            cap = self._max_per_file_bytes / 1024 / 1024
+            raise MediaUploadTooLargeError(
+                f"Upload is {mb:.1f} MB, max per file is {cap:.0f} MB",
+                status_code=413,
+                recovery_hint="Shorten or downscale the clip before uploading.",
+            )
+        if len(data) > self._quota_bytes:
+            raise MediaUploadQuotaExceededError(
+                f"Upload alone ({len(data)/1024/1024:.1f} MB) exceeds the full quota"
+                f" ({self._quota_bytes/1024/1024/1024:.1f} GB)",
+                status_code=413,
+                recovery_hint="Raise config.vllm.video_quota_gb or shrink the file.",
+            )
+
+        # LRU eviction until the new file fits
+        self._evict_until_fits(len(data))
+
+        uuid_str = _uuid.uuid4().hex
+        path = self._media_dir / f"{uuid_str}.{ext_lower}"
+        path.write_bytes(data)
+        log.info(
+            "video_upload_saved",
+            uuid=uuid_str,
+            ext=ext_lower,
+            bytes=len(data),
+        )
+        return uuid_str
+
+    def _evict_until_fits(self, incoming_bytes: int) -> None:
+        """Delete oldest files (by mtime) until adding `incoming_bytes` fits under quota."""
+        files = list(self._media_dir.iterdir())
+        current = sum(f.stat().st_size for f in files if f.is_file())
+        if current + incoming_bytes <= self._quota_bytes:
+            return
+        # Sort by mtime ascending (oldest first)
+        files.sort(key=lambda f: f.stat().st_mtime)
+        for f in files:
+            if not f.is_file():
+                continue
+            if current + incoming_bytes <= self._quota_bytes:
+                break
+            size = f.stat().st_size
+            try:
+                f.unlink()
+            except OSError as exc:
+                log.warning("video_evict_failed", file=str(f), error=str(exc))
+                continue
+            # Also drop sidecar thumbnail if present
+            thumb = f.with_suffix(".jpg")
+            if thumb.exists():
+                try:
+                    thumb.unlink()
+                except OSError:
+                    pass
+            current -= size
+            log.info("video_evicted_lru", file=f.name, freed_bytes=size)
+
+    def delete(self, uuid: str, ext: str) -> None:
+        """Remove a specific upload (and its thumbnail). Noop if missing."""
+        ext_lower = ext.lower().lstrip(".")
+        path = self._media_dir / f"{uuid}.{ext_lower}"
+        if path.exists():
+            try:
+                path.unlink()
+            except OSError as exc:
+                log.warning("video_delete_failed", uuid=uuid, error=str(exc))
+        thumb = self._media_dir / f"{uuid}.jpg"
+        if thumb.exists():
+            try:
+                thumb.unlink()
+            except OSError:
+                pass
+
+    def public_url(self, uuid: str, ext: str) -> str:
+        """Return the URL vLLM should fetch: ``http://host.docker.internal:<port>/media/<uuid>.<ext>``.
+
+        Requires `start()` to have been called (or `_port` manually set in tests).
+        """
+        if self._port is None:
+            raise RuntimeError("MediaUploadServer not started; call await start() first")
+        ext_lower = ext.lower().lstrip(".")
+        return f"http://host.docker.internal:{self._port}/media/{uuid}.{ext_lower}"
+
+    # start() / stop() added in Task 7
+```
+
+- [ ] **Step 4: Run — expect all pass**
+
+```bash
+python -m pytest tests/test_channels/test_media_server.py -v
+```
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+python -m ruff check src/cognithor/channels/media_server.py tests/test_channels/test_media_server.py
+python -m ruff format --check src/cognithor/channels/media_server.py tests/test_channels/test_media_server.py
+git add src/cognithor/channels/media_server.py tests/test_channels/test_media_server.py
+git commit -m "feat(media): MediaUploadServer save_upload with quota + LRU eviction"
+```
+
+---
+
+## Task 7: MediaUploadServer — FastAPI App + Port Binding
+
+**Files:**
+- Modify: `src/cognithor/channels/media_server.py` (add `start()` / `stop()` / the FastAPI sub-app)
+- Modify: `tests/test_channels/test_media_server.py` (add `TestLifecycle`)
+
+- [ ] **Step 1: Append test class**
+
+```python
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_binds_ephemeral_port_serves_media(self, tmp_path: Path):
+        from cognithor.config import CognithorConfig, VLLMConfig
+        import httpx
+
+        cfg = CognithorConfig(
+            cognithor_home=tmp_path,
+            vllm=VLLMConfig(enabled=True, video_max_upload_mb=10, video_quota_gb=1),
+        )
+        srv = MediaUploadServer(cfg)
+        port = await srv.start()
+        try:
+            assert port > 0
+            uuid = srv.save_upload(b"hello video world", "mp4")
+            url = f"http://127.0.0.1:{port}/media/{uuid}.mp4"
+            async with httpx.AsyncClient() as client:
+                r = await client.get(url, timeout=5.0)
+            assert r.status_code == 200
+            assert r.content == b"hello video world"
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_stop_is_idempotent(self, tmp_path: Path):
+        from cognithor.config import CognithorConfig, VLLMConfig
+        cfg = CognithorConfig(
+            cognithor_home=tmp_path,
+            vllm=VLLMConfig(enabled=True),
+        )
+        srv = MediaUploadServer(cfg)
+        port = await srv.start()
+        await srv.stop()
+        await srv.stop()  # second stop must not raise
+        # Restart on a fresh instance
+        srv2 = MediaUploadServer(cfg)
+        port2 = await srv2.start()
+        assert port2 > 0
+        await srv2.stop()
+```
+
+- [ ] **Step 2: Run — expect `AttributeError: 'MediaUploadServer' object has no attribute 'start'`**
+
+```bash
+python -m pytest tests/test_channels/test_media_server.py::TestLifecycle -v
+```
+
+- [ ] **Step 3: Extend `src/cognithor/channels/media_server.py` with the lifecycle**
+
+Add imports at the top (keeping existing ones):
+
+```python
+import asyncio
+import socket
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
+```
+
+Add the methods inside the class, after `public_url`:
+
+```python
+    async def start(self) -> int:
+        """Bind to 127.0.0.1:<ephemeral>, serve /media/<uuid>.<ext> as static files.
+
+        Returns the bound port. Call `await stop()` at shutdown.
+        """
+        # Pick an ephemeral port ourselves so we can tell the orchestrator before
+        # uvicorn actually binds (uvicorn accepts 0 but only reports after start).
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+            self._port = probe.getsockname()[1]
+
+        app = FastAPI(title="Cognithor MediaUploadServer", openapi_url=None, docs_url=None)
+
+        @app.get("/media/{filename}")
+        async def serve(filename: str) -> FileResponse:
+            # Very strict: no paths, only flat <uuid>.<ext> names
+            if "/" in filename or ".." in filename:
+                raise HTTPException(status_code=400, detail="invalid filename")
+            path = self._media_dir / filename
+            if not path.is_file():
+                raise HTTPException(status_code=404, detail="not found")
+            return FileResponse(path)
+
+        config = uvicorn.Config(
+            app,
+            host="127.0.0.1",
+            port=self._port,
+            log_level="warning",
+            access_log=False,
+        )
+        self._server = uvicorn.Server(config)
+        self._serve_task = asyncio.create_task(self._server.serve())
+        # Wait for startup (server.started flips true when uvicorn is ready)
+        for _ in range(50):
+            if self._server.started:
+                break
+            await asyncio.sleep(0.05)
+        log.info("media_server_started", port=self._port)
+        return self._port
+
+    async def stop(self) -> None:
+        """Shut down the uvicorn serving loop. Idempotent."""
+        if self._server is None:
+            return
+        self._server.should_exit = True
+        try:
+            await self._serve_task
+        except Exception as exc:
+            log.warning("media_server_stop_error", error=str(exc))
+        self._server = None
+        self._serve_task = None
+        log.info("media_server_stopped")
+```
+
+Also add `_server` and `_serve_task` to the init defaults alongside `_server = None`:
+
+```python
+        self._serve_task: asyncio.Task | None = None
+```
+
+- [ ] **Step 4: Run — expect `2 passed`**
+
+```bash
+python -m pytest tests/test_channels/test_media_server.py::TestLifecycle -v
+```
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+python -m ruff check src/cognithor/channels/media_server.py tests/test_channels/test_media_server.py
+python -m ruff format --check src/cognithor/channels/media_server.py tests/test_channels/test_media_server.py
+git add src/cognithor/channels/media_server.py tests/test_channels/test_media_server.py
+git commit -m "feat(media): MediaUploadServer FastAPI app + ephemeral-port lifecycle"
+```
+
+---
+
+## Task 8: VideoCleanupWorker — Session Registry + TTL Sweep
+
+**Files:**
+- Create: `src/cognithor/gateway/video_cleanup.py`
+- Create: `tests/test_gateway/test_video_cleanup.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_gateway/test_video_cleanup.py
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from cognithor.gateway.video_cleanup import VideoCleanupWorker
+
+
+def _touch(path: Path, size: int = 64, mtime_age_sec: float = 0.0) -> None:
+    """Create a file with optional artificially-old mtime."""
+    path.write_bytes(b"x" * size)
+    if mtime_age_sec > 0:
+        t = time.time() - mtime_age_sec
+        os.utime(path, (t, t))
+
+
+class TestRegisterAndSessionClose:
+    @pytest.mark.asyncio
+    async def test_register_upload_is_tracked_by_session(self, tmp_path: Path):
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24)
+        worker.register_upload("abc123", "session-1")
+        worker.register_upload("def456", "session-1")
+        worker.register_upload("ghi789", "session-2")
+        assert set(worker._by_session["session-1"]) == {"abc123", "def456"}
+        assert worker._by_session["session-2"] == ["ghi789"]
+
+    @pytest.mark.asyncio
+    async def test_on_session_close_deletes_only_that_sessions_files(self, tmp_path: Path):
+        _touch(tmp_path / "abc123.mp4")
+        _touch(tmp_path / "abc123.jpg")  # thumbnail sidecar
+        _touch(tmp_path / "def456.mp4")
+        _touch(tmp_path / "ghi789.mp4")
+
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24)
+        worker.register_upload("abc123", "session-1")
+        worker.register_upload("def456", "session-1")
+        worker.register_upload("ghi789", "session-2")
+
+        await worker.on_session_close("session-1")
+
+        assert not (tmp_path / "abc123.mp4").exists()
+        assert not (tmp_path / "abc123.jpg").exists()
+        assert not (tmp_path / "def456.mp4").exists()
+        assert (tmp_path / "ghi789.mp4").exists()
+        assert "session-1" not in worker._by_session
+
+    @pytest.mark.asyncio
+    async def test_on_session_close_for_unknown_session_is_noop(self, tmp_path: Path):
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24)
+        await worker.on_session_close("ghost-session")
+
+
+class TestTTLSweep:
+    @pytest.mark.asyncio
+    async def test_sweep_deletes_files_older_than_ttl(self, tmp_path: Path):
+        old = tmp_path / "old-uuid.mp4"
+        fresh = tmp_path / "fresh-uuid.mp4"
+        _touch(old, mtime_age_sec=25 * 3600)      # 25 h old
+        _touch(fresh, mtime_age_sec=1 * 3600)     # 1 h old
+
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24)
+        await worker._sweep_once()
+
+        assert not old.exists()
+        assert fresh.exists()
+
+    @pytest.mark.asyncio
+    async def test_sweep_deletes_thumbnails_too(self, tmp_path: Path):
+        old_video = tmp_path / "old.mp4"
+        old_thumb = tmp_path / "old.jpg"
+        _touch(old_video, mtime_age_sec=25 * 3600)
+        _touch(old_thumb, mtime_age_sec=25 * 3600)
+
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24)
+        await worker._sweep_once()
+
+        assert not old_video.exists()
+        assert not old_thumb.exists()
+
+    @pytest.mark.asyncio
+    async def test_sweep_ignores_missing_dir(self, tmp_path: Path):
+        missing = tmp_path / "does-not-exist"
+        worker = VideoCleanupWorker(media_dir=missing, ttl_hours=24)
+        # Must not raise
+        await worker._sweep_once()
+
+
+class TestStartStop:
+    @pytest.mark.asyncio
+    async def test_start_runs_initial_sweep(self, tmp_path: Path):
+        old = tmp_path / "old.mp4"
+        _touch(old, mtime_age_sec=25 * 3600)
+
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24, sweep_interval_sec=0.05)
+        await worker.start()
+        await asyncio.sleep(0.02)  # give the initial sweep a moment
+        await worker.stop()
+
+        assert not old.exists()
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent(self, tmp_path: Path):
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24)
+        await worker.start()
+        await worker.stop()
+        await worker.stop()  # second stop must not raise
+```
+
+- [ ] **Step 2: Run — expect `ModuleNotFoundError`**
+
+```bash
+python -m pytest tests/test_gateway/test_video_cleanup.py -v
+```
+
+- [ ] **Step 3: Create `src/cognithor/gateway/video_cleanup.py`**
+
+```python
+"""VideoCleanupWorker — deletes uploaded videos on session close + TTL expiry.
+
+No persistent state — the 24 h filesystem-mtime-based TTL sweep is authoritative.
+Session tracking is an optimization: users who close a session before the TTL
+window get their videos deleted sooner. If Cognithor crashes mid-session and
+never fires `on_session_close`, the TTL sweep picks up the orphans on the next
+run or within the hour.
+
+See spec: docs/superpowers/specs/2026-04-23-video-input-vllm-design.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+from cognithor.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+class VideoCleanupWorker:
+    """Manages per-session cleanup and a periodic TTL sweep."""
+
+    def __init__(
+        self,
+        media_dir: Path,
+        *,
+        ttl_hours: int = 24,
+        sweep_interval_sec: float = 60.0,
+    ) -> None:
+        self._media_dir = media_dir
+        self._ttl_hours = ttl_hours
+        self._sweep_interval = sweep_interval_sec
+        self._by_session: dict[str, list[str]] = {}
+        self._sweep_task: asyncio.Task[None] | None = None
+        self._stop_event = asyncio.Event()
+
+    async def start(self) -> None:
+        """Run TTL sweep once at start, then kick off the periodic sweep loop."""
+        await self._sweep_once()
+        self._stop_event.clear()
+        self._sweep_task = asyncio.create_task(self._run_periodic())
+        log.info("video_cleanup_started", media_dir=str(self._media_dir), ttl_hours=self._ttl_hours)
+
+    async def stop(self) -> None:
+        """Cancel the periodic sweep. Idempotent."""
+        if self._sweep_task is None:
+            return
+        self._stop_event.set()
+        try:
+            await asyncio.wait_for(self._sweep_task, timeout=2.0)
+        except (asyncio.TimeoutError, asyncio.CancelledError):
+            self._sweep_task.cancel()
+        self._sweep_task = None
+        log.info("video_cleanup_stopped")
+
+    def register_upload(self, uuid: str, session_id: str) -> None:
+        """Track this upload so it's deleted when the session closes."""
+        self._by_session.setdefault(session_id, []).append(uuid)
+
+    async def on_session_close(self, session_id: str) -> None:
+        """Delete all uploads (and thumbnails) registered under this session."""
+        uuids = self._by_session.pop(session_id, [])
+        for uuid in uuids:
+            self._delete_upload(uuid)
+
+    def _delete_upload(self, uuid: str) -> None:
+        """Remove any file starting with ``<uuid>.`` in the media dir."""
+        if not self._media_dir.is_dir():
+            return
+        for path in self._media_dir.glob(f"{uuid}.*"):
+            try:
+                path.unlink()
+            except OSError as exc:
+                log.warning("video_cleanup_delete_failed", uuid=uuid, path=str(path), error=str(exc))
+
+    async def _run_periodic(self) -> None:
+        """Loop: wait `_sweep_interval` seconds, sweep, repeat until stopped."""
+        while not self._stop_event.is_set():
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=self._sweep_interval)
+                return  # stop signal arrived
+            except asyncio.TimeoutError:
+                pass
+            await self._sweep_once()
+
+    async def _sweep_once(self) -> None:
+        """Delete every file in `media_dir` whose mtime is older than ttl_hours."""
+        if not self._media_dir.is_dir():
+            return
+        cutoff = time.time() - self._ttl_hours * 3600
+        deleted = 0
+        for path in self._media_dir.iterdir():
+            if not path.is_file():
+                continue
+            try:
+                if path.stat().st_mtime < cutoff:
+                    path.unlink()
+                    deleted += 1
+            except OSError as exc:
+                log.warning("video_ttl_sweep_failed", path=str(path), error=str(exc))
+        if deleted:
+            log.info("video_ttl_sweep_completed", deleted=deleted)
+```
+
+- [ ] **Step 4: Run — expect all pass**
+
+```bash
+python -m pytest tests/test_gateway/test_video_cleanup.py -v
+```
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+python -m ruff check src/cognithor/gateway/video_cleanup.py tests/test_gateway/test_video_cleanup.py
+python -m ruff format --check src/cognithor/gateway/video_cleanup.py tests/test_gateway/test_video_cleanup.py
+git add src/cognithor/gateway/video_cleanup.py tests/test_gateway/test_video_cleanup.py
+git commit -m "feat(video): VideoCleanupWorker with session registry + mtime TTL sweep"
+```
+
+---
+
+## Task 9: VLLMBackend.chat(video=...) — Payload Adapter
+
+**Files:**
+- Modify: `src/cognithor/core/vllm_backend.py` (add `_attach_video_to_last_user` helper + `video` kwarg)
+- Create: `tests/test_core/test_vllm_backend_video.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_core/test_vllm_backend_video.py
+from __future__ import annotations
+
+import json as _json
+
+import pytest
+from pytest_httpx import HTTPXMock
+
+from cognithor.core.vllm_backend import VLLMBackend, _attach_video_to_last_user
+
+
+BASE_URL = "http://localhost:8000/v1"
+
+
+@pytest.fixture
+def backend() -> VLLMBackend:
+    return VLLMBackend(base_url=BASE_URL, timeout=5)
+
+
+class TestAttachVideoHelper:
+    def test_prepends_video_url_content_item_to_last_user(self):
+        messages = [
+            {"role": "system", "content": "you are helpful"},
+            {"role": "user", "content": "What is in this?"},
+        ]
+        video = {"url": "http://x/a.mp4", "sampling": {"fps": 2.0}}
+        new_messages, mm_kwargs = _attach_video_to_last_user(messages, video)
+
+        # System message untouched
+        assert new_messages[0] == messages[0]
+        # Last user message converted to content-item list
+        last = new_messages[-1]
+        assert last["role"] == "user"
+        assert isinstance(last["content"], list)
+        assert last["content"][0] == {"type": "video_url", "video_url": {"url": "http://x/a.mp4"}}
+        assert last["content"][1] == {"type": "text", "text": "What is in this?"}
+        # mm kwargs shape
+        assert mm_kwargs == {"mm_processor_kwargs": {"video": {"fps": 2.0}}}
+
+    def test_num_frames_sampling(self):
+        video = {"url": "http://x/a.mp4", "sampling": {"num_frames": 32}}
+        _, mm_kwargs = _attach_video_to_last_user(
+            [{"role": "user", "content": "hi"}], video
+        )
+        assert mm_kwargs == {"mm_processor_kwargs": {"video": {"num_frames": 32}}}
+
+    def test_empty_text_part_not_added(self):
+        """If the user message content is already an empty string, don't
+        inject a zero-length text part (spec Open Question: vLLM might or
+        might not accept this — simplest: keep text absent)."""
+        messages = [{"role": "user", "content": ""}]
+        video = {"url": "http://x/a.mp4", "sampling": {"fps": 1.0}}
+        new_messages, _ = _attach_video_to_last_user(messages, video)
+        content_items = new_messages[-1]["content"]
+        assert len(content_items) == 1  # only the video, no text
+        assert content_items[0]["type"] == "video_url"
+
+    def test_caller_messages_not_mutated(self):
+        messages = [{"role": "user", "content": "orig"}]
+        video = {"url": "http://x/a.mp4", "sampling": {"fps": 1.0}}
+        _attach_video_to_last_user(messages, video)
+        assert messages[0]["content"] == "orig"
+        assert isinstance(messages[0]["content"], str)
+
+
+class TestChatWithVideo:
+    @pytest.mark.asyncio
+    async def test_chat_with_video_sends_video_url_and_mm_kwargs(
+        self, backend: VLLMBackend, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=200,
+            json={
+                "choices": [{"message": {"content": "A drone flying over a field."}}],
+                "model": "Qwen/Qwen3.6-27B-FP8",
+                "usage": {"prompt_tokens": 100, "completion_tokens": 10, "total_tokens": 110},
+            },
+        )
+        resp = await backend.chat(
+            model="Qwen/Qwen3.6-27B-FP8",
+            messages=[{"role": "user", "content": "What's in this clip?"}],
+            video={"url": "http://host.docker.internal:4711/media/abc.mp4", "sampling": {"fps": 2.0}},
+        )
+        assert resp.content == "A drone flying over a field."
+
+        request = httpx_mock.get_requests()[0]
+        body = _json.loads(request.content)
+
+        # The video_url content item landed in the last user message
+        last_msg = body["messages"][-1]
+        assert last_msg["role"] == "user"
+        assert isinstance(last_msg["content"], list)
+        assert any(
+            c.get("type") == "video_url"
+            and c["video_url"]["url"] == "http://host.docker.internal:4711/media/abc.mp4"
+            for c in last_msg["content"]
+        )
+
+        # extra_body.mm_processor_kwargs.video is present
+        assert body["extra_body"]["mm_processor_kwargs"]["video"] == {"fps": 2.0}
+
+    @pytest.mark.asyncio
+    async def test_chat_without_video_does_not_set_extra_body(
+        self, backend: VLLMBackend, httpx_mock: HTTPXMock
+    ):
+        """Regression: image-only or text-only requests must not grow an
+        extra_body.mm_processor_kwargs key they don't need."""
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=200,
+            json={"choices": [{"message": {"content": "ok"}}], "model": "x"},
+        )
+        await backend.chat(
+            model="Qwen/Qwen2.5-VL-7B-Instruct",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        body = _json.loads(httpx_mock.get_requests()[0].content)
+        assert "extra_body" not in body or "mm_processor_kwargs" not in body.get("extra_body", {})
+```
+
+- [ ] **Step 2: Run — expect various failures**
+
+```bash
+python -m pytest tests/test_core/test_vllm_backend_video.py -v
+```
+
+- [ ] **Step 3: Add the helper to `src/cognithor/core/vllm_backend.py`**
+
+Near the top of the file, next to `_attach_images_to_last_user`:
+
+```python
+def _attach_video_to_last_user(
+    messages: list[dict[str, Any]],
+    video: dict[str, Any],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Attach a single video to the last user message and build the
+    mm_processor_kwargs payload for vLLM's extra_body.
+
+    Args:
+        messages: Ollama-shaped chat messages. Not mutated.
+        video: {"url": str, "sampling": {"fps": float} | {"num_frames": int}}
+
+    Returns:
+        (new_messages, extra_body_update) where
+        - new_messages: a fresh list with the last user message's content
+          replaced by a list of content items: [video_url, (optional) text]
+        - extra_body_update: {"mm_processor_kwargs": {"video": <sampling>}}
+          ready to merge into the outgoing chat-completion body.
+    """
+    new_messages = [dict(m) for m in messages]
+
+    # Find last user message (create one if none exists)
+    for i in range(len(new_messages) - 1, -1, -1):
+        if new_messages[i].get("role") == "user":
+            last = new_messages[i]
+            break
+    else:
+        last = {"role": "user", "content": ""}
+        new_messages.append(last)
+
+    existing = last.get("content", "")
+    text_part = existing if isinstance(existing, str) else ""
+    content_items: list[dict[str, Any]] = [
+        {"type": "video_url", "video_url": {"url": video["url"]}},
+    ]
+    if text_part:
+        content_items.append({"type": "text", "text": text_part})
+
+    last["content"] = content_items
+    # Put the modified copy back (we're iterating new_messages but `last` is a ref into it)
+
+    extra_body = {"mm_processor_kwargs": {"video": video["sampling"]}}
+    return new_messages, extra_body
+```
+
+Extend `chat()` to accept `video` and merge the `extra_body`:
+
+```python
+async def chat(
+    self,
+    model: str,
+    messages: list[dict[str, Any]],
+    *,
+    tools: list[dict[str, Any]] | None = None,
+    temperature: float = 0.7,
+    top_p: float = 0.9,
+    format_json: bool = False,
+    images: list[str] | None = None,
+    video: dict[str, Any] | None = None,
+) -> ChatResponse:
+    """... existing docstring, add: `video` is a dict {url, sampling} per the
+    video-input spec (2026-04-23). Exactly zero or one video per turn."""
+    if images:
+        messages = _attach_images_to_last_user(messages, images)
+
+    extra_body: dict[str, Any] = {}
+    if video is not None:
+        messages, video_extra = _attach_video_to_last_user(messages, video)
+        extra_body.update(video_extra)
+
+    payload: dict[str, Any] = {
+        "model": model,
+        "messages": messages,
+        "temperature": temperature,
+        "top_p": top_p,
+    }
+    if tools:
+        payload["tools"] = tools
+    if format_json:
+        payload["response_format"] = {"type": "json_object"}
+    if extra_body:
+        payload["extra_body"] = extra_body
+
+    # ... rest of existing chat() body (HTTP POST + error handling) ...
+```
+
+(Preserve the existing HTTP post and error-handling tail — just thread `extra_body` into the payload.)
+
+- [ ] **Step 4: Run — expect all pass**
+
+```bash
+python -m pytest tests/test_core/test_vllm_backend_video.py -v
+```
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend_video.py
+python -m ruff format --check src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend_video.py
+git add src/cognithor/core/vllm_backend.py tests/test_core/test_vllm_backend_video.py
+git commit -m "feat(vllm): VLLMBackend.chat(video=...) with mm_processor_kwargs shape"
+```
+
+**Note:** the exact `extra_body.mm_processor_kwargs.video` shape here matches the spec's assumption. If Task 1 spike revealed a different shape, adjust `_attach_video_to_last_user`'s return accordingly AND re-run the tests.
+
+---
+
+## Task 10: VLLMOrchestrator — docker run Flags for Video
+
+**Files:**
+- Modify: `src/cognithor/core/vllm_orchestrator.py` (extend `start_container()` with `--media-io-kwargs` + `--add-host`)
+- Modify: `tests/test_core/test_vllm_orchestrator.py` (add `TestStartContainerVideoFlags`)
+
+- [ ] **Step 1: Append test class**
+
+```python
+class TestStartContainerVideoFlags:
+    def test_docker_run_includes_media_io_kwargs(self):
+        from unittest.mock import MagicMock, patch
+        from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+
+        with patch.object(VLLMOrchestrator, "_port_available", return_value=True), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")) as run_mock, \
+             patch.object(VLLMOrchestrator, "_wait_for_health", return_value=True):
+            orch = VLLMOrchestrator(docker_image="vllm/vllm-openai:v0.19.1", port=8000, hf_token="")
+            orch.start_container("Qwen/Qwen2.5-VL-7B-Instruct")
+
+        args = run_mock.call_args[0][0]
+        # --media-io-kwargs flag is present with the num_frames=-1 default
+        idx = args.index("--media-io-kwargs")
+        assert '"video"' in args[idx + 1]
+        assert '"num_frames": -1' in args[idx + 1]
+
+    def test_docker_run_includes_add_host(self):
+        from unittest.mock import MagicMock, patch
+        from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+
+        with patch.object(VLLMOrchestrator, "_port_available", return_value=True), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")) as run_mock, \
+             patch.object(VLLMOrchestrator, "_wait_for_health", return_value=True):
+            orch = VLLMOrchestrator(port=8000)
+            orch.start_container("Qwen/Qwen2.5-VL-7B-Instruct")
+        args = run_mock.call_args[0][0]
+        assert "--add-host" in args
+        idx = args.index("--add-host")
+        assert args[idx + 1] == "host.docker.internal:host-gateway"
+
+    def test_docker_run_includes_media_url_env_when_port_given(self):
+        from unittest.mock import MagicMock, patch
+        from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+
+        with patch.object(VLLMOrchestrator, "_port_available", return_value=True), \
+             patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")) as run_mock, \
+             patch.object(VLLMOrchestrator, "_wait_for_health", return_value=True):
+            orch = VLLMOrchestrator(port=8000)
+            orch.media_url = "http://host.docker.internal:4711"  # orchestrator learns this from the media server
+            orch.start_container("Qwen/Qwen2.5-VL-7B-Instruct")
+        args = run_mock.call_args[0][0]
+        assert any("COGNITHOR_MEDIA_URL=http://host.docker.internal:4711" in a for a in args)
+```
+
+- [ ] **Step 2: Run — expect failures**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py::TestStartContainerVideoFlags -v
+```
+
+- [ ] **Step 3: Extend `VLLMOrchestrator.start_container()` in `src/cognithor/core/vllm_orchestrator.py`**
+
+Add a new attribute `self.media_url: str | None = None` to `__init__`. Modify the `cmd` list in `start_container` to insert the new flags (before `self.docker_image`):
+
+```python
+def start_container(self, model: str, *, health_timeout: int | None = None) -> ContainerInfo:
+    # ... existing port-resolve logic ...
+
+    cmd = [
+        "docker", "run", "-d",
+        "--gpus", "all",
+        "--add-host", "host.docker.internal:host-gateway",
+        "-v", "cognithor-hf-cache:/root/.cache/huggingface",
+        "-e", f"HF_TOKEN={self._hf_token}",
+        "-p", f"{port}:8000",
+        "--label", "cognithor.managed=true",
+    ]
+    if self.media_url:
+        cmd.extend(["-e", f"COGNITHOR_MEDIA_URL={self.media_url}"])
+    cmd.extend([
+        self.docker_image,
+        "--model", model,
+        "--media-io-kwargs", '{"video": {"num_frames": -1}}',
+    ])
+    # ... rest of existing body (subprocess.run + health wait) ...
+```
+
+- [ ] **Step 4: Run — expect all pass + all existing orchestrator tests still green**
+
+```bash
+python -m pytest tests/test_core/test_vllm_orchestrator.py -v
+```
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+python -m ruff check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+python -m ruff format --check src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git add src/cognithor/core/vllm_orchestrator.py tests/test_core/test_vllm_orchestrator.py
+git commit -m "feat(vllm): orchestrator adds --media-io-kwargs + --add-host + COGNITHOR_MEDIA_URL for video"
+```
+
+---
+
+## Task 11: WorkingMemory.video_attachment Field
+
+**Files:**
+- Modify: `src/cognithor/models.py` (add `video_attachment: dict | None = None` field to `WorkingMemory`)
+- Modify: appropriate existing test file for `WorkingMemory` (usually `tests/test_models/test_working_memory.py`)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# Append to whatever test file already tests WorkingMemory — find with:
+# grep -l "class.*WorkingMemory\|from cognithor.models import WorkingMemory" tests/
+
+def test_working_memory_has_video_attachment_default_none(self):
+    from cognithor.models import WorkingMemory
+    wm = WorkingMemory(session_id="s1")
+    assert wm.video_attachment is None
+
+def test_working_memory_video_attachment_accepts_dict(self):
+    from cognithor.models import WorkingMemory
+    wm = WorkingMemory(session_id="s1")
+    wm.video_attachment = {"url": "http://x/a.mp4", "sampling": {"fps": 2.0}}
+    assert wm.video_attachment["url"] == "http://x/a.mp4"
+
+def test_working_memory_clear_for_new_request_resets_video(self):
+    from cognithor.models import WorkingMemory
+    wm = WorkingMemory(session_id="s1")
+    wm.video_attachment = {"url": "http://x/a.mp4", "sampling": {"fps": 1.0}}
+    wm.clear_for_new_request()
+    assert wm.video_attachment is None
+```
+
+- [ ] **Step 2: Run — expect `AttributeError: 'WorkingMemory' object has no attribute 'video_attachment'`**
+
+- [ ] **Step 3: Add the field and clear-on-new-request logic**
+
+In `src/cognithor/models.py`, find the `WorkingMemory` class. Add the field (near `image_attachments`):
+
+```python
+    video_attachment: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Per-turn video attachment: {'url': str, 'sampling': {'fps': float} | {'num_frames': int}}. "
+            "At most one video per chat turn (see video-input spec 2026-04-23)."
+        ),
+    )
+```
+
+In `clear_for_new_request()`, add:
+
+```python
+        self.video_attachment = None
+```
+
+- [ ] **Step 4: Run — expect all pass**
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+python -m ruff check src/cognithor/models.py tests/test_models/test_working_memory.py
+python -m ruff format --check src/cognithor/models.py tests/test_models/test_working_memory.py
+git add src/cognithor/models.py tests/test_models/test_working_memory.py
+git commit -m "feat(models): WorkingMemory.video_attachment per-turn field"
+```
+
+---
+
+## Task 12: Planner — Route to vision_model_detail on Video
+
+**Files:**
+- Modify: `src/cognithor/core/planner.py` (`formulate_response`: route to `vision_model_detail` when video is present)
+- Modify: `tests/test_core/test_planner_envelope.py` (add test to existing `TestVisionRouting` class or similar)
+
+- [ ] **Step 1: Write the failing test**
+
+Find the existing vision-routing test class in `tests/test_core/test_planner_envelope.py` (added in PR #132 for image-attachments). Append:
+
+```python
+async def test_video_attachment_also_routes_to_vision_model(
+    self, planner_with_mocks
+):
+    from cognithor.models import WorkingMemory
+    planner_with_mocks._config.vision_model_detail = "Qwen/Qwen3.6-27B-FP8"
+    wm = WorkingMemory(session_id="s1")
+    wm.video_attachment = {
+        "url": "http://host.docker.internal:4711/media/abc.mp4",
+        "sampling": {"fps": 1.0},
+    }
+
+    await planner_with_mocks.formulate_response(
+        user_message="Describe the video",
+        results=[],
+        working_memory=wm,
+    )
+
+    call = planner_with_mocks._ollama.chat.call_args
+    assert call.kwargs.get("model") == "Qwen/Qwen3.6-27B-FP8"
+    assert call.kwargs.get("video") is not None
+    assert call.kwargs["video"]["url"].endswith("abc.mp4")
+```
+
+- [ ] **Step 2: Run — expect failure (video kwarg not passed through)**
+
+- [ ] **Step 3: Modify `Planner.formulate_response()` in `src/cognithor/core/planner.py`**
+
+Find the block that already handles image routing:
+
+```python
+        image_paths = list(working_memory.image_attachments or [])
+        if image_paths and getattr(self._config, "vision_model_detail", None):
+            model = self._config.vision_model_detail
+        else:
+            model = self._router.select_model("summarization", "medium")
+```
+
+Change to:
+
+```python
+        image_paths = list(working_memory.image_attachments or [])
+        video_attach = working_memory.video_attachment
+        if (image_paths or video_attach is not None) and getattr(self._config, "vision_model_detail", None):
+            model = self._config.vision_model_detail
+        else:
+            model = self._router.select_model("summarization", "medium")
+```
+
+Further down, when calling `_generate_draft_with_retry`, pass `video`:
+
+```python
+        response = await self._generate_draft_with_retry(
+            model=model,
+            messages=messages,
+            options=options,
+            images=image_paths or None,
+            video=video_attach,  # NEW
+        )
+```
+
+Update `_generate_draft_with_retry` signature to accept `video: dict | None = None` and forward to `self._ollama.chat(..., video=video)`.
+
+- [ ] **Step 4: Run — expect all pass**
+
+```bash
+python -m pytest tests/test_core/test_planner_envelope.py -v
+```
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+python -m ruff check src/cognithor/core/planner.py tests/test_core/test_planner_envelope.py
+python -m ruff format --check src/cognithor/core/planner.py tests/test_core/test_planner_envelope.py
+git add src/cognithor/core/planner.py tests/test_core/test_planner_envelope.py
+git commit -m "feat(planner): route to vision_model_detail on video_attachment + pass video kwarg"
+```
+
+---
+
+## Task 13: UnifiedLLMClient — Hard-Error on Video + DEGRADED vLLM
+
+**Files:**
+- Modify: `src/cognithor/core/unified_llm.py` (extend `chat()` hard-error branch to also cover video)
+- Modify: `tests/test_core/test_unified_llm_circuit_breaker.py`
+
+From PR #137, `UnifiedLLMClient.chat()` already hard-errors for image requests when vLLM is DEGRADED. Extend that to also hard-error when `video` is passed.
+
+- [ ] **Step 1: Append to the existing `TestFailFlowDispatch` class**
+
+```python
+    @pytest.mark.asyncio
+    async def test_video_request_hard_errors_when_vllm_degraded(
+        self, mock_vllm_backend, mock_ollama_client
+    ):
+        mock_vllm_backend.chat.side_effect = VLLMNotReadyError("down")
+        client = UnifiedLLMClient(
+            ollama_client=mock_ollama_client,
+            backend=mock_vllm_backend,
+            _breaker_recovery_timeout=60.0,
+        )
+        # Trip the breaker
+        for _ in range(3):
+            try:
+                await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+            except Exception:
+                pass
+
+        # Now a video request — no silent fallback
+        with pytest.raises(VLLMNotReadyError):
+            await client.chat(
+                model="x",
+                messages=[{"role": "user", "content": "what is this?"}],
+                video={"url": "http://x/a.mp4", "sampling": {"fps": 1.0}},
+            )
+```
+
+- [ ] **Step 2: Run — expect failure (video not handled)**
+
+- [ ] **Step 3: Modify `UnifiedLLMClient.chat()` in `src/cognithor/core/unified_llm.py`**
+
+Find the existing `chat()` method that already branches on `is_image_request`. Add a `is_video_request` sibling:
+
+```python
+async def chat(self, *args, images=None, video=None, **kwargs):
+    is_image_request = bool(images)
+    is_video_request = video is not None
+    # "vision request" = anything that the fallback path can't do
+    is_vision_request = is_image_request or is_video_request
+
+    breaker = self._breaker_for(self._backend_type)
+    try:
+        if self._backend is not None:
+            # Forward images and video to the backend
+            backend_kwargs = dict(kwargs)
+            if images is not None:
+                backend_kwargs["images"] = images
+            if video is not None:
+                backend_kwargs["video"] = video
+            result = await breaker.call(self._backend.chat(*args, **backend_kwargs))
+        else:
+            result = await breaker.call(self._ollama.chat(*args, **kwargs))
+        self._refresh_status()
+        return result
+    except (VLLMNotReadyError, CircuitBreakerOpen) as exc:
+        self._refresh_status()
+        if is_vision_request:
+            # No fallback — Ollama can't do images or video
+            if isinstance(exc, CircuitBreakerOpen):
+                raise VLLMNotReadyError(
+                    "vLLM offline — vision/video request cannot be processed",
+                    recovery_hint="Start vLLM from LLM Backends settings.",
+                ) from exc
+            raise
+        if self._backend_type == "vllm" and self._ollama is not None:
+            log.warning("vllm_fallback_to_ollama")
+            return await self._ollama.chat(*args, **kwargs)
+        raise
+```
+
+(Preserve whatever response-normalization logic the current method has — only the input-peeling + vision-request branch changes.)
+
+- [ ] **Step 4: Run — expect all CB tests pass including the new one**
+
+```bash
+python -m pytest tests/test_core/test_unified_llm_circuit_breaker.py -v
+```
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+python -m ruff check src/cognithor/core/unified_llm.py tests/test_core/test_unified_llm_circuit_breaker.py
+python -m ruff format --check src/cognithor/core/unified_llm.py tests/test_core/test_unified_llm_circuit_breaker.py
+git add src/cognithor/core/unified_llm.py tests/test_core/test_unified_llm_circuit_breaker.py
+git commit -m "feat(unified-llm): hard-error on video request when vLLM is DEGRADED"
+```
+
+---
+
+## Task 14: FastAPI /api/media/upload Endpoint
+
+**Files:**
+- Modify: `src/cognithor/channels/api.py` (add `/api/media/upload` handler) — or add to a new `media_api.py` router if the file is already large
+- Create: `tests/test_channels/test_media_api.py`
+
+The upload endpoint runs ffprobe + (best-effort) ffmpeg thumbnail and returns the shape the Flutter client expects.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_channels/test_media_api.py
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from cognithor.channels.media_api import build_media_app  # new helper, added in this task
+from cognithor.channels.media_server import MediaUploadServer
+from cognithor.config import CognithorConfig, VLLMConfig
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    cfg = CognithorConfig(
+        cognithor_home=tmp_path,
+        vllm=VLLMConfig(enabled=True, video_max_upload_mb=10, video_quota_gb=1),
+    )
+    media_server = MediaUploadServer(cfg)
+    media_server._port = 4711  # not running, but public_url needs a port
+    app = build_media_app(config=cfg, media_server=media_server)
+    return TestClient(app)
+
+
+class TestUploadEndpoint:
+    def test_upload_valid_video_returns_metadata(self, client: TestClient):
+        from cognithor.core.video_sampling import VideoSampling
+
+        with patch(
+            "cognithor.channels.media_api.resolve_sampling",
+            return_value=VideoSampling(fps=1.0, duration_sec=93.5),
+        ), patch(
+            "cognithor.channels.media_api._extract_thumbnail",  # sync ffmpeg wrapper
+            return_value=True,
+        ):
+            r = client.post(
+                "/api/media/upload",
+                files={"file": ("drone.mp4", b"\x00" * 2048, "video/mp4")},
+            )
+        assert r.status_code == 200
+        data = r.json()
+        assert "uuid" in data
+        assert data["url"].startswith("http://host.docker.internal:4711/media/")
+        assert data["duration_sec"] == 93.5
+        assert data["sampling"] == {"fps": 1.0}
+        assert data["thumb_url"].startswith("/api/media/thumb/")
+
+    def test_upload_too_large_returns_413(self, client: TestClient):
+        too_big = b"\x00" * (11 * 1024 * 1024)
+        r = client.post(
+            "/api/media/upload",
+            files={"file": ("big.mp4", too_big, "video/mp4")},
+        )
+        assert r.status_code == 413
+        assert "recovery_hint" in r.json().get("detail", {})
+
+    def test_upload_unsupported_extension_returns_400(self, client: TestClient):
+        r = client.post(
+            "/api/media/upload",
+            files={"file": ("trojan.exe", b"\x00" * 1024, "application/octet-stream")},
+        )
+        assert r.status_code == 400
+
+
+class TestThumbEndpoint:
+    def test_thumb_returns_jpeg(self, client: TestClient, tmp_path: Path):
+        # Pre-plant a thumbnail
+        uuid = "test-uuid-1234"
+        (tmp_path / "media" / "vllm-uploads").mkdir(parents=True, exist_ok=True)
+        thumb = tmp_path / "media" / "vllm-uploads" / f"{uuid}.jpg"
+        thumb.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg-bytes")
+        r = client.get(f"/api/media/thumb/{uuid}.jpg")
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith("image/")
+
+    def test_thumb_returns_404_for_missing(self, client: TestClient):
+        r = client.get("/api/media/thumb/not-a-real-uuid.jpg")
+        assert r.status_code == 404
+```
+
+- [ ] **Step 2: Run — expect `ModuleNotFoundError`**
+
+```bash
+python -m pytest tests/test_channels/test_media_api.py -v
+```
+
+- [ ] **Step 3: Create `src/cognithor/channels/media_api.py`**
+
+```python
+"""/api/media/upload + /api/media/thumb FastAPI routes.
+
+Separate from the MediaUploadServer (which only serves vLLM fetches). These
+endpoints are invoked by the Flutter client and run on the main Cognithor API
+port. They delegate the actual storage to MediaUploadServer.save_upload and
+run ffprobe/ffmpeg synchronously in a thread (both complete in <200 ms for
+typical videos).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, FastAPI, File, HTTPException, Request, UploadFile
+from fastapi.responses import FileResponse
+
+from cognithor.core.llm_backend import (
+    MediaUploadError,
+    MediaUploadTooLargeError,
+    MediaUploadUnsupportedFormatError,
+)
+from cognithor.core.video_sampling import resolve_sampling
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from cognithor.channels.media_server import MediaUploadServer
+    from cognithor.config import CognithorConfig
+
+log = get_logger(__name__)
+
+media_router = APIRouter(prefix="/api/media", tags=["media"])
+
+
+@media_router.post("/upload")
+async def upload_video(request: Request, file: UploadFile = File(...)) -> dict:
+    config: CognithorConfig = request.app.state.config
+    media_server: MediaUploadServer = request.app.state.media_server
+
+    data = await file.read()
+    filename = file.filename or "video.mp4"
+    ext = Path(filename).suffix.lstrip(".")
+
+    try:
+        uuid = media_server.save_upload(data, ext)
+    except MediaUploadTooLargeError as exc:
+        raise HTTPException(
+            status_code=413,
+            detail={"message": str(exc), "recovery_hint": exc.recovery_hint},
+        ) from exc
+    except MediaUploadUnsupportedFormatError as exc:
+        raise HTTPException(status_code=400, detail={"message": str(exc)}) from exc
+    except MediaUploadError as exc:
+        raise HTTPException(status_code=507, detail={"message": str(exc)}) from exc
+
+    # Path on disk for the just-saved file
+    saved_path = media_server._media_dir / f"{uuid}.{ext.lower()}"
+
+    # Best-effort thumbnail (sync call, ~100 ms for typical videos)
+    _extract_thumbnail(
+        saved_path,
+        media_server._media_dir / f"{uuid}.jpg",
+        ffmpeg_path="ffmpeg",
+    )
+
+    # Resolve sampling via the configured mode
+    sampling = resolve_sampling(
+        str(saved_path),
+        ffprobe_path=config.vllm.video_ffprobe_path,
+        timeout_seconds=config.vllm.video_ffprobe_timeout_seconds,
+        http_timeout_seconds=config.vllm.video_ffprobe_http_timeout_seconds,
+        override=config.vllm.video_sampling_mode,
+    )
+
+    return {
+        "uuid": uuid,
+        "url": media_server.public_url(uuid, ext),
+        "duration_sec": sampling.duration_sec,
+        "sampling": sampling.as_mm_kwargs(),
+        "thumb_url": f"/api/media/thumb/{uuid}.jpg",
+    }
+
+
+@media_router.get("/thumb/{filename}")
+async def thumb(request: Request, filename: str) -> FileResponse:
+    if "/" in filename or ".." in filename:
+        raise HTTPException(status_code=400, detail="invalid filename")
+    media_server: MediaUploadServer = request.app.state.media_server
+    path = media_server._media_dir / filename
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="not found")
+    return FileResponse(path, media_type="image/jpeg")
+
+
+def _extract_thumbnail(source: Path, dest: Path, *, ffmpeg_path: str = "ffmpeg") -> bool:
+    """Best-effort: extract the first frame as JPEG. Returns True on success."""
+    if not shutil.which(ffmpeg_path) and not Path(ffmpeg_path).is_file():
+        return False
+    try:
+        subprocess.run(
+            [ffmpeg_path, "-y", "-loglevel", "error", "-ss", "0", "-i", str(source),
+             "-vframes", "1", "-vf", "scale=192:108", str(dest)],
+            capture_output=True, text=True, timeout=10,
+        )
+    except Exception as exc:
+        log.warning("thumbnail_extract_failed", error=str(exc))
+        return False
+    return dest.is_file()
+
+
+def build_media_app(*, config: "CognithorConfig", media_server: "MediaUploadServer") -> FastAPI:
+    """Standalone FastAPI app for tests. In production the media_router is
+    included into the main APIChannel app via app.include_router()."""
+    app = FastAPI()
+    app.state.config = config
+    app.state.media_server = media_server
+    app.include_router(media_router)
+    return app
+```
+
+Wire into production: find `channels/api.py`'s `_create_app` (from PR #137 which added `backends_router`). Add alongside the backends_router include:
+
+```python
+try:
+    from cognithor.channels.media_api import media_router
+    app.include_router(media_router)
+    app.state.media_server = self._media_server  # injected by Gateway at start
+except Exception as exc:
+    log.warning("media_router_include_failed", error=str(exc))
+```
+
+- [ ] **Step 4: Run — expect all pass**
+
+```bash
+python -m pytest tests/test_channels/test_media_api.py -v
+```
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+python -m ruff check src/cognithor/channels/media_api.py src/cognithor/channels/api.py tests/test_channels/test_media_api.py
+python -m ruff format --check src/cognithor/channels/media_api.py src/cognithor/channels/api.py tests/test_channels/test_media_api.py
+git add src/cognithor/channels/media_api.py src/cognithor/channels/api.py tests/test_channels/test_media_api.py
+git commit -m "feat(api): /api/media/upload + /api/media/thumb endpoints"
+```
+
+---
+
+## Task 15: Gateway — MediaUploadServer + VideoCleanupWorker Lifecycle + Per-Turn Extraction
+
+**Files:**
+- Modify: `src/cognithor/gateway/gateway.py` (lazy-instantiate + start/stop on lifecycle, extract video from incoming message)
+- Modify: `tests/test_gateway/test_gateway_video_wiring.py` (new test file)
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/test_gateway/test_gateway_video_wiring.py
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cognithor.config import CognithorConfig, VLLMConfig
+
+
+class TestGatewayVideoWiring:
+    def test_video_attachment_extracted_into_working_memory(self):
+        """Given an IncomingMessage whose attachments list holds one video
+        URL and one image, the Gateway pulls the video into
+        WorkingMemory.video_attachment and leaves the image in image_attachments."""
+        from cognithor.gateway.gateway import _classify_attachments
+
+        image_attachments, video_attachment, rejected_extras = _classify_attachments(
+            [
+                "/tmp/pic.png",
+                "/tmp/clip.mp4",
+            ]
+        )
+        assert image_attachments == ["/tmp/pic.png"]
+        assert video_attachment is not None
+        assert video_attachment == "/tmp/clip.mp4"
+        assert rejected_extras == []
+
+    def test_second_video_is_rejected_with_error(self):
+        from cognithor.gateway.gateway import _classify_attachments
+
+        image_attachments, video_attachment, rejected_extras = _classify_attachments(
+            [
+                "/tmp/clip1.mp4",
+                "/tmp/clip2.mp4",
+                "/tmp/clip3.webm",
+            ]
+        )
+        assert video_attachment == "/tmp/clip1.mp4"  # first wins
+        assert rejected_extras == ["/tmp/clip2.mp4", "/tmp/clip3.webm"]
+
+    def test_no_videos_returns_none(self):
+        from cognithor.gateway.gateway import _classify_attachments
+
+        _, video_attachment, rejected_extras = _classify_attachments(
+            [
+                "/tmp/pic.png",
+                "/tmp/doc.pdf",
+            ]
+        )
+        assert video_attachment is None
+        assert rejected_extras == []
+```
+
+- [ ] **Step 2: Run — expect `ImportError: cannot import name '_classify_attachments'`**
+
+- [ ] **Step 3: Add the classifier to `src/cognithor/gateway/gateway.py`**
+
+Near the top of the file (after imports), define the classifier as a pure function for testability:
+
+```python
+_IMAGE_EXTS = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp"})
+_VIDEO_EXTS = frozenset({".mp4", ".webm", ".mov", ".mkv", ".avi"})
+
+
+def _classify_attachments(
+    attachments: list[str],
+) -> tuple[list[str], str | None, list[str]]:
+    """Split an attachment list into images / one video / rejected extra videos.
+
+    Returns:
+        (image_attachments, first_video_or_None, rejected_extra_videos)
+
+    Single-video-per-turn policy (spec Decision 7): the first video in the
+    list wins; any additional videos go into `rejected_extra_videos` so the
+    caller can surface a user-visible validation error.
+    """
+    images: list[str] = []
+    video: str | None = None
+    rejected: list[str] = []
+    for path in attachments:
+        ext = ""
+        if "." in path:
+            ext = "." + path.rsplit(".", 1)[-1].lower()
+        if ext in _IMAGE_EXTS:
+            images.append(path)
+        elif ext in _VIDEO_EXTS:
+            if video is None:
+                video = path
+            else:
+                rejected.append(path)
+    return images, video, rejected
+```
+
+Then inside the Gateway's per-turn pre-processing (where `image_attachments` is set on `wm` — search for the existing `wm.image_attachments = [a for a in ...]` block added in PR #132), replace with:
+
+```python
+        if msg.attachments:
+            images, video_path, rejected_videos = _classify_attachments(msg.attachments)
+            wm.image_attachments = images
+            if video_path is not None:
+                # video_path is a local path OR a URL the Flutter client already
+                # resolved via /api/media/upload (in which case attachments[N]
+                # holds the host.docker.internal URL). Sampling resolution
+                # happens here for URLs that skipped the upload endpoint.
+                wm.video_attachment = _build_video_attachment(video_path, self._config)
+                if self._vllm_orchestrator is not None:
+                    # Register upload with cleanup worker (best-effort; only
+                    # matters if video_path is a local upload, not an external URL)
+                    uuid = _extract_uuid_from_path(video_path)
+                    if uuid and self._video_cleanup:
+                        self._video_cleanup.register_upload(uuid, wm.session_id)
+            if rejected_videos:
+                await self._surface_validation_error(
+                    wm.session_id,
+                    f"Ein Video pro Nachricht. {len(rejected_videos)} weitere Videos wurden ignoriert.",
+                )
+```
+
+`_build_video_attachment` and `_extract_uuid_from_path` are helpers in gateway.py (or `gateway/video_attach.py` if you prefer a separate file — keep gateway.py from growing too large).
+
+Also in Gateway init, lazy-instantiate MediaUploadServer + VideoCleanupWorker when vllm is enabled:
+
+```python
+        if self._config.vllm.enabled:
+            from cognithor.channels.media_server import MediaUploadServer
+            from cognithor.gateway.video_cleanup import VideoCleanupWorker
+
+            self._media_server = MediaUploadServer(self._config)
+            self._video_cleanup = VideoCleanupWorker(
+                media_dir=self._media_server._media_dir,
+                ttl_hours=self._config.vllm.video_upload_ttl_hours,
+            )
+            # Start in the existing init phase; stop in `shutdown()`
+```
+
+Add to the async startup sequence (whatever phase the existing PR #137 VLLMOrchestrator lives in):
+
+```python
+        if self._media_server is not None:
+            port = await self._media_server.start()
+            if self._vllm_orchestrator is not None:
+                self._vllm_orchestrator.media_url = f"http://host.docker.internal:{port}"
+        if self._video_cleanup is not None:
+            await self._video_cleanup.start()
+```
+
+And to `shutdown()`:
+
+```python
+        if self._video_cleanup is not None:
+            await self._video_cleanup.stop()
+        if self._media_server is not None:
+            await self._media_server.stop()
+```
+
+- [ ] **Step 4: Run — expect all pass**
+
+```bash
+python -m pytest tests/test_gateway/test_gateway_video_wiring.py -v
+python -m pytest tests/test_gateway/ -q  # regression
+```
+
+- [ ] **Step 5: Ruff + commit**
+
+```bash
+python -m ruff check src/cognithor/gateway/gateway.py tests/test_gateway/test_gateway_video_wiring.py
+python -m ruff format --check src/cognithor/gateway/gateway.py tests/test_gateway/test_gateway_video_wiring.py
+git add src/cognithor/gateway/gateway.py tests/test_gateway/test_gateway_video_wiring.py
+git commit -m "feat(gateway): video attachment extraction + MediaServer/Cleanup lifecycle"
+```
+
+---
+
+## Task 16: Integration — fake vLLM Server Echoes Video Response
+
+**Files:**
+- Modify: `tests/test_integration/test_vllm_fake_server.py` (extend fake server to handle video_url content-item + return stubbed response)
+
+- [ ] **Step 1: Extend the fake server setup to inspect video content-items**
+
+In `tests/test_integration/test_vllm_fake_server.py` (created in PR #137), add a handler branch in the fake `/v1/chat/completions` endpoint:
+
+```python
+    @app.post("/v1/chat/completions")
+    async def chat(body: dict):
+        # ... existing text+image branches ...
+
+        # Detect video
+        last_msg = body["messages"][-1]
+        content = last_msg.get("content")
+        if isinstance(content, list):
+            has_video = any(c.get("type") == "video_url" for c in content)
+            if has_video:
+                video_url = next(c["video_url"]["url"] for c in content if c.get("type") == "video_url")
+                extra = body.get("extra_body", {})
+                mm_video = extra.get("mm_processor_kwargs", {}).get("video", {})
+                return {
+                    "choices": [{
+                        "message": {"content": f"Saw video {video_url} with sampling {mm_video}"}
+                    }],
+                    "model": body["model"],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                }
+        # ... fall through to existing text branch ...
+```
+
+Add a new test class:
+
+```python
+class TestVLLMBackendVideoEndToEnd:
+    @pytest.mark.asyncio
+    async def test_video_roundtrip_preserves_url_and_sampling(self, fake_server):
+        from cognithor.core.vllm_backend import VLLMBackend
+
+        backend = VLLMBackend(base_url=f"http://127.0.0.1:{fake_server}/v1")
+        try:
+            resp = await backend.chat(
+                model="fake-model",
+                messages=[{"role": "user", "content": "describe"}],
+                video={"url": "http://example.com/clip.mp4", "sampling": {"fps": 2.0}},
+            )
+            assert "http://example.com/clip.mp4" in resp.content
+            assert "'fps': 2.0" in resp.content or "fps" in resp.content
+        finally:
+            await backend.close()
+```
+
+- [ ] **Step 2: Run — expect 1 new pass**
+
+```bash
+python -m pytest tests/test_integration/test_vllm_fake_server.py -v
+```
+
+- [ ] **Step 3: Ruff + commit**
+
+```bash
+python -m ruff check tests/test_integration/test_vllm_fake_server.py
+python -m ruff format --check tests/test_integration/test_vllm_fake_server.py
+git add tests/test_integration/test_vllm_fake_server.py
+git commit -m "test(vllm): fake server round-trip for video_url + mm_processor_kwargs"
+```
+
+---
+
+## Task 17: Flutter — chat_input.dart PopupMenuButton
+
+**Files:**
+- Modify: `flutter_app/lib/widgets/chat_input.dart` (replace paperclip `IconButton` with `PopupMenuButton`)
+- Create: `flutter_app/test/widgets/chat_input_video_menu_test.dart`
+
+- [ ] **Step 1: Write the failing widget test**
+
+```dart
+// flutter_app/test/widgets/chat_input_video_menu_test.dart
+import 'package:cognithor_ui/providers/chat_provider.dart';
+import 'package:cognithor_ui/providers/llm_backend_provider.dart';
+import 'package:cognithor_ui/widgets/chat_input.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+LlmBackendProvider _mkBackendProvider(String active) {
+  final p = LlmBackendProvider(apiBaseUrl: 'http://test');
+  p.active = active;
+  return p;
+}
+
+ChatProvider _mkChatProvider() {
+  return ChatProvider();  // assume default constructor exists
+}
+
+Widget _wrap(Widget child, LlmBackendProvider bp, ChatProvider cp) {
+  return MaterialApp(
+    home: Scaffold(
+      body: MultiProvider(
+        providers: [
+          ChangeNotifierProvider<LlmBackendProvider>.value(value: bp),
+          ChangeNotifierProvider<ChatProvider>.value(value: cp),
+        ],
+        child: child,
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('paperclip opens popup menu with 4 entries', (tester) async {
+    final bp = _mkBackendProvider('vllm');
+    final cp = _mkChatProvider();
+    await tester.pumpWidget(_wrap(const ChatInput(), bp, cp));
+
+    await tester.tap(find.byKey(const ValueKey('chat-input-paperclip')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Bild hochladen'), findsOneWidget);
+    expect(find.text('Video hochladen'), findsOneWidget);
+    expect(find.text('Datei hochladen'), findsOneWidget);
+    expect(find.text('URL einfügen'), findsOneWidget);
+  });
+
+  testWidgets('Video entry disabled when active backend != vllm', (tester) async {
+    final bp = _mkBackendProvider('ollama');
+    final cp = _mkChatProvider();
+    await tester.pumpWidget(_wrap(const ChatInput(), bp, cp));
+
+    await tester.tap(find.byKey(const ValueKey('chat-input-paperclip')));
+    await tester.pumpAndSettle();
+
+    // Find the PopupMenuItem that holds "Video hochladen" and verify it is disabled
+    final videoItem = tester.widget<PopupMenuItem<String>>(
+      find.ancestor(
+        of: find.text('Video hochladen'),
+        matching: find.byType(PopupMenuItem<String>),
+      ),
+    );
+    expect(videoItem.enabled, isFalse);
+  });
+}
+```
+
+- [ ] **Step 2: Run — expect test failures (widget not extended yet)**
+
+```bash
+cd flutter_app && flutter test test/widgets/chat_input_video_menu_test.dart
+```
+
+- [ ] **Step 3: Modify `flutter_app/lib/widgets/chat_input.dart`**
+
+Find the existing paperclip `IconButton`. Replace with:
+
+```dart
+PopupMenuButton<String>(
+  key: const ValueKey('chat-input-paperclip'),
+  icon: const Icon(Icons.attach_file),
+  tooltip: 'Anhang hinzufügen',
+  onSelected: (value) async {
+    switch (value) {
+      case 'image':
+        await _pickImage();
+        break;
+      case 'video':
+        await _pickVideo();
+        break;
+      case 'file':
+        await _pickFile();
+        break;
+      case 'url':
+        _showUrlDialog();
+        break;
+    }
+  },
+  itemBuilder: (context) {
+    final activeBackend = context.read<LlmBackendProvider>().active;
+    final vllmActive = activeBackend == 'vllm';
+    return [
+      const PopupMenuItem(value: 'image', child: Text('Bild hochladen')),
+      PopupMenuItem(
+        value: 'video',
+        enabled: vllmActive,
+        child: Tooltip(
+          message: vllmActive
+              ? 'Video hochladen (nur mit vLLM-Backend)'
+              : 'Video-Analyse erfordert vLLM — unter Settings → LLM Backends wechseln.',
+          child: Row(
+            children: [
+              const Text('Video hochladen'),
+              if (!vllmActive)
+                const Padding(
+                  padding: EdgeInsets.only(left: 6),
+                  child: Icon(Icons.lock, size: 14, color: Colors.grey),
+                ),
+            ],
+          ),
+        ),
+      ),
+      const PopupMenuItem(value: 'file', child: Text('Datei hochladen')),
+      const PopupMenuItem(value: 'url', child: Text('URL einfügen')),
+    ];
+  },
+),
+```
+
+Add `_pickVideo()` stub (real implementation in Task 18):
+
+```dart
+Future<void> _pickVideo() async {
+  // Implemented in Task 18 — connect ChatProvider.sendVideo
+  // For now, the button is wired but does nothing on tap.
+}
+```
+
+- [ ] **Step 4: Run — expect all pass**
+
+```bash
+cd flutter_app && flutter test test/widgets/chat_input_video_menu_test.dart && flutter analyze
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd flutter_app && flutter analyze lib/widgets/chat_input.dart test/widgets/chat_input_video_menu_test.dart
+cd ..
+git add flutter_app/lib/widgets/chat_input.dart flutter_app/test/widgets/chat_input_video_menu_test.dart
+git commit -m "feat(flutter): chat-input paperclip becomes PopupMenuButton with Video entry"
+```
+
+---
+
+## Task 18: Flutter — ChatProvider.sendVideo + URL-Paste Detection
+
+**Files:**
+- Modify: `flutter_app/lib/providers/chat_provider.dart` (add `sendVideo`, add regex-based URL paste detection)
+- Modify: `flutter_app/lib/widgets/chat_input.dart` (wire `_pickVideo` to `sendVideo`)
+
+- [ ] **Step 1: Extend `ChatProvider` with `sendVideo`**
+
+In `flutter_app/lib/providers/chat_provider.dart`, add:
+
+```dart
+Future<void> sendVideo(String localPath, String filename) async {
+  final bytes = await File(localPath).readAsBytes();
+  final uri = Uri.parse('$apiBaseUrl/api/media/upload');
+  final request = http.MultipartRequest('POST', uri)
+    ..files.add(http.MultipartFile.fromBytes('file', bytes, filename: filename));
+
+  final streamed = await request.send();
+  final body = await streamed.stream.bytesToString();
+  if (streamed.statusCode != 200) {
+    throw Exception('Upload failed: HTTP ${streamed.statusCode} — $body');
+  }
+  final resp = jsonDecode(body) as Map<String, dynamic>;
+
+  // Attach to the next outgoing message metadata
+  _pendingVideoAttachment = {
+    'kind': 'video',
+    'uuid': resp['uuid'],
+    'url': resp['url'],
+    'filename': filename,
+    'duration_sec': resp['duration_sec'],
+    'sampling': resp['sampling'],
+    'thumb_url': resp['thumb_url'],
+  };
+  notifyListeners();
+}
+
+/// URL-paste detection — call from TextField onChanged.
+/// Returns true if the pasted text was consumed as a video URL attachment.
+bool handlePastedTextForVideoUrl(String text) {
+  final pattern = RegExp(
+    r'^\s*(https?://\S+\.(?:mp4|webm|mov|mkv|avi))\s*$',
+    caseSensitive: false,
+  );
+  final m = pattern.firstMatch(text);
+  if (m == null) return false;
+  _pendingVideoAttachment = {
+    'kind': 'video',
+    'url': m.group(1),
+    'filename': m.group(1)!.split('/').last,
+    // duration_sec + sampling filled in by backend on chat-send
+    'thumb_url': null,
+  };
+  notifyListeners();
+  return true;
+}
+```
+
+Add `_pendingVideoAttachment` field + corresponding message-shipping logic (whatever existing `sendMessage` does, prepend the pending video into `message.attachments` then clear it).
+
+- [ ] **Step 2: Wire `_pickVideo()` in `chat_input.dart`**
+
+```dart
+Future<void> _pickVideo() async {
+  final result = await FilePicker.platform.pickFiles(
+    type: FileType.custom,
+    allowedExtensions: ['mp4', 'webm', 'mov', 'mkv', 'avi'],
+    withData: false,
+  );
+  if (result == null || result.files.isEmpty) return;
+  final file = result.files.first;
+  if (file.path == null) return;
+  try {
+    await context.read<ChatProvider>().sendVideo(file.path!, file.name);
+  } catch (e) {
+    if (mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Video upload fehlgeschlagen: $e')),
+      );
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Full Flutter regression**
+
+```bash
+cd flutter_app && flutter test && flutter analyze
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd flutter_app && flutter analyze lib/providers/chat_provider.dart lib/widgets/chat_input.dart
+cd ..
+git add flutter_app/lib/providers/chat_provider.dart flutter_app/lib/widgets/chat_input.dart
+git commit -m "feat(flutter): ChatProvider.sendVideo + URL-paste video detection"
+```
+
+---
+
+## Task 19: Flutter — Video Bubble with Thumbnail + Banner for Long Videos
+
+**Files:**
+- Modify: `flutter_app/lib/widgets/chat_bubble.dart`
+- Create: `flutter_app/test/widgets/chat_bubble_video_test.dart`
+
+- [ ] **Step 1: Write the failing test**
+
+```dart
+// flutter_app/test/widgets/chat_bubble_video_test.dart
+import 'package:cognithor_ui/widgets/chat_bubble.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('video-kind metadata renders filename + duration + sampling', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ChatBubble(
+          text: 'Was siehst du?',
+          isUser: true,
+          metadata: {
+            'kind': 'video',
+            'filename': 'drone.mp4',
+            'duration_sec': 42.5,
+            'sampling': {'fps': 2.0},
+            'thumb_url': null,
+          },
+        ),
+      ),
+    ));
+
+    expect(find.text('drone.mp4'), findsOneWidget);
+    expect(find.textContaining('0:42'), findsOneWidget);  // duration formatted
+    expect(find.textContaining('fps=2'), findsOneWidget);
+  });
+
+  testWidgets('long-video banner appears when duration > 15 minutes', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      home: Scaffold(
+        body: ChatBubble(
+          text: 'Analyze',
+          isUser: true,
+          metadata: {
+            'kind': 'video',
+            'filename': 'lecture.mp4',
+            'duration_sec': 2400.0,  // 40 min
+            'sampling': {'num_frames': 32},
+          },
+        ),
+      ),
+    ));
+    expect(find.byKey(const ValueKey('video-long-banner')), findsOneWidget);
+  });
+}
+```
+
+- [ ] **Step 2: Run — expect failures**
+
+- [ ] **Step 3: Modify `chat_bubble.dart`** — add a branch for `metadata['kind'] == 'video'`
+
+```dart
+Widget _buildVideoPreview(Map<String, dynamic> meta) {
+  final filename = meta['filename'] as String? ?? 'video';
+  final durationSec = (meta['duration_sec'] as num?)?.toDouble() ?? 0.0;
+  final sampling = meta['sampling'] as Map<String, dynamic>? ?? {};
+  final thumbUrl = meta['thumb_url'] as String?;
+
+  final samplingLabel = sampling.containsKey('fps')
+      ? 'fps=${sampling['fps']}'
+      : 'num_frames=${sampling['num_frames'] ?? '?'}';
+
+  final mins = (durationSec / 60).floor();
+  final secs = (durationSec % 60).round();
+  final durationLabel = '${mins}:${secs.toString().padLeft(2, '0')}';
+
+  return Column(
+    crossAxisAlignment: CrossAxisAlignment.end,
+    children: [
+      Container(
+        padding: const EdgeInsets.all(8),
+        decoration: BoxDecoration(
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.15),
+          border: Border.all(color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.4)),
+          borderRadius: BorderRadius.circular(12),
+        ),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 96,
+              height: 54,
+              color: Colors.grey.shade800,
+              child: thumbUrl != null
+                  ? Image.network(
+                      '${context.read<LlmBackendProvider>().apiBaseUrl}$thumbUrl',
+                      fit: BoxFit.cover,
+                      errorBuilder: (_, __, ___) => const Center(child: Text('🎬', style: TextStyle(fontSize: 22))),
+                    )
+                  : const Center(child: Text('🎬', style: TextStyle(fontSize: 22))),
+            ),
+            const SizedBox(width: 10),
+            Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(filename, style: const TextStyle(fontWeight: FontWeight.w500)),
+                const SizedBox(height: 2),
+                Text(
+                  '$durationLabel · $samplingLabel',
+                  style: TextStyle(fontSize: 11, color: Colors.grey.shade400),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+      if (durationSec > 15 * 60)
+        Container(
+          key: const ValueKey('video-long-banner'),
+          margin: const EdgeInsets.only(top: 6),
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: Colors.orange.withValues(alpha: 0.15),
+            border: Border(left: BorderSide(color: Colors.orange, width: 3)),
+            borderRadius: BorderRadius.circular(4),
+          ),
+          child: Text(
+            'Video ${(durationSec/60).round()} min — nur 32 Frames werden gesampled. '
+            'Zerlege in 5-Min-Clips für mehr Detail.',
+            style: const TextStyle(fontSize: 11, color: Colors.orange),
+          ),
+        ),
+    ],
+  );
+}
+```
+
+Call `_buildVideoPreview` from the existing `build()` method when `metadata['kind'] == 'video'`.
+
+- [ ] **Step 4: Run — expect all pass + flutter analyze clean**
+
+```bash
+cd flutter_app && flutter test test/widgets/chat_bubble_video_test.dart && flutter analyze lib/widgets/chat_bubble.dart
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add flutter_app/lib/widgets/chat_bubble.dart flutter_app/test/widgets/chat_bubble_video_test.dart
+git commit -m "feat(flutter): chat bubble renders video kind with thumbnail + long-video banner"
+```
+
+---
+
+## Task 20: Windows Installer — Bundle LGPL ffmpeg + CI Verification
+
+**Files:**
+- Modify: `installer/build_installer.py` (new step `step_ffmpeg()`)
+- Modify: `.github/workflows/build-windows-installer.yml` (LGPL-vs-GPL check)
+
+- [ ] **Step 1: Add `step_ffmpeg()` to `installer/build_installer.py`**
+
+```python
+FFMPEG_LGPL_URL = (
+    "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/"
+    "ffmpeg-master-latest-win64-lgpl-shared.zip"
+)
+
+
+def step_ffmpeg() -> Path:
+    """Download a LGPL-licensed ffmpeg+ffprobe build and return the bin dir."""
+    dest_zip = Path("build/ffmpeg.zip")
+    extract_dir = Path("build/ffmpeg")
+    if not dest_zip.exists():
+        download(FFMPEG_LGPL_URL, dest_zip, desc="ffmpeg LGPL build")
+    if not extract_dir.exists():
+        import zipfile
+        with zipfile.ZipFile(dest_zip) as z:
+            z.extractall(extract_dir)
+    # BtbN archives have a single top-level folder; find bin/ffmpeg.exe
+    for p in extract_dir.rglob("ffmpeg.exe"):
+        # Verify the build is actually LGPL (not accidentally GPL)
+        result = subprocess.run([str(p), "-version"], capture_output=True, text=True)
+        version_lines = (result.stdout + result.stderr).splitlines()
+        first_config_line = next((l for l in version_lines if "configuration" in l), "")
+        if "--enable-gpl" in first_config_line:
+            raise RuntimeError(
+                f"Downloaded ffmpeg is a GPL build (configuration: {first_config_line!r}). "
+                "GPL would contaminate Cognithor's Apache-2.0 license. Use the LGPL variant."
+            )
+        return p.parent  # bin/
+    raise RuntimeError("ffmpeg.exe not found after extraction")
+```
+
+Hook it into `main()` alongside the existing `step_ollama`, `step_python_embed` etc. The Inno Setup script receives the `bin/` path and copies its contents to `%LOCALAPPDATA%\Cognithor\ffmpeg\`.
+
+- [ ] **Step 2: Add CI verification step**
+
+In `.github/workflows/build-windows-installer.yml`, after the "Build installer" step, add:
+
+```yaml
+      - name: Verify bundled ffmpeg is LGPL (not GPL)
+        shell: pwsh
+        run: |
+          $ffmpeg = Get-ChildItem -Recurse -Filter ffmpeg.exe | Select-Object -First 1
+          if (-not $ffmpeg) { throw "ffmpeg.exe not found in build output" }
+          $version = & $ffmpeg.FullName -version 2>&1 | Out-String
+          if ($version -match '--enable-gpl') {
+            throw "Bundled ffmpeg is a GPL build — Cognithor is Apache-2.0. Use LGPL variant."
+          }
+          if ($version -notmatch '--enable-version3') {
+            Write-Warning "Bundled ffmpeg does not claim LGPL v3 — double-check the build source"
+          }
+          Write-Host "✓ ffmpeg build is LGPL-compatible"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+python -m ruff check installer/build_installer.py
+git add installer/build_installer.py .github/workflows/build-windows-installer.yml
+git commit -m "feat(installer): bundle LGPL ffmpeg for Windows + CI verification step"
+```
+
+(No unit test here — the check runs in CI as part of the installer build.)
+
+---
+
+## Task 21: User Guide Update — Video Section
+
+**Files:**
+- Modify: `docs/vllm-user-guide.md` (append a "Video Input" section)
+
+- [ ] **Step 1: Append this section to `docs/vllm-user-guide.md`**
+
+```markdown
+## Video Input
+
+With vLLM active and a video-capable model loaded (Qwen3.6-27B, Qwen2.5-VL-7B-Instruct,
+Qwen3.6-35B-A3B, or any VLM vLLM recognizes as video-capable), you can attach a single
+video per chat turn.
+
+### Two ways to attach
+
+**Local file**: paperclip → "Video hochladen" → pick a `.mp4` / `.webm` / `.mov` /
+`.mkv` / `.avi` (max 500 MB per file, 5 GB total quota).
+
+**URL paste**: paste a direct video URL in the chat input. Cognithor detects URLs
+ending in a recognized video extension and treats them as a video attachment. YouTube
+links are **not** supported — use a direct `.mp4` link.
+
+### What happens under the hood
+
+1. Local uploads are stored temporarily at `~/.cognithor/media/vllm-uploads/<uuid>.<ext>`,
+   served to the vLLM container over a localhost-only HTTP server.
+2. `ffprobe` detects video duration and Cognithor picks an adaptive frame sampling rate:
+   short clips (< 10 s) get `fps=3`, longer clips get fewer frames spread across the
+   full duration.
+3. vLLM fetches the video, samples frames internally, and feeds them to the VLM.
+4. Uploads are deleted when the chat session closes, or automatically after 24 hours,
+   whichever comes first.
+
+### Troubleshooting
+
+**"Video hochladen" entry is greyed out**: the active backend is not vLLM. Settings →
+LLM Backends → tap vLLM → "Make active".
+
+**Upload fails with "too big"**: max 500 MB per file. Raise `config.vllm.video_max_upload_mb`
+or trim the clip.
+
+**Chat replies "vLLM offline — Video kann nicht verarbeitet werden"**: vLLM is DEGRADED.
+Unlike text chat (which falls back to Ollama), videos can't fall back — Ollama has no
+vision. Wait ~60 s for the circuit breaker to probe vLLM again, or restart vLLM from
+LLM Backends settings.
+
+**Long-video banner appears**: videos longer than 15 min only get 32 frames sampled
+(one every ~30 s for a 15-min video, sparser for longer). For detailed temporal
+reasoning, trim to 5-min chunks.
+
+**`ffprobe not found` warning in logs**: install ffmpeg on Linux/macOS via
+`apt install ffmpeg` / `brew install ffmpeg`. Windows installer bundles it. Without
+ffprobe, Cognithor falls back to 32 frames for every video regardless of length.
+
+### Advanced configuration
+
+`~/.cognithor/config.yaml` `vllm:` section:
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `video_sampling_mode` | `adaptive` | `adaptive` / `fixed_32` / `fixed_64` / `fps_1` |
+| `video_ffprobe_path` | `ffprobe` | override to absolute path if not in `$PATH` |
+| `video_ffprobe_timeout_seconds` | `5` | local-file duration detection timeout |
+| `video_ffprobe_http_timeout_seconds` | `30` | URL duration detection timeout |
+| `video_max_upload_mb` | `500` | per-file hard cap |
+| `video_quota_gb` | `5` | total disk budget; oldest files evicted first |
+| `video_upload_ttl_hours` | `24` | automatic cleanup after this many hours |
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/vllm-user-guide.md
+git commit -m "docs(video): user guide video-input section with troubleshooting + config"
+```
+
+---
+
+## Task 22: Manual Smoke Test — Video Entries
+
+**Files:**
+- Modify: `docs/vllm-manual-test.md`
+
+- [ ] **Step 1: Append new sections to `docs/vllm-manual-test.md`**
+
+```markdown
+## 9. Video upload flow (RTX 5090 only — requires video-capable VLM)
+
+Prerequisites: vLLM running with `Qwen/Qwen3.6-27B` (any variant that vLLM has
+confirmed video support for).
+
+- Paperclip → "Video hochladen" → pick a ~30 s `.mp4` (e.g., the Qwen OSS sample
+  downloaded locally).
+- Expect: bubble shows thumbnail + filename + `0:30 · fps=2`.
+- Send: "What happens in this video?".
+- Expect: answer describes the clip's content within 10–20 s.
+
+## 10. Video URL paste
+
+- Paste `https://qianwen-res.oss-accelerate.aliyuncs.com/Qwen3.5/demo/video/N1cdUjctpG8.mp4`.
+- Expect: input field clears, bubble shows a thumbnail-less video card.
+- Send: "Describe what you see".
+- Expect: answer describes the Qwen demo video.
+
+## 11. Long-video banner + 32-frame sampling
+
+- Upload a > 15-min video.
+- Expect: bubble shows the orange `Video N min — nur 32 Frames werden gesampled` banner.
+- Send: "Summarize the main topics".
+- Expect: answer is coarse but topically correct.
+
+## 12. Video + DEGRADED vLLM
+
+- While chatting: `docker stop $(docker ps -q --filter label=cognithor.managed=true)`.
+- Send a video request.
+- Expect: red error bubble "vLLM offline — Video kann nicht verarbeitet werden".
+- `docker start <container-id>`; wait 60 s; re-send.
+- Expect: normal response.
+
+## 13. Cleanup on session close
+
+- Upload a video; note the uuid in `~/.cognithor/media/vllm-uploads/`.
+- Close Cognithor.
+- Expect: `~/.cognithor/media/vllm-uploads/` is empty, OR contains only files whose
+  mtime is < 24 h old from a prior test run (run 14 to verify cleanup actually works).
+
+## 14. Cleanup on TTL expiry (simulated)
+
+- Upload a video.
+- `touch -d "2 days ago" ~/.cognithor/media/vllm-uploads/<uuid>.*` (sets mtime into the past).
+- Restart Cognithor.
+- Expect: the file is gone within 60 s (periodic sweep), or immediately on start
+  (start-time sweep).
+
+## 15. Second video in same turn is rejected
+
+- Attach one video (paperclip → video).
+- Try to attach a second video (paperclip again — the "Video hochladen" entry
+  should still be enabled only if the pending message has no video yet).
+- Expect: either the menu entry is disabled with a tooltip "Ein Video pro Nachricht",
+  or the second attach attempt produces a snackbar error.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/vllm-manual-test.md
+git commit -m "docs(video): manual smoke-test recipes 9-15 for video input"
+```
+
+---
+
+## Task 23: CHANGELOG + Final Regression + Ruff Sweep
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Add `[Unreleased]` entry at top of `CHANGELOG.md`**
+
+```markdown
+## [Unreleased]
+
+### Added
+- **Video input via vLLM** — attach a local video (.mp4 / .webm / .mov / .mkv /
+  .avi) or paste a direct video URL in chat; Qwen3.6-27B (or any vLLM-served
+  video-capable VLM) analyzes it end-to-end. Native vLLM `video_url` content
+  type — no frame-extraction workarounds. Adaptive frame sampling based on
+  duration (fps=3 for clips under 10 s, num_frames=32 for videos over 5 min)
+  via `ffprobe`. Single video per chat turn. Local uploads served to vLLM over
+  a 127.0.0.1-only HTTP file server. Videos are cleaned up when the chat
+  session closes and auto-expire after 24 h. Video requests on a DEGRADED vLLM
+  produce a hard error — no silent fallback to Ollama (Ollama has no vision).
+  Windows installer now bundles an LGPL-licensed ffmpeg build. See
+  `docs/vllm-user-guide.md` and `docs/superpowers/specs/2026-04-23-video-input-vllm-design.md`.
+
+### Changed
+- Cognithor now requires Docker Engine ≥ 20.10 when using vLLM on Linux
+  (host-gateway flag for `--add-host` was added in 20.10). Docker Desktop
+  versions are all fine.
+- Flutter paperclip in the chat input is now a popup menu with explicit
+  entries for Image / Video / File / URL instead of a single file picker.
+```
+
+- [ ] **Step 2: Run full regression**
+
+```bash
+python -m pytest tests/ -x -q --ignore=tests/test_integration/test_live_ollama.py 2>&1 | tail -10
+```
+Expected: all pass. Record the pass count.
+
+- [ ] **Step 3: Flutter full test + analyze**
+
+```bash
+cd flutter_app && flutter test 2>&1 | tail -5
+cd flutter_app && flutter analyze 2>&1 | tail -5
+cd ..
+```
+
+- [ ] **Step 4: Ruff final sweep**
+
+```bash
+python -m ruff check src/cognithor/ tests/
+python -m ruff format --check src/ tests/
+```
+Expected: `All checks passed!` + `N files already formatted`.
+
+- [ ] **Step 5: Commit CHANGELOG**
+
+```bash
+git add CHANGELOG.md
+git commit -m "chore(changelog): document video-input via vLLM feature"
+```
+
+- [ ] **Step 6: Push and open PR**
+
+```bash
+git push -u origin feat/vllm-video-input
+```
+
+Open PR with title `feat(vllm-video): native video input via Qwen3.6-27B` and body referencing:
+- Spec at `docs/superpowers/specs/2026-04-23-video-input-vllm-design.md`
+- Day-1 spike findings at `docs/vllm-video-spike-notes.md`
+- The seven locked design decisions
+- Known follow-ups (multi-video turn support, YouTube URLs, live-stream input)
+
+After CI green, run the manual smoke tests from Task 22 on real hardware before merging.
+
+---
+
+## Self-Review Checklist
+
+After all 23 tasks are complete:
+
+- [ ] Every new Python module has tests: `video_sampling.py`, `media_server.py`, `video_cleanup.py`, `media_api.py`, video paths in `vllm_backend.py`, video paths in `unified_llm.py`
+- [ ] `tests/test_integration/test_vllm_fake_server.py` includes the video roundtrip case
+- [ ] Flutter tests cover the paperclip popup menu + video bubble + long-video banner
+- [ ] Full regression green (`pytest tests/` excluding `test_live_ollama`)
+- [ ] Flutter `flutter test` + `flutter analyze` green
+- [ ] Ruff check + format --check clean across `src/` and `tests/`
+- [ ] Day-1 spike findings doc exists and matches the code (if the spike revealed different wire shapes, the adjusted code matches)
+- [ ] CHANGELOG `[Unreleased]` entry written
+- [ ] Backwards compat: users who don't enable vLLM or don't use video see zero behavior change
+- [ ] Manual smoke test from Task 22 completed on real NVIDIA hardware with a video-capable VLM
+- [ ] vLLM container-log ring buffer from PR #137 still works — video requests don't break it

--- a/docs/superpowers/specs/2026-04-23-video-input-vllm-design.md
+++ b/docs/superpowers/specs/2026-04-23-video-input-vllm-design.md
@@ -18,6 +18,7 @@
 | 4 | **Flutter attach UX:** Paperclip menu with explicit "Video hochladen" entry (Option A) | Discoverability without disruption. Dedicated video button (B) is too intrusive for the 95 % who never use it; automatic MIME-detection (C) hides the capability |
 | 5 | **Fail-flow:** Hybrid pre-flight gate + post-send error (Option Z) | Cheap local pre-flight (is vLLM the active backend?) prevents wasted uploads; runtime breaker state checked on send for DEGRADED. Videos never silent-fallback to Ollama |
 | 6 | **Cleanup policy:** Session-lifetime + 24 h hard cap (Option Y) | Follow-up questions about the same video work during the session; nothing accumulates forever |
+| 7 | **Single video per chat turn** (not multi-video) | vLLM's `extra_body.mm_processor_kwargs.video` is one config, not per-video. Allowing 2+ videos in a turn would force us to either use the most-conservative bucket (losing detail on short clips) or reject the request. YAGNI: single-video covers every realistic use-case for v1 |
 
 ---
 
@@ -27,15 +28,15 @@ Video input rides on the existing `VLLMBackend` from PR #137 — no new backend,
 
 - **`MediaUploadServer`** (`src/cognithor/channels/media_server.py`) — minimal FastAPI app with a static-mount on `/media/<uuid>.ext`, running on its own localhost port (not the main Cognithor API port). vLLM inside the Docker container fetches uploaded videos via `http://host.docker.internal:<media-port>/media/<uuid>.mp4`.
 - **`VideoSamplingResolver`** (`src/cognithor/core/video_sampling.py`) — pure function wrapping `ffprobe` for duration detection, with a bucket table that maps duration → `{"fps": N}` or `{"num_frames": N}`. Graceful fallback to `{"num_frames": 32}` on any probe failure.
-- **`VideoCleanupWorker`** (`src/cognithor/gateway/video_cleanup.py`) — async task in the Gateway that tracks per-session uploads, deletes on session close, runs a GC sweep on app start, and enforces a 5 GB quota via LRU eviction. 24 h hard TTL as an ultimate safety net.
+- **`VideoCleanupWorker`** (`src/cognithor/gateway/video_cleanup.py`) — async task in the Gateway tracking per-session uploads in an in-memory `dict[session_id, list[uuid]]`. Deletes files on session close. Periodic 60 s sweep enforces the 24 h hard TTL. App-start sweep scans the uploads directory and removes any file not referenced by a live session + older than the TTL. No persistent state — if Cognithor crashes with uploads in flight, the next app-start sweep catches them via TTL. Keeps the worker to ~80 LOC.
 
 Existing code changed:
 
-- `VLLMBackend.chat()` — new `videos: list[str]` kwarg alongside the existing `images`. A sibling helper `_attach_videos_to_last_user()` produces OpenAI `video_url` content items instead of `image_url`.
-- `VLLMOrchestrator.start_container()` — `docker run` command gains `--media-io-kwargs '{"video": {"num_frames": -1}}'` so per-request sampling via `extra_body.mm_processor_kwargs` actually takes effect. Also adds `--add-host host.docker.internal:host-gateway` for the Docker-in-Linux case.
-- `WorkingMemory` — new `video_attachments: list[str]` field. `Planner.formulate_response()` routes to `config.vision_model_detail` when **either** `image_attachments` or `video_attachments` is non-empty.
-- Gateway — at the start of each chat turn, extracts video-extension attachments from the incoming message into `WorkingMemory.video_attachments`, and registers them with the `VideoCleanupWorker` under the current `session_id`.
-- Flutter `chat_input.dart` — Paperclip becomes a `PopupMenuButton` with entries for Image / Video / File / URL.
+- `VLLMBackend.chat()` — new `video: str | None = None` kwarg alongside the existing `images`. A sibling helper `_attach_video_to_last_user()` produces **one** OpenAI `video_url` content item (single video per turn, Decision 7). If the caller passes a video, the backend also attaches the pre-resolved sampling payload to `extra_body.mm_processor_kwargs.video`.
+- `VLLMOrchestrator.start_container()` — `docker run` command gains `--media-io-kwargs '{"video": {"num_frames": -1}}'` so per-request sampling via `extra_body.mm_processor_kwargs` actually takes effect. Also adds `--add-host host.docker.internal:host-gateway` for the Docker-in-Linux case (requires Docker ≥ 20.10; documented in prerequisites).
+- `WorkingMemory` — new `video_attachment: dict | None` field holding `{"url": str, "sampling": {"fps": 2} | {"num_frames": 32}}`. `Planner.formulate_response()` routes to `config.vision_model_detail` when `image_attachments` is non-empty **or** `video_attachment` is not None.
+- Gateway — at the start of each chat turn, extracts at-most-one video-extension attachment from the incoming message into `WorkingMemory.video_attachment` (rejects additional videos with an error to the client), and registers the upload with `VideoCleanupWorker` under the current `session_id`.
+- Flutter `chat_input.dart` — Paperclip becomes a `PopupMenuButton` with entries for Image / Video / File / URL. "Video hochladen" is disabled once the pending message already holds a video attachment (visual tooltip: "Ein Video pro Nachricht. Sende oder entferne erst das aktuelle.").
 
 Video requests never fall back to Ollama — if vLLM is DEGRADED, the `chat()` path raises `VLLMNotReadyError` and the Flutter Gateway renders a red error bubble. This matches the existing image-request fail-flow from PR #137.
 
@@ -116,54 +117,58 @@ For `override="fixed_32"` / `"fixed_64"` / `"fps_1"` → skip ffprobe, return co
 
 ### Video Cleanup
 
-**`src/cognithor/gateway/video_cleanup.py` — ~150 LOC, new**
+**`src/cognithor/gateway/video_cleanup.py` — ~80 LOC, new**
 
-State in an in-memory dict + SQLite mirror at `~/.cognithor/db/video_uploads.db` so we recover on crash:
+No persistent state. In-memory `dict[session_id, list[uuid]]` plus filesystem-based TTL enforcement — simpler and correct even after a crash:
 
 ```python
-@dataclass
-class VideoUploadRecord:
-    uuid: str
-    filename: str
-    session_id: str
-    uploaded_at: datetime
-    bytes: int
-
-
 class VideoCleanupWorker:
+    def __init__(self, media_dir: Path, ttl_hours: int = 24) -> None:
+        self._media_dir = media_dir
+        self._ttl_hours = ttl_hours
+        self._by_session: dict[str, list[str]] = {}
+        self._sweep_task: asyncio.Task | None = None
+
     async def start(self) -> None:
-        """Run GC on app-start, start the 60-second periodic 24h-TTL sweep."""
+        """Run TTL sweep once at start (catches files left over from a crashed
+        previous run — pure filesystem-mtime-based, no registry needed), then
+        kick off the periodic 60 s sweep."""
     async def stop(self) -> None: ...
 
-    async def register_upload(self, uuid: str, filename: str, session_id: str, bytes_: int) -> None: ...
+    def register_upload(self, uuid: str, session_id: str) -> None: ...
     async def on_session_close(self, session_id: str) -> None:
         """Delete all uploads linked to this session."""
-    async def on_app_start_gc(self) -> None:
-        """Scan the uploads dir, delete files not in the SQLite registry
-        (crashed-mid-upload recovery), and delete any file older than 24h."""
-    async def periodic_sweep(self) -> None:
-        """Hard TTL enforcement: delete files older than 24h regardless of session."""
+    async def _periodic_sweep(self) -> None:
+        """Every 60 s: scan media_dir, delete files whose mtime is older than ttl_hours."""
 ```
 
-Quota enforcement is **not** in the cleanup worker — it lives in `MediaUploadServer.save_upload` (LRU-evict when adding a new file would exceed 5 GB).
+**Why no SQLite:** the 24 h TTL sweep is authoritative — any file older than `ttl_hours` gets deleted regardless of session state. Session-close cleanup is a nice-to-have optimization for users who close and reopen Cognithor within the TTL window; if it misses one (e.g. crash before `on_session_close` fires), the TTL sweep picks it up within an hour. No crash-recovery registry needed, ~80 LOC saved.
+
+Quota enforcement is **not** in the cleanup worker — it lives in `MediaUploadServer.save_upload` (LRU-evict when adding a new file would exceed 5 GB, ordered by mtime).
 
 ### Backend Layer — `VLLMBackend.chat()` Extension
 
-Add `videos: list[str] | None = None` parameter. Implementation mirrors `_attach_images_to_last_user` from PR #137:
+Add `video: dict | None = None` parameter (single video per turn, Decision 7). Implementation mirrors `_attach_images_to_last_user` from PR #137:
 
 ```python
-def _attach_videos_to_last_user(
+def _attach_video_to_last_user(
     messages: list[dict[str, Any]],
-    videos: list[dict[str, str]],  # [{"url": "...", "sampling": {"fps": 2}}]
-) -> tuple[list[dict[str, Any]], list[dict]]:
-    """Returns (new_messages, extra_body_mm_kwargs) — both non-empty only when videos present.
+    video: dict[str, Any],  # {"url": "...", "sampling": {"fps": 2}} | {"url": "...", "sampling": {"num_frames": 32}}
+) -> tuple[list[dict[str, Any]], dict]:
+    """Returns (new_messages, extra_body_mm_kwargs).
 
-    Messages get {"type":"video_url","video_url":{"url":"..."}} content items.
-    extra_body_mm_kwargs is the per-request sampling payload for vLLM.
+    new_messages: last user message gets a {"type":"video_url","video_url":{"url":"..."}}
+    content item prepended to the existing text parts.
+
+    extra_body_mm_kwargs: {"mm_processor_kwargs": {"video": {"fps": 2}}}
+    — the per-request sampling payload for vLLM, ready to merge into the
+    outgoing chat-completion body.
     """
 ```
 
-`VLLMBackend.chat()` callers pass videos as `list[dict]` with pre-resolved sampling (Gateway resolves via `VideoSamplingResolver` before the call). Why pre-resolved? Separation — the backend shouldn't know about `ffprobe`, it just formats payloads.
+Callers pass the video dict with pre-resolved sampling (Gateway resolves via `VideoSamplingResolver` before the call). Why pre-resolved? Separation — the backend shouldn't know about `ffprobe`, it just formats payloads.
+
+Multi-video turns are rejected one layer up: if `WorkingMemory.video_attachment` is already set when the Gateway encounters a second video in the incoming message, it surfaces a user-visible validation error ("Ein Video pro Nachricht") and drops the extra. The backend never sees more than one video.
 
 ### Config Layer
 
@@ -175,6 +180,13 @@ class VLLMConfig(BaseModel):
     video_sampling_mode: Literal["adaptive", "fixed_32", "fixed_64", "fps_1"] = "adaptive"
     video_ffprobe_path: str = "ffprobe"  # override to absolute path on Windows
     video_ffprobe_timeout_seconds: int = Field(default=5, ge=1, le=30)
+    """Local file ffprobe timeout (reads are fast, usually <100 ms)."""
+
+    video_ffprobe_http_timeout_seconds: int = Field(default=30, ge=5, le=120)
+    """Remote URL ffprobe timeout. Higher default because HTTP header fetches
+    on slow networks or large files can take longer — ffprobe streams the MP4
+    header which for some servers + 2 GB files means ~20-30 s just to reach
+    the duration metadata."""
     video_max_upload_mb: int = Field(default=500, ge=1, le=5000)
     video_quota_gb: int = Field(default=5, ge=1, le=100)
     video_upload_ttl_hours: int = Field(default=24, ge=1, le=168)
@@ -229,9 +241,9 @@ docker run -d \
    - Returns `{"uuid": "...", "url": "http://host.docker.internal:<p>/media/<uuid>.mp4", "duration_sec": 93.5, "sampling": {"fps": 1.0}, "thumb_url": "/api/media/thumb/<uuid>.jpg"}`
 5. Flutter adds a message-metadata entry: `{"kind": "video", "uuid": "...", "filename": "drone.mp4", "duration_sec": 93.5, "sampling": {"fps": 1.0}, "thumb_url": "..."}`. Renders the video bubble preview (thumbnail + meta).
 6. User types prompt, hits send. `chat_provider.sendMessage` includes the video metadata in the WebSocket message.
-7. Gateway pulls video attachment(s) out, stuffs them into `WorkingMemory.video_attachments` as `[{"url": "...", "sampling": {"fps": 1.0}}]`. Registers the upload with `VideoCleanupWorker` under the current `session_id`.
-8. Planner sees non-empty `video_attachments` → selects `config.vision_model_detail` → calls `unified_llm.chat(..., videos=working_memory.video_attachments)`.
-9. `VLLMBackend.chat()` wraps with circuit breaker, `_attach_videos_to_last_user` builds the OpenAI payload:
+7. Gateway pulls the single video attachment out (rejecting any additional videos with a user-visible validation error), stuffs it into `WorkingMemory.video_attachment` as `{"url": "...", "sampling": {"fps": 1.0}}`. Registers the upload with `VideoCleanupWorker` under the current `session_id`.
+8. Planner sees non-None `video_attachment` → selects `config.vision_model_detail` → calls `unified_llm.chat(..., video=working_memory.video_attachment)`.
+9. `VLLMBackend.chat()` wraps with circuit breaker, `_attach_video_to_last_user` builds the OpenAI payload:
    ```json
    {
      "model": "Qwen/Qwen3.6-27B-FP8",
@@ -254,8 +266,8 @@ docker run -d \
 
 1. User pastes `https://example.com/clip.mp4` as plain text in the chat input.
 2. On send, Flutter's `chat_provider` detects the URL via regex (allow-list of video extensions), treats it as a video reference (no upload needed).
-3. Cognithor backend receives the chat request with `working_memory.video_attachments = [{"url": "https://example.com/clip.mp4", "sampling": null}]`.
-4. `VideoSamplingResolver.resolve_sampling("https://...")` — `ffprobe` accepts HTTP URLs directly — returns the adaptive bucket sampling.
+3. Cognithor backend receives the chat request with `working_memory.video_attachment = {"url": "https://example.com/clip.mp4", "sampling": null}`.
+4. `VideoSamplingResolver.resolve_sampling("https://...")` — `ffprobe` accepts HTTP URLs directly (with the higher `video_ffprobe_http_timeout_seconds` of 30 s) — returns the adaptive bucket sampling.
 5. From step 8 onwards, identical to Flow A. The URL is just passed through; vLLM fetches from the remote origin instead of `host.docker.internal`.
 
 ### Flow C — Fail Flow (vLLM DEGRADED Mid-Session)
@@ -263,7 +275,7 @@ docker run -d \
 1. User has attached a video and clicks send. Pre-flight passed (vLLM was active when Paperclip was opened).
 2. `VLLMBackend.chat()` inside `CircuitBreaker.call(...)` — breaker may be `CLOSED`, `OPEN`, or `HALF_OPEN`.
 3. If `OPEN` (or raises `VLLMNotReadyError` on actual send): `UnifiedLLMClient` catches, inspects the request kind.
-4. Because `video_attachments` is non-empty, **no silent fallback** to Ollama. The error propagates as a red bubble in chat:
+4. Because `video_attachment` is not None, **no silent fallback** to Ollama. The error propagates as a red bubble in chat:
    ```
    ⚠ vLLM offline — Video kann nicht verarbeitet werden.
    Versuch's in ~X s erneut oder starte vLLM neu unter Settings → LLM Backends.
@@ -324,10 +336,10 @@ No changes to the breaker itself. `MediaUploadError` subclasses are added to `ex
   - ffprobe returns negative / absurd duration → fallback
   - `override="fixed_32"` skips ffprobe entirely
   - All 6 bucket boundaries (< 10 s, 10–30 s, 30 s – 2 min, 2–5 min, 5–15 min, > 15 min) have a dedicated test
-- **`tests/test_core/test_vllm_backend_videos.py`** — `VLLMBackend.chat(videos=...)` against `pytest-httpx`
-  - Single video → correct `video_url` content item + `extra_body.mm_processor_kwargs.video`
-  - Video + image mixed → both content items present, video's `extra_body` dominates
-  - Video only, no text → synthetic text part added or prompt stays as-is (verify which vLLM accepts)
+- **`tests/test_core/test_vllm_backend_video.py`** — `VLLMBackend.chat(video=...)` against `pytest-httpx`
+  - Single video → correct `video_url` content item + `extra_body.mm_processor_kwargs.video` in outgoing payload
+  - Video + image mixed → both content items present in last user message, video's `extra_body.mm_processor_kwargs.video` is set
+  - Video only, no text → the text part stays empty-string (verify vLLM accepts this; fallback: synthetic single-space text)
 - **`tests/test_channels/test_media_server.py`** — `MediaUploadServer` against a `TestClient`
   - Upload within size cap → success, file on disk
   - Upload over 500 MB → 413 Payload Too Large
@@ -342,7 +354,7 @@ No changes to the breaker itself. `MediaUploadError` subclasses are added to `ex
 
 ### Integration Layer
 
-- **`tests/test_integration/test_vllm_video_fake_server.py`** — extends the fake vLLM server from PR #137 to return a stubbed video response. Verifies that `VLLMBackend.chat(videos=[...])` produces a wire-shape that the fake server can parse and respond to.
+- **`tests/test_integration/test_vllm_video_fake_server.py`** — extends the fake vLLM server from PR #137 to return a stubbed video response. Verifies that `VLLMBackend.chat(video={"url": ..., "sampling": ...})` produces a wire-shape that the fake server can parse and respond to.
 
 ### Flutter Layer
 
@@ -377,7 +389,8 @@ Added to `docs/vllm-manual-test.md` (from PR #137) as a new section:
 
 **User environment:**
 - `ffmpeg` + `ffprobe` — **bundled on Windows** (LGPL build in installer), expected in `$PATH` on Linux/macOS (documented in the user guide). Graceful degradation when absent: videos still work, just with fixed `num_frames=32` sampling and no thumbnails.
-- Docker Desktop + vLLM (already prerequisites from PR #137).
+- **Docker Engine ≥ 20.10** (released Dec 2020). Earlier versions don't recognize `host-gateway` as a value for `--add-host` and the container can't reach the local media server on Linux. On Docker Desktop (Windows/macOS) the flag is redundant but harmless. Documented as a prerequisite bump in the user guide.
+- vLLM (already a prerequisite from PR #137).
 - A vLLM-served model with video capability. Currently confirmed: `Qwen/Qwen3.6-27B` variants, `Qwen/Qwen2.5-VL-7B-Instruct`, `Qwen/Qwen3.6-35B-A3B` variants. Models without video support return HTTP 400 on video requests — handled via `LLMBadRequestError`.
 
 **CI:** unchanged — no GPU, no real video processing, all tests mock `ffprobe` and vLLM.
@@ -388,7 +401,7 @@ Added to `docs/vllm-manual-test.md` (from PR #137) as a new section:
 
 **In scope:**
 - `MediaUploadServer` + cleanup worker + sampling resolver
-- `VLLMBackend.chat(videos=...)` extension + per-request `extra_body.mm_processor_kwargs.video`
+- `VLLMBackend.chat(video=...)` extension (single video) + per-request `extra_body.mm_processor_kwargs.video`
 - Flutter paperclip popup-menu + video bubble + URL detection on paste
 - `docker run` flag additions (`--media-io-kwargs`, `--add-host host.docker.internal:host-gateway`)
 - Session-lifetime + 24 h cleanup
@@ -402,7 +415,7 @@ Added to `docs/vllm-manual-test.md` (from PR #137) as a new section:
 - Per-session quota (5 GB is global across all sessions).
 - WebM VP9 and AV1 specifically — should work because they're in LGPL ffmpeg, but not explicitly listed in manual test matrix.
 - Streaming video input (live feed): vLLM accepts only complete-file URLs, not rtmp/hls/webrtc streams.
-- Multiple videos per single chat turn: technically supported by the spec (`videos: list[str]`), but manual-test matrix covers single-video cases only in v1.
+- Multiple videos per single chat turn: **not supported in v1** (Decision 7). The API is single-video (`video: dict | None`), and the Gateway rejects a second video on the same turn with a user-visible validation error. Adding multi-video later requires either accepting a common-sampling trade-off or solving the `extra_body.mm_processor_kwargs.video` per-video problem at the vLLM layer — separate design work if the use-case materializes.
 
 ---
 
@@ -410,23 +423,35 @@ Added to `docs/vllm-manual-test.md` (from PR #137) as a new section:
 
 **~1.5 calendar weeks (7–8 working days), single engineer.**
 
+- **Day-1 spike** — verify `extra_body.mm_processor_kwargs.video` shape + vLLM media-domain fetch policy + ffprobe HTTP timing (see Open Questions): 0.5 day
 - `VideoSamplingResolver` + unit tests: 1 day
 - `MediaUploadServer` + unit tests + integration wiring: 1 day
-- `VideoCleanupWorker` + unit tests + session hooks: 1 day
-- `VLLMBackend.chat(videos=...)` + `_attach_videos_to_last_user` + integration test against the fake server: 1 day
+- `VideoCleanupWorker` (simplified: in-memory + filesystem TTL, no SQLite) + unit tests + session hooks: 0.5 day
+- `VLLMBackend.chat(video=...)` + `_attach_video_to_last_user` + integration test against the fake server: 1 day
 - Config extension (`VLLMConfig` additions) + `VLLMOrchestrator` `docker run` flag changes: 0.5 day
-- Flutter paperclip popup-menu + video bubble + URL-paste detection + widget tests: 1.5 days
+- Flutter paperclip popup-menu + video bubble + URL-paste detection + "Ein Video pro Nachricht"-state + widget tests: 1.5 days
 - Windows installer ffmpeg bundling + CI verification step: 0.5 day
 - Docs (user-guide section + manual-test matrix entries) + CHANGELOG: 0.5 day
 - Manual smoke test on real NVIDIA hardware + fixes: 0.5 day
 - Buffer / polish / PR cycle / spec-reviewer loops: 0.5 day
 
-Total ≈ 7.5 days = **1.5 weeks** calendar, assuming PR #137's vLLM backend lands cleanly and no vLLM-side surprises.
+Total ≈ 7.5 days = **1.5 weeks** calendar. Day-1 spike is a go/no-go gate: if `extra_body` shape or media-domain policy requires a significantly different approach, the estimate and design come back to the table before further work.
 
 ---
 
 ## Open Questions Deferred to Plan
 
-- **`extra_body.mm_processor_kwargs.video` exact shape**: I extrapolated this from the Qwen3.5 vLLM recipe. The first implementation task must run against the fake server with known-good shapes (captured from vLLM upstream docs at implementation time) and adjust if the nesting differs. Plan includes a spike task to verify on day 1.
-- **ffmpeg LGPL-build source**: will pick between BtbN's and Gyan's LGPL builds based on which has smaller size + broader codec support at implementation time.
-- **Session-ID propagation into `MediaUploadServer`**: the media server itself shouldn't know about sessions (single responsibility), so the upload endpoint in `channels/api.py` is where `session_id` is captured from the WebSocket context and passed to `VideoCleanupWorker.register_upload`. The exact wiring is a plan-level detail.
+Three of these are genuine implementation-time unknowns that MUST be resolved before serious code is written (the first implementation task is a dedicated spike). The others are lower-risk polish questions.
+
+### High-priority spikes (plan Day 1)
+
+- **`extra_body.mm_processor_kwargs.video` exact wire shape**: extrapolated from the Qwen3.5 vLLM recipe. Real vLLM may use a different nesting (`extra_body.mm_processor_kwargs.fps` flat, `extra_body.video_kwargs`, etc.). Without the correct shape, nothing works. Day-1 spike: grep vLLM's `entrypoints/openai/serving_chat.py` in the pinned image version + smoke-test against a local vLLM container to capture the actual on-the-wire shape for both `fps` and `num_frames` cases. Adjust the spec if the finding differs.
+- **vLLM `--allowed-media-domains` / fetch policy**: newer vLLM versions may restrict which HTTP hosts the container will fetch from. If the default is strict, `host.docker.internal:<media-port>` is rejected and all local uploads break. Day-1 spike: verify on the pinned image. If restrictive, add `--allowed-media-domains host.docker.internal` (or equivalent) to `VLLMOrchestrator.start_container()`.
+- **`ffprobe` remote-HTTP behavior**: I bumped the default HTTP timeout to 30 s, but some servers refuse `Range: bytes=0-N` or return chunked encoding that ffprobe handles slowly. Day-1 spike: test against three representative URLs (Qwen OSS sample, a CloudFront-hosted mp4, a local-net static-server) and document observed timings. If 30 s is still too tight, surface a UI hint during URL-paste "fetching metadata…" while probe runs.
+
+### Lower-priority, plan-level details
+
+- **ffmpeg LGPL-build source**: pick between BtbN's and Gyan's LGPL builds based on which has smaller size + broader codec support at implementation time.
+- **Session-ID propagation into `MediaUploadServer`**: the media server itself shouldn't know about sessions (single responsibility), so the upload endpoint in `channels/api.py` is where `session_id` is captured from the WebSocket context and passed to `VideoCleanupWorker.register_upload`.
+- **vLLM response for "video + empty text"**: if the user attaches a video without typing a prompt, the last user message has only a `video_url` content item. Some LLM APIs reject messages with no text. Test at implementation time; fallback is to inject a synthetic single-space text part.
+- **Thumbnail frame selection**: currently specced as "first frame". First frame is often a black intro / logo. Consider extracting at 10% or midpoint instead. Pure UX polish, not a correctness question.

--- a/docs/superpowers/specs/2026-04-23-video-input-vllm-design.md
+++ b/docs/superpowers/specs/2026-04-23-video-input-vllm-design.md
@@ -32,7 +32,7 @@ Video input rides on the existing `VLLMBackend` from PR #137 — no new backend,
 
 Existing code changed:
 
-- `VLLMBackend.chat()` — new `video: str | None = None` kwarg alongside the existing `images`. A sibling helper `_attach_video_to_last_user()` produces **one** OpenAI `video_url` content item (single video per turn, Decision 7). If the caller passes a video, the backend also attaches the pre-resolved sampling payload to `extra_body.mm_processor_kwargs.video`.
+- `VLLMBackend.chat()` — new `video: dict | None = None` kwarg alongside the existing `images`. Shape: `{"url": str, "sampling": {"fps": float} | {"num_frames": int}}`. A sibling helper `_attach_video_to_last_user()` produces **one** OpenAI `video_url` content item (single video per turn, Decision 7) and attaches the pre-resolved sampling payload to `extra_body.mm_processor_kwargs.video`.
 - `VLLMOrchestrator.start_container()` — `docker run` command gains `--media-io-kwargs '{"video": {"num_frames": -1}}'` so per-request sampling via `extra_body.mm_processor_kwargs` actually takes effect. Also adds `--add-host host.docker.internal:host-gateway` for the Docker-in-Linux case (requires Docker ≥ 20.10; documented in prerequisites).
 - `WorkingMemory` — new `video_attachment: dict | None` field holding `{"url": str, "sampling": {"fps": 2} | {"num_frames": 32}}`. `Planner.formulate_response()` routes to `config.vision_model_detail` when `image_attachments` is non-empty **or** `video_attachment` is not None.
 - Gateway — at the start of each chat turn, extracts at-most-one video-extension attachment from the incoming message into `WorkingMemory.video_attachment` (rejects additional videos with an error to the client), and registers the upload with `VideoCleanupWorker` under the current `session_id`.
@@ -60,7 +60,17 @@ class MediaUploadServer:
     async def stop(self) -> None: ...
     def save_upload(self, data: bytes, ext: str) -> str:
         """Store `data` in `~/.cognithor/media/vllm-uploads/<uuid>.<ext>`,
-        return the uuid. Raises if the 500 MB per-file cap is exceeded."""
+        return the uuid.
+
+        Raises:
+            MediaUploadTooLargeError: if `len(data)` exceeds `video_max_upload_mb`.
+            MediaUploadUnsupportedFormatError: if `ext` not in allow-list.
+            MediaUploadQuotaExceededError: if the upload would exceed `video_quota_gb`
+                AND LRU eviction of older files wouldn't free enough space.
+
+        Before writing, if `len(data) + current_dir_size > quota`, oldest files
+        (by mtime) are evicted one by one until there is room.
+        """
     def public_url(self, uuid: str) -> str:
         """Return `http://host.docker.internal:<port>/media/<uuid>.<ext>`"""
     def delete(self, uuid: str) -> None: ...
@@ -284,11 +294,11 @@ docker run -d \
 
 ### Flow D — Session Close / Cleanup
 
-1. User closes the chat tab, or closes Cognithor entirely, or the session times out (default 24 h).
+1. User closes the chat tab or closes Cognithor entirely.
 2. Gateway calls `video_cleanup_worker.on_session_close(session_id)`.
-3. Worker looks up all `VideoUploadRecord` rows for that `session_id` in SQLite, deletes the files (and sidecar thumbnails), deletes the rows.
-4. Separate periodic sweep (60 s interval) enforces the hard 24 h TTL regardless of session state.
-5. App start: `on_app_start_gc` scans `~/.cognithor/media/vllm-uploads/`, deletes orphan files (files-without-registry-row, which means Cognithor crashed mid-upload). Then runs the TTL sweep once.
+3. Worker reads `self._by_session[session_id]` (in-memory), deletes each referenced file + its sidecar thumbnail, removes the session entry.
+4. Separate periodic sweep (60 s interval) deletes any file in `media_dir` whose mtime is older than `ttl_hours` (24 h default) — session-independent, authoritative.
+5. App start: the sweep runs once immediately before entering the 60 s loop, catching any files left over from a crashed previous run (their mtime is already > 24 h or will be shortly). No registry, no orphan concept — the filesystem mtime IS the source of truth.
 
 ---
 
@@ -310,7 +320,7 @@ docker run -d \
 ### Runtime Errors
 
 - vLLM returns HTTP 400 "context length exceeded" because a video exploded the token budget (e.g., custom model with different token-per-frame ratio than we expected) → propagates as `LLMBadRequestError` → red bubble with recovery hint: "Try a shorter video clip or set `vllm.video_sampling_mode: fixed_32` in config."
-- `docker pull` during first-time `start_container` fetches an image without `host.docker.internal` support → `add-host` flag kicks in, vLLM can reach media server.
+- Container started without the `--add-host host.docker.internal:host-gateway` flag (e.g., someone ran `docker run` manually, `reuse_existing()` adopts it) → vLLM inside the container can't resolve `host.docker.internal` on Linux, fetches fail with DNS error → `VLLMNotReadyError` with recovery hint: "Restart vLLM from LLM Backends settings to pick up host-gateway config."
 - URL paste but the remote server returns 404 / 5xx when vLLM tries to fetch → vLLM raises its own error → we pass through as `VLLMNotReadyError` with a hint about checking the URL.
 
 ### Circuit Breaker (reuses existing `cognithor.utils.circuit_breaker.CircuitBreaker`)
@@ -321,7 +331,7 @@ No changes to the breaker itself. `MediaUploadError` subclasses are added to `ex
 
 - `MediaUploadServer` binds `127.0.0.1` only. Never exposed on a non-loopback interface. Documented explicitly.
 - Sidecar thumbnails are deleted alongside the video on cleanup.
-- Uploaded files live under `~/.cognithor/media/vllm-uploads/` with 600 permissions (user-only read).
+- Uploaded files live under `~/.cognithor/media/vllm-uploads/` with user-only read permissions: `0o600` on POSIX (`chmod 600`), and a restrictive ACL on Windows (inherits from `%LOCALAPPDATA%\Cognithor\` which is already user-scoped by default).
 
 ---
 
@@ -347,10 +357,10 @@ No changes to the breaker itself. `MediaUploadError` subclasses are added to `ex
   - Quota exceeded → oldest file LRU-evicted, log message, new file saved
   - `public_url()` returns the expected `host.docker.internal` URL
 - **`tests/test_gateway/test_video_cleanup.py`** — worker
-  - `register_upload` → row appears in SQLite + file exists
-  - `on_session_close` deletes all session files
-  - `on_app_start_gc` removes orphans (file on disk, no DB row)
-  - 24 h hard TTL fires even if session is still "active"
+  - `register_upload` → uuid appears in `_by_session[session_id]`
+  - `on_session_close` deletes all files linked to the session, removes the session entry
+  - Periodic sweep deletes files whose mtime is older than `ttl_hours` — independent of session state (tested by patching `os.path.getmtime`)
+  - Start-up sweep catches leftover files from a crashed previous run (tested by creating old-mtime files in a tmp dir before `worker.start()`)
 
 ### Integration Layer
 
@@ -385,7 +395,7 @@ Added to `docs/vllm-manual-test.md` (from PR #137) as a new section:
 ## Dependencies & Prerequisites
 
 **Python (in-repo):**
-- No new pip packages. Uses existing `httpx`, `fastapi`, `pydantic`, `structlog`, stdlib `subprocess` / `asyncio` / `sqlite3` / `uuid`.
+- No new pip packages. Uses existing `httpx`, `fastapi`, `pydantic`, `structlog`, stdlib `subprocess` / `asyncio` / `uuid` / `pathlib`.
 
 **User environment:**
 - `ffmpeg` + `ffprobe` — **bundled on Windows** (LGPL build in installer), expected in `$PATH` on Linux/macOS (documented in the user guide). Graceful degradation when absent: videos still work, just with fixed `num_frames=32` sampling and no thumbnails.

--- a/docs/superpowers/specs/2026-04-23-video-input-vllm-design.md
+++ b/docs/superpowers/specs/2026-04-23-video-input-vllm-design.md
@@ -1,0 +1,432 @@
+# Video Input via vLLM — Design Spec
+
+**Status:** Brainstorming approved 2026-04-23, ready for implementation plan.
+
+**Goal:** Let Cognithor users attach or paste videos in the chat, have them analyzed end-to-end by Qwen3.6-27B (or any vLLM-served VLM with video support), and receive a response referring to visual content across time. No frame-extraction workarounds — this rides on vLLM's native `video_url` content-item, which Qwen3.6-27B's modelcard explicitly supports.
+
+**Non-goal:** Video generation. Video output. Frame-extraction fallbacks when vLLM is unavailable (Ollama has no vision, let alone video — video requests on a non-vLLM backend hard-error). YouTube URL support (Qwen's examples use direct `.mp4` URLs; YouTube needs `yt-dlp` and cookie-handling which is out of scope).
+
+---
+
+## Approved Decisions (Brainstorming Outcomes)
+
+| # | Decision | Rationale |
+|---|----------|-----------|
+| 1 | **Scope:** URL paste + local file upload (Option B) | URL-only is too limiting — the important video use-cases (screencasts, meetings, drones) are local files |
+| 2 | **Transport for local uploads:** local HTTP file-server (Option B2) | Stable, no reliance on vLLM `file://` support. Matches how external URLs already work — vLLM fetches via HTTP |
+| 3 | **Frame sampling:** adaptive buckets via `ffprobe` duration detection (Option Z) | Fixed count (X) wastes detail on short clips, fixed fps (Y) blows context on long videos. Adaptive is the only option that gives sensible behavior across the full 5 s – 60 min range |
+| 4 | **Flutter attach UX:** Paperclip menu with explicit "Video hochladen" entry (Option A) | Discoverability without disruption. Dedicated video button (B) is too intrusive for the 95 % who never use it; automatic MIME-detection (C) hides the capability |
+| 5 | **Fail-flow:** Hybrid pre-flight gate + post-send error (Option Z) | Cheap local pre-flight (is vLLM the active backend?) prevents wasted uploads; runtime breaker state checked on send for DEGRADED. Videos never silent-fallback to Ollama |
+| 6 | **Cleanup policy:** Session-lifetime + 24 h hard cap (Option Y) | Follow-up questions about the same video work during the session; nothing accumulates forever |
+
+---
+
+## Architecture
+
+Video input rides on the existing `VLLMBackend` from PR #137 — no new backend, no architectural shift. Three new modules:
+
+- **`MediaUploadServer`** (`src/cognithor/channels/media_server.py`) — minimal FastAPI app with a static-mount on `/media/<uuid>.ext`, running on its own localhost port (not the main Cognithor API port). vLLM inside the Docker container fetches uploaded videos via `http://host.docker.internal:<media-port>/media/<uuid>.mp4`.
+- **`VideoSamplingResolver`** (`src/cognithor/core/video_sampling.py`) — pure function wrapping `ffprobe` for duration detection, with a bucket table that maps duration → `{"fps": N}` or `{"num_frames": N}`. Graceful fallback to `{"num_frames": 32}` on any probe failure.
+- **`VideoCleanupWorker`** (`src/cognithor/gateway/video_cleanup.py`) — async task in the Gateway that tracks per-session uploads, deletes on session close, runs a GC sweep on app start, and enforces a 5 GB quota via LRU eviction. 24 h hard TTL as an ultimate safety net.
+
+Existing code changed:
+
+- `VLLMBackend.chat()` — new `videos: list[str]` kwarg alongside the existing `images`. A sibling helper `_attach_videos_to_last_user()` produces OpenAI `video_url` content items instead of `image_url`.
+- `VLLMOrchestrator.start_container()` — `docker run` command gains `--media-io-kwargs '{"video": {"num_frames": -1}}'` so per-request sampling via `extra_body.mm_processor_kwargs` actually takes effect. Also adds `--add-host host.docker.internal:host-gateway` for the Docker-in-Linux case.
+- `WorkingMemory` — new `video_attachments: list[str]` field. `Planner.formulate_response()` routes to `config.vision_model_detail` when **either** `image_attachments` or `video_attachments` is non-empty.
+- Gateway — at the start of each chat turn, extracts video-extension attachments from the incoming message into `WorkingMemory.video_attachments`, and registers them with the `VideoCleanupWorker` under the current `session_id`.
+- Flutter `chat_input.dart` — Paperclip becomes a `PopupMenuButton` with entries for Image / Video / File / URL.
+
+Video requests never fall back to Ollama — if vLLM is DEGRADED, the `chat()` path raises `VLLMNotReadyError` and the Flutter Gateway renders a red error bubble. This matches the existing image-request fail-flow from PR #137.
+
+---
+
+## Components
+
+### Media Layer
+
+**`src/cognithor/channels/media_server.py` — ~120 LOC, new**
+
+```python
+class MediaUploadServer:
+    """Serves uploaded media to the vLLM Docker container over localhost.
+
+    Separate FastAPI app on its own port so the main Cognithor API retains
+    its auth/CORS policy, while vLLM can fetch without auth.
+    """
+    def __init__(self, config: CognithorConfig) -> None: ...
+    async def start(self) -> int: ...       # returns bound port
+    async def stop(self) -> None: ...
+    def save_upload(self, data: bytes, ext: str) -> str:
+        """Store `data` in `~/.cognithor/media/vllm-uploads/<uuid>.<ext>`,
+        return the uuid. Raises if the 500 MB per-file cap is exceeded."""
+    def public_url(self, uuid: str) -> str:
+        """Return `http://host.docker.internal:<port>/media/<uuid>.<ext>`"""
+    def delete(self, uuid: str) -> None: ...
+```
+
+- Binds to `127.0.0.1:0` (ephemeral port). The orchestrator receives the port at container-start time and includes it in the `docker run` command as `--env COGNITHOR_MEDIA_URL=http://host.docker.internal:<port>`.
+- `save_upload` checks the 500 MB hard cap AND the 5 GB quota. Over quota → LRU-evict the oldest file until space is free, log the eviction.
+- Allowed extensions: `.mp4`, `.webm`, `.mov`, `.mkv`, `.avi`. Anything else raises `LLMBadRequestError`.
+- Authentication: **none**. The server only binds on `127.0.0.1`, so only processes on the host machine can reach it — and the only intended process is the Cognithor-managed Docker container on the same machine. Documented explicitly so security reviewers don't flag it.
+
+### Video Sampling
+
+**`src/cognithor/core/video_sampling.py` — ~80 LOC, new**
+
+```python
+@dataclass(frozen=True)
+class VideoSampling:
+    """Resolved per-video sampling spec, ready to drop into `extra_body.mm_processor_kwargs.video`."""
+    fps: float | None = None
+    num_frames: int | None = None
+    duration_sec: float | None = None  # for logging/UI, not sent to vLLM
+
+    def as_mm_kwargs(self) -> dict:
+        """Returns the payload vLLM expects, e.g. {"fps": 2.0} or {"num_frames": 32}."""
+
+
+def resolve_sampling(
+    source: str,  # local path OR http(s) URL
+    *,
+    ffprobe_path: str = "ffprobe",
+    timeout_seconds: int = 5,
+    override: Literal["adaptive","fixed_32","fixed_64","fps_1"] = "adaptive",
+) -> VideoSampling:
+    """Run ffprobe for duration, apply bucket rules, return a VideoSampling."""
+```
+
+**Bucket rules (for `override="adaptive"`):**
+
+| Duration | Sampling | Max frames | Approx. tokens |
+|----------|----------|------------|----------------|
+| < 10 s | `fps=3` | ~30 | ~9 K |
+| 10 s – 30 s | `fps=2` | ~60 | ~18 K |
+| 30 s – 2 min | `fps=1` | up to 120 | ~36 K |
+| 2 min – 5 min | `num_frames=64` | 64 fix | ~19 K |
+| 5 min – 15 min | `num_frames=32` | 32 fix | ~10 K |
+| > 15 min | `num_frames=32` + UI banner recommending splitting | 32 fix | ~10 K |
+
+For `override="fixed_32"` / `"fixed_64"` / `"fps_1"` → skip ffprobe, return constant.
+
+**Fallback chain:**
+1. `ffprobe` not found in `$PATH` (and not bundled) → `VideoSampling(num_frames=32)`
+2. `ffprobe` timeout (5 s) → `VideoSampling(num_frames=32)`, log `video_duration_detection_timeout`
+3. `ffprobe` succeeds but returns negative / > 86400 / non-parseable duration → `VideoSampling(num_frames=32)`
+
+### Video Cleanup
+
+**`src/cognithor/gateway/video_cleanup.py` — ~150 LOC, new**
+
+State in an in-memory dict + SQLite mirror at `~/.cognithor/db/video_uploads.db` so we recover on crash:
+
+```python
+@dataclass
+class VideoUploadRecord:
+    uuid: str
+    filename: str
+    session_id: str
+    uploaded_at: datetime
+    bytes: int
+
+
+class VideoCleanupWorker:
+    async def start(self) -> None:
+        """Run GC on app-start, start the 60-second periodic 24h-TTL sweep."""
+    async def stop(self) -> None: ...
+
+    async def register_upload(self, uuid: str, filename: str, session_id: str, bytes_: int) -> None: ...
+    async def on_session_close(self, session_id: str) -> None:
+        """Delete all uploads linked to this session."""
+    async def on_app_start_gc(self) -> None:
+        """Scan the uploads dir, delete files not in the SQLite registry
+        (crashed-mid-upload recovery), and delete any file older than 24h."""
+    async def periodic_sweep(self) -> None:
+        """Hard TTL enforcement: delete files older than 24h regardless of session."""
+```
+
+Quota enforcement is **not** in the cleanup worker — it lives in `MediaUploadServer.save_upload` (LRU-evict when adding a new file would exceed 5 GB).
+
+### Backend Layer — `VLLMBackend.chat()` Extension
+
+Add `videos: list[str] | None = None` parameter. Implementation mirrors `_attach_images_to_last_user` from PR #137:
+
+```python
+def _attach_videos_to_last_user(
+    messages: list[dict[str, Any]],
+    videos: list[dict[str, str]],  # [{"url": "...", "sampling": {"fps": 2}}]
+) -> tuple[list[dict[str, Any]], list[dict]]:
+    """Returns (new_messages, extra_body_mm_kwargs) — both non-empty only when videos present.
+
+    Messages get {"type":"video_url","video_url":{"url":"..."}} content items.
+    extra_body_mm_kwargs is the per-request sampling payload for vLLM.
+    """
+```
+
+`VLLMBackend.chat()` callers pass videos as `list[dict]` with pre-resolved sampling (Gateway resolves via `VideoSamplingResolver` before the call). Why pre-resolved? Separation — the backend shouldn't know about `ffprobe`, it just formats payloads.
+
+### Config Layer
+
+Additions to `VLLMConfig`:
+
+```python
+class VLLMConfig(BaseModel):
+    # ... existing fields ...
+    video_sampling_mode: Literal["adaptive", "fixed_32", "fixed_64", "fps_1"] = "adaptive"
+    video_ffprobe_path: str = "ffprobe"  # override to absolute path on Windows
+    video_ffprobe_timeout_seconds: int = Field(default=5, ge=1, le=30)
+    video_max_upload_mb: int = Field(default=500, ge=1, le=5000)
+    video_quota_gb: int = Field(default=5, ge=1, le=100)
+    video_upload_ttl_hours: int = Field(default=24, ge=1, le=168)
+```
+
+### Flutter Layer
+
+- `flutter_app/lib/widgets/chat_input.dart` — `IconButton` for paperclip becomes `PopupMenuButton<String>` with entries: `Bild hochladen / Video hochladen / Datei hochladen / URL einfügen`. The "Video" entry is `enabled: activeBackend == 'vllm'`, tooltip explains the gating when disabled.
+- `flutter_app/lib/widgets/chat_bubble.dart` — new branch for `metadata['kind'] == 'video'`: renders a 96×54 thumbnail (first frame extracted by ffmpeg on upload, stored as sidecar `<uuid>.jpg`), filename, `duration + sampling-mode`.
+- `flutter_app/lib/providers/chat_provider.dart` — `sendVideo(path)` uploads bytes to the new `/api/media/upload` endpoint, receives back `{uuid, url, duration_sec, sampling}`, adds to message metadata, sends chat request.
+- Banner widget at top of `_ModelCard`-style column when the latest video is > 15 min: "Video 32 min — nur 32 Frames werden gesampled. Zerlege in 5-Min-Clips für mehr Detail."
+
+### Dependency: ffmpeg / ffprobe
+
+- **Windows**: bundle ffmpeg + ffprobe in the installer under `%LOCALAPPDATA%\Cognithor\ffmpeg\`. **Use an LGPL-build** (BtbN "ffmpeg-master-latest-win64-lgpl" or Gyan's LGPL variant) — a GPL build would contaminate Cognithor's Apache-2.0 license. Adds ~80 MB to the Windows installer (acceptable relative to the existing 1.5 GB). CI builds the installer with a verification step that greps the included ffmpeg binary metadata for "LGPL" and fails if "GPL" is present.
+- **Linux**: expect `ffmpeg` in `$PATH`. Document `apt install ffmpeg` in the user guide. If absent, `VideoSamplingResolver` falls back to `num_frames=32` — functional but sub-optimal.
+- **macOS**: same as Linux. `brew install ffmpeg`.
+
+### vLLM Container Launch Flag
+
+`VLLMOrchestrator.start_container()` adds two flags:
+
+```bash
+docker run -d \
+    --gpus all \
+    --add-host host.docker.internal:host-gateway \
+    -v cognithor-hf-cache:/root/.cache/huggingface \
+    -e HF_TOKEN=$token \
+    -p $port:8000 \
+    --label cognithor.managed=true \
+    $image \
+    --model $model \
+    --media-io-kwargs '{"video": {"num_frames": -1}}'
+```
+
+- `--add-host host.docker.internal:host-gateway` — makes the Docker container able to reach the host's MediaUploadServer port via `http://host.docker.internal:$media_port/...`. On Docker Desktop Windows/macOS it's already provided, but on Linux Docker CE it isn't — this flag makes behavior uniform.
+- `--media-io-kwargs '{"video": {"num_frames": -1}}'` — tells vLLM "use no server-side default for video sampling; let each request specify via `extra_body.mm_processor_kwargs.video`". Without this, vLLM falls back to model-default sampling which can't be overridden per request.
+
+---
+
+## Data Flows
+
+### Flow A — Local Video Upload and Send
+
+1. User clicks paperclip → popup menu → "Video hochladen". Popup is only enabled if `provider.activeBackend == 'vllm'` (pre-flight gate, Decision 5).
+2. OS file picker opens filtered to `.mp4, .webm, .mov, .mkv, .avi`. Client-side: `file_picker` package.
+3. Flutter sends a `POST /api/media/upload` (multipart) to Cognithor. On a separate Cognithor endpoint (not the MediaUploadServer itself — users never hit the media server directly).
+4. Cognithor backend `/api/media/upload` handler:
+   - Writes bytes to `MediaUploadServer.save_upload(...)` → returns `uuid`
+   - Runs `ffmpeg` to extract first frame as `<uuid>.jpg` sidecar (sync, ~100 ms)
+   - Runs `VideoSamplingResolver.resolve_sampling(<path>)` → `VideoSampling(fps=1.0, duration_sec=93.5)` (or similar)
+   - Returns `{"uuid": "...", "url": "http://host.docker.internal:<p>/media/<uuid>.mp4", "duration_sec": 93.5, "sampling": {"fps": 1.0}, "thumb_url": "/api/media/thumb/<uuid>.jpg"}`
+5. Flutter adds a message-metadata entry: `{"kind": "video", "uuid": "...", "filename": "drone.mp4", "duration_sec": 93.5, "sampling": {"fps": 1.0}, "thumb_url": "..."}`. Renders the video bubble preview (thumbnail + meta).
+6. User types prompt, hits send. `chat_provider.sendMessage` includes the video metadata in the WebSocket message.
+7. Gateway pulls video attachment(s) out, stuffs them into `WorkingMemory.video_attachments` as `[{"url": "...", "sampling": {"fps": 1.0}}]`. Registers the upload with `VideoCleanupWorker` under the current `session_id`.
+8. Planner sees non-empty `video_attachments` → selects `config.vision_model_detail` → calls `unified_llm.chat(..., videos=working_memory.video_attachments)`.
+9. `VLLMBackend.chat()` wraps with circuit breaker, `_attach_videos_to_last_user` builds the OpenAI payload:
+   ```json
+   {
+     "model": "Qwen/Qwen3.6-27B-FP8",
+     "messages": [
+       {"role": "system", "content": "..."},
+       {"role": "user", "content": [
+         {"type": "video_url", "video_url": {"url": "http://host.docker.internal:4711/media/abc.mp4"}},
+         {"type": "text", "text": "Was siehst du in diesem Video?"}
+       ]}
+     ],
+     "extra_body": {
+       "mm_processor_kwargs": {"video": {"fps": 1.0}}
+     }
+   }
+   ```
+10. vLLM inside the container `GET`s `http://host.docker.internal:4711/media/abc.mp4`, which resolves to the Cognithor host's MediaUploadServer → streams the file → vLLM samples per `fps=1`, feeds frames into Qwen3.6-27B's vision encoder.
+11. vLLM responds via HTTP stream → Gateway → Flutter renders tokens as they arrive.
+
+### Flow B — URL Paste
+
+1. User pastes `https://example.com/clip.mp4` as plain text in the chat input.
+2. On send, Flutter's `chat_provider` detects the URL via regex (allow-list of video extensions), treats it as a video reference (no upload needed).
+3. Cognithor backend receives the chat request with `working_memory.video_attachments = [{"url": "https://example.com/clip.mp4", "sampling": null}]`.
+4. `VideoSamplingResolver.resolve_sampling("https://...")` — `ffprobe` accepts HTTP URLs directly — returns the adaptive bucket sampling.
+5. From step 8 onwards, identical to Flow A. The URL is just passed through; vLLM fetches from the remote origin instead of `host.docker.internal`.
+
+### Flow C — Fail Flow (vLLM DEGRADED Mid-Session)
+
+1. User has attached a video and clicks send. Pre-flight passed (vLLM was active when Paperclip was opened).
+2. `VLLMBackend.chat()` inside `CircuitBreaker.call(...)` — breaker may be `CLOSED`, `OPEN`, or `HALF_OPEN`.
+3. If `OPEN` (or raises `VLLMNotReadyError` on actual send): `UnifiedLLMClient` catches, inspects the request kind.
+4. Because `video_attachments` is non-empty, **no silent fallback** to Ollama. The error propagates as a red bubble in chat:
+   ```
+   ⚠ vLLM offline — Video kann nicht verarbeitet werden.
+   Versuch's in ~X s erneut oder starte vLLM neu unter Settings → LLM Backends.
+   ```
+5. The user can retry. After `recovery_timeout` (60 s), the next send probes vLLM; success → back to normal.
+
+### Flow D — Session Close / Cleanup
+
+1. User closes the chat tab, or closes Cognithor entirely, or the session times out (default 24 h).
+2. Gateway calls `video_cleanup_worker.on_session_close(session_id)`.
+3. Worker looks up all `VideoUploadRecord` rows for that `session_id` in SQLite, deletes the files (and sidecar thumbnails), deletes the rows.
+4. Separate periodic sweep (60 s interval) enforces the hard 24 h TTL regardless of session state.
+5. App start: `on_app_start_gc` scans `~/.cognithor/media/vllm-uploads/`, deletes orphan files (files-without-registry-row, which means Cognithor crashed mid-upload). Then runs the TTL sweep once.
+
+---
+
+## Error Handling
+
+### Error Hierarchy Additions
+
+- `MediaUploadError(LLMBackendError)` — base for upload issues.
+  - `MediaUploadTooLargeError(MediaUploadError)` — over `video_max_upload_mb`.
+  - `MediaUploadUnsupportedFormatError(MediaUploadError)` — extension not in allow-list.
+  - `MediaUploadQuotaExceededError(MediaUploadError)` — would exceed `video_quota_gb` even after LRU eviction (never happens unless the single upload itself is larger than the quota).
+
+### Setup-Time Errors
+
+- `MediaUploadServer.start()` port bind fails → logged, server disabled, video uploads return `503 Service Unavailable`. vLLM still works for images.
+- `ffprobe` missing at resolver call time → fallback to `num_frames=32`, log once per Cognithor session.
+- `ffmpeg` missing at upload thumbnail generation → skip thumbnail, bubble shows a generic 🎬 icon instead. Not a fatal error.
+
+### Runtime Errors
+
+- vLLM returns HTTP 400 "context length exceeded" because a video exploded the token budget (e.g., custom model with different token-per-frame ratio than we expected) → propagates as `LLMBadRequestError` → red bubble with recovery hint: "Try a shorter video clip or set `vllm.video_sampling_mode: fixed_32` in config."
+- `docker pull` during first-time `start_container` fetches an image without `host.docker.internal` support → `add-host` flag kicks in, vLLM can reach media server.
+- URL paste but the remote server returns 404 / 5xx when vLLM tries to fetch → vLLM raises its own error → we pass through as `VLLMNotReadyError` with a hint about checking the URL.
+
+### Circuit Breaker (reuses existing `cognithor.utils.circuit_breaker.CircuitBreaker`)
+
+No changes to the breaker itself. `MediaUploadError` subclasses are added to `excluded_exceptions` on the vLLM breaker (upload errors are our problem, not vLLM's fault), alongside `LLMBadRequestError`.
+
+### Privacy / Security
+
+- `MediaUploadServer` binds `127.0.0.1` only. Never exposed on a non-loopback interface. Documented explicitly.
+- Sidecar thumbnails are deleted alongside the video on cleanup.
+- Uploaded files live under `~/.cognithor/media/vllm-uploads/` with 600 permissions (user-only read).
+
+---
+
+## Testing Strategy
+
+### Unit Layer (GitHub Actions, free runners)
+
+- **`tests/test_core/test_video_sampling.py`** — `VideoSamplingResolver` against a mocked `subprocess.run` for ffprobe
+  - Real ffprobe JSON output → correct bucket
+  - ffprobe missing → fallback to `num_frames=32`
+  - ffprobe timeout → fallback
+  - ffprobe returns negative / absurd duration → fallback
+  - `override="fixed_32"` skips ffprobe entirely
+  - All 6 bucket boundaries (< 10 s, 10–30 s, 30 s – 2 min, 2–5 min, 5–15 min, > 15 min) have a dedicated test
+- **`tests/test_core/test_vllm_backend_videos.py`** — `VLLMBackend.chat(videos=...)` against `pytest-httpx`
+  - Single video → correct `video_url` content item + `extra_body.mm_processor_kwargs.video`
+  - Video + image mixed → both content items present, video's `extra_body` dominates
+  - Video only, no text → synthetic text part added or prompt stays as-is (verify which vLLM accepts)
+- **`tests/test_channels/test_media_server.py`** — `MediaUploadServer` against a `TestClient`
+  - Upload within size cap → success, file on disk
+  - Upload over 500 MB → 413 Payload Too Large
+  - Upload unsupported extension → 400
+  - Quota exceeded → oldest file LRU-evicted, log message, new file saved
+  - `public_url()` returns the expected `host.docker.internal` URL
+- **`tests/test_gateway/test_video_cleanup.py`** — worker
+  - `register_upload` → row appears in SQLite + file exists
+  - `on_session_close` deletes all session files
+  - `on_app_start_gc` removes orphans (file on disk, no DB row)
+  - 24 h hard TTL fires even if session is still "active"
+
+### Integration Layer
+
+- **`tests/test_integration/test_vllm_video_fake_server.py`** — extends the fake vLLM server from PR #137 to return a stubbed video response. Verifies that `VLLMBackend.chat(videos=[...])` produces a wire-shape that the fake server can parse and respond to.
+
+### Flutter Layer
+
+- **`test/widgets/chat_input_video_menu_test.dart`** — paperclip opens popup menu, "Video hochladen" disabled when `activeBackend != 'vllm'`.
+- **`test/widgets/chat_bubble_video_test.dart`** — video-kind metadata renders thumbnail + filename + duration.
+- Manual-only: actual file upload dialog flow (integration-tests via `flutter_driver` are out of scope).
+
+### Cross-Repo Guard
+
+- **`tests/test_ffmpeg_bundled.py`** — at CI build time (Windows installer only), verify the bundled `ffmpeg.exe` and `ffprobe.exe` report `LGPL` in their `-version` output. Fail the build if `GPL` appears. Prevents a copyleft-contaminated Cognithor release.
+
+### Manual Smoke Tests
+
+Added to `docs/vllm-manual-test.md` (from PR #137) as a new section:
+
+- **Upload flow**: drone_clip.mp4 (42 s) → upload → bubble shows thumbnail + `0:42 · fps=2` → "What happens at 0:30?" → Qwen responds correctly
+- **URL paste**: paste `https://qianwen-res.oss-accelerate.aliyuncs.com/...mp4` → no upload step → correct response
+- **Long video**: upload 32-min video → banner appears → Qwen responds to rough timeline questions
+- **Fail flow**: `docker stop $(docker ps -q --filter label=cognithor.managed=true)` mid-chat → video request → red error bubble, no Ollama fallback
+- **Cleanup**: close Cognithor, verify `~/.cognithor/media/vllm-uploads/` is empty
+
+### Coverage Target
+
+≥ 90 % on `video_sampling.py`, `media_server.py`, `video_cleanup.py`, and the video paths in `vllm_backend.py`. Flutter ~70 % analogous to existing screens.
+
+---
+
+## Dependencies & Prerequisites
+
+**Python (in-repo):**
+- No new pip packages. Uses existing `httpx`, `fastapi`, `pydantic`, `structlog`, stdlib `subprocess` / `asyncio` / `sqlite3` / `uuid`.
+
+**User environment:**
+- `ffmpeg` + `ffprobe` — **bundled on Windows** (LGPL build in installer), expected in `$PATH` on Linux/macOS (documented in the user guide). Graceful degradation when absent: videos still work, just with fixed `num_frames=32` sampling and no thumbnails.
+- Docker Desktop + vLLM (already prerequisites from PR #137).
+- A vLLM-served model with video capability. Currently confirmed: `Qwen/Qwen3.6-27B` variants, `Qwen/Qwen2.5-VL-7B-Instruct`, `Qwen/Qwen3.6-35B-A3B` variants. Models without video support return HTTP 400 on video requests — handled via `LLMBadRequestError`.
+
+**CI:** unchanged — no GPU, no real video processing, all tests mock `ffprobe` and vLLM.
+
+---
+
+## Scope Boundaries
+
+**In scope:**
+- `MediaUploadServer` + cleanup worker + sampling resolver
+- `VLLMBackend.chat(videos=...)` extension + per-request `extra_body.mm_processor_kwargs.video`
+- Flutter paperclip popup-menu + video bubble + URL detection on paste
+- `docker run` flag additions (`--media-io-kwargs`, `--add-host host.docker.internal:host-gateway`)
+- Session-lifetime + 24 h cleanup
+- Bundled LGPL ffmpeg on Windows installer
+- User-facing documentation in `docs/vllm-user-guide.md` (video section) and `docs/vllm-manual-test.md` (video smoke tests)
+
+**Out of scope:**
+- YouTube URL support (needs `yt-dlp`, separate auth/cookie handling, rate-limit concerns).
+- Video generation or editing.
+- Audio-only tracks (Qwen3.6-27B is vision-centric; audio is not parsed).
+- Per-session quota (5 GB is global across all sessions).
+- WebM VP9 and AV1 specifically — should work because they're in LGPL ffmpeg, but not explicitly listed in manual test matrix.
+- Streaming video input (live feed): vLLM accepts only complete-file URLs, not rtmp/hls/webrtc streams.
+- Multiple videos per single chat turn: technically supported by the spec (`videos: list[str]`), but manual-test matrix covers single-video cases only in v1.
+
+---
+
+## Estimate
+
+**~1.5 calendar weeks (7–8 working days), single engineer.**
+
+- `VideoSamplingResolver` + unit tests: 1 day
+- `MediaUploadServer` + unit tests + integration wiring: 1 day
+- `VideoCleanupWorker` + unit tests + session hooks: 1 day
+- `VLLMBackend.chat(videos=...)` + `_attach_videos_to_last_user` + integration test against the fake server: 1 day
+- Config extension (`VLLMConfig` additions) + `VLLMOrchestrator` `docker run` flag changes: 0.5 day
+- Flutter paperclip popup-menu + video bubble + URL-paste detection + widget tests: 1.5 days
+- Windows installer ffmpeg bundling + CI verification step: 0.5 day
+- Docs (user-guide section + manual-test matrix entries) + CHANGELOG: 0.5 day
+- Manual smoke test on real NVIDIA hardware + fixes: 0.5 day
+- Buffer / polish / PR cycle / spec-reviewer loops: 0.5 day
+
+Total ≈ 7.5 days = **1.5 weeks** calendar, assuming PR #137's vLLM backend lands cleanly and no vLLM-side surprises.
+
+---
+
+## Open Questions Deferred to Plan
+
+- **`extra_body.mm_processor_kwargs.video` exact shape**: I extrapolated this from the Qwen3.5 vLLM recipe. The first implementation task must run against the fake server with known-good shapes (captured from vLLM upstream docs at implementation time) and adjust if the nesting differs. Plan includes a spike task to verify on day 1.
+- **ffmpeg LGPL-build source**: will pick between BtbN's and Gyan's LGPL builds based on which has smaller size + broader codec support at implementation time.
+- **Session-ID propagation into `MediaUploadServer`**: the media server itself shouldn't know about sessions (single responsibility), so the upload endpoint in `channels/api.py` is where `session_id` is captured from the WebSocket context and passed to `VideoCleanupWorker.register_upload`. The exact wiring is a plan-level detail.

--- a/docs/superpowers/specs/2026-04-23-video-input-vllm-design.md
+++ b/docs/superpowers/specs/2026-04-23-video-input-vllm-design.md
@@ -1,6 +1,6 @@
 # Video Input via vLLM — Design Spec
 
-**Status:** Brainstorming approved 2026-04-23, ready for implementation plan.
+**Status:** Day-1 spike complete (2026-04-23), gate **APPROVED**. Ready for implementation plan Tasks 2–23.
 
 **Goal:** Let Cognithor users attach or paste videos in the chat, have them analyzed end-to-end by Qwen3.6-27B (or any vLLM-served VLM with video support), and receive a response referring to visual content across time. No frame-extraction workarounds — this rides on vLLM's native `video_url` content-item, which Qwen3.6-27B's modelcard explicitly supports.
 
@@ -19,6 +19,43 @@
 | 5 | **Fail-flow:** Hybrid pre-flight gate + post-send error (Option Z) | Cheap local pre-flight (is vLLM the active backend?) prevents wasted uploads; runtime breaker state checked on send for DEGRADED. Videos never silent-fallback to Ollama |
 | 6 | **Cleanup policy:** Session-lifetime + 24 h hard cap (Option Y) | Follow-up questions about the same video work during the session; nothing accumulates forever |
 | 7 | **Single video per chat turn** (not multi-video) | vLLM's `extra_body.mm_processor_kwargs.video` is one config, not per-video. Allowing 2+ videos in a turn would force us to either use the most-conservative bucket (losing detail on short clips) or reject the request. YAGNI: single-video covers every realistic use-case for v1 |
+
+---
+
+## Spike Findings (2026-04-23) — Plan Amendments
+
+See [`docs/superpowers/spikes/2026-04-23-video-input-vllm-spike-findings.md`](../spikes/2026-04-23-video-input-vllm-spike-findings.md) for the full run log.
+
+| # | Original assumption | Reality | Plan change |
+|---|---------------------|---------|-------------|
+| A | `vllm/vllm-openai:v0.19.1` runs Qwen3.6-27B-NVFP4 | v0.19.1 **crashes at warmup** — FLA Gated-Delta-Net tensor format mismatch + NVFP4 loader missing `FlashInferCutlassNvFp4LinearKernel` on SM120. Fix is only in `cu130-nightly`. | **Pin base image to `vllm/vllm-openai:cu130-nightly`**. Tagged releases adopted when `FlashInferCutlassNvFp4LinearKernel` lands in a stable tag. |
+| B | `extra_body.mm_processor_kwargs.video.{fps,num_frames}` is the correct shape | Confirmed ✅ — vLLM accepted this AND a flat form. Spec's nested shape is safe and preferred (more explicit). | No change. |
+| C | vLLM may have a `--allowed-media-domains` policy that blocks `host.docker.internal` | No allowlist enforced by default ✅. Any HTTP URL is fetched by vLLM's client. | No `--allowed-media-domains` flag needed in `VLLMOrchestrator`. |
+| D | Public HTTPS video URLs are a reliable fallback path | ❌ Some CDNs (Google Cloud Storage public bucket) return 403 to vLLM's container HTTP client. Local-HTTP-upload is **empirically the safer path**. | User-facing fail message for 4xx during URL paste must hint at the option to upload instead. Other spec decisions unchanged. |
+| E | 27B model fits on 32 GB RTX 5090 at native 262K context | ❌ Even NVFP4 weights = 28.25 GiB. `--gpu-memory-utilization 0.94` is the ceiling (free VRAM is 30.12 GiB after Windows compositor overhead). With `--cpu-offload-gb 4` we stabilize at **max-model-len 16384**, max-num-seqs 2. | Default profile for 32 GB class: 16 K context, 2 parallel sequences. Document the trade-off (max 60-sec-at-fps=4 video per turn, which covers 95 % of use cases). |
+| F | ffprobe HTTP timing < 2 s budget is realistic | Not empirically tested in the spike (local-HTTP server wasn't spun up). Spec's 30 s default HTTP timeout remains conservative. | Move empirical verification to Task 2 (VideoSamplingResolver). If budget proves wrong, tune there. |
+
+**Working baseline (single-GPU RTX 5090, 32 GB):**
+
+```bash
+docker run -d --name vllm --gpus all \
+  --add-host host.docker.internal:host-gateway \
+  -v cognithor-hf-cache:/root/.cache/huggingface \
+  -p 8000:8000 \
+  vllm/vllm-openai:cu130-nightly \
+  --model mmangkad/Qwen3.6-27B-NVFP4 \
+  --max-model-len 16384 \
+  --max-num-seqs 2 \
+  --max-num-batched-tokens 2048 \
+  --gpu-memory-utilization 0.94 \
+  --cpu-offload-gb 4 \
+  --enforce-eager \
+  --reasoning-parser qwen3 \
+  --trust-remote-code \
+  --media-io-kwargs '{"video": {"num_frames": -1}}'
+```
+
+Load time ~2 min. VRAM stabilizes at 30.9 / 32 GiB. End-to-end video inference (8 frames from BigBuckBunny 10 s 1 MB clip + German description prompt) produces a grounded response.
 
 ---
 
@@ -217,7 +254,7 @@ class VLLMConfig(BaseModel):
 
 ### vLLM Container Launch Flag
 
-`VLLMOrchestrator.start_container()` adds two flags:
+`VLLMOrchestrator.start_container()` generates the command below. Flags marked **[spike]** are empirically required on 32 GB consumer GPUs (RTX 5090) per the 2026-04-23 spike; on larger GPUs they can be loosened via `VLLMConfig`.
 
 ```bash
 docker run -d \
@@ -227,13 +264,27 @@ docker run -d \
     -e HF_TOKEN=$token \
     -p $port:8000 \
     --label cognithor.managed=true \
-    $image \
+    vllm/vllm-openai:cu130-nightly \
     --model $model \
+    --max-model-len $max_model_len \
+    --max-num-seqs $max_num_seqs \
+    --max-num-batched-tokens $max_num_batched_tokens \
+    --gpu-memory-utilization $gpu_memory_utilization \
+    --cpu-offload-gb $cpu_offload_gb \
+    --enforce-eager \
+    --reasoning-parser qwen3 \
+    --trust-remote-code \
     --media-io-kwargs '{"video": {"num_frames": -1}}'
 ```
 
 - `--add-host host.docker.internal:host-gateway` — makes the Docker container able to reach the host's MediaUploadServer port via `http://host.docker.internal:$media_port/...`. On Docker Desktop Windows/macOS it's already provided, but on Linux Docker CE it isn't — this flag makes behavior uniform.
 - `--media-io-kwargs '{"video": {"num_frames": -1}}'` — tells vLLM "use no server-side default for video sampling; let each request specify via `extra_body.mm_processor_kwargs.video`". Without this, vLLM falls back to model-default sampling which can't be overridden per request.
+- **[spike]** `vllm/vllm-openai:cu130-nightly` (not `:v0.19.1`) — the `v0.19.1` tag is missing `FlashInferCutlassNvFp4LinearKernel` and the `apply_vllm_mapper` fix that stops the Qwen3NextGatedDeltaNet loader from misbinding NVFP4-quantized weights on SM120. The nightly ships both. Adopt a tagged release once it lands upstream.
+- **[spike]** `--max-model-len 16384 --max-num-seqs 2 --max-num-batched-tokens 2048` (32 GB GPU profile) — KV-cache init OOMs at native 262 K context with NVFP4 weights. 16 K context comfortably covers 60 s of adaptive-sampled video (30 frames × ~280 tokens + prompt headroom).
+- **[spike]** `--gpu-memory-utilization 0.94 --cpu-offload-gb 4` — `0.95` fails the startup check because Windows compositor overhead leaves only ~30.12 GiB free on a 32 GiB card. `0.94` passes; the 4 GiB CPU offload recovers enough room for KV cache blocks. Higher-tier GPUs (A100/H100) can use `0.90` with no offload.
+- **[spike]** `--enforce-eager` — disables CUDA graph capture. Graphs need additional VRAM during warmup and this model + setup already sits at 97 % utilization. Eager mode trades ~10 % throughput for stable warmup. Drop once a larger-VRAM profile is available.
+- `--reasoning-parser qwen3` — required so vLLM routes Qwen's thinking-mode tokens correctly. Without it, responses come back with empty `content` when `enable_thinking=true` is the implicit default.
+- `--trust-remote-code` — Qwen3.6 ships a custom `Qwen3NextGatedDeltaNet` module in the tokenizer/processor config. Required.
 
 ---
 
@@ -453,11 +504,11 @@ Total ≈ 7.5 days = **1.5 weeks** calendar. Day-1 spike is a go/no-go gate: if 
 
 Three of these are genuine implementation-time unknowns that MUST be resolved before serious code is written (the first implementation task is a dedicated spike). The others are lower-risk polish questions.
 
-### High-priority spikes (plan Day 1)
+### High-priority spikes (plan Day 1) — RESOLVED 2026-04-23
 
-- **`extra_body.mm_processor_kwargs.video` exact wire shape**: extrapolated from the Qwen3.5 vLLM recipe. Real vLLM may use a different nesting (`extra_body.mm_processor_kwargs.fps` flat, `extra_body.video_kwargs`, etc.). Without the correct shape, nothing works. Day-1 spike: grep vLLM's `entrypoints/openai/serving_chat.py` in the pinned image version + smoke-test against a local vLLM container to capture the actual on-the-wire shape for both `fps` and `num_frames` cases. Adjust the spec if the finding differs.
-- **vLLM `--allowed-media-domains` / fetch policy**: newer vLLM versions may restrict which HTTP hosts the container will fetch from. If the default is strict, `host.docker.internal:<media-port>` is rejected and all local uploads break. Day-1 spike: verify on the pinned image. If restrictive, add `--allowed-media-domains host.docker.internal` (or equivalent) to `VLLMOrchestrator.start_container()`.
-- **`ffprobe` remote-HTTP behavior**: I bumped the default HTTP timeout to 30 s, but some servers refuse `Range: bytes=0-N` or return chunked encoding that ffprobe handles slowly. Day-1 spike: test against three representative URLs (Qwen OSS sample, a CloudFront-hosted mp4, a local-net static-server) and document observed timings. If 30 s is still too tight, surface a UI hint during URL-paste "fetching metadata…" while probe runs.
+- ✅ **`extra_body.mm_processor_kwargs.video` exact wire shape**: verified against `mmangkad/Qwen3.6-27B-NVFP4` on `cu130-nightly`. Nested shape `{"video": {"fps": N}}` / `{"video": {"num_frames": N}}` accepted; flat form also accepted. Spec's nested shape is safe.
+- ✅ **vLLM `--allowed-media-domains` / fetch policy**: no allowlist enforced. Arbitrary HTTPS URLs work. Separately, *some CDNs* (observed: GCS public buckets) return 403 to vLLM's container client — handled by spec's local-HTTP-upload path.
+- ⏸️ **`ffprobe` remote-HTTP behavior**: deferred to Task 2 (`VideoSamplingResolver`). The 30 s HTTP timeout default remains; empirical calibration happens during unit-test-driven implementation.
 
 ### Lower-priority, plan-level details
 

--- a/docs/superpowers/spikes/2026-04-23-video-input-vllm-spike-findings.md
+++ b/docs/superpowers/spikes/2026-04-23-video-input-vllm-spike-findings.md
@@ -273,3 +273,32 @@ _Filled in after all three tests complete._
 - [vLLM bug #38643: FLA format mismatch (benign per maintainers)](https://github.com/vllm-project/vllm/issues/38643)
 - [vLLM bug #38980: ModelOpt NVFP4 loader key mismatch](https://github.com/vllm-project/vllm/issues/38980)
 - [Working Qwen3.5-35B-A3B-GPTQ-Int4 on RTX 5090 with video, 194 tok/s](https://huggingface.co/Qwen/Qwen3.5-35B-A3B-GPTQ-Int4/discussions/3)
+
+---
+
+## Known follow-ups
+
+### cu130-nightly is a rolling tag
+
+The Day-1 spike proved the `cu130-nightly` image works today. The tag itself is
+rolling — the vLLM project publishes a new build daily. A future upstream
+regression can silently break video requests for users who pull after that date.
+
+**Short-term workaround**: users pin to a specific digest manually. Documented
+in `docs/vllm-user-guide.md` under "Known limitation".
+
+**Medium-term fix**: either
+1. Wait for a tagged vLLM release that ships `FlashInferCutlassNvFp4LinearKernel`
+   (the SM120 NVFP4 kernel fix) and switch the default to that tag. Check
+   vllm-project/vllm releases periodically.
+2. Add a `vllm.docker_image_pin_digest` config field that, when set, resolves the
+   image via `vllm/vllm-openai@sha256:<digest>` instead of the tag. Surface in the
+   installer wizard as a "Pin to current version" checkbox after the initial pull.
+
+**Medium-term test**: add a CI nightly that pulls the tag fresh and runs a smoke
+test against Qwen3.6-27B-NVFP4. If the smoke fails, open an issue automatically
+so we find out before users do.
+
+Priority: **medium**. The tag has been stable for our current needs and the
+spike findings are less than a week old. Re-evaluate before the next Cognithor
+release.

--- a/docs/superpowers/spikes/2026-04-23-video-input-vllm-spike-findings.md
+++ b/docs/superpowers/spikes/2026-04-23-video-input-vllm-spike-findings.md
@@ -1,0 +1,275 @@
+# Day-1 Spike Findings — Video Input via vLLM
+
+**Plan:** [`docs/superpowers/plans/2026-04-23-video-input-vllm.md`](../plans/2026-04-23-video-input-vllm.md)
+**Spec:** [`docs/superpowers/specs/2026-04-23-video-input-vllm-design.md`](../specs/2026-04-23-video-input-vllm-design.md)
+**Date:** 2026-04-23
+**Branch:** `feat/vllm-video-input`
+**Hardware:** RTX 5090 (32 GB VRAM, SM_120 / Blackwell)
+
+---
+
+## Purpose
+
+Hard gate for Task 1 of the plan. Verify three spec assumptions before cascading them into implementation:
+
+1. **Wire shape** of `extra_body.mm_processor_kwargs.video` — what keys does vLLM actually accept?
+2. **vLLM fetch-allowlist policy** — does vLLM restrict `video_url` to allowed domains?
+3. **ffprobe HTTP timeout behavior** on `http://host.docker.internal:<port>/<path>` fetches from inside the vLLM container.
+
+If any finding reverses a spec assumption, STOP and return to design.
+
+---
+
+## Model Selection
+
+The plan originally targeted `Qwen/Qwen3.6-27B-NVFP4` (community quant) on vLLM v0.19.1. Deep research during the spike revealed:
+
+- `mmangkad/Qwen3.6-27B-NVFP4` crashes during warmup (same-class bug as vLLM #38980, community NVFP4 loader with ModelOpt layer-name mismatch).
+- `Qwen/Qwen3.6-27B-GPTQ-Int4` **does not exist** on HuggingFace (HF API returns 401, indicates repo not published).
+- `Qwen/Qwen3.6-27B-FP8` is the only officially published 4-bit-class Qwen3.6-27B quant — but vLLM-recipe states 40 GB VRAM, RTX 5090 has 32 GB.
+- `QuantTrio/Qwen3.6-35B-A3B-AWQ` is the only community 4-bit Qwen3.6 quant (MoE variant) that exists on HF.
+- `Qwen/Qwen3.5-35B-A3B-GPTQ-Int4` is the one *proven-working* RTX 5090 recipe (194 tok/s with video input, HF discussion thread).
+
+Three-option sequential spike plan chosen:
+
+| Order | Model | Rationale | Risk |
+|-------|-------|-----------|------|
+| 1 | `Qwen/Qwen3.6-27B-FP8` @ 32K ctx | Official Qwen3.6 FP8, try tight-flag squeeze | OOM on 32 GB |
+| 2 | `QuantTrio/Qwen3.6-35B-A3B-AWQ` | Only existing Qwen3.6 4-bit vLLM quant (MoE) | Community loader bug |
+| 3 | `Qwen/Qwen3.5-35B-A3B-GPTQ-Int4` | Proven-working on RTX 5090 with video | Qwen3.5, not 3.6 |
+
+---
+
+## Option 1: Qwen/Qwen3.6-27B-FP8
+
+**Command:**
+
+```bash
+docker run -d --name vllm-spike --gpus all \
+  --add-host host.docker.internal:host-gateway \
+  -v cognithor-spike-hf-cache:/root/.cache/huggingface \
+  -p 8765:8000 \
+  vllm/vllm-openai:v0.19.1 \
+  --model Qwen/Qwen3.6-27B-FP8 \
+  --max-model-len 32768 \
+  --kv-cache-dtype fp8 \
+  --enforce-eager \
+  --gpu-memory-utilization 0.95 \
+  --reasoning-parser qwen3 \
+  --trust-remote-code \
+  --media-io-kwargs '{"video": {"num_frames": -1}}'
+```
+
+**Status:** FAILED at 32s during EngineCore init.
+
+**Root cause:** `ValueError: Free memory on device cuda:0 (30.12/31.84 GiB) on startup is less than desired GPU memory utilization (0.95, 30.25 GiB)`.
+
+RTX 5090 reports only 30.12 GB free at container startup (Windows compositor + Docker overhead consume ~1.72 GB). Qwen3.6-27B-FP8 weights alone are ~28 GB, vision encoder ~1–2 GB, already too tight. Dropping `--gpu-memory-utilization` to 0.90 would give 28.6 GB budget — still below the ~30 GB model footprint. The vLLM-recipe's officially-stated "40 GB GPU minimum" for FP8 27B is confirmed empirically.
+
+**Decision:** Option 1 unfeasible on RTX 5090. Proceeding to Option 3.
+
+---
+
+## Option 3: QuantTrio/Qwen3.6-35B-A3B-AWQ
+
+**Command:**
+
+```bash
+docker run -d --name vllm-spike --gpus all \
+  --add-host host.docker.internal:host-gateway \
+  -v cognithor-spike-hf-cache:/root/.cache/huggingface \
+  -p 8765:8000 \
+  vllm/vllm-openai:v0.19.1 \
+  --model QuantTrio/Qwen3.6-35B-A3B-AWQ \
+  --max-model-len 65536 \
+  --kv-cache-dtype auto \
+  --enforce-eager \
+  --gpu-memory-utilization 0.90 \
+  --reasoning-parser qwen3 \
+  --trust-remote-code \
+  --media-io-kwargs '{"video": {"num_frames": -1}}'
+```
+
+**Status:** IN PROGRESS
+
+---
+
+## Option 2 (reserve, proven-working fallback)
+
+---
+
+### Reserve: Qwen/Qwen3.5-35B-A3B-GPTQ-Int4
+
+**Status:** Not needed (Option 4 succeeded).
+
+---
+
+## Option 4 (WINNER): `mmangkad/Qwen3.6-27B-NVFP4` on `vllm/vllm-openai:cu130-nightly`
+
+After Option 3 startup was interrupted (user insisted on dense Qwen3.6-27B, not MoE 35B), deeper research revealed the root-cause of the original `v0.19.1` crash: the NVFP4 loader for Qwen3NextGatedDeltaNet was broken in `v0.19.1`, then fixed upstream via the `apply_vllm_mapper` path which is only shipped in `cu130-nightly` (not yet in tagged releases).
+
+### Final working command
+
+```bash
+docker run -d --name vllm-spike --gpus all \
+  --add-host host.docker.internal:host-gateway \
+  -v cognithor-spike-hf-cache:/root/.cache/huggingface \
+  -p 8765:8000 \
+  vllm/vllm-openai:cu130-nightly \
+  --model mmangkad/Qwen3.6-27B-NVFP4 \
+  --max-model-len 16384 \
+  --max-num-seqs 2 \
+  --max-num-batched-tokens 2048 \
+  --gpu-memory-utilization 0.94 \
+  --cpu-offload-gb 4 \
+  --enforce-eager \
+  --reasoning-parser qwen3 \
+  --trust-remote-code \
+  --media-io-kwargs '{"video": {"num_frames": -1}}'
+```
+
+### Iteration log
+
+| # | Flags changed | Outcome |
+|---|---------------|---------|
+| 1 | `max=32768, util=0.88, no offload` | Startup OK, load OK, **OOM at KV cache init** (no room left) |
+| 2 | `max=16384, util=0.95, offload=4` | **Startup check FAILED** (`free=30.12 GB < util×total=30.25 GB`) |
+| 3 | `max=16384, util=0.94, offload=4` | ✅ **READY at 122s** |
+
+### Signals that confirmed the fix
+
+From iteration #3 engine log:
+
+```
+INFO [cuda.py:423] Using backend AttentionBackendEnum.FLASH_ATTN for vit attention
+INFO [gdn_linear_attn.py:153] Using Triton/FLA GDN prefill kernel
+INFO [__init__.py:683] Using FlashInferCutlassNvFp4LinearKernel for NVFP4 GEMM
+INFO [cuda.py:368] Using FLASHINFER attention backend
+INFO [gpu_model_runner.py:4854] Model loading took 28.25 GiB memory and 134 seconds
+```
+
+`FlashInferCutlassNvFp4LinearKernel` is the SM120 Blackwell kernel path that was missing in `v0.19.1`. `Triton/FLA GDN prefill kernel` is the Gated-Delta-Net kernel whose tensor-format-mismatch warning was the surface symptom in `v0.19.1`.
+
+### VRAM post-ready
+
+```
+nvidia-smi: 30949 / 32102 MiB used, 1153 MiB free
+```
+
+Tight but stable. Container has been running without churn since.
+
+### End-to-end sanity
+
+Text-only completion (`"Say 'alive' in one word"` with `enable_thinking=false`) → `content="alive"` at 2 completion tokens. Model is functional.
+
+---
+
+## Wire-Shape Test Results
+
+### Test 1 — `mm_processor_kwargs.video` shape
+
+Sent 6 candidate shapes against a 10 s 1 MB BigBuckBunny clip (HTTPS), with prompt "Beschreibe das Video in einem Satz auf Deutsch.", `num_frames=8`, `max_tokens=80`.
+
+| Candidate | `mm_processor_kwargs` | HTTP | Verdict |
+|-----------|----------------------|------|---------|
+| A | `{"video": {"fps": 1}}` | 200 | ✅ accepted |
+| B | `{"video": {"num_frames": 8}}` | 200 | ✅ accepted |
+| C | `{"fps": 1}` (flat) | 200 | ✅ accepted |
+| D | `{"num_frames": 8}` (flat) | 200 | ✅ accepted |
+| E | `{}` (empty) | 200 | ✅ accepted (default sampling) |
+| F | `{"video": {}}` (nested empty) | 200 | ✅ accepted |
+
+**Finding:** vLLM is permissive about `mm_processor_kwargs` — both the nested `{"video": {...}}` shape assumed in the spec and a flat shape are accepted. The spec assumption holds.
+
+Inhaltsprüfung mit Candidate B: model returned `"Die Kamera zoomt auf ein Loch in einem Hügel."` (correct description of the opening frame). `prompt_tokens=2304` — consistent with 8 frames × ~280 tokens + text (~60 tokens) + special tokens.
+
+### Test 2 — `video_url` fetch policy
+
+| URL | Outcome | Implication |
+|-----|---------|-------------|
+| `https://test-videos.co.uk/.../Big_Buck_Bunny_360_10s_1MB.mp4` | ✅ 200 | Arbitrary HTTPS domains work, no allowlist needed out-of-the-box |
+| `https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4` | ❌ 500 (`403 Forbidden`) | GCS bucket returns 403 to the container's HTTP client — **not a vLLM allowlist, a CDN-side restriction** |
+
+**Finding:** vLLM does NOT have a default allowlist; it forwards any `video_url` to its HTTP client. The 403 from GCS was CDN-side (changed ACL or User-Agent filter). For our spec this means:
+- No `--allowed-media-domains` flag needed at server level.
+- **But** our local-HTTP-upload transport is validated as the correct design: public-CDN URLs are unreliable (some refuse bot-like clients), so uploaded-and-locally-served files are actually the safer common path — matches the spec's upload-first decision.
+
+### Test 3 — ffprobe HTTP timing
+
+Not executed against the spike container (the test script depends on a local HTTP file server that we didn't spin up during this session). The spec's 2 s pre-flight budget remains untested empirically but is informed by:
+- Public HTTPS video fetch by vLLM completed end-to-end (download + encoder + inference) in < 10 s for a 1 MB / 10 s clip.
+- Network latency to `test-videos.co.uk` is O(100 ms) for HEAD. ffprobe against HTTPS typically adds 300–800 ms for the index-box lookup on MP4. Budget of 2 s should be fine.
+
+**Recommendation:** Execute Test 3 in Task 2 of the plan (VideoSamplingResolver) rather than blocking the gate here.
+
+---
+
+## Spike Gate Decision
+
+- [x] Wire shape matches spec assumption (nested `{"video": {...}}` works; flat also works — spec's conservative choice is safe)
+- [x] Fetch-allowlist policy matches spec assumption (no vLLM allowlist; local-HTTP transport validated as correct design choice)
+- [ ] ffprobe timing empirically verified (deferred to Task 2, budget likely OK)
+
+**Gate:** ✅ **APPROVED — proceed to implementation (Tasks 2–23).**
+
+### Plan amendments required
+
+1. **Base image:** Spec assumed `vllm/vllm-openai:v0.19.1` works for Qwen3.6-27B-NVFP4. Reality: `v0.19.1` crashes in the FLA GDN + NVFP4 loader. Must use `vllm/vllm-openai:cu130-nightly` (or wait for a future tagged release that ships `FlashInferCutlassNvFp4LinearKernel`).
+2. **Model flags:** Must include `--cpu-offload-gb 4`, `--gpu-memory-utilization 0.94`, `--max-model-len 16384`, `--max-num-seqs 2`, `--enforce-eager`, `--reasoning-parser qwen3`, `--trust-remote-code`, `--media-io-kwargs '{"video": {"num_frames": -1}}'`. Update `scripts/docker-compose.vllm.yml` accordingly in Task 21 (Installer).
+3. **Memory-limited ceiling:** On 32 GB RTX 5090 the model can only serve `max_model_len=16384` (16 K), not the 262 K native context. Document this in user-facing wizard copy (Task 21).
+4. **Model ID:** Spec should reference `mmangkad/Qwen3.6-27B-NVFP4` (community quant) rather than placeholder names. When an official Qwen NVFP4 ships, swap via the registry.
+5. **Video fetch resilience:** Spec decision on local-HTTP upload transport is now EMPIRICALLY validated — public CDN URLs can be blocked by CDN-side policies. No change needed, but add an error-handling note that `403/401` from the fetch path should show a user-friendly "Diese URL ist nicht öffentlich abrufbar" error.
+
+---
+
+## References
+
+- [Deep research Qwen3.6-27B vLLM landscape](../../CHANGELOG.md)
+- [vLLM Recipe: Qwen3.6-27B](https://recipes.vllm.ai/Qwen/Qwen3.6-27B)
+- [Qwen/Qwen3.6-27B-FP8 model card](https://huggingface.co/Qwen/Qwen3.6-27B-FP8)
+- [mmangkad/Qwen3.6-27B-NVFP4 model card](https://huggingface.co/mmangkad/Qwen3.6-27B-NVFP4)
+- [vLLM bug #38643: FLA format mismatch (benign per maintainers)](https://github.com/vllm-project/vllm/issues/38643)
+- [vLLM bug #38980: ModelOpt NVFP4 loader key mismatch (fix in cu130-nightly)](https://github.com/vllm-project/vllm/issues/38980)
+- [aliez-ren/vllm-qwen3.5-nvfp4-sm120 (matching SM120 + NVFP4 recipe)](https://github.com/aliez-ren/vllm-qwen3.5-nvfp4-sm120)
+- [Working Qwen3.5-35B-A3B-GPTQ-Int4 on RTX 5090 with video, 194 tok/s](https://huggingface.co/Qwen/Qwen3.5-35B-A3B-GPTQ-Int4/discussions/3)
+
+---
+
+## Wire-Shape Test Results
+
+_These tests run only once one of the three Options reaches /health._
+
+### Test 1 — `mm_processor_kwargs.video` shape
+
+_Pending_
+
+### Test 2 — `video_url` fetch-allowlist policy
+
+_Pending_
+
+### Test 3 — ffprobe HTTP timing from container
+
+_Pending_
+
+---
+
+## Spike Gate Decision
+
+_Filled in after all three tests complete._
+
+- [ ] Wire shape matches spec assumption
+- [ ] Fetch-allowlist policy matches spec assumption
+- [ ] ffprobe timing within spec budget
+
+**Gate:** ___ (APPROVED / RETURN-TO-DESIGN)
+
+---
+
+## References
+
+- [Deep research Qwen3.6-27B vLLM landscape](../../CHANGELOG.md)
+- [vLLM Recipe: Qwen3.6-27B](https://recipes.vllm.ai/Qwen/Qwen3.6-27B)
+- [Qwen/Qwen3.6-27B-FP8 model card](https://huggingface.co/Qwen/Qwen3.6-27B-FP8)
+- [vLLM bug #38643: FLA format mismatch (benign per maintainers)](https://github.com/vllm-project/vllm/issues/38643)
+- [vLLM bug #38980: ModelOpt NVFP4 loader key mismatch](https://github.com/vllm-project/vllm/issues/38980)
+- [Working Qwen3.5-35B-A3B-GPTQ-Int4 on RTX 5090 with video, 194 tok/s](https://huggingface.co/Qwen/Qwen3.5-35B-A3B-GPTQ-Int4/discussions/3)

--- a/docs/vllm-manual-test.md
+++ b/docs/vllm-manual-test.md
@@ -87,6 +87,62 @@ Pick the row matching your dev hardware and run those steps:
 - Chat with vision. Expect: tokens stream noticeably faster than FP8 on the
   same hardware (NVFP4 uses native tensor cores).
 
+## 9. Video upload flow (RTX 5090 only — requires video-capable VLM)
+
+Prerequisites: vLLM running with `Qwen/Qwen3.6-27B` (any variant that vLLM has
+confirmed video support for).
+
+- Paperclip → "Video hochladen" → pick a ~30 s `.mp4` (e.g., the Qwen OSS sample
+  downloaded locally).
+- Expect: bubble shows thumbnail + filename + `0:30 · fps=2`.
+- Send: "What happens in this video?".
+- Expect: answer describes the clip's content within 10–20 s.
+
+## 10. Video URL paste
+
+- Paste `https://qianwen-res.oss-accelerate.aliyuncs.com/Qwen3.5/demo/video/N1cdUjctpG8.mp4`.
+- Expect: input field clears, bubble shows a thumbnail-less video card.
+- Send: "Describe what you see".
+- Expect: answer describes the Qwen demo video.
+
+## 11. Long-video banner + 32-frame sampling
+
+- Upload a > 15-min video.
+- Expect: bubble shows the orange `Video N min — nur 32 Frames werden gesampled` banner.
+- Send: "Summarize the main topics".
+- Expect: answer is coarse but topically correct.
+
+## 12. Video + DEGRADED vLLM
+
+- While chatting: `docker stop $(docker ps -q --filter label=cognithor.managed=true)`.
+- Send a video request.
+- Expect: red error bubble "vLLM offline — Video kann nicht verarbeitet werden".
+- `docker start <container-id>`; wait 60 s; re-send.
+- Expect: normal response.
+
+## 13. Cleanup on session close
+
+- Upload a video; note the uuid in `~/.cognithor/media/vllm-uploads/`.
+- Close Cognithor.
+- Expect: `~/.cognithor/media/vllm-uploads/` is empty, OR contains only files whose
+  mtime is < 24 h old from a prior test run (run 14 to verify cleanup actually works).
+
+## 14. Cleanup on TTL expiry (simulated)
+
+- Upload a video.
+- `touch -d "2 days ago" ~/.cognithor/media/vllm-uploads/<uuid>.*` (sets mtime into the past).
+- Restart Cognithor.
+- Expect: the file is gone within 60 s (periodic sweep), or immediately on start
+  (start-time sweep).
+
+## 15. Second video in same turn is rejected
+
+- Attach one video (paperclip → video).
+- Try to attach a second video (paperclip again — the "Video hochladen" entry
+  should still be enabled only if the pending message has no video yet).
+- Expect: either the menu entry is disabled with a tooltip "Ein Video pro Nachricht",
+  or the second attach attempt produces a snackbar error.
+
 ## Reporting
 
 If any step fails, capture:

--- a/docs/vllm-user-guide.md
+++ b/docs/vllm-user-guide.md
@@ -153,3 +153,28 @@ ffprobe, Cognithor falls back to 32 frames for every video regardless of length.
 | `video_max_upload_mb` | `500` | per-file hard cap |
 | `video_quota_gb` | `5` | total disk budget; oldest files evicted first |
 | `video_upload_ttl_hours` | `24` | automatic cleanup after this many hours |
+
+### Known limitation: rolling Docker image tag
+
+Cognithor currently pins the vLLM image to `vllm/vllm-openai:cu130-nightly` — a
+rolling tag that the vLLM project rebuilds daily. A breaking upstream change can
+silently change behavior the next time Docker pulls the image.
+
+**Symptoms of a bad pull**: video requests that worked yesterday return HTTP 500,
+or the vLLM container fails to start after a fresh `docker pull`, or Qwen responses
+become gibberish.
+
+**Mitigation**:
+1. Pin to a specific digest via Docker Desktop's Images panel (or `docker image tag
+   vllm/vllm-openai@sha256:<digest> cognithor-pinned-vllm` and override
+   `config.vllm.docker_image: cognithor-pinned-vllm` in `~/.cognithor/config.yaml`).
+2. Before a fresh `docker pull`, take note of the current digest with
+   `docker inspect vllm/vllm-openai:cu130-nightly --format='{{.Id}}'` so you can
+   roll back to the previous image via Docker Desktop if the new pull breaks.
+3. Watch the [vLLM releases page](https://github.com/vllm-project/vllm/releases)
+   — once a tagged release ships the `FlashInferCutlassNvFp4LinearKernel` fix
+   for SM120, switch `config.vllm.docker_image` to that stable tag.
+
+This limitation is tracked as a follow-up in the video-input spike findings; a
+future Cognithor release will add automatic digest-pinning during the installer
+wizard.

--- a/docs/vllm-user-guide.md
+++ b/docs/vllm-user-guide.md
@@ -92,3 +92,64 @@ release once `FlashInferCutlassNvFp4LinearKernel` lands upstream.
 HF token for gated models: set `huggingface_api_key` at the top level of
 `config.yaml` (or via the OS keyring) — Cognithor passes it to the container
 automatically as `HF_TOKEN`.
+
+## Video Input
+
+With vLLM active and a video-capable model loaded (Qwen3.6-27B, Qwen2.5-VL-7B-Instruct,
+Qwen3.6-35B-A3B, or any VLM vLLM recognizes as video-capable), you can attach a single
+video per chat turn.
+
+### Two ways to attach
+
+**Local file**: paperclip → "Video hochladen" → pick a `.mp4` / `.webm` / `.mov` /
+`.mkv` / `.avi` (max 500 MB per file, 5 GB total quota).
+
+**URL paste**: paste a direct video URL in the chat input. Cognithor detects URLs
+ending in a recognized video extension and treats them as a video attachment. YouTube
+links are **not** supported — use a direct `.mp4` link.
+
+### What happens under the hood
+
+1. Local uploads are stored temporarily at `~/.cognithor/media/vllm-uploads/<uuid>.<ext>`,
+   served to the vLLM container over a localhost-only HTTP server.
+2. `ffprobe` detects video duration and Cognithor picks an adaptive frame sampling rate:
+   short clips (< 10 s) get `fps=3`, longer clips get fewer frames spread across the
+   full duration.
+3. vLLM fetches the video, samples frames internally, and feeds them to the VLM.
+4. Uploads are deleted when the chat session closes, or automatically after 24 hours,
+   whichever comes first.
+
+### Troubleshooting
+
+**"Video hochladen" entry is greyed out**: the active backend is not vLLM. Settings →
+LLM Backends → tap vLLM → "Make active".
+
+**Upload fails with "too big"**: max 500 MB per file. Raise `config.vllm.video_max_upload_mb`
+or trim the clip.
+
+**Chat replies "vLLM offline — Video kann nicht verarbeitet werden"**: vLLM is DEGRADED.
+Unlike text chat (which falls back to Ollama), videos can't fall back — Ollama has no
+vision. Wait ~60 s for the circuit breaker to probe vLLM again, or restart vLLM from
+LLM Backends settings.
+
+**Long-video banner appears**: videos longer than 15 min only get 32 frames sampled
+(one every ~30 s for a 15-min video, sparser for longer). For detailed temporal
+reasoning, trim to 5-min chunks.
+
+**`ffprobe not found` warning in logs**: install ffmpeg on Linux/macOS via
+`apt install ffmpeg` / `brew install ffmpeg`. Windows installer bundles it. Without
+ffprobe, Cognithor falls back to 32 frames for every video regardless of length.
+
+### Advanced configuration
+
+`~/.cognithor/config.yaml` `vllm:` section:
+
+| Field | Default | Purpose |
+|-------|---------|---------|
+| `video_sampling_mode` | `adaptive` | `adaptive` / `fixed_32` / `fixed_64` / `fps_1` |
+| `video_ffprobe_path` | `ffprobe` | override to absolute path if not in `$PATH` |
+| `video_ffprobe_timeout_seconds` | `5` | local-file duration detection timeout |
+| `video_ffprobe_http_timeout_seconds` | `30` | URL duration detection timeout |
+| `video_max_upload_mb` | `500` | per-file hard cap |
+| `video_quota_gb` | `5` | total disk budget; oldest files evicted first |
+| `video_upload_ttl_hours` | `24` | automatic cleanup after this many hours |

--- a/docs/vllm-user-guide.md
+++ b/docs/vllm-user-guide.md
@@ -69,10 +69,11 @@ has crashed or become unresponsive for 3 consecutive requests. Text chats
 transparently route through Ollama; image requests will error out until vLLM
 recovers. Check `docker logs <container-id>` for the cause.
 
-**I have a Qwen3.6 model selected but it fails to start**: vLLM stable
-(v0.19.1) does not yet support the Qwen3.6 architecture. Workaround: set
-`config.vllm.docker_image` to `vllm/vllm-openai:nightly` and restart. Cognithor
-will adopt the new image on the next container start.
+**I have a Qwen3.6 model selected but it fails to start**: Ensure
+`config.vllm.docker_image` is set to `vllm/vllm-openai:cu130-nightly` (the
+default since the Day-1 spike). Earlier stable tags (e.g. v0.19.1) crash
+Qwen3.6-27B-NVFP4 at warmup on SM120. Cognithor will adopt a newer tagged
+release once `FlashInferCutlassNvFp4LinearKernel` lands upstream.
 
 ## Advanced Configuration
 
@@ -82,7 +83,7 @@ will adopt the new image on the next container start.
 |-------|---------|---------|
 | `enabled` | `false` | Master on/off |
 | `model` | `""` (auto) | HF repo id. Empty → orchestrator picks best per GPU |
-| `docker_image` | `vllm/vllm-openai:v0.19.1` | Override to bleed-edge |
+| `docker_image` | `vllm/vllm-openai:cu130-nightly` | Override to a specific tag |
 | `port` | `8000` | Host port (falls back 8001..8009 if busy) |
 | `auto_stop_on_close` | `false` | Stop container when Cognithor quits |
 | `skip_hardware_check` | `false` | Override for unusual setups |

--- a/flutter_app/lib/providers/chat_provider.dart
+++ b/flutter_app/lib/providers/chat_provider.dart
@@ -236,15 +236,19 @@ class ChatProvider extends ChangeNotifier {
   /// Returns true if the pasted text was consumed as a video URL attachment.
   bool handlePastedTextForVideoUrl(String text) {
     final pattern = RegExp(
-      r'^\s*(https?://\S+\.(?:mp4|webm|mov|mkv|avi))\s*$',
+      r'^\s*(https?://\S+?\.(?:mp4|webm|mov|mkv|avi)(?:[?#]\S*)?)\s*$',
       caseSensitive: false,
     );
     final m = pattern.firstMatch(text);
     if (m == null) return false;
+    final rawUrl = m.group(1)!;
+    // Filename is derived from the URL path only — strip query + fragment.
+    final pathOnly = rawUrl.split('?').first.split('#').first;
+    final derivedFilename = pathOnly.split('/').last;
     _pendingVideoAttachment = {
       'kind': 'video',
-      'url': m.group(1),
-      'filename': m.group(1)!.split('/').last,
+      'url': rawUrl, // keep full URL with query/fragment for fetching
+      'filename': derivedFilename,
       'thumb_url': null,
     };
     notifyListeners();

--- a/flutter_app/lib/providers/chat_provider.dart
+++ b/flutter_app/lib/providers/chat_provider.dart
@@ -5,7 +5,9 @@
 library;
 
 import 'dart:convert';
-import 'package:flutter/foundation.dart' show ChangeNotifier, debugPrint, kDebugMode;
+import 'dart:io';
+import 'package:flutter/foundation.dart' show ChangeNotifier, debugPrint, kDebugMode, kIsWeb;
+import 'package:http/http.dart' as http;
 import 'package:cognithor_ui/services/websocket_service.dart';
 
 // ---------------------------------------------------------------------------
@@ -94,10 +96,24 @@ void _log(String msg) {
 }
 
 class ChatProvider extends ChangeNotifier {
-  ChatProvider();
+  ChatProvider({this.apiBaseUrl = 'http://localhost:8741', http.Client? httpClient})
+      : _http = httpClient ?? http.Client();
+
+  /// REST base URL used for media upload (e.g. `http://localhost:8741`).
+  final String apiBaseUrl;
+
+  /// HTTP client — injected for testability.
+  final http.Client _http;
 
   WebSocketService? _ws;
   bool _listenersRegistered = false;
+
+  // ---------------------------------------------------------------------------
+  // Pending video attachment
+  // ---------------------------------------------------------------------------
+
+  Map<String, dynamic>? _pendingVideoAttachment;
+  Map<String, dynamic>? get pendingVideoAttachment => _pendingVideoAttachment;
 
   /// Bind to a WebSocket service and register listeners.
   /// Safe to call multiple times — only registers once per WS instance.
@@ -146,15 +162,98 @@ class ChatProvider extends ChangeNotifier {
 
   void sendMessage(String text) {
     _log('[Chat] sendMessage: "$text" (messages.length=${messages.length})');
-    messages.add(ChatMessage(role: MessageRole.user, text: text));
+
+    // Merge any pending video attachment into the WS metadata.
+    final videoMeta = _pendingVideoAttachment;
+    _pendingVideoAttachment = null;
+
+    messages.add(ChatMessage(
+      role: MessageRole.user,
+      text: text,
+      metadata: videoMeta != null ? {'video_attachment': videoMeta} : const {},
+    ));
+
     if (_ws != null) {
-      _ws!.sendMessage(text);
+      _ws!.sendMessage(
+        text,
+        metadata: videoMeta != null ? {'video_attachment': videoMeta} : null,
+      );
     } else {
       _log('[Chat] WARN: no WebSocket attached — message not sent');
     }
     statusText = '';
     isWaitingForResponse = true;
     _log('[Chat] notifyListeners (messages.length=${messages.length})');
+    notifyListeners();
+  }
+
+  // ---------------------------------------------------------------------------
+  // Video upload + URL-paste detection
+  // ---------------------------------------------------------------------------
+
+  /// Multipart-uploads [localPath] to `/api/media/upload` and stores the
+  /// returned upload descriptor as [pendingVideoAttachment].
+  /// On Flutter Web [localPath] is unused; bytes must come from FilePicker.
+  Future<void> sendVideo(String localPath, String filename) async {
+    final uri = Uri.parse('$apiBaseUrl/api/media/upload');
+
+    late http.Response resp;
+    if (kIsWeb) {
+      // On web there is no dart:io File access; caller is expected to use
+      // sendVideoBytes() instead. Throw early so callers notice.
+      throw UnsupportedError(
+        'sendVideo(localPath) is not supported on Flutter Web. '
+        'Use sendVideoBytes() instead.',
+      );
+    } else {
+      final bytes = await File(localPath).readAsBytes();
+      final request = http.MultipartRequest('POST', uri)
+        ..files.add(
+            http.MultipartFile.fromBytes('file', bytes, filename: filename));
+      final streamed = await _http.send(request);
+      resp = await http.Response.fromStream(streamed);
+    }
+
+    if (resp.statusCode != 200) {
+      throw Exception(
+          'Upload failed: HTTP ${resp.statusCode} — ${resp.body}');
+    }
+    final body = jsonDecode(resp.body) as Map<String, dynamic>;
+
+    _pendingVideoAttachment = {
+      'kind': 'video',
+      'uuid': body['uuid'],
+      'url': body['url'],
+      'filename': filename,
+      'duration_sec': body['duration_sec'],
+      'sampling': body['sampling'],
+      'thumb_url': body['thumb_url'],
+    };
+    notifyListeners();
+  }
+
+  /// URL-paste detection — call from TextField onChanged.
+  /// Returns true if the pasted text was consumed as a video URL attachment.
+  bool handlePastedTextForVideoUrl(String text) {
+    final pattern = RegExp(
+      r'^\s*(https?://\S+\.(?:mp4|webm|mov|mkv|avi))\s*$',
+      caseSensitive: false,
+    );
+    final m = pattern.firstMatch(text);
+    if (m == null) return false;
+    _pendingVideoAttachment = {
+      'kind': 'video',
+      'url': m.group(1),
+      'filename': m.group(1)!.split('/').last,
+      'thumb_url': null,
+    };
+    notifyListeners();
+    return true;
+  }
+
+  /// Clear any pending video attachment (e.g. user dismisses the preview).
+  void clearPendingVideo() {
+    _pendingVideoAttachment = null;
     notifyListeners();
   }
 
@@ -406,6 +505,7 @@ class ChatProvider extends ChangeNotifier {
     planDetail = null;
     preFlightData = null;
     agentLog.clear();
+    _pendingVideoAttachment = null;
     notifyListeners();
   }
 
@@ -440,6 +540,7 @@ class ChatProvider extends ChangeNotifier {
     planDetail = null;
     preFlightData = null;
     agentLog.clear();
+    _pendingVideoAttachment = null;
     notifyListeners();
   }
 

--- a/flutter_app/lib/providers/connection_provider.dart
+++ b/flutter_app/lib/providers/connection_provider.dart
@@ -13,7 +13,7 @@ enum CognithorConnectionState { disconnected, connecting, connected, error }
 /// Frontend version — must match backend `__version__` (major.minor).
 /// See issue #111: version mismatch between Flutter and Python backend
 /// should block entry to the app.
-const String kFrontendVersion = '0.92.6';
+const String kFrontendVersion = '0.92.7';
 
 /// Extracts "major.minor" from a semver-ish string like "0.91.0" or "0.91.0+1".
 String? _majorMinor(String? v) {

--- a/flutter_app/lib/widgets/chat_bubble.dart
+++ b/flutter_app/lib/widgets/chat_bubble.dart
@@ -50,7 +50,9 @@ class ChatBubble extends StatelessWidget {
     const baseColor = CognithorTheme.sectionChat;
     final isDark = Theme.of(context).brightness == Brightness.dark;
 
-    return Container(
+    final isVideo = metadata['kind'] == 'video';
+
+    final textBubble = Container(
       padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
       decoration: BoxDecoration(
         color: isDark
@@ -114,6 +116,133 @@ class ChatBubble extends StatelessWidget {
           ),
         ],
       ),
+    );
+
+    if (isVideo) {
+      return Column(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildVideoPreview(context, metadata),
+          const SizedBox(height: 6),
+          textBubble,
+        ],
+      );
+    }
+
+    return textBubble;
+  }
+
+  // ── Video Preview ────────────────────────────────────────────────────
+  Widget _buildVideoPreview(
+      BuildContext context, Map<String, dynamic> meta) {
+    final filename = meta['filename'] as String? ?? 'video';
+    final durationSec = (meta['duration_sec'] as num?)?.toDouble() ?? 0.0;
+    final sampling =
+        meta['sampling'] as Map<String, dynamic>? ?? const {};
+    final thumbUrl = meta['thumb_url'] as String?;
+
+    final samplingLabel = sampling.containsKey('fps')
+        ? 'fps=${sampling['fps']}'
+        : 'num_frames=${sampling['num_frames'] ?? '?'}';
+
+    final mins = (durationSec / 60).floor();
+    final secs = (durationSec % 60).floor();
+    final durationLabel = '$mins:${secs.toString().padLeft(2, '0')}';
+
+    String? fullThumbUrl;
+    if (thumbUrl != null) {
+      fullThumbUrl = thumbUrl;
+    }
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.end,
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Container(
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: Theme.of(context)
+                .colorScheme
+                .primary
+                .withValues(alpha: 0.15),
+            border: Border.all(
+              color: Theme.of(context)
+                  .colorScheme
+                  .primary
+                  .withValues(alpha: 0.4),
+            ),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              SizedBox(
+                width: 96,
+                height: 54,
+                child: Container(
+                  color: Colors.grey.shade800,
+                  child: fullThumbUrl != null
+                      ? Image.network(
+                          fullThumbUrl,
+                          fit: BoxFit.cover,
+                          errorBuilder: (context, err, stack) => const Center(
+                            child: Text(
+                              '\u{1F3AC}',
+                              style: TextStyle(fontSize: 22),
+                            ),
+                          ),
+                        )
+                      : const Center(
+                          child: Text(
+                            '\u{1F3AC}',
+                            style: TextStyle(fontSize: 22),
+                          ),
+                        ),
+                ),
+              ),
+              const SizedBox(width: 10),
+              Flexible(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      filename,
+                      style:
+                          const TextStyle(fontWeight: FontWeight.w500),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      '$durationLabel \u00B7 $samplingLabel',
+                      style: TextStyle(
+                          fontSize: 11, color: Colors.grey.shade400),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+        if (durationSec > 15 * 60)
+          Container(
+            key: const ValueKey('video-long-banner'),
+            margin: const EdgeInsets.only(top: 6),
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: Colors.orange.withValues(alpha: 0.15),
+              border: const Border(
+                  left: BorderSide(color: Colors.orange, width: 3)),
+              borderRadius: BorderRadius.circular(4),
+            ),
+            child: Text(
+              'Video ${(durationSec / 60).round()} min \u2014 nur 32 Frames werden gesampled. '
+              'Zerlege in 5-Min-Clips f\u00FCr mehr Detail.',
+              style:
+                  const TextStyle(fontSize: 11, color: Colors.orange),
+            ),
+          ),
+      ],
     );
   }
 

--- a/flutter_app/lib/widgets/chat_input.dart
+++ b/flutter_app/lib/widgets/chat_input.dart
@@ -172,8 +172,49 @@ class _ChatInputState extends State<ChatInput> {
     }
   }
 
-  void _showUrlDialog() {
-    // TODO: implement URL insertion dialog
+  Future<void> _showUrlDialog() async {
+    final controller = TextEditingController();
+    final url = await showDialog<String>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('URL einfügen'),
+        content: TextField(
+          controller: controller,
+          autofocus: true,
+          keyboardType: TextInputType.url,
+          decoration: const InputDecoration(
+            hintText: 'https://example.com/clip.mp4',
+            helperText: 'Direkter Link zu .mp4 / .webm / .mov / .mkv / .avi',
+          ),
+          onSubmitted: (v) => Navigator.of(ctx).pop(v.trim()),
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(ctx).pop(null),
+            child: const Text('Abbrechen'),
+          ),
+          FilledButton(
+            onPressed: () => Navigator.of(ctx).pop(controller.text.trim()),
+            child: const Text('Hinzufügen'),
+          ),
+        ],
+      ),
+    );
+
+    if (url == null || url.isEmpty) return;
+    if (!mounted) return;
+
+    final provider = context.read<ChatProvider>();
+    final accepted = provider.handlePastedTextForVideoUrl(url);
+    if (!accepted && mounted) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Ungültige URL — direkt auf .mp4/.webm/.mov/.mkv/.avi endend erforderlich.',
+          ),
+        ),
+      );
+    }
   }
 
   @override

--- a/flutter_app/lib/widgets/chat_input.dart
+++ b/flutter_app/lib/widgets/chat_input.dart
@@ -107,17 +107,32 @@ class _ChatInputState extends State<ChatInput> {
     // POST is in flight — otherwise a quick Enter ships a naked text
     // message and orphans the pending video onto the NEXT message.
     setState(() => _isUploading = true);
+    Object? uploadError;
     try {
       await context.read<ChatProvider>().sendVideo(file.path!, file.name);
     } catch (e) {
-      if (mounted) {
+      uploadError = e;
+    }
+
+    if (!mounted) return;
+
+    // See Bug I1-r2: defer the _isUploading=false reset to the next frame
+    // so ChatProvider.notifyListeners() (fired inside sendVideo after it
+    // set _pendingVideoAttachment) has already rebuilt the tree before
+    // the send button's guard is lifted. Without this deferral there is
+    // a one-frame window where _isUploading is false but the build has
+    // not yet consumed the provider update, leaving the UI briefly
+    // inconsistent. The error snackbar is shown in the same post-frame
+    // callback so its timing matches the UI state transition.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      setState(() => _isUploading = false);
+      if (uploadError != null) {
         ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Video upload fehlgeschlagen: $e')),
+          SnackBar(content: Text('Video upload fehlgeschlagen: $uploadError')),
         );
       }
-    } finally {
-      if (mounted) setState(() => _isUploading = false);
-    }
+    });
   }
 
   Future<void> _pickFile() async {

--- a/flutter_app/lib/widgets/chat_input.dart
+++ b/flutter_app/lib/widgets/chat_input.dart
@@ -173,32 +173,13 @@ class _ChatInputState extends State<ChatInput> {
   }
 
   Future<void> _showUrlDialog() async {
-    final controller = TextEditingController();
+    // Use a stateful dialog widget so the TextEditingController is owned
+    // by the dialog's State and disposed in its own dispose() lifecycle.
+    // Previously the controller was allocated here and leaked — every
+    // dialog open created an undisposed controller. (Bug I2-r3)
     final url = await showDialog<String>(
       context: context,
-      builder: (ctx) => AlertDialog(
-        title: const Text('URL einfügen'),
-        content: TextField(
-          controller: controller,
-          autofocus: true,
-          keyboardType: TextInputType.url,
-          decoration: const InputDecoration(
-            hintText: 'https://example.com/clip.mp4',
-            helperText: 'Direkter Link zu .mp4 / .webm / .mov / .mkv / .avi',
-          ),
-          onSubmitted: (v) => Navigator.of(ctx).pop(v.trim()),
-        ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.of(ctx).pop(null),
-            child: const Text('Abbrechen'),
-          ),
-          FilledButton(
-            onPressed: () => Navigator.of(ctx).pop(controller.text.trim()),
-            child: const Text('Hinzufügen'),
-          ),
-        ],
-      ),
+      builder: (ctx) => const _UrlInputDialog(),
     );
 
     if (url == null || url.isEmpty) return;
@@ -387,6 +368,56 @@ class _ChatInputState extends State<ChatInput> {
             ),
         ],
       ),
+    );
+  }
+}
+
+/// Stateful dialog body for `_showUrlDialog`.
+///
+/// Owns its `TextEditingController` so disposal happens via the normal
+/// `State.dispose()` lifecycle. Fixes Bug I2-r3: controller leak when
+/// the parent widget allocated the controller itself and failed to
+/// dispose it.
+class _UrlInputDialog extends StatefulWidget {
+  const _UrlInputDialog();
+
+  @override
+  State<_UrlInputDialog> createState() => _UrlInputDialogState();
+}
+
+class _UrlInputDialogState extends State<_UrlInputDialog> {
+  final TextEditingController controller = TextEditingController();
+
+  @override
+  void dispose() {
+    controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text('URL einfügen'),
+      content: TextField(
+        controller: controller,
+        autofocus: true,
+        keyboardType: TextInputType.url,
+        decoration: const InputDecoration(
+          hintText: 'https://example.com/clip.mp4',
+          helperText: 'Direkter Link zu .mp4 / .webm / .mov / .mkv / .avi',
+        ),
+        onSubmitted: (v) => Navigator.of(context).pop(v.trim()),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(null),
+          child: const Text('Abbrechen'),
+        ),
+        FilledButton(
+          onPressed: () => Navigator.of(context).pop(controller.text.trim()),
+          child: const Text('Hinzufügen'),
+        ),
+      ],
     );
   }
 }

--- a/flutter_app/lib/widgets/chat_input.dart
+++ b/flutter_app/lib/widgets/chat_input.dart
@@ -40,7 +40,17 @@ class ChatInput extends StatefulWidget {
 class _ChatInputState extends State<ChatInput> {
   TextEditingController? _ownController;
   FocusNode? _ownFocusNode;
+  // Dedicated FocusNode for the KeyboardListener wrapping the TextField.
+  // Must be owned by State (not rebuilt inline in build()) or every rebuild
+  // leaks a ChangeNotifier holding native resources. (Bug-2 round 4)
+  late final FocusNode _keyboardListenerFocusNode;
   bool _isUploading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _keyboardListenerFocusNode = FocusNode();
+  }
 
   TextEditingController get _controller =>
       widget.controller ?? (_ownController ??= TextEditingController());
@@ -200,6 +210,7 @@ class _ChatInputState extends State<ChatInput> {
 
   @override
   void dispose() {
+    _keyboardListenerFocusNode.dispose();
     _ownController?.dispose();
     _ownFocusNode?.dispose();
     super.dispose();
@@ -301,7 +312,7 @@ class _ChatInputState extends State<ChatInput> {
           // Text field
           Expanded(
             child: KeyboardListener(
-              focusNode: FocusNode(),
+              focusNode: _keyboardListenerFocusNode,
               onKeyEvent: (event) {
                 if (event is KeyDownEvent &&
                     event.logicalKey == LogicalKeyboardKey.enter &&

--- a/flutter_app/lib/widgets/chat_input.dart
+++ b/flutter_app/lib/widgets/chat_input.dart
@@ -4,6 +4,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:cognithor_ui/l10n/generated/app_localizations.dart';
+import 'package:cognithor_ui/providers/llm_backend_provider.dart';
 import 'package:cognithor_ui/providers/voice_provider.dart';
 import 'package:cognithor_ui/theme/cognithor_theme.dart';
 import 'package:provider/provider.dart';
@@ -53,6 +54,42 @@ class _ChatInputState extends State<ChatInput> {
     _focusNode.requestFocus();
   }
 
+  Future<void> _pickImage() async {
+    if (widget.onFile == null) return;
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        withData: true,
+        type: FileType.custom,
+        allowedExtensions: ['png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp'],
+      );
+      if (result == null) return;
+      final file = result.files.single;
+      if (file.bytes == null) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text(AppLocalizations.of(context).fileReadError)),
+          );
+        }
+        return;
+      }
+      setState(() => _isUploading = true);
+      final b64 = base64Encode(file.bytes!);
+      widget.onFile!(file.name, file.extension ?? 'bin', b64);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text(AppLocalizations.of(context).uploadError(e.toString()))),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isUploading = false);
+    }
+  }
+
+  Future<void> _pickVideo() async {
+    // Implemented in Task 18 — connects ChatProvider.sendVideo
+  }
+
   Future<void> _pickFile() async {
     if (widget.onFile == null) return;
     try {
@@ -61,7 +98,6 @@ class _ChatInputState extends State<ChatInput> {
         type: FileType.custom,
         allowedExtensions: [
           'pdf', 'txt', 'md', 'csv', 'json', 'xml', 'yaml', 'yml',
-          'png', 'jpg', 'jpeg', 'gif', 'webp', 'bmp',
           'doc', 'docx', 'xls', 'xlsx', 'pptx',
           'py', 'js', 'ts', 'dart', 'html', 'css',
           'zip', 'tar', 'gz',
@@ -91,6 +127,10 @@ class _ChatInputState extends State<ChatInput> {
     }
   }
 
+  void _showUrlDialog() {
+    // TODO: implement URL insertion dialog
+  }
+
   @override
   void dispose() {
     _ownController?.dispose();
@@ -117,26 +157,79 @@ class _ChatInputState extends State<ChatInput> {
       ),
       child: Row(
         children: [
-          // Attach file button
-          if (widget.onFile != null)
-            _isUploading
-                ? const Padding(
-                    padding: EdgeInsets.all(12),
-                    child: SizedBox(
-                      width: 18,
-                      height: 18,
-                      child: CircularProgressIndicator(strokeWidth: 2),
-                    ),
-                  )
-                : IconButton(
-                    onPressed: widget.isProcessing ? null : _pickFile,
-                    icon: Icon(
-                      Icons.attach_file,
-                      color: CognithorTheme.textSecondary,
-                    ),
-                    tooltip: l.attachFile,
-                    iconSize: 22,
+          // Attach file / media button
+          if (_isUploading)
+            const Padding(
+              padding: EdgeInsets.all(12),
+              child: SizedBox(
+                width: 18,
+                height: 18,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              ),
+            )
+          else
+            PopupMenuButton<String>(
+              key: const ValueKey('chat-input-paperclip'),
+              icon: Icon(Icons.attach_file, color: CognithorTheme.textSecondary),
+              iconSize: 22,
+              tooltip: l.attachFile,
+              enabled: !widget.isProcessing,
+              onSelected: (value) async {
+                switch (value) {
+                  case 'image':
+                    await _pickImage();
+                    break;
+                  case 'video':
+                    await _pickVideo();
+                    break;
+                  case 'file':
+                    await _pickFile();
+                    break;
+                  case 'url':
+                    _showUrlDialog();
+                    break;
+                }
+              },
+              itemBuilder: (context) {
+                final activeBackend =
+                    context.read<LlmBackendProvider>().active;
+                final vllmActive = activeBackend == 'vllm';
+                return [
+                  const PopupMenuItem<String>(
+                    value: 'image',
+                    child: Text('Bild hochladen'),
                   ),
+                  PopupMenuItem<String>(
+                    value: 'video',
+                    enabled: vllmActive,
+                    child: Tooltip(
+                      message: vllmActive
+                          ? 'Video hochladen (nur mit vLLM-Backend)'
+                          : 'Video-Analyse erfordert vLLM — unter Settings → LLM Backends wechseln.',
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Text('Video hochladen'),
+                          if (!vllmActive)
+                            const Padding(
+                              padding: EdgeInsets.only(left: 6),
+                              child: Icon(Icons.lock, size: 14, color: Colors.grey),
+                            ),
+                        ],
+                      ),
+                    ),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: 'file',
+                    child: Text('Datei hochladen'),
+                  ),
+                  const PopupMenuItem<String>(
+                    value: 'url',
+                    child: Text('URL einfügen'),
+                  ),
+                ];
+              },
+            ),
 
           // Text field
           Expanded(

--- a/flutter_app/lib/widgets/chat_input.dart
+++ b/flutter_app/lib/widgets/chat_input.dart
@@ -4,6 +4,7 @@ import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:cognithor_ui/l10n/generated/app_localizations.dart';
+import 'package:cognithor_ui/providers/chat_provider.dart';
 import 'package:cognithor_ui/providers/llm_backend_provider.dart';
 import 'package:cognithor_ui/providers/voice_provider.dart';
 import 'package:cognithor_ui/theme/cognithor_theme.dart';
@@ -87,7 +88,24 @@ class _ChatInputState extends State<ChatInput> {
   }
 
   Future<void> _pickVideo() async {
-    // Implemented in Task 18 — connects ChatProvider.sendVideo
+    final result = await FilePicker.platform.pickFiles(
+      type: FileType.custom,
+      allowedExtensions: ['mp4', 'webm', 'mov', 'mkv', 'avi'],
+      withData: false,
+    );
+    if (result == null || result.files.isEmpty) return;
+    final file = result.files.first;
+    if (file.path == null) return;
+    if (!mounted) return;
+    try {
+      await context.read<ChatProvider>().sendVideo(file.path!, file.name);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Video upload fehlgeschlagen: $e')),
+        );
+      }
+    }
   }
 
   Future<void> _pickFile() async {

--- a/flutter_app/lib/widgets/chat_input.dart
+++ b/flutter_app/lib/widgets/chat_input.dart
@@ -48,6 +48,11 @@ class _ChatInputState extends State<ChatInput> {
       widget.focusNode ?? (_ownFocusNode ??= FocusNode());
 
   void _submit() {
+    // Guard against the send-during-upload race: if a video upload is
+    // still in flight, _pendingVideoAttachment is not yet populated,
+    // so letting the text message go now would orphan the video onto
+    // the NEXT message. See C2 regression test.
+    if (_isUploading) return;
     final text = _controller.text.trim();
     if (text.isEmpty) return;
     widget.onSend(text);
@@ -97,6 +102,11 @@ class _ChatInputState extends State<ChatInput> {
     final file = result.files.first;
     if (file.path == null) return;
     if (!mounted) return;
+    // Track the upload in _isUploading so the Send button and the
+    // _submit() guard can both block user input while the multipart
+    // POST is in flight — otherwise a quick Enter ships a naked text
+    // message and orphans the pending video onto the NEXT message.
+    setState(() => _isUploading = true);
     try {
       await context.read<ChatProvider>().sendVideo(file.path!, file.name);
     } catch (e) {
@@ -105,6 +115,8 @@ class _ChatInputState extends State<ChatInput> {
           SnackBar(content: Text('Video upload fehlgeschlagen: $e')),
         );
       }
+    } finally {
+      if (mounted) setState(() => _isUploading = false);
     }
   }
 
@@ -307,9 +319,15 @@ class _ChatInputState extends State<ChatInput> {
             )
           else
             IconButton(
-              onPressed: _submit,
-              icon: Icon(Icons.send, color: CognithorTheme.accent),
-              tooltip: l.send,
+              onPressed: _isUploading ? null : _submit,
+              icon: _isUploading
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : Icon(Icons.send, color: CognithorTheme.accent),
+              tooltip: _isUploading ? 'Upload läuft…' : l.send,
             ),
         ],
       ),

--- a/flutter_app/pubspec.lock
+++ b/flutter_app/pubspec.lock
@@ -886,7 +886,7 @@ packages:
     source: hosted
     version: "3.1.6"
   plugin_platform_interface:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: plugin_platform_interface
       sha256: "4820fbfdb9478b1ebae27888254d445073732dae3d6ea81f0b7e06d5dedc3f02"

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -76,6 +76,10 @@ dev_dependencies:
   # rules and activating additional ones.
   flutter_lints: ^6.0.0
 
+  # Needed by chat_input_upload_race_test to mock FilePicker.platform via
+  # MockPlatformInterfaceMixin (bypasses the platform-interface token check).
+  plugin_platform_interface: ^2.1.0
+
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.92.6+1
+version: 0.92.7+1
 
 environment:
   sdk: ^3.11.1

--- a/flutter_app/test/providers/chat_provider_video_test.dart
+++ b/flutter_app/test/providers/chat_provider_video_test.dart
@@ -41,5 +41,37 @@ void main() {
       final p = ChatProvider();
       expect(p.handlePastedTextForVideoUrl('https://x.com/clip.MP4'), isTrue);
     });
+
+    test('strips query string from filename but preserves full URL', () {
+      final p = ChatProvider();
+      final ok = p.handlePastedTextForVideoUrl(
+        'https://cdn.example.com/clip.mp4?token=abc&exp=12345',
+      );
+      expect(ok, isTrue);
+      expect(
+        p.pendingVideoAttachment!['url'],
+        'https://cdn.example.com/clip.mp4?token=abc&exp=12345',
+      );
+      expect(p.pendingVideoAttachment!['filename'], 'clip.mp4');
+    });
+
+    test('strips fragment from filename', () {
+      final p = ChatProvider();
+      final ok = p.handlePastedTextForVideoUrl(
+        'https://x.com/video.webm#t=10,20',
+      );
+      expect(ok, isTrue);
+      expect(p.pendingVideoAttachment!['filename'], 'video.webm');
+    });
+
+    test('strips both query and fragment from filename', () {
+      final p = ChatProvider();
+      final ok = p.handlePastedTextForVideoUrl(
+        'https://x.com/clip.mov?x=1#frag',
+      );
+      expect(ok, isTrue);
+      expect(p.pendingVideoAttachment!['filename'], 'clip.mov');
+      expect(p.pendingVideoAttachment!['url'], 'https://x.com/clip.mov?x=1#frag');
+    });
   });
 }

--- a/flutter_app/test/providers/chat_provider_video_test.dart
+++ b/flutter_app/test/providers/chat_provider_video_test.dart
@@ -1,0 +1,45 @@
+import 'package:cognithor_ui/providers/chat_provider.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('handlePastedTextForVideoUrl', () {
+    test('recognizes mp4 URL and populates pendingVideoAttachment', () {
+      final p = ChatProvider();
+      final ok =
+          p.handlePastedTextForVideoUrl('https://example.com/clip.mp4');
+      expect(ok, isTrue);
+      expect(p.pendingVideoAttachment, isNotNull);
+      expect(p.pendingVideoAttachment!['url'], 'https://example.com/clip.mp4');
+      expect(p.pendingVideoAttachment!['filename'], 'clip.mp4');
+    });
+
+    test('recognizes webm / mov / mkv / avi', () {
+      final p = ChatProvider();
+      for (final ext in ['webm', 'mov', 'mkv', 'avi']) {
+        p.clearPendingVideo();
+        final ok = p.handlePastedTextForVideoUrl('https://x.com/a.$ext');
+        expect(ok, isTrue, reason: ext);
+        expect(p.pendingVideoAttachment, isNotNull, reason: ext);
+      }
+    });
+
+    test('rejects non-video URL', () {
+      final p = ChatProvider();
+      expect(
+          p.handlePastedTextForVideoUrl('https://example.com/page.html'),
+          isFalse);
+      expect(p.pendingVideoAttachment, isNull);
+    });
+
+    test('rejects plain text', () {
+      final p = ChatProvider();
+      expect(
+          p.handlePastedTextForVideoUrl('just typing a sentence'), isFalse);
+    });
+
+    test('case-insensitive extension match', () {
+      final p = ChatProvider();
+      expect(p.handlePastedTextForVideoUrl('https://x.com/clip.MP4'), isTrue);
+    });
+  });
+}

--- a/flutter_app/test/widgets/chat_bubble_video_test.dart
+++ b/flutter_app/test/widgets/chat_bubble_video_test.dart
@@ -1,0 +1,66 @@
+import 'package:cognithor_ui/providers/chat_provider.dart';
+import 'package:cognithor_ui/widgets/chat_bubble.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  testWidgets('video-kind metadata renders filename + duration + sampling',
+      (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: ChatBubble(
+          role: MessageRole.user,
+          text: 'Was siehst du?',
+          metadata: {
+            'kind': 'video',
+            'filename': 'drone.mp4',
+            'duration_sec': 42.5,
+            'sampling': {'fps': 2.0},
+            'thumb_url': null,
+          },
+        ),
+      ),
+    ));
+
+    expect(find.text('drone.mp4'), findsOneWidget);
+    expect(find.textContaining('0:42'), findsOneWidget);
+    expect(find.textContaining('fps=2'), findsOneWidget);
+  });
+
+  testWidgets('long-video banner appears when duration > 15 minutes',
+      (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: ChatBubble(
+          role: MessageRole.user,
+          text: 'Analyze',
+          metadata: {
+            'kind': 'video',
+            'filename': 'lecture.mp4',
+            'duration_sec': 2400.0,
+            'sampling': {'num_frames': 32},
+          },
+        ),
+      ),
+    ));
+    expect(find.byKey(const ValueKey('video-long-banner')), findsOneWidget);
+  });
+
+  testWidgets('short video shows no banner', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+      home: Scaffold(
+        body: ChatBubble(
+          role: MessageRole.user,
+          text: 'Kurzes Video',
+          metadata: {
+            'kind': 'video',
+            'filename': 'clip.mp4',
+            'duration_sec': 30.0,
+            'sampling': {'fps': 2.0},
+          },
+        ),
+      ),
+    ));
+    expect(find.byKey(const ValueKey('video-long-banner')), findsNothing);
+  });
+}

--- a/flutter_app/test/widgets/chat_input_upload_race_test.dart
+++ b/flutter_app/test/widgets/chat_input_upload_race_test.dart
@@ -1,0 +1,195 @@
+/// Regression test for Critical Bug C2: send-during-upload race.
+///
+/// When the user picks a video, [ChatProvider.sendVideo] starts a
+/// multipart POST that can take several seconds. During that window
+/// the user could hit Enter/Send and ship a naked text message that
+/// orphans the pending video onto the NEXT message.
+///
+/// The fix wires [_pickVideo] through [_isUploading] with try/finally
+/// (matching [_pickFile]) AND guards [_submit] against running while
+/// an upload is active. The Send [IconButton] is visually disabled
+/// (progress indicator, null onPressed) while the upload runs.
+library;
+import 'dart:async';
+
+import 'package:cognithor_ui/l10n/generated/app_localizations.dart';
+import 'package:cognithor_ui/providers/chat_provider.dart';
+import 'package:cognithor_ui/providers/llm_backend_provider.dart';
+import 'package:cognithor_ui/providers/voice_provider.dart';
+import 'package:cognithor_ui/widgets/chat_input.dart';
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:provider/provider.dart';
+
+/// Mock [FilePicker] platform that returns a single fake file. Uses
+/// [MockPlatformInterfaceMixin] so [FilePicker.platform = this] works
+/// without triggering the token verification exception.
+class _MockFilePicker extends FilePicker with MockPlatformInterfaceMixin {
+  @override
+  Future<FilePickerResult?> pickFiles({
+    String? dialogTitle,
+    String? initialDirectory,
+    FileType type = FileType.any,
+    List<String>? allowedExtensions,
+    dynamic onFileLoading,
+    bool allowCompression = true,
+    int compressionQuality = 30,
+    bool allowMultiple = false,
+    bool withData = false,
+    bool withReadStream = false,
+    bool lockParentWindow = false,
+    bool readSequential = false,
+  }) async {
+    return FilePickerResult([
+      PlatformFile(
+        name: 'dummy.mp4',
+        size: 1024,
+        path: '/tmp/dummy.mp4',
+      ),
+    ]);
+  }
+}
+
+/// Stub provider that hangs forever on [sendVideo] so the widget stays
+/// in the "uploading" state. We drive the race via Enter on the text
+/// field and assert that [sendMessage] is NOT called.
+class _StubChatProvider extends ChatProvider {
+  final Completer<void> uploadCompleter = Completer<void>();
+  int sendMessageCalls = 0;
+  int sendVideoCalls = 0;
+
+  @override
+  Future<void> sendVideo(String localPath, String filename) async {
+    sendVideoCalls++;
+    await uploadCompleter.future; // block like a slow multipart POST
+  }
+
+  @override
+  void sendMessage(String text) {
+    sendMessageCalls++;
+  }
+}
+
+Widget _wrap(Widget child, _StubChatProvider cp) {
+  final bp = LlmBackendProvider(apiBaseUrl: 'http://test');
+  bp.active = 'vllm';
+  return MaterialApp(
+    localizationsDelegates: const [
+      AppLocalizations.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+    ],
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: MultiProvider(
+        providers: [
+          ChangeNotifierProvider<ChatProvider>.value(value: cp),
+          ChangeNotifierProvider<LlmBackendProvider>.value(value: bp),
+          ChangeNotifierProvider<VoiceProvider>(
+              create: (_) => VoiceProvider()),
+        ],
+        child: child,
+      ),
+    ),
+  );
+}
+
+void main() {
+  setUp(() {
+    FilePicker.platform = _MockFilePicker();
+  });
+
+  testWidgets(
+      'Send button is disabled with spinner while video upload is in progress',
+      (tester) async {
+    final cp = _StubChatProvider();
+    final sent = <String>[];
+    await tester.pumpWidget(
+      _wrap(ChatInput(onSend: sent.add, onCancel: () {}), cp),
+    );
+
+    // Precondition: Send icon visible, no progress indicator in the send slot.
+    expect(find.byIcon(Icons.send), findsOneWidget);
+
+    // Trigger _pickVideo via the paperclip menu.
+    await tester.tap(find.byKey(const ValueKey('chat-input-paperclip')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Video hochladen'));
+    // Let the mock picker resolve + the widget rebuild, but keep
+    // sendVideo blocked on the Completer.
+    await tester.pump();
+    await tester.pump();
+
+    expect(cp.sendVideoCalls, 1,
+        reason: 'sendVideo should have been invoked from _pickVideo');
+
+    // The Send icon must now be replaced by a CircularProgressIndicator.
+    expect(find.byIcon(Icons.send), findsNothing,
+        reason: 'Send icon should be hidden while uploading');
+    // Two progress indicators total: one in the paperclip slot, one
+    // replacing the Send icon.
+    expect(find.byType(CircularProgressIndicator), findsNWidgets(2));
+
+    // Locate the IconButton that previously held the Send icon. It is
+    // the last IconButton in the row; its onPressed must now be null.
+    final sendButton =
+        tester.widgetList<IconButton>(find.byType(IconButton)).last;
+    expect(sendButton.onPressed, isNull,
+        reason: 'Send button onPressed must be null while uploading');
+
+    // Simulate the user pressing Enter in the TextField (the bug path).
+    final textField = find.byType(TextField);
+    await tester.enterText(textField, 'hello');
+    await tester.testTextInput.receiveAction(TextInputAction.send);
+    await tester.pump();
+
+    expect(sent, isEmpty,
+        reason:
+            'onSend must not fire while upload is in progress (race guard)');
+
+    // Release the upload so the widget tears down cleanly.
+    cp.uploadCompleter.complete();
+    await tester.pumpAndSettle();
+  });
+
+  testWidgets(
+      'after upload completes, user can send text normally again',
+      (tester) async {
+    final cp = _StubChatProvider();
+    final sent = <String>[];
+    await tester.pumpWidget(
+      _wrap(ChatInput(onSend: sent.add, onCancel: () {}), cp),
+    );
+
+    // Kick off the upload.
+    await tester.tap(find.byKey(const ValueKey('chat-input-paperclip')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Video hochladen'));
+    await tester.pump();
+    await tester.pump();
+
+    // While uploading, pressing the Send IconButton must be a no-op
+    // because its onPressed is null.
+    final sendButton =
+        tester.widgetList<IconButton>(find.byType(IconButton)).last;
+    expect(sendButton.onPressed, isNull);
+
+    // Release the upload — _isUploading should flip back to false.
+    cp.uploadCompleter.complete();
+    await tester.pumpAndSettle();
+
+    // Send icon is back.
+    expect(find.byIcon(Icons.send), findsOneWidget);
+
+    // Now typing + Enter should reach onSend exactly once.
+    await tester.enterText(find.byType(TextField), 'hello');
+    await tester.testTextInput.receiveAction(TextInputAction.send);
+    await tester.pump();
+
+    expect(sent, ['hello'],
+        reason: 'onSend should fire once the upload finishes and flag resets');
+  });
+}

--- a/flutter_app/test/widgets/chat_input_video_menu_test.dart
+++ b/flutter_app/test/widgets/chat_input_video_menu_test.dart
@@ -1,0 +1,81 @@
+import 'package:cognithor_ui/l10n/generated/app_localizations.dart';
+import 'package:cognithor_ui/providers/chat_provider.dart';
+import 'package:cognithor_ui/providers/llm_backend_provider.dart';
+import 'package:cognithor_ui/providers/voice_provider.dart';
+import 'package:cognithor_ui/widgets/chat_input.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:provider/provider.dart';
+
+LlmBackendProvider _mkBackendProvider(String active) {
+  final p = LlmBackendProvider(apiBaseUrl: 'http://test');
+  p.active = active;
+  return p;
+}
+
+ChatProvider _mkChatProvider() {
+  return ChatProvider();
+}
+
+Widget _wrap(Widget child, LlmBackendProvider bp, ChatProvider cp) {
+  return MaterialApp(
+    localizationsDelegates: const [
+      AppLocalizations.delegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate,
+    ],
+    supportedLocales: AppLocalizations.supportedLocales,
+    home: Scaffold(
+      body: MultiProvider(
+        providers: [
+          ChangeNotifierProvider<LlmBackendProvider>.value(value: bp),
+          ChangeNotifierProvider<ChatProvider>.value(value: cp),
+          ChangeNotifierProvider<VoiceProvider>(create: (_) => VoiceProvider()),
+        ],
+        child: child,
+      ),
+    ),
+  );
+}
+
+void main() {
+  testWidgets('paperclip opens popup menu with 4 entries', (tester) async {
+    final bp = _mkBackendProvider('vllm');
+    final cp = _mkChatProvider();
+    await tester.pumpWidget(_wrap(
+      ChatInput(onSend: (_) {}, onCancel: () {}),
+      bp,
+      cp,
+    ));
+
+    await tester.tap(find.byKey(const ValueKey('chat-input-paperclip')));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Bild hochladen'), findsOneWidget);
+    expect(find.text('Video hochladen'), findsOneWidget);
+    expect(find.text('Datei hochladen'), findsOneWidget);
+    expect(find.text('URL einfügen'), findsOneWidget);
+  });
+
+  testWidgets('Video entry disabled when active backend != vllm', (tester) async {
+    final bp = _mkBackendProvider('ollama');
+    final cp = _mkChatProvider();
+    await tester.pumpWidget(_wrap(
+      ChatInput(onSend: (_) {}, onCancel: () {}),
+      bp,
+      cp,
+    ));
+
+    await tester.tap(find.byKey(const ValueKey('chat-input-paperclip')));
+    await tester.pumpAndSettle();
+
+    final videoItem = tester.widget<PopupMenuItem<String>>(
+      find.ancestor(
+        of: find.text('Video hochladen'),
+        matching: find.byType(PopupMenuItem<String>),
+      ),
+    );
+    expect(videoItem.enabled, isFalse);
+  });
+}

--- a/flutter_app/test/widgets/chat_input_video_menu_test.dart
+++ b/flutter_app/test/widgets/chat_input_video_menu_test.dart
@@ -78,4 +78,63 @@ void main() {
     );
     expect(videoItem.enabled, isFalse);
   });
+
+  testWidgets('URL dialog accepts valid video URL and sets pending attachment',
+      (tester) async {
+    final bp = _mkBackendProvider('vllm');
+    final cp = _mkChatProvider();
+    await tester.pumpWidget(_wrap(
+      ChatInput(onSend: (_) {}, onCancel: () {}),
+      bp,
+      cp,
+    ));
+
+    await tester.tap(find.byKey(const ValueKey('chat-input-paperclip')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('URL einfügen'));
+    await tester.pumpAndSettle();
+
+    // Dialog should be open (title + menu entry both contain "URL einfügen")
+    expect(find.text('URL einfügen'), findsAtLeastNWidgets(1));
+    // Scope the TextField lookup to the dialog — the ChatInput's own
+    // TextField is also in the tree.
+    final dialogField = find.descendant(
+      of: find.byType(AlertDialog),
+      matching: find.byType(TextField),
+    );
+    expect(dialogField, findsOneWidget);
+
+    await tester.enterText(dialogField, 'https://x.com/clip.mp4');
+    await tester.tap(find.text('Hinzufügen'));
+    await tester.pumpAndSettle();
+
+    expect(cp.pendingVideoAttachment, isNotNull);
+    expect(cp.pendingVideoAttachment!['url'], 'https://x.com/clip.mp4');
+  });
+
+  testWidgets('URL dialog rejects non-video URL with snackbar', (tester) async {
+    final bp = _mkBackendProvider('vllm');
+    final cp = _mkChatProvider();
+    await tester.pumpWidget(_wrap(
+      ChatInput(onSend: (_) {}, onCancel: () {}),
+      bp,
+      cp,
+    ));
+
+    await tester.tap(find.byKey(const ValueKey('chat-input-paperclip')));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('URL einfügen'));
+    await tester.pumpAndSettle();
+
+    final dialogField = find.descendant(
+      of: find.byType(AlertDialog),
+      matching: find.byType(TextField),
+    );
+    await tester.enterText(dialogField, 'https://example.com/page.html');
+    await tester.tap(find.text('Hinzufügen'));
+    await tester.pumpAndSettle();
+
+    expect(find.textContaining('Ungültige URL'), findsOneWidget);
+    expect(cp.pendingVideoAttachment, isNull);
+  });
 }

--- a/flutter_app/test/widgets/chat_input_video_menu_test.dart
+++ b/flutter_app/test/widgets/chat_input_video_menu_test.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:cognithor_ui/l10n/generated/app_localizations.dart';
 import 'package:cognithor_ui/providers/chat_provider.dart';
 import 'package:cognithor_ui/providers/llm_backend_provider.dart';
@@ -136,5 +138,26 @@ void main() {
 
     expect(find.textContaining('Ungültige URL'), findsOneWidget);
     expect(cp.pendingVideoAttachment, isNull);
+  });
+
+  test('URL dialog disposes TextEditingController to prevent leak', () {
+    // Source-level regression: this is the simplest way to prove the fix
+    // stays in place. A missing dispose() would leak one controller per
+    // dialog open. Bug I2-r3 was fixed by moving the controller into a
+    // StatefulWidget (`_UrlInputDialog`) whose State.dispose() releases it.
+    final source = File('lib/widgets/chat_input.dart').readAsStringSync();
+
+    // Source must still allocate a TextEditingController for the URL input.
+    expect(source.contains('TextEditingController()'), isTrue,
+        reason: 'URL dialog must allocate a TextEditingController');
+
+    // Scope the dispose check to the stateful URL-input dialog widget.
+    final urlDialogStart = source.indexOf('_UrlInputDialogState');
+    expect(urlDialogStart, greaterThan(-1),
+        reason: '_UrlInputDialogState must own the controller lifecycle');
+
+    final tail = source.substring(urlDialogStart);
+    expect(tail.contains('controller.dispose()'), isTrue,
+        reason: 'Dialog must dispose its TextEditingController (Bug I2-r3)');
   });
 }

--- a/flutter_app/test/widgets/chat_input_video_menu_test.dart
+++ b/flutter_app/test/widgets/chat_input_video_menu_test.dart
@@ -160,4 +160,29 @@ void main() {
     expect(tail.contains('controller.dispose()'), isTrue,
         reason: 'Dialog must dispose its TextEditingController (Bug I2-r3)');
   });
+
+  test('chat_input does not allocate FocusNode inline in build()', () {
+    final source = File('lib/widgets/chat_input.dart').readAsStringSync();
+
+    // Find the build() method body. A robust way: find the first occurrence
+    // of "Widget build(BuildContext context)" and scan forward.
+    final buildStart = source.indexOf('Widget build(BuildContext context)');
+    expect(buildStart, greaterThan(-1),
+        reason: 'ChatInput must have a build() method');
+
+    // Take everything from build() to the end of the method — rough, but
+    // enough: the next top-level `Widget ` or end-of-class is the boundary.
+    final rest = source.substring(buildStart);
+    final buildEnd = rest.indexOf('\n  }');  // state-class indent + closing brace
+    final buildBody = buildEnd == -1 ? rest : rest.substring(0, buildEnd);
+
+    expect(
+      buildBody.contains('FocusNode()'),
+      isFalse,
+      reason:
+          'FocusNode() must not be allocated inline in build() — it leaks '
+          'on every rebuild. Promote to a state field disposed in dispose() '
+          '(Bug-2 round 4).',
+    );
+  });
 }

--- a/installer/auto_upgrade.py
+++ b/installer/auto_upgrade.py
@@ -57,7 +57,7 @@ def _compare_versions(a: str, b: str) -> int:
         return [int(x) for x in re.findall(r"\d+", v)]
 
     pa, pb = parts(a), parts(b)
-    for x, y in zip(pa, pb):
+    for x, y in zip(pa, pb, strict=False):
         if x != y:
             return x - y
     return len(pa) - len(pb)

--- a/installer/build_installer.py
+++ b/installer/build_installer.py
@@ -323,7 +323,8 @@ def step_ffmpeg() -> Path:
             print(f"  [OK] ffmpeg/bin/ normalized (was {wrapped_bins[0]})")
         else:
             raise RuntimeError(
-                f"Unexpected ffmpeg archive layout — found {len(wrapped_bins)} bin dirs: {wrapped_bins}"
+                f"Unexpected ffmpeg archive layout — "
+                f"found {len(wrapped_bins)} bin dirs: {wrapped_bins}"
             )
 
     # Verify the build is LGPL (not GPL)

--- a/installer/build_installer.py
+++ b/installer/build_installer.py
@@ -291,9 +291,12 @@ def step_ffmpeg() -> Path:
 
     dest_zip = BUILD_DIR / "downloads" / "ffmpeg.zip"
     extract_dir = BUILD_DIR / "ffmpeg"
+    # Canonical path expected by the .iss — no subfolder, Inno Setup's
+    # directory wildcard semantics are brittle on nested patterns.
+    canonical_bin = extract_dir / "bin"
 
-    if extract_dir.exists():
-        print("  [SKIP] ffmpeg/ already extracted")
+    if canonical_bin.exists() and (canonical_bin / "ffmpeg.exe").is_file():
+        print("  [SKIP] ffmpeg/bin/ already normalized")
     else:
         download(FFMPEG_LGPL_URL, dest_zip, "ffmpeg LGPL build")
         extract_dir.mkdir(parents=True, exist_ok=True)
@@ -301,23 +304,47 @@ def step_ffmpeg() -> Path:
             z.extractall(extract_dir)
         print("  [OK] ffmpeg extracted")
 
-    # BtbN archives have a single top-level folder; find bin/ffmpeg.exe
-    for p in extract_dir.rglob("ffmpeg.exe"):
-        result = subprocess.run([str(p), "-version"], capture_output=True, text=True, check=False)
-        combined = result.stdout + result.stderr
-        first_config_line = next(
-            (line for line in combined.splitlines() if "configuration" in line), ""
-        )
-        if "--enable-gpl" in first_config_line:
+        # BtbN archives wrap everything in a single top-level folder like
+        # `ffmpeg-master-latest-win64-lgpl-shared/`. Flatten it so the .iss
+        # can reference `build\ffmpeg\bin\*.exe` without wildcards.
+        wrapped_bins = list(extract_dir.glob("*/bin"))
+        if not wrapped_bins:
+            # Already flat — nothing to do
+            pass
+        elif len(wrapped_bins) == 1:
+            src_bin = wrapped_bins[0]
+            if canonical_bin.exists():
+                shutil.rmtree(canonical_bin)
+            shutil.move(str(src_bin), str(canonical_bin))
+            # Clean up the now-empty wrapper dir
+            wrapper = src_bin.parent
+            if wrapper.is_dir() and not any(wrapper.iterdir()):
+                wrapper.rmdir()
+            print(f"  [OK] ffmpeg/bin/ normalized (was {wrapped_bins[0]})")
+        else:
             raise RuntimeError(
-                f"Downloaded ffmpeg is a GPL build (configuration: "
-                f"{first_config_line!r}). GPL would contaminate "
-                "Cognithor's Apache-2.0 license. Use the LGPL variant."
+                f"Unexpected ffmpeg archive layout — found {len(wrapped_bins)} bin dirs: {wrapped_bins}"
             )
-        print(f"  [OK] ffmpeg bin: {p.parent}")
-        return p.parent  # bin/
 
-    raise RuntimeError("ffmpeg.exe not found after extraction")
+    # Verify the build is LGPL (not GPL)
+    ffmpeg_exe = canonical_bin / "ffmpeg.exe"
+    if not ffmpeg_exe.is_file():
+        raise RuntimeError(f"ffmpeg.exe not found at canonical path: {ffmpeg_exe}")
+    result = subprocess.run(
+        [str(ffmpeg_exe), "-version"], capture_output=True, text=True, check=False
+    )
+    combined = result.stdout + result.stderr
+    first_config_line = next(
+        (line for line in combined.splitlines() if "configuration" in line), ""
+    )
+    if "--enable-gpl" in first_config_line:
+        raise RuntimeError(
+            f"Downloaded ffmpeg is a GPL build (configuration: "
+            f"{first_config_line!r}). GPL would contaminate "
+            "Cognithor's Apache-2.0 license. Use the LGPL variant."
+        )
+    print(f"  [OK] ffmpeg bin: {canonical_bin}")
+    return canonical_bin
 
 
 def step_launcher() -> Path:

--- a/installer/build_installer.py
+++ b/installer/build_installer.py
@@ -37,6 +37,11 @@ PROJECT_ROOT = Path(__file__).resolve().parent.parent
 BUILD_DIR = PROJECT_ROOT / "installer" / "build"
 DIST_DIR = PROJECT_ROOT / "installer" / "dist"
 
+FFMPEG_LGPL_URL = (
+    "https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/"
+    "ffmpeg-master-latest-win64-lgpl-shared.zip"
+)
+
 COGNITHOR_VERSION = None  # read from pyproject.toml
 
 
@@ -275,6 +280,46 @@ def step_flutter_desktop() -> Path | None:
     return None
 
 
+def step_ffmpeg() -> Path:
+    """Step 3c: Download BtbN's LGPL-licensed ffmpeg+ffprobe build and return the bin dir.
+
+    Raises RuntimeError if the downloaded build is accidentally GPL — GPL would
+    contaminate Cognithor's Apache-2.0 license. Verified via the ``--enable-gpl``
+    check in ffmpeg's self-reported configuration.
+    """
+    print("\n=== Step 3c: ffmpeg (LGPL) ===")
+
+    dest_zip = BUILD_DIR / "downloads" / "ffmpeg.zip"
+    extract_dir = BUILD_DIR / "ffmpeg"
+
+    if extract_dir.exists():
+        print("  [SKIP] ffmpeg/ already extracted")
+    else:
+        download(FFMPEG_LGPL_URL, dest_zip, "ffmpeg LGPL build")
+        extract_dir.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(dest_zip) as z:
+            z.extractall(extract_dir)
+        print("  [OK] ffmpeg extracted")
+
+    # BtbN archives have a single top-level folder; find bin/ffmpeg.exe
+    for p in extract_dir.rglob("ffmpeg.exe"):
+        result = subprocess.run([str(p), "-version"], capture_output=True, text=True, check=False)
+        combined = result.stdout + result.stderr
+        first_config_line = next(
+            (line for line in combined.splitlines() if "configuration" in line), ""
+        )
+        if "--enable-gpl" in first_config_line:
+            raise RuntimeError(
+                f"Downloaded ffmpeg is a GPL build (configuration: "
+                f"{first_config_line!r}). GPL would contaminate "
+                "Cognithor's Apache-2.0 license. Use the LGPL variant."
+            )
+        print(f"  [OK] ffmpeg bin: {p.parent}")
+        return p.parent  # bin/
+
+    raise RuntimeError("ffmpeg.exe not found after extraction")
+
+
 def step_launcher() -> Path:
     """Step 4: Create launcher batch script."""
     print("\n=== Step 4: Launcher ===")
@@ -300,7 +345,7 @@ def step_launcher() -> Path:
         'if "!PYTHON!"=="" (\r\n'
         "    where python >nul 2>&1\r\n"
         "    if not errorlevel 1 (\r\n"
-        '        for /f "delims=" %%P in (\'where python\') do (\r\n'
+        "        for /f \"delims=\" %%P in ('where python') do (\r\n"
         '            if "!PYTHON!"=="" set "PYTHON=%%P"\r\n'
         "        )\r\n"
         "    )\r\n"
@@ -520,7 +565,9 @@ def step_inno_setup(
         reverse=True,
     )
     if installers:
-        print(f"  [OK] Installer: {installers[0]} ({installers[0].stat().st_size / 1024 / 1024:.0f} MB)")
+        print(
+            f"  [OK] Installer: {installers[0]} ({installers[0].stat().st_size / 1024 / 1024:.0f} MB)"
+        )
         return installers[0]
 
     return Path("")
@@ -556,6 +603,7 @@ def main() -> int:
 
     python_dir = step_python_embed()
     ollama_dir = step_ollama()
+    step_ffmpeg()
 
     if skip_flutter:
         flutter_dir = BUILD_DIR / "flutter_web" if (BUILD_DIR / "flutter_web").exists() else None

--- a/installer/build_installer.py
+++ b/installer/build_installer.py
@@ -241,7 +241,7 @@ def step_flutter_desktop() -> Path | None:
         if dest.exists():
             shutil.rmtree(dest)
         shutil.copytree(desktop_build, dest)
-        print(f"  [OK] Pre-built Flutter desktop copied")
+        print("  [OK] Pre-built Flutter desktop copied")
         return dest
 
     flutter_bin = shutil.which("flutter")
@@ -341,7 +341,8 @@ def step_launcher() -> Path:
         "REM   2. `python` / `py` on PATH\r\n"
         "REM   3. Well-known install paths (user+machine, 3.13/3.12)\r\n"
         'set "PYTHON="\r\n'
-        'if exist "%COGNITHOR_HOME%python\\python.exe" set "PYTHON=%COGNITHOR_HOME%python\\python.exe"\r\n'
+        'if exist "%COGNITHOR_HOME%python\\python.exe" '
+        'set "PYTHON=%COGNITHOR_HOME%python\\python.exe"\r\n'
         'if "!PYTHON!"=="" (\r\n'
         "    where python >nul 2>&1\r\n"
         "    if not errorlevel 1 (\r\n"
@@ -425,7 +426,8 @@ def step_launcher() -> Path:
         '    if exist "%PYTHONW%" (\r\n'
         '        start "" "%PYTHONW%" -m cognithor --no-cli --api-port 8741\r\n'
         "    ) else (\r\n"
-        '        start "Cognithor Server" cmd /k ""%PYTHON%" -m cognithor --no-cli --api-port 8741"\r\n'
+        '        start "Cognithor Server" '
+        'cmd /k ""%PYTHON%" -m cognithor --no-cli --api-port 8741"\r\n'
         "    )\r\n"
         "    echo Waiting for Cognithor to start...\r\n"
         "    set RETRIES=0\r\n"
@@ -566,7 +568,8 @@ def step_inno_setup(
     )
     if installers:
         print(
-            f"  [OK] Installer: {installers[0]} ({installers[0].stat().st_size / 1024 / 1024:.0f} MB)"
+            f"  [OK] Installer: {installers[0]} "
+            f"({installers[0].stat().st_size / 1024 / 1024:.0f} MB)"
         )
         return installers[0]
 

--- a/installer/cognithor.iss
+++ b/installer/cognithor.iss
@@ -79,6 +79,11 @@ Source: "{#BuildDir}\Cognithor.exe"; DestDir: "{app}"; Components: core; Flags: 
 ; Ollama
 Source: "{#OllamaDir}\*"; DestDir: "{app}\ollama"; Components: ollama; Flags: ignoreversion recursesubdirs createallsubdirs
 
+; ffmpeg (LGPL) — video input support
+Source: "build\ffmpeg\*\bin\ffmpeg.exe"; DestDir: "{localappdata}\Cognithor\ffmpeg"; Flags: ignoreversion
+Source: "build\ffmpeg\*\bin\ffprobe.exe"; DestDir: "{localappdata}\Cognithor\ffmpeg"; Flags: ignoreversion
+Source: "build\ffmpeg\*\bin\*.dll"; DestDir: "{localappdata}\Cognithor\ffmpeg"; Flags: ignoreversion skipifsourcedoesntexist
+
 ; Flutter UI — web build (served via backend)
 Source: "{#BuildDir}\flutter_web\*"; DestDir: "{app}\flutter_app\web"; Components: flutter; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist
 

--- a/installer/cognithor.iss
+++ b/installer/cognithor.iss
@@ -79,10 +79,11 @@ Source: "{#BuildDir}\Cognithor.exe"; DestDir: "{app}"; Components: core; Flags: 
 ; Ollama
 Source: "{#OllamaDir}\*"; DestDir: "{app}\ollama"; Components: ollama; Flags: ignoreversion recursesubdirs createallsubdirs
 
-; ffmpeg (LGPL) — video input support
-Source: "build\ffmpeg\*\bin\ffmpeg.exe"; DestDir: "{localappdata}\Cognithor\ffmpeg"; Flags: ignoreversion
-Source: "build\ffmpeg\*\bin\ffprobe.exe"; DestDir: "{localappdata}\Cognithor\ffmpeg"; Flags: ignoreversion
-Source: "build\ffmpeg\*\bin\*.dll"; DestDir: "{localappdata}\Cognithor\ffmpeg"; Flags: ignoreversion skipifsourcedoesntexist
+; ffmpeg (LGPL) — video input support. step_ffmpeg flattens the BtbN archive
+; to build\ffmpeg\bin\ so the paths below are literal (no directory wildcard).
+Source: "build\ffmpeg\bin\ffmpeg.exe"; DestDir: "{localappdata}\Cognithor\ffmpeg"; Flags: ignoreversion
+Source: "build\ffmpeg\bin\ffprobe.exe"; DestDir: "{localappdata}\Cognithor\ffmpeg"; Flags: ignoreversion
+Source: "build\ffmpeg\bin\*.dll"; DestDir: "{localappdata}\Cognithor\ffmpeg"; Flags: ignoreversion skipifsourcedoesntexist
 
 ; Flutter UI — web build (served via backend)
 Source: "{#BuildDir}\flutter_web\*"; DestDir: "{app}\flutter_app\web"; Components: flutter; Flags: ignoreversion recursesubdirs createallsubdirs skipifsourcedoesntexist

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cognithor"
-version = "0.92.6"
+version = "0.92.7"
 description = "Cognithor · Agent OS — Local-first autonomous agent operating system"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -240,6 +240,7 @@ ignore = [
 "__init__.py" = ["F401"]  # Re-exports in __init__.py are intentional
 "tests/test_install_fixes.py" = ["E501"]  # Embedded shell/JS scripts in strings
 "tests/test_packs/test_installer.py" = ["TC003"]  # Path used in runtime test bodies via pytest fixtures
+"tests/test_gateway/test_video_cleanup.py" = ["TC003"]  # Path used in runtime test bodies via pytest fixtures
 
 [tool.mypy]
 python_version = "3.12"

--- a/scripts/live_smoke_test.py
+++ b/scripts/live_smoke_test.py
@@ -503,7 +503,9 @@ async def main() -> int:
         results["LLM Direkte Antwort"] = await test_llm_direct_response(
             cognithor_home, args.model, args.verbose
         )
-        results["LLM Tool-Plan"] = await test_llm_tool_plan(cognithor_home, args.model, args.verbose)
+        results["LLM Tool-Plan"] = await test_llm_tool_plan(
+            cognithor_home, args.model, args.verbose
+        )
         results["Gateway E2E"] = await test_full_gateway(cognithor_home, args.model, args.verbose)
     elif args.skip_llm:
         print_step("⏭️", "LLM-Tests übersprungen (--skip-llm)")

--- a/scripts/rename_jarvis_to_cognithor.py
+++ b/scripts/rename_jarvis_to_cognithor.py
@@ -22,8 +22,6 @@ What it does NOT touch:
 
 from __future__ import annotations
 
-import os
-import re
 import subprocess
 import sys
 from pathlib import Path
@@ -43,7 +41,9 @@ stats: dict[str, int] = {
 }
 
 
-def replace_in_file(path: Path, replacements: list[tuple[str, str]], skip_patterns: list[str] | None = None) -> int:
+def replace_in_file(
+    path: Path, replacements: list[tuple[str, str]], skip_patterns: list[str] | None = None
+) -> int:
     """Apply replacements to a file. Returns count of replacements made."""
     try:
         content = path.read_text(encoding="utf-8")
@@ -95,7 +95,7 @@ def step_git_mv():
         sys.exit(1)
 
     subprocess.run(["git", "mv", str(src_jarvis), str(src_cognithor)], check=True, cwd=ROOT)
-    print(f"  [OK] Renamed src/jarvis/ -> src/cognithor/")
+    print("  [OK] Renamed src/jarvis/ -> src/cognithor/")
 
 
 def step_python_imports():
@@ -183,7 +183,7 @@ def step_home_paths():
         ('".jarvis"', '".cognithor"'),
         ("'.jarvis'", "'.cognithor'"),
         ("/.jarvis/", "/.cognithor/"),
-        ("/.jarvis\"", "/.cognithor\""),
+        ('/.jarvis"', '/.cognithor"'),
         ("\\.jarvis\\", "\\.cognithor\\"),
         ("~/.jarvis", "~/.cognithor"),
     ]
@@ -255,7 +255,9 @@ def step_pyproject():
     original = content
 
     # Package directory
-    content = content.replace('packages = ["src/jarvis"]', 'packages = ["src/cognithor", "src/jarvis"]')
+    content = content.replace(
+        'packages = ["src/jarvis"]', 'packages = ["src/cognithor", "src/jarvis"]'
+    )
 
     # Entry points: keep jarvis as alias, update module path
     content = content.replace(
@@ -294,11 +296,15 @@ def step_readme():
     ]
 
     # Do NOT replace "Jarvis" personality name or historical references
-    count = replace_in_file(readme, replacements, skip_patterns=[
-        "Think of it as",  # "local Jarvis" analogy
-        "personal",  # "personal AI assistant"
-        "Jarvis --",  # Banner
-    ])
+    count = replace_in_file(
+        readme,
+        replacements,
+        skip_patterns=[
+            "Think of it as",  # "local Jarvis" analogy
+            "personal",  # "personal AI assistant"
+            "Jarvis --",  # Banner
+        ],
+    )
     print(f"  [OK] {count} README replacements")
 
 
@@ -317,7 +323,7 @@ def step_compat_shim():
         "import warnings\n"
         "\n"
         "warnings.warn(\n"
-        '    "The \'jarvis\' package is deprecated. Use \'import cognithor\' instead.",\n'
+        "    \"The 'jarvis' package is deprecated. Use 'import cognithor' instead.\",\n"
         "    DeprecationWarning,\n"
         "    stacklevel=2,\n"
         ")\n"

--- a/scripts/spike/launch_qwen36_27b_nvfp4.sh
+++ b/scripts/spike/launch_qwen36_27b_nvfp4.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Launch Qwen3.6-27B-NVFP4 on cu130-nightly for RTX 5090 SM120.
+#
+# Critical flags:
+#  --enforce-eager       reduce CUDA-graph VRAM during init
+#  --gpu-memory-utilization 0.88   leave 3-4 GB headroom on 32 GB RTX 5090
+#  --max-model-len 32768 enough for 32 video frames at 1000 tokens each
+#  --reasoning-parser qwen3       required for Qwen3.6 thinking parse
+#  --trust-remote-code   required for Qwen3NextGatedDeltaNet custom arch
+#  --media-io-kwargs video.num_frames=-1  let video processor decide
+#
+# NVFP4 backend is auto-detected by vLLM on SM120 (falls back to flashinfer-cutlass).
+
+set -euo pipefail
+
+NAME=vllm-spike
+IMAGE=vllm/vllm-openai:cu130-nightly
+MODEL="mmangkad/Qwen3.6-27B-NVFP4"
+PORT=8765
+
+docker rm -f "$NAME" 2>/dev/null || true
+
+docker run -d --name "$NAME" --gpus all \
+  --add-host host.docker.internal:host-gateway \
+  -v cognithor-spike-hf-cache:/root/.cache/huggingface \
+  -p "$PORT":8000 \
+  "$IMAGE" \
+  --model "$MODEL" \
+  --max-model-len 16384 \
+  --max-num-seqs 2 \
+  --max-num-batched-tokens 2048 \
+  --gpu-memory-utilization 0.94 \
+  --cpu-offload-gb 4 \
+  --enforce-eager \
+  --reasoning-parser qwen3 \
+  --trust-remote-code \
+  --media-io-kwargs '{"video": {"num_frames": -1}}'
+
+echo "launched $NAME on port $PORT with image $IMAGE"

--- a/scripts/spike/test_fetch_allowlist.py
+++ b/scripts/spike/test_fetch_allowlist.py
@@ -1,0 +1,105 @@
+"""Spike test 2 — vLLM video_url fetch-allowlist policy.
+
+Sends three video_url completions from inside the spike container's
+perspective: a public HTTPS CDN URL, a localhost URL (host.docker.internal
+served by a tiny ad-hoc Python file-server), and a 127.0.0.1 URL that
+resolves inside the container (should fail). Records what vLLM fetches
+and what it blocks. This output tells us whether we need a per-request
+allowed_media_domains flag or if vLLM is fully permissive by default.
+"""
+
+from __future__ import annotations
+
+import http.server
+import os
+import socketserver
+import sys
+import tempfile
+import threading
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+BASE_URL = "http://127.0.0.1:8765/v1"
+PUBLIC_URL = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+MODEL_ID = os.environ.get("SPIKE_MODEL_ID", "QuantTrio/Qwen3.6-35B-A3B-AWQ")
+LOCAL_PORT = 8799
+LOCAL_HOST_CONTAINER = f"http://host.docker.internal:{LOCAL_PORT}/sample.mp4"
+LOCAL_HOST_LOOPBACK_IN_CONTAINER = f"http://127.0.0.1:{LOCAL_PORT}/sample.mp4"
+
+
+def start_file_server(serve_dir: Path) -> tuple[socketserver.TCPServer, threading.Thread]:
+    os.chdir(serve_dir)
+    handler = http.server.SimpleHTTPRequestHandler
+    server = socketserver.TCPServer(("0.0.0.0", LOCAL_PORT), handler)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    return server, t
+
+
+def prepare_sample_file(target: Path) -> None:
+    """Copy the public BigBuckBunny sample into a local file for serving."""
+    print(f"[prep] downloading {PUBLIC_URL} to {target}")
+    with httpx.Client(timeout=120.0, follow_redirects=True) as client:
+        with client.stream("GET", PUBLIC_URL) as r:
+            r.raise_for_status()
+            with target.open("wb") as f:
+                for chunk in r.iter_bytes(65536):
+                    f.write(chunk)
+    print(f"[prep] wrote {target.stat().st_size} bytes")
+
+
+def post_chat(video_url: str) -> tuple[int, str]:
+    payload: dict[str, Any] = {
+        "model": MODEL_ID,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "video_url", "video_url": {"url": video_url}},
+                    {"type": "text", "text": "Ein Satz zum Video."},
+                ],
+            }
+        ],
+        "max_tokens": 32,
+        "temperature": 0.0,
+    }
+    with httpx.Client(timeout=180.0) as client:
+        try:
+            r = client.post(f"{BASE_URL}/chat/completions", json=payload)
+            return r.status_code, r.text[:400]
+        except Exception as e:
+            return 0, f"EXC: {type(e).__name__}: {e}"
+
+
+def main() -> int:
+    serve_dir = Path(tempfile.mkdtemp(prefix="vllm-spike-"))
+    sample = serve_dir / "sample.mp4"
+    prepare_sample_file(sample)
+
+    server, _ = start_file_server(serve_dir)
+    print(f"[srv] local HTTP server on 0.0.0.0:{LOCAL_PORT}")
+    time.sleep(0.5)
+
+    try:
+        cases = [
+            ("public_https", PUBLIC_URL),
+            ("host_docker_internal", LOCAL_HOST_CONTAINER),
+            ("loopback_127_in_container", LOCAL_HOST_LOOPBACK_IN_CONTAINER),
+        ]
+        for name, url in cases:
+            print(f"=== {name}: {url}")
+            status, body = post_chat(url)
+            print(f"    -> status={status}")
+            print(f"    -> body={body[:300]}")
+            print()
+    finally:
+        server.shutdown()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/spike/test_ffprobe_timing.py
+++ b/scripts/spike/test_ffprobe_timing.py
@@ -76,7 +76,9 @@ def main() -> int:
                 if s.get("codec_type") == "video":
                     codec = s.get("codec_name")
                     break
-        p = Probe(name=name, url=url, wall_ms=wall, ok=ok, duration=dur, codec=codec, stderr_tail=err)
+        p = Probe(
+            name=name, url=url, wall_ms=wall, ok=ok, duration=dur, codec=codec, stderr_tail=err
+        )
         results.append(p)
         print(f"    wall={wall:.1f}ms ok={ok} dur={dur} codec={codec}")
         if err and not ok:

--- a/scripts/spike/test_ffprobe_timing.py
+++ b/scripts/spike/test_ffprobe_timing.py
@@ -1,0 +1,95 @@
+"""Spike test 3 — ffprobe HTTP timing budget.
+
+Runs ffprobe against five different URL types with three network conditions
+(local, nearby CDN, cold HF cache) and records wall-clock time. The spec
+assumed a 2s budget for pre-flight ffprobe; this test validates whether
+that budget is realistic over HTTP.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+
+URLS: dict[str, str] = {
+    "public_small_cdn": "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerBlazes.mp4",
+    "public_medium_cdn": "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+    "local_file_server": "http://127.0.0.1:8799/sample.mp4",
+}
+
+
+@dataclass
+class Probe:
+    name: str
+    url: str
+    wall_ms: float
+    ok: bool
+    duration: float | None
+    codec: str | None
+    stderr_tail: str
+
+
+def ffprobe(url: str) -> tuple[bool, dict, str]:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-print_format",
+        "json",
+        "-show_streams",
+        "-show_format",
+        "-i",
+        url,
+    ]
+    t0 = time.perf_counter()
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=10.0)
+    except subprocess.TimeoutExpired:
+        return False, {}, "TIMEOUT after 10s"
+    wall = (time.perf_counter() - t0) * 1000.0
+    if r.returncode != 0:
+        return False, {"wall_ms": wall}, r.stderr[-240:]
+    try:
+        info = json.loads(r.stdout)
+    except json.JSONDecodeError:
+        return False, {"wall_ms": wall}, "JSON decode failed"
+    info["wall_ms"] = wall
+    return True, info, r.stderr[-240:]
+
+
+def main() -> int:
+    results: list[Probe] = []
+    for name, url in URLS.items():
+        print(f"=== {name}: {url}")
+        ok, info, err = ffprobe(url)
+        wall = info.get("wall_ms", 0.0)
+        dur = None
+        codec = None
+        if ok:
+            fmt = info.get("format", {})
+            dur = float(fmt.get("duration", 0.0))
+            streams = info.get("streams", [])
+            for s in streams:
+                if s.get("codec_type") == "video":
+                    codec = s.get("codec_name")
+                    break
+        p = Probe(name=name, url=url, wall_ms=wall, ok=ok, duration=dur, codec=codec, stderr_tail=err)
+        results.append(p)
+        print(f"    wall={wall:.1f}ms ok={ok} dur={dur} codec={codec}")
+        if err and not ok:
+            print(f"    err={err}")
+        print()
+
+    print("=== SUMMARY ===")
+    budget_ms = 2000.0
+    for p in results:
+        verdict = "UNDER BUDGET" if p.wall_ms < budget_ms else "OVER BUDGET"
+        print(f"  {p.name:30s} {p.wall_ms:7.1f}ms {verdict}")
+    return 0 if all(r.ok for r in results) else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/spike/test_wire_shape.py
+++ b/scripts/spike/test_wire_shape.py
@@ -1,0 +1,99 @@
+"""Spike test 1 — extra_body.mm_processor_kwargs.video wire shape.
+
+Sends a minimal video chat completion against the spike vLLM server with
+a known-good public video URL and three candidate wire shapes. Records
+which shape(s) vLLM accepts and which it rejects with what error. This
+output feeds the Day-1 gate decision in docs/superpowers/spikes/.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any
+
+import httpx
+
+BASE_URL = "http://127.0.0.1:8765/v1"
+# 10 sec, 1 MB BigBuckBunny 360p from test-videos.co.uk (returns HTTP 200 from inside container)
+VIDEO_URL = "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/360/Big_Buck_Bunny_360_10s_1MB.mp4"
+MODEL_ID_ENV_KEY = "SPIKE_MODEL_ID"
+
+
+def load_model_id() -> str:
+    import os
+
+    return os.environ.get(MODEL_ID_ENV_KEY, "mmangkad/Qwen3.6-27B-NVFP4")
+
+
+def post_chat(payload: dict[str, Any]) -> tuple[int, dict[str, Any] | str]:
+    with httpx.Client(timeout=180.0) as client:
+        r = client.post(f"{BASE_URL}/chat/completions", json=payload)
+        try:
+            return r.status_code, r.json()
+        except Exception:
+            return r.status_code, r.text
+
+
+def build_base_payload(model_id: str, mm_kwargs: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "model": model_id,
+        "messages": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "video_url", "video_url": {"url": VIDEO_URL}},
+                    {"type": "text", "text": "Beschreibe das Video in einem Satz."},
+                ],
+            }
+        ],
+        "max_tokens": 64,
+        "temperature": 0.0,
+        "extra_body": {"mm_processor_kwargs": mm_kwargs},
+    }
+
+
+CANDIDATES: dict[str, dict[str, Any]] = {
+    "A_nested_video_fps": {"video": {"fps": 1}},
+    "B_nested_video_num_frames": {"video": {"num_frames": 8}},
+    "C_flat_fps": {"fps": 1},
+    "D_flat_num_frames": {"num_frames": 8},
+    "E_empty": {},
+    "F_nested_video_empty": {"video": {}},
+}
+
+
+def main() -> int:
+    model_id = load_model_id()
+    print(f"[wire-shape] model={model_id}")
+    print(f"[wire-shape] video_url={VIDEO_URL}")
+    print()
+
+    results: dict[str, dict[str, Any]] = {}
+    for name, mm in CANDIDATES.items():
+        print(f"=== {name}: mm_processor_kwargs={json.dumps(mm)}")
+        try:
+            status, body = post_chat(build_base_payload(model_id, mm))
+        except Exception as e:
+            status, body = 0, f"EXCEPTION: {type(e).__name__}: {e}"
+        err_hint = ""
+        if isinstance(body, dict) and "error" in body:
+            err_hint = str(body["error"])[:240]
+        elif isinstance(body, str):
+            err_hint = body[:240]
+        else:
+            err_hint = "(accepted)"
+        print(f"    -> status={status} {err_hint}")
+        results[name] = {"status": status, "body_hint": err_hint}
+
+    print()
+    print("=== SUMMARY ===")
+    accepted = [k for k, v in results.items() if v["status"] == 200]
+    rejected = [k for k, v in results.items() if v["status"] != 200]
+    print(f"accepted: {accepted}")
+    print(f"rejected: {rejected}")
+    return 0 if accepted else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/spike/test_wire_shape.py
+++ b/scripts/spike/test_wire_shape.py
@@ -16,7 +16,9 @@ import httpx
 
 BASE_URL = "http://127.0.0.1:8765/v1"
 # 10 sec, 1 MB BigBuckBunny 360p from test-videos.co.uk (returns HTTP 200 from inside container)
-VIDEO_URL = "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/360/Big_Buck_Bunny_360_10s_1MB.mp4"
+VIDEO_URL = (
+    "https://test-videos.co.uk/vids/bigbuckbunny/mp4/h264/360/Big_Buck_Bunny_360_10s_1MB.mp4"
+)
 MODEL_ID_ENV_KEY = "SPIKE_MODEL_ID"
 
 

--- a/scripts/verify_all.py
+++ b/scripts/verify_all.py
@@ -40,11 +40,6 @@ def check(name: str, ok: bool) -> None:
 # ----------------------------------------------------------------------
 print("=== 1. Core Module Imports ===")
 try:
-    from cognithor.leads.service import LeadService
-    from cognithor.leads.source import LeadSource
-    from cognithor.packs.installer import PackInstaller
-    from cognithor.packs.loader import PackLoader
-
     check("Pack+Leads SDK importable", True)
 except Exception as e:
     check(f"Import failed: {e}", False)

--- a/skills/backup/test_skill.py
+++ b/skills/backup/test_skill.py
@@ -1,5 +1,7 @@
 """Tests."""
+
 from .skill import BackupSkill
+
 
 def test_cron() -> None:
     assert BackupSkill.CRON is not None

--- a/skills/gmail_sync/skill.py
+++ b/skills/gmail_sync/skill.py
@@ -1,6 +1,7 @@
 """Jarvis Skill: Gmail Sync (API)."""
 
 import httpx
+
 from cognithor.skills.base import BaseSkill
 
 

--- a/skills/gmail_sync/test_skill.py
+++ b/skills/gmail_sync/test_skill.py
@@ -1,6 +1,7 @@
 """Tests fuer Gmail Sync."""
-import pytest
+
 from .skill import GmailSyncSkill
+
 
 class TestGmailSyncSkill:
     def test_name(self) -> None:

--- a/skills/test/test_skill.py
+++ b/skills/test/test_skill.py
@@ -1,6 +1,5 @@
 """Tests fuer Test."""
 
-import pytest
 from .skill import TestSkill
 
 

--- a/skills/test_skill/test_skill.py
+++ b/skills/test_skill/test_skill.py
@@ -1,6 +1,5 @@
 """Tests fuer Test Skill."""
 
-import pytest
 from .skill import TestSkillSkill
 
 

--- a/skills/wetter_abfrage/test_skill.py
+++ b/skills/wetter_abfrage/test_skill.py
@@ -1,6 +1,5 @@
 """Tests fuer Wetter Abfrage."""
 
-import pytest
 from .skill import WetterAbfrageSkill
 
 

--- a/src/cognithor/__init__.py
+++ b/src/cognithor/__init__.py
@@ -1,6 +1,6 @@
 """Cognithor · Agent OS -- Local-first autonomous agent operating system."""
 
-__version__ = "0.92.6"
+__version__ = "0.92.7"
 __author__ = "Alexander Söllner"
 
 # ── Centralized branding — single source of truth for banner + version ──

--- a/src/cognithor/channels/api.py
+++ b/src/cognithor/channels/api.py
@@ -340,6 +340,15 @@ class APIChannel(Channel):
         except Exception as exc:
             log.warning("backends_router_include_failed", error=str(exc))
 
+        # Include the media router for Flutter upload + thumbnail endpoints.
+        # Note: app.state.media_server is set by Gateway at startup (Task 15).
+        try:
+            from cognithor.channels.media_api import media_router as _media_router
+
+            app.include_router(_media_router)
+        except Exception as exc:
+            log.warning("media_router_include_failed", error=str(exc))
+
         return app
 
     @property

--- a/src/cognithor/channels/backends_api.py
+++ b/src/cognithor/channels/backends_api.py
@@ -70,6 +70,26 @@ def _get_orchestrator(config: CognithorConfig) -> VLLMOrchestrator:
     return _orchestrator_cache[key]
 
 
+def _resolve_orchestrator(request: Request) -> VLLMOrchestrator:
+    """Return the VLLMOrchestrator for this request.
+
+    Prefers the Gateway-owned instance registered on ``app.state.vllm_orchestrator``
+    (which has ``media_url`` wired after the MediaUploadServer starts). Falls back
+    to the module-level cache only in standalone API mode, when no Gateway is
+    attached to the app (e.g. test fixtures, future headless-daemon mode).
+
+    Bug C1-r3: without this unification the backends_api endpoints and the
+    Gateway held two separate VLLMOrchestrator instances, so ``start_container``
+    launched vLLM without ``-e COGNITHOR_MEDIA_URL=...`` and the container
+    could not fetch uploaded media.
+    """
+    orch = getattr(request.app.state, "vllm_orchestrator", None)
+    if orch is not None:
+        return orch
+    config: CognithorConfig = request.app.state.config
+    return _get_orchestrator(config)
+
+
 @backends_router.get("")
 async def list_backends(request: Request) -> dict:
     """Return every configured backend with its current readiness."""
@@ -81,7 +101,7 @@ async def list_backends(request: Request) -> dict:
             "status": "ready",
         }
     ]
-    orch = _get_orchestrator(config)
+    orch = _resolve_orchestrator(request)
     st = orch.status()
     if st.container_running:
         vllm_status = "ready"
@@ -102,8 +122,7 @@ async def list_backends(request: Request) -> dict:
 @backends_router.get("/vllm/status")
 async def vllm_status(request: Request) -> dict:
     """Return the current VLLMState as JSON for the Flutter setup page."""
-    config: CognithorConfig = request.app.state.config
-    orch = _get_orchestrator(config)
+    orch = _resolve_orchestrator(request)
     st = orch.status()
     hw = None
     if st.hardware_info:
@@ -125,8 +144,7 @@ async def vllm_status(request: Request) -> dict:
 
 @backends_router.post("/vllm/check-hardware")
 async def check_hardware_endpoint(request: Request) -> dict:
-    config: CognithorConfig = request.app.state.config
-    orch = _get_orchestrator(config)
+    orch = _resolve_orchestrator(request)
     try:
         info = orch.check_hardware()
     except Exception as exc:
@@ -150,8 +168,7 @@ async def check_hardware_endpoint(request: Request) -> dict:
 
 @backends_router.post("/vllm/start")
 async def vllm_start(request: Request, body: StartRequest) -> dict:
-    config: CognithorConfig = request.app.state.config
-    orch = _get_orchestrator(config)
+    orch = _resolve_orchestrator(request)
     try:
         info = orch.start_container(body.model)
     except Exception as exc:
@@ -175,8 +192,7 @@ async def vllm_start(request: Request, body: StartRequest) -> dict:
 
 @backends_router.post("/vllm/stop")
 async def vllm_stop(request: Request) -> dict:
-    config: CognithorConfig = request.app.state.config
-    orch = _get_orchestrator(config)
+    orch = _resolve_orchestrator(request)
     orch.stop_container()
     return {"status": "stopped"}
 
@@ -196,8 +212,7 @@ async def set_active_backend(request: Request, body: SetActiveRequest) -> dict:
 
 @backends_router.get("/vllm/logs")
 async def vllm_logs(request: Request) -> dict:
-    config: CognithorConfig = request.app.state.config
-    orch = _get_orchestrator(config)
+    orch = _resolve_orchestrator(request)
     return {"lines": orch.get_logs()}
 
 
@@ -216,8 +231,7 @@ async def vllm_available_models(request: Request) -> dict:
 
     from cognithor.core.vllm_orchestrator import ModelEntry
 
-    config: CognithorConfig = request.app.state.config
-    orch = _get_orchestrator(config)
+    orch = _resolve_orchestrator(request)
 
     registry_path = Path(__file__).resolve().parents[1] / "cli" / "model_registry.json"
     registry_data = _json.loads(registry_path.read_text(encoding="utf-8"))
@@ -260,7 +274,7 @@ async def vllm_available_models(request: Request) -> dict:
 async def vllm_pull_image(request: Request) -> StreamingResponse:
     """Stream docker-pull progress to the client as SSE."""
     config: CognithorConfig = request.app.state.config
-    orch = _get_orchestrator(config)
+    orch = _resolve_orchestrator(request)
 
     queue: asyncio.Queue[dict | None] = asyncio.Queue()
 

--- a/src/cognithor/channels/backends_api.py
+++ b/src/cognithor/channels/backends_api.py
@@ -66,6 +66,7 @@ def _get_orchestrator(config: CognithorConfig) -> VLLMOrchestrator:
             docker_image=config.vllm.docker_image,
             port=config.vllm.port,
             hf_token=config.huggingface_api_key,
+            config=config.vllm,
         )
     return _orchestrator_cache[key]
 

--- a/src/cognithor/channels/media_api.py
+++ b/src/cognithor/channels/media_api.py
@@ -1,0 +1,136 @@
+"""/api/media/upload + /api/media/thumb FastAPI routes.
+
+Separate from the MediaUploadServer (which only serves vLLM fetches). These
+endpoints are invoked by the Flutter client and run on the main Cognithor API
+port. They delegate the actual storage to MediaUploadServer.save_upload and
+run ffprobe/ffmpeg synchronously (both complete in <200 ms for typical videos).
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, FastAPI, File, HTTPException, Request, UploadFile
+from fastapi.responses import FileResponse
+
+from cognithor.core.llm_backend import (
+    MediaUploadError,
+    MediaUploadTooLargeError,
+    MediaUploadUnsupportedFormatError,
+)
+from cognithor.core.video_sampling import resolve_sampling
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from cognithor.channels.media_server import MediaUploadServer
+    from cognithor.config import CognithorConfig
+
+log = get_logger(__name__)
+
+media_router = APIRouter(prefix="/api/media", tags=["media"])
+
+
+@media_router.post("/upload")
+async def upload_video(request: Request, file: UploadFile = File(...)) -> dict:  # noqa: B008
+    config: CognithorConfig = request.app.state.config
+    media_server: MediaUploadServer = request.app.state.media_server
+
+    data = await file.read()
+    filename = file.filename or "video.mp4"
+    ext = Path(filename).suffix.lstrip(".")
+
+    try:
+        uuid = media_server.save_upload(data, ext)
+    except MediaUploadTooLargeError as exc:
+        raise HTTPException(
+            status_code=413,
+            detail={"message": str(exc), "recovery_hint": exc.recovery_hint},
+        ) from exc
+    except MediaUploadUnsupportedFormatError as exc:
+        raise HTTPException(status_code=400, detail={"message": str(exc)}) from exc
+    except MediaUploadError as exc:
+        raise HTTPException(status_code=507, detail={"message": str(exc)}) from exc
+
+    saved_path = media_server._media_dir / f"{uuid}.{ext.lower()}"
+
+    _extract_thumbnail(
+        saved_path,
+        media_server._media_dir / f"{uuid}.jpg",
+        ffmpeg_path="ffmpeg",
+    )
+
+    sampling = resolve_sampling(
+        str(saved_path),
+        ffprobe_path=config.vllm.video_ffprobe_path,
+        timeout_seconds=config.vllm.video_ffprobe_timeout_seconds,
+        http_timeout_seconds=config.vllm.video_ffprobe_http_timeout_seconds,
+        override=config.vllm.video_sampling_mode,
+    )
+
+    return {
+        "uuid": uuid,
+        "url": media_server.public_url(uuid, ext),
+        "duration_sec": sampling.duration_sec,
+        "sampling": sampling.as_mm_kwargs(),
+        "thumb_url": f"/api/media/thumb/{uuid}.jpg",
+    }
+
+
+@media_router.get("/thumb/{filename}")
+async def thumb(request: Request, filename: str) -> FileResponse:
+    if "/" in filename or ".." in filename:
+        raise HTTPException(status_code=400, detail="invalid filename")
+    media_server: MediaUploadServer = request.app.state.media_server
+    path = media_server._media_dir / filename
+    if not path.is_file():
+        raise HTTPException(status_code=404, detail="not found")
+    return FileResponse(path, media_type="image/jpeg")
+
+
+def _extract_thumbnail(source: Path, dest: Path, *, ffmpeg_path: str = "ffmpeg") -> bool:
+    """Best-effort: extract the first frame as JPEG. Returns True on success."""
+    if not shutil.which(ffmpeg_path) and not Path(ffmpeg_path).is_file():
+        return False
+    try:
+        subprocess.run(
+            [
+                ffmpeg_path,
+                "-y",
+                "-loglevel",
+                "error",
+                "-ss",
+                "0",
+                "-i",
+                str(source),
+                "-vframes",
+                "1",
+                "-vf",
+                "scale=192:108",
+                str(dest),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except Exception as exc:
+        log.warning("thumbnail_extract_failed", error=str(exc))
+        return False
+    return dest.is_file()
+
+
+def build_media_app(
+    *,
+    config: CognithorConfig,
+    media_server: MediaUploadServer,
+) -> FastAPI:
+    """Standalone FastAPI app for tests. In production the media_router is
+    included into the main APIChannel app via app.include_router()."""
+    app = FastAPI()
+    app.state.config = config
+    app.state.media_server = media_server
+    app.include_router(media_router)
+    return app

--- a/src/cognithor/channels/media_api.py
+++ b/src/cognithor/channels/media_api.py
@@ -3,11 +3,13 @@
 Separate from the MediaUploadServer (which only serves vLLM fetches). These
 endpoints are invoked by the Flutter client and run on the main Cognithor API
 port. They delegate the actual storage to MediaUploadServer.save_upload and
-run ffprobe/ffmpeg synchronously (both complete in <200 ms for typical videos).
+run ffprobe/ffmpeg via asyncio.to_thread so the uvicorn event loop stays
+responsive even for 500 MB uploads or slow remote URLs.
 """
 
 from __future__ import annotations
 
+import asyncio
 import shutil
 import subprocess
 from pathlib import Path
@@ -56,13 +58,15 @@ async def upload_video(request: Request, file: UploadFile = File(...)) -> dict: 
 
     saved_path = media_server._media_dir / f"{uuid}.{ext.lower()}"
 
-    _extract_thumbnail(
+    await asyncio.to_thread(
+        _extract_thumbnail,
         saved_path,
         media_server._media_dir / f"{uuid}.jpg",
         ffmpeg_path="ffmpeg",
     )
 
-    sampling = resolve_sampling(
+    sampling = await asyncio.to_thread(
+        resolve_sampling,
         str(saved_path),
         ffprobe_path=config.vllm.video_ffprobe_path,
         timeout_seconds=config.vllm.video_ffprobe_timeout_seconds,

--- a/src/cognithor/channels/media_api.py
+++ b/src/cognithor/channels/media_api.py
@@ -20,6 +20,7 @@ from fastapi.responses import FileResponse
 
 from cognithor.core.llm_backend import (
     MediaUploadError,
+    MediaUploadQuotaExceededError,
     MediaUploadTooLargeError,
     MediaUploadUnsupportedFormatError,
 )
@@ -53,6 +54,11 @@ async def upload_video(request: Request, file: UploadFile = File(...)) -> dict: 
         ) from exc
     except MediaUploadUnsupportedFormatError as exc:
         raise HTTPException(status_code=400, detail={"message": str(exc)}) from exc
+    except MediaUploadQuotaExceededError as exc:
+        raise HTTPException(
+            status_code=507,
+            detail={"message": str(exc), "recovery_hint": exc.recovery_hint},
+        ) from exc
     except MediaUploadError as exc:
         raise HTTPException(status_code=507, detail={"message": str(exc)}) from exc
 

--- a/src/cognithor/channels/media_api.py
+++ b/src/cognithor/channels/media_api.py
@@ -85,10 +85,15 @@ async def upload_video(request: Request, file: UploadFile = File(...)) -> dict: 
 
 @media_router.get("/thumb/{filename}")
 async def thumb(request: Request, filename: str) -> FileResponse:
-    if "/" in filename or ".." in filename:
-        raise HTTPException(status_code=400, detail="invalid filename")
     media_server: MediaUploadServer = request.app.state.media_server
-    path = media_server._media_dir / filename
+    media_dir = media_server._media_dir
+    path = media_dir / filename
+    try:
+        resolved = path.resolve()
+        if not resolved.is_relative_to(media_dir.resolve()):
+            raise HTTPException(status_code=400, detail="invalid filename")
+    except (OSError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail="invalid filename") from exc
     if not path.is_file():
         raise HTTPException(status_code=404, detail="not found")
     return FileResponse(path, media_type="image/jpeg")

--- a/src/cognithor/channels/media_server.py
+++ b/src/cognithor/channels/media_server.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import socket
+import threading
 import uuid as _uuid
 from typing import TYPE_CHECKING
 
@@ -28,6 +29,8 @@ from cognithor.core.llm_backend import (
 from cognithor.utils.logging import get_logger
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     from cognithor.config import CognithorConfig
 
 log = get_logger(__name__)
@@ -53,6 +56,10 @@ class MediaUploadServer:
         self._port: int | None = None
         self._server = None  # filled by start() in Task 7
         self._serve_task: asyncio.Task | None = None
+        # Guards the evict+write critical section in save_upload. save_upload
+        # is called from async FastAPI handlers via asyncio.to_thread, so
+        # threading.Lock (not asyncio.Lock) is the right primitive here.
+        self._lock = threading.Lock()
 
     def save_upload(self, data: bytes, ext: str) -> str:
         """Store ``data`` under ``<uuid>.<ext>`` in the media dir, return uuid.
@@ -83,12 +90,14 @@ class MediaUploadServer:
                 recovery_hint="Raise config.vllm.video_quota_gb or shrink the file.",
             )
 
-        # LRU eviction until the new file fits
-        self._evict_until_fits(len(data))
-
-        uuid_str = _uuid.uuid4().hex
-        path = self._media_dir / f"{uuid_str}.{ext_lower}"
-        path.write_bytes(data)
+        # LRU eviction + write must be atomic relative to other save_upload
+        # calls, otherwise two concurrent uploads can both pass the quota
+        # check and both write, leaving the directory above quota.
+        with self._lock:
+            self._evict_until_fits(len(data))
+            uuid_str = _uuid.uuid4().hex
+            path = self._media_dir / f"{uuid_str}.{ext_lower}"
+            path.write_bytes(data)
         log.info(
             "video_upload_saved",
             uuid=uuid_str,
@@ -98,16 +107,30 @@ class MediaUploadServer:
         return uuid_str
 
     def _evict_until_fits(self, incoming_bytes: int) -> None:
-        """Delete oldest files (by mtime) until adding ``incoming_bytes`` fits under quota."""
-        files = [f for f in self._media_dir.iterdir() if f.is_file()]
-        current = sum(f.stat().st_size for f in files)
+        """Delete oldest files (by mtime) until adding ``incoming_bytes`` fits under quota.
+
+        Snapshots (path, size, mtime) once per file to avoid racy double-stat
+        calls (the file could vanish between two stat() invocations on a
+        busy directory).
+        """
+        entries: list[tuple[Path, int, float]] = []
+        for p in self._media_dir.iterdir():
+            if not p.is_file():
+                continue
+            try:
+                st = p.stat()
+            except OSError:
+                continue
+            entries.append((p, st.st_size, st.st_mtime))
+
+        current = sum(size for _, size, _ in entries)
         if current + incoming_bytes <= self._quota_bytes:
             return
-        files.sort(key=lambda f: f.stat().st_mtime)  # oldest first
-        for f in files:
+
+        entries.sort(key=lambda e: e[2])  # oldest first
+        for f, size, _ in entries:
             if current + incoming_bytes <= self._quota_bytes:
                 break
-            size = f.stat().st_size
             try:
                 f.unlink()
             except OSError as exc:

--- a/src/cognithor/channels/media_server.py
+++ b/src/cognithor/channels/media_server.py
@@ -160,10 +160,18 @@ class MediaUploadServer:
 
         @app.get("/media/{filename}")
         async def serve(filename: str) -> FileResponse:
-            # Very strict: no paths, only flat <uuid>.<ext> names
-            if "/" in filename or ".." in filename:
-                raise HTTPException(status_code=400, detail="invalid filename")
-            path = self._media_dir / filename
+            # Defense-in-depth: resolve the full path and verify it's still
+            # inside media_dir. Substring checks like `"/" in filename` miss
+            # Windows absolute paths (e.g. `C:\Windows\...`) because pathlib
+            # treats absolute args as replacing the base.
+            media_dir = self._media_dir
+            path = media_dir / filename
+            try:
+                resolved = path.resolve()
+                if not resolved.is_relative_to(media_dir.resolve()):
+                    raise HTTPException(status_code=400, detail="invalid filename")
+            except (OSError, ValueError) as exc:
+                raise HTTPException(status_code=400, detail="invalid filename") from exc
             if not path.is_file():
                 raise HTTPException(status_code=404, detail="not found")
             return FileResponse(path)

--- a/src/cognithor/channels/media_server.py
+++ b/src/cognithor/channels/media_server.py
@@ -10,9 +10,15 @@ live in companion methods `start()` / `stop()` added in Task 7.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
+import socket
 import uuid as _uuid
 from typing import TYPE_CHECKING
+
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import FileResponse
 
 from cognithor.core.llm_backend import (
     MediaUploadQuotaExceededError,
@@ -46,6 +52,7 @@ class MediaUploadServer:
         self._quota_bytes = config.vllm.video_quota_gb * 1024 * 1024 * 1024
         self._port: int | None = None
         self._server = None  # filled by start() in Task 7
+        self._serve_task: asyncio.Task | None = None
 
     def save_upload(self, data: bytes, ext: str) -> str:
         """Store ``data`` under ``<uuid>.<ext>`` in the media dir, return uuid.
@@ -138,4 +145,55 @@ class MediaUploadServer:
         ext_lower = ext.lower().lstrip(".")
         return f"http://host.docker.internal:{self._port}/media/{uuid}.{ext_lower}"
 
-    # start() / stop() added in Task 7
+    async def start(self) -> int:
+        """Bind to 127.0.0.1:<ephemeral>, serve /media/<uuid>.<ext> as static files.
+
+        Returns the bound port. Call ``await stop()`` at shutdown.
+        """
+        # Pick an ephemeral port ourselves so we can tell the orchestrator before
+        # uvicorn actually binds (uvicorn accepts 0 but only reports after start).
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as probe:
+            probe.bind(("127.0.0.1", 0))
+            self._port = probe.getsockname()[1]
+
+        app = FastAPI(title="Cognithor MediaUploadServer", openapi_url=None, docs_url=None)
+
+        @app.get("/media/{filename}")
+        async def serve(filename: str) -> FileResponse:
+            # Very strict: no paths, only flat <uuid>.<ext> names
+            if "/" in filename or ".." in filename:
+                raise HTTPException(status_code=400, detail="invalid filename")
+            path = self._media_dir / filename
+            if not path.is_file():
+                raise HTTPException(status_code=404, detail="not found")
+            return FileResponse(path)
+
+        config = uvicorn.Config(
+            app,
+            host="127.0.0.1",
+            port=self._port,
+            log_level="warning",
+            access_log=False,
+        )
+        self._server = uvicorn.Server(config)
+        self._serve_task = asyncio.create_task(self._server.serve())
+        # Wait for startup (server.started flips true when uvicorn is ready)
+        for _ in range(50):
+            if self._server.started:
+                break
+            await asyncio.sleep(0.05)
+        log.info("media_server_started", port=self._port)
+        return self._port
+
+    async def stop(self) -> None:
+        """Shut down the uvicorn serving loop. Idempotent."""
+        if self._server is None:
+            return
+        self._server.should_exit = True
+        try:
+            await self._serve_task
+        except Exception as exc:
+            log.warning("media_server_stop_error", error=str(exc))
+        self._server = None
+        self._serve_task = None
+        log.info("media_server_stopped")

--- a/src/cognithor/channels/media_server.py
+++ b/src/cognithor/channels/media_server.py
@@ -1,0 +1,141 @@
+"""MediaUploadServer — local HTTP file-server for vLLM to fetch user uploads.
+
+vLLM inside the Cognithor-managed Docker container reaches this server via
+``http://host.docker.internal:<port>/media/<uuid>.<ext>``. The server binds
+only on ``127.0.0.1``, so only processes on the host machine can reach it.
+
+This file contains the storage + quota logic. The FastAPI app + port binding
+live in companion methods `start()` / `stop()` added in Task 7.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import uuid as _uuid
+from typing import TYPE_CHECKING
+
+from cognithor.core.llm_backend import (
+    MediaUploadQuotaExceededError,
+    MediaUploadTooLargeError,
+    MediaUploadUnsupportedFormatError,
+)
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from cognithor.config import CognithorConfig
+
+log = get_logger(__name__)
+
+_ALLOWED_EXTS = frozenset({"mp4", "webm", "mov", "mkv", "avi"})
+
+
+class MediaUploadServer:
+    """Local-loopback static file server for vLLM media fetches.
+
+    Lifecycle: instantiate with the live CognithorConfig, call ``await start()``
+    to bind the ephemeral port (returns the port number), ``await stop()`` at
+    shutdown. In between, call ``save_upload(data, ext) -> uuid`` to store
+    bytes and ``public_url(uuid, ext) -> str`` to get the URL vLLM should fetch.
+    """
+
+    def __init__(self, config: CognithorConfig) -> None:
+        self._config = config
+        self._media_dir = config.cognithor_home / "media" / "vllm-uploads"
+        self._media_dir.mkdir(parents=True, exist_ok=True)
+        self._max_per_file_bytes = config.vllm.video_max_upload_mb * 1024 * 1024
+        self._quota_bytes = config.vllm.video_quota_gb * 1024 * 1024 * 1024
+        self._port: int | None = None
+        self._server = None  # filled by start() in Task 7
+
+    def save_upload(self, data: bytes, ext: str) -> str:
+        """Store ``data`` under ``<uuid>.<ext>`` in the media dir, return uuid.
+
+        Raises MediaUploadTooLargeError / MediaUploadUnsupportedFormatError /
+        MediaUploadQuotaExceededError on the respective failure modes. LRU-
+        evicts older files if the new upload would push total size over quota.
+        """
+        ext_lower = ext.lower().lstrip(".")
+        if ext_lower not in _ALLOWED_EXTS:
+            raise MediaUploadUnsupportedFormatError(
+                f"Unsupported extension: {ext!r}. Allowed: {sorted(_ALLOWED_EXTS)}",
+                status_code=400,
+            )
+        if len(data) > self._max_per_file_bytes:
+            mb = len(data) / 1024 / 1024
+            cap = self._max_per_file_bytes / 1024 / 1024
+            raise MediaUploadTooLargeError(
+                f"Upload is {mb:.1f} MB, max per file is {cap:.0f} MB",
+                status_code=413,
+                recovery_hint="Shorten or downscale the clip before uploading.",
+            )
+        if len(data) > self._quota_bytes:
+            raise MediaUploadQuotaExceededError(
+                f"Upload alone ({len(data) / 1024 / 1024:.1f} MB) exceeds the full quota"
+                f" ({self._quota_bytes / 1024 / 1024 / 1024:.1f} GB)",
+                status_code=413,
+                recovery_hint="Raise config.vllm.video_quota_gb or shrink the file.",
+            )
+
+        # LRU eviction until the new file fits
+        self._evict_until_fits(len(data))
+
+        uuid_str = _uuid.uuid4().hex
+        path = self._media_dir / f"{uuid_str}.{ext_lower}"
+        path.write_bytes(data)
+        log.info(
+            "video_upload_saved",
+            uuid=uuid_str,
+            ext=ext_lower,
+            bytes=len(data),
+        )
+        return uuid_str
+
+    def _evict_until_fits(self, incoming_bytes: int) -> None:
+        """Delete oldest files (by mtime) until adding ``incoming_bytes`` fits under quota."""
+        files = [f for f in self._media_dir.iterdir() if f.is_file()]
+        current = sum(f.stat().st_size for f in files)
+        if current + incoming_bytes <= self._quota_bytes:
+            return
+        files.sort(key=lambda f: f.stat().st_mtime)  # oldest first
+        for f in files:
+            if current + incoming_bytes <= self._quota_bytes:
+                break
+            size = f.stat().st_size
+            try:
+                f.unlink()
+            except OSError as exc:
+                log.warning("video_evict_failed", file=str(f), error=str(exc))
+                continue
+            # Also drop sidecar thumbnail if present
+            thumb = f.with_suffix(".jpg")
+            if thumb.exists():
+                with contextlib.suppress(OSError):
+                    thumb.unlink()
+            current -= size
+            log.info("video_evicted_lru", file=f.name, freed_bytes=size)
+
+    def delete(self, uuid: str, ext: str) -> None:
+        """Remove a specific upload (and its thumbnail). Noop if missing."""
+        ext_lower = ext.lower().lstrip(".")
+        path = self._media_dir / f"{uuid}.{ext_lower}"
+        if path.exists():
+            try:
+                path.unlink()
+            except OSError as exc:
+                log.warning("video_delete_failed", uuid=uuid, error=str(exc))
+        thumb = self._media_dir / f"{uuid}.jpg"
+        if thumb.exists():
+            with contextlib.suppress(OSError):
+                thumb.unlink()
+
+    def public_url(self, uuid: str, ext: str) -> str:
+        """Return the URL vLLM should fetch: ``http://host.docker.internal:<port>/media/<uuid>.<ext>``.
+
+        Requires ``start()`` to have been called (or ``_port`` manually set in tests).
+        """
+        if self._port is None:
+            raise RuntimeError("MediaUploadServer not started; call await start() first")
+        ext_lower = ext.lower().lstrip(".")
+        return f"http://host.docker.internal:{self._port}/media/{uuid}.{ext_lower}"
+
+    # start() / stop() added in Task 7

--- a/src/cognithor/config.py
+++ b/src/cognithor/config.py
@@ -2565,6 +2565,26 @@ class VLLMConfig(BaseModel):
     skip_hardware_check: bool = Field(default=False)
     request_timeout_seconds: int = Field(default=60, ge=5, le=600)
 
+    # Video-input (from video-input-vllm spec 2026-04-23)
+    video_sampling_mode: Literal["adaptive", "fixed_32", "fixed_64", "fps_1"] = Field(
+        default="adaptive"
+    )
+    video_ffprobe_path: str = Field(default="ffprobe")
+    video_ffprobe_timeout_seconds: int = Field(default=5, ge=1, le=30)
+    video_ffprobe_http_timeout_seconds: int = Field(default=30, ge=5, le=120)
+    video_max_upload_mb: int = Field(default=500, ge=1, le=5000)
+    video_quota_gb: int = Field(default=5, ge=1, le=100)
+    video_upload_ttl_hours: int = Field(default=24, ge=1, le=168)
+
+    # Launcher flags for the vLLM `docker run` command (see Day-1 spike findings).
+    # Defaults target a 32 GB-class consumer GPU (RTX 5090) — loosen on larger cards.
+    max_model_len: int = Field(default=16384, ge=2048, le=1_010_000)
+    max_num_seqs: int = Field(default=2, ge=1, le=256)
+    max_num_batched_tokens: int = Field(default=2048, ge=512, le=131072)
+    gpu_memory_utilization: float = Field(default=0.94, gt=0.0, le=1.0)
+    cpu_offload_gb: int = Field(default=4, ge=0, le=128)
+    enforce_eager: bool = Field(default=True)
+
 
 # ============================================================================
 # Haupt-Konfiguration

--- a/src/cognithor/config.py
+++ b/src/cognithor/config.py
@@ -2559,7 +2559,7 @@ class VLLMConfig(BaseModel):
 
     enabled: bool = Field(default=False)
     model: str = Field(default="")
-    docker_image: str = Field(default="vllm/vllm-openai:v0.19.1")
+    docker_image: str = Field(default="vllm/vllm-openai:cu130-nightly")
     port: int = Field(default=8000, ge=1024, le=65535)
     auto_stop_on_close: bool = Field(default=False)
     skip_hardware_check: bool = Field(default=False)

--- a/src/cognithor/core/llm_backend.py
+++ b/src/cognithor/core/llm_backend.py
@@ -96,6 +96,30 @@ class LLMBadRequestError(LLMBackendError):
     """
 
 
+class MediaUploadError(LLMBackendError):
+    """Upload of a media file (video in v1) could not be accepted by the
+    local media server. User-side problem, not a vLLM/backend fault —
+    excluded from circuit-breaker failure counting in UnifiedLLMClient.
+    """
+
+
+class MediaUploadTooLargeError(MediaUploadError):
+    """Upload exceeds ``config.vllm.video_max_upload_mb``."""
+
+
+class MediaUploadUnsupportedFormatError(MediaUploadError):
+    """File extension not in the allow-list (.mp4, .webm, .mov, .mkv, .avi)."""
+
+
+class MediaUploadQuotaExceededError(MediaUploadError):
+    """Would exceed ``config.vllm.video_quota_gb`` even after LRU eviction.
+
+    This can only happen if the single upload is larger than the entire
+    quota — otherwise LRU eviction always makes room. Practically means
+    the user needs to raise ``video_quota_gb`` or shrink the file.
+    """
+
+
 class VLLMNotReadyError(LLMBackendError):
     """vLLM container not running or model not loaded."""
 

--- a/src/cognithor/core/planner.py
+++ b/src/cognithor/core/planner.py
@@ -1048,7 +1048,9 @@ class Planner:
         # through the detail vision model so the VLM can actually see them.
         # Falls back to the text planner model when no attachments.
         image_paths = list(working_memory.image_attachments or [])
-        if image_paths and getattr(self._config, "vision_model_detail", None):
+        video_attach = working_memory.video_attachment
+        has_visual = image_paths or video_attach is not None
+        if has_visual and getattr(self._config, "vision_model_detail", None):
             model = self._config.vision_model_detail
         else:
             model = self._router.select_model("summarization", "medium")
@@ -1076,6 +1078,7 @@ class Planner:
                 messages=messages,
                 session_id=working_memory.session_id,
                 images=image_paths or None,
+                video=video_attach,
             )
             if content is None:
                 # Both LLM attempts failed — existing fallback behavior.
@@ -1269,12 +1272,16 @@ class Planner:
         messages: list[dict[str, Any]],
         session_id: str,
         images: list[str] | None = None,
+        video: dict[str, Any] | None = None,
     ) -> str | None:
         """Call ollama.chat with 2 attempts. Returns None if both fail (caller uses fallback).
 
         When ``images`` is non-empty the call routes to a VLM (see
         ``OllamaClient.chat`` — attaches base64-encoded images to the
         last user message per Ollama's multimodal API).
+
+        When ``video`` is non-None the call routes to a VLM that supports
+        video input (vLLM backend) — the dict is forwarded verbatim.
         """
         for _fmt_attempt in range(2):
             try:
@@ -1283,6 +1290,7 @@ class Planner:
                     messages=messages,
                     options=self._build_llm_options(),
                     images=images,
+                    video=video,
                 )
                 self._record_cost(response, model, session_id=session_id)
                 return response.get("message", {}).get("content", "")

--- a/src/cognithor/core/unified_llm.py
+++ b/src/cognithor/core/unified_llm.py
@@ -216,6 +216,7 @@ class UnifiedLLMClient:
         options: dict[str, Any] | None = None,
         backend_override: str = "",
         images: list[str] | None = None,
+        video: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Chat-Completion im Ollama-Response-Format.
 
@@ -312,6 +313,8 @@ class UnifiedLLMClient:
 
         # Via LLMBackend
         is_image_request = bool(images)
+        is_video_request = video is not None
+        is_vision_request = is_image_request or is_video_request
         effective_backend_type = getattr(effective_backend, "backend_type", self._backend_type)
         if hasattr(effective_backend_type, "value"):
             effective_backend_type = effective_backend_type.value
@@ -327,17 +330,19 @@ class UnifiedLLMClient:
             }
             if images is not None:
                 backend_call_kwargs["images"] = images
+            if video is not None:
+                backend_call_kwargs["video"] = video
             response = await breaker.call(effective_backend.chat(**backend_call_kwargs))
         except LLMBadRequestError:
             self._refresh_status()
             raise
         except (VLLMNotReadyError, CircuitBreakerOpen) as exc:
             self._refresh_status()
-            if is_image_request:
-                # Images cannot be processed by Ollama fallback — hard error
+            if is_vision_request:
+                # Images and video cannot be processed by Ollama fallback — hard error
                 if isinstance(exc, CircuitBreakerOpen):
                     raise VLLMNotReadyError(
-                        "vLLM offline — cannot process image",
+                        "vLLM offline — vision/video request cannot be processed",
                         recovery_hint="Start vLLM from LLM Backends settings.",
                     ) from exc
                 raise

--- a/src/cognithor/core/video_sampling.py
+++ b/src/cognithor/core/video_sampling.py
@@ -1,10 +1,8 @@
-"""Video sampling: pick fps or num_frames for a vLLM `video_url` request.
+"""Video sampling: map video duration to fps/num_frames for a vLLM request.
 
-Uses ffprobe to detect duration, then maps to the bucket table from the
-spec (docs/superpowers/specs/2026-04-23-video-input-vllm-design.md).
-
-This module is pure-logic-plus-subprocess. `_bucket_for_duration` is
-pure; `resolve_sampling` (added in Task 3) is the I/O entry point.
+Maps duration to the bucket table from
+docs/superpowers/specs/2026-04-23-video-input-vllm-design.md.
+Pure logic only; I/O entry point ``resolve_sampling`` is added in Task 3.
 """
 
 from __future__ import annotations

--- a/src/cognithor/core/video_sampling.py
+++ b/src/cognithor/core/video_sampling.py
@@ -1,0 +1,67 @@
+"""Video sampling: pick fps or num_frames for a vLLM `video_url` request.
+
+Uses ffprobe to detect duration, then maps to the bucket table from the
+spec (docs/superpowers/specs/2026-04-23-video-input-vllm-design.md).
+
+This module is pure-logic-plus-subprocess. `_bucket_for_duration` is
+pure; `resolve_sampling` (added in Task 3) is the I/O entry point.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class VideoSampling:
+    """Resolved per-video sampling spec.
+
+    Exactly one of `fps` or `num_frames` is set when sampling is active.
+    Both None is a default-constructed placeholder and will raise from
+    `as_mm_kwargs()`.
+    """
+
+    fps: float | None = None
+    num_frames: int | None = None
+    duration_sec: float | None = None  # for logging/UI, not sent to vLLM
+
+    def as_mm_kwargs(self) -> dict[str, Any]:
+        """Return the dict suitable for `extra_body.mm_processor_kwargs.video`.
+
+        Shape confirmed by Task-1 spike.
+        """
+        if self.fps is not None:
+            return {"fps": self.fps}
+        if self.num_frames is not None:
+            return {"num_frames": self.num_frames}
+        raise ValueError("VideoSampling has neither fps nor num_frames set")
+
+
+# Bucket thresholds in seconds
+_BUCKET_LT_10 = 10.0
+_BUCKET_LT_30 = 30.0
+_BUCKET_LT_2MIN = 120.0
+_BUCKET_LT_5MIN = 300.0
+_BUCKET_LT_15MIN = 900.0
+
+
+def _bucket_for_duration(duration_sec: float) -> VideoSampling:
+    """Map a duration in seconds to a VideoSampling per the spec's bucket table.
+
+    Defensive default for non-positive durations: `num_frames=32` so callers
+    don't have to special-case ffprobe edge-cases.
+    """
+    if duration_sec <= 0:
+        return VideoSampling(num_frames=32, duration_sec=duration_sec)
+    if duration_sec < _BUCKET_LT_10:
+        return VideoSampling(fps=3.0, duration_sec=duration_sec)
+    if duration_sec < _BUCKET_LT_30:
+        return VideoSampling(fps=2.0, duration_sec=duration_sec)
+    if duration_sec < _BUCKET_LT_2MIN:
+        return VideoSampling(fps=1.0, duration_sec=duration_sec)
+    if duration_sec < _BUCKET_LT_5MIN:
+        return VideoSampling(num_frames=64, duration_sec=duration_sec)
+    # 5 min - 15 min AND > 15 min both use num_frames=32; UI banner is
+    # a display concern not a sampling one.
+    return VideoSampling(num_frames=32, duration_sec=duration_sec)

--- a/src/cognithor/core/video_sampling.py
+++ b/src/cognithor/core/video_sampling.py
@@ -7,8 +7,16 @@ Pure logic only; I/O entry point ``resolve_sampling`` is added in Task 3.
 
 from __future__ import annotations
 
+import json as _json
+import subprocess
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
+
+from cognithor.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+_MAX_PLAUSIBLE_DURATION_SEC = 86400.0  # 24 hours; anything bigger is almost certainly garbage
 
 
 @dataclass(frozen=True)
@@ -63,3 +71,83 @@ def _bucket_for_duration(duration_sec: float) -> VideoSampling:
     # 5 min - 15 min AND > 15 min both use num_frames=32; UI banner is
     # a display concern not a sampling one.
     return VideoSampling(num_frames=32, duration_sec=duration_sec)
+
+
+SamplingOverride = Literal["adaptive", "fixed_32", "fixed_64", "fps_1"]
+
+
+def resolve_sampling(
+    source: str,
+    *,
+    ffprobe_path: str = "ffprobe",
+    timeout_seconds: int = 5,
+    http_timeout_seconds: int = 30,
+    override: SamplingOverride = "adaptive",
+) -> VideoSampling:
+    """Resolve a video source URL or local path to a VideoSampling.
+
+    For ``override != "adaptive"``, returns a fixed sampling without touching
+    ffprobe. For adaptive, runs ffprobe with the appropriate timeout
+    (``timeout_seconds`` for local paths, ``http_timeout_seconds`` for URLs)
+    and falls back to ``VideoSampling(num_frames=32)`` on any failure.
+    """
+    if override == "fixed_32":
+        return VideoSampling(num_frames=32)
+    if override == "fixed_64":
+        return VideoSampling(num_frames=64)
+    if override == "fps_1":
+        return VideoSampling(fps=1.0)
+
+    is_http = source.lower().startswith(("http://", "https://"))
+    timeout = http_timeout_seconds if is_http else timeout_seconds
+
+    cmd = [
+        ffprobe_path,
+        "-v",
+        "error",
+        "-show_entries",
+        "format=duration",
+        "-of",
+        "json",
+        source,
+    ]
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError:
+        log.warning("video_ffprobe_missing", recovery="fallback to num_frames=32")
+        return VideoSampling(num_frames=32)
+    except subprocess.TimeoutExpired:
+        log.warning(
+            "video_duration_detection_timeout",
+            source=_redact_source(source),
+            timeout_seconds=timeout,
+        )
+        return VideoSampling(num_frames=32)
+
+    if result.returncode != 0:
+        log.warning(
+            "video_ffprobe_failed",
+            returncode=result.returncode,
+            stderr=result.stderr.strip()[:200],
+        )
+        return VideoSampling(num_frames=32)
+
+    try:
+        data = _json.loads(result.stdout)
+        duration = float(data["format"]["duration"])
+    except (_json.JSONDecodeError, KeyError, ValueError, TypeError):
+        log.warning("video_ffprobe_unparseable", stdout=result.stdout[:200])
+        return VideoSampling(num_frames=32)
+
+    if duration <= 0 or duration > _MAX_PLAUSIBLE_DURATION_SEC:
+        log.warning("video_duration_implausible", duration=duration)
+        return VideoSampling(num_frames=32)
+
+    return _bucket_for_duration(duration)
+
+
+def _redact_source(source: str) -> str:
+    """Strip query strings from URLs so we don't log credentials / tokens."""
+    if "?" in source:
+        return source.split("?", 1)[0] + "?…"
+    return source

--- a/src/cognithor/core/vllm_backend.py
+++ b/src/cognithor/core/vllm_backend.py
@@ -88,6 +88,49 @@ def _attach_images_to_last_user(
     return new_messages
 
 
+def _attach_video_to_last_user(
+    messages: list[dict[str, Any]],
+    video: dict[str, Any],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Attach a single video to the last user message and build the
+    mm_processor_kwargs payload for vLLM's extra_body.
+
+    Args:
+        messages: Ollama-shaped chat messages. Not mutated.
+        video: ``{"url": str, "sampling": {"fps": float} | {"num_frames": int}}``
+
+    Returns:
+        ``(new_messages, extra_body_update)`` where
+        - ``new_messages``: a fresh list with the last user message's content
+          replaced by a list of content items: ``[video_url, (optional) text]``
+        - ``extra_body_update``: ``{"mm_processor_kwargs": {"video": <sampling>}}``
+          ready to merge into the outgoing chat-completion body.
+    """
+    new_messages = [dict(m) for m in messages]
+
+    # Find last user message (create one if none exists)
+    for i in range(len(new_messages) - 1, -1, -1):
+        if new_messages[i].get("role") == "user":
+            last = new_messages[i]
+            break
+    else:
+        last = {"role": "user", "content": ""}
+        new_messages.append(last)
+
+    existing = last.get("content", "")
+    text_part = existing if isinstance(existing, str) else ""
+    content_items: list[dict[str, Any]] = [
+        {"type": "video_url", "video_url": {"url": video["url"]}},
+    ]
+    if text_part:
+        content_items.append({"type": "text", "text": text_part})
+
+    last["content"] = content_items
+
+    extra_body = {"mm_processor_kwargs": {"video": video["sampling"]}}
+    return new_messages, extra_body
+
+
 class VLLMBackend(LLMBackend):
     """vLLM OpenAI-compat adapter."""
 
@@ -148,6 +191,7 @@ class VLLMBackend(LLMBackend):
         top_p: float = 0.9,
         format_json: bool = False,
         images: list[str] | None = None,
+        video: dict[str, Any] | None = None,
     ) -> ChatResponse:
         """Send a chat-completion request to vLLM.
 
@@ -159,6 +203,11 @@ class VLLMBackend(LLMBackend):
         if images:
             messages = _attach_images_to_last_user(messages, images)
 
+        extra_body: dict[str, Any] = {}
+        if video is not None:
+            messages, video_extra = _attach_video_to_last_user(messages, video)
+            extra_body.update(video_extra)
+
         payload: dict[str, Any] = {
             "model": model,
             "messages": messages,
@@ -169,6 +218,8 @@ class VLLMBackend(LLMBackend):
             payload["tools"] = tools
         if format_json:
             payload["response_format"] = {"type": "json_object"}
+        if extra_body:
+            payload["extra_body"] = extra_body
 
         client = await self._ensure_client()
         try:

--- a/src/cognithor/core/vllm_backend.py
+++ b/src/cognithor/core/vllm_backend.py
@@ -280,18 +280,32 @@ class VLLMBackend(LLMBackend):
         temperature: float = 0.7,
         top_p: float = 0.9,
         images: list[str] | None = None,
+        video: dict[str, Any] | None = None,
     ) -> AsyncIterator[str]:
-        """Stream response tokens from vLLM. Parses OpenAI SSE format."""
+        """Stream response tokens from vLLM. Parses OpenAI SSE format.
+
+        ``video`` is a dict ``{url, sampling}`` per the video-input spec
+        (2026-04-23). Exactly zero or one video per turn. Streaming responses
+        for video are structurally identical to text responses — vLLM returns
+        SSE tokens as it decodes.
+        """
         if images:
             messages = _attach_images_to_last_user(messages, images)
 
-        payload = {
+        extra_body: dict[str, Any] = {}
+        if video is not None:
+            messages, video_extra = _attach_video_to_last_user(messages, video)
+            extra_body.update(video_extra)
+
+        payload: dict[str, Any] = {
             "model": model,
             "messages": messages,
             "temperature": temperature,
             "top_p": top_p,
             "stream": True,
         }
+        if extra_body:
+            payload["extra_body"] = extra_body
         client = await self._ensure_client()
         try:
             async with client.stream(

--- a/src/cognithor/core/vllm_backend.py
+++ b/src/cognithor/core/vllm_backend.py
@@ -74,8 +74,19 @@ def _attach_images_to_last_user(
     for i in range(len(new_messages) - 1, -1, -1):
         if new_messages[i].get("role") == "user":
             existing = new_messages[i].get("content")
-            text_part = existing if isinstance(existing, str) else ""
-            content_list: list[dict[str, Any]] = []
+            if isinstance(existing, list):
+                # Pre-existing list content (e.g. a prior video attachment in
+                # the same turn): extract the text item and preserve all other
+                # non-text items so they are not silently dropped.
+                text_part = next(
+                    (c["text"] for c in existing if c.get("type") == "text"),
+                    "",
+                )
+                preserved_items = [c for c in existing if c.get("type") != "text"]
+            else:
+                text_part = existing if isinstance(existing, str) else ""
+                preserved_items = []
+            content_list: list[dict[str, Any]] = list(preserved_items)
             if text_part:
                 content_list.append({"type": "text", "text": text_part})
             for url in encoded:

--- a/src/cognithor/core/vllm_backend.py
+++ b/src/cognithor/core/vllm_backend.py
@@ -108,24 +108,37 @@ def _attach_video_to_last_user(
     """
     new_messages = [dict(m) for m in messages]
 
-    # Find last user message (create one if none exists)
+    # Find last user message index (create one if none exists)
+    last_idx: int | None = None
     for i in range(len(new_messages) - 1, -1, -1):
         if new_messages[i].get("role") == "user":
-            last = new_messages[i]
+            last_idx = i
             break
-    else:
-        last = {"role": "user", "content": ""}
-        new_messages.append(last)
+    if last_idx is None:
+        new_messages.append({"role": "user", "content": ""})
+        last_idx = len(new_messages) - 1
 
-    existing = last.get("content", "")
-    text_part = existing if isinstance(existing, str) else ""
+    existing = new_messages[last_idx].get("content", "")
+    if isinstance(existing, list):
+        # Pre-existing list content (e.g. prior image attachment in same turn):
+        # extract the text item and preserve all other non-text items.
+        text_part = next(
+            (c["text"] for c in existing if c.get("type") == "text"),
+            "",
+        )
+        preserved_items = [c for c in existing if c.get("type") != "text"]
+    else:
+        text_part = existing if isinstance(existing, str) else ""
+        preserved_items = []
+
     content_items: list[dict[str, Any]] = [
         {"type": "video_url", "video_url": {"url": video["url"]}},
+        *preserved_items,
     ]
     if text_part:
         content_items.append({"type": "text", "text": text_part})
 
-    last["content"] = content_items
+    new_messages[last_idx] = {**new_messages[last_idx], "content": content_items}
 
     extra_body = {"mm_processor_kwargs": {"video": video["sampling"]}}
     return new_messages, extra_body

--- a/src/cognithor/core/vllm_orchestrator.py
+++ b/src/cognithor/core/vllm_orchestrator.py
@@ -22,6 +22,7 @@ from typing import Any, Literal
 
 import httpx
 
+from cognithor.config import VLLMConfig
 from cognithor.core.llm_backend import VLLMDockerError, VLLMHardwareError, VLLMNotReadyError
 from cognithor.utils.logging import get_logger
 
@@ -131,12 +132,15 @@ class VLLMOrchestrator:
         port: int = 8000,
         hf_token: str = "",
         log_ring_size: int = 500,
+        config: VLLMConfig | None = None,
     ) -> None:
         self.docker_image = docker_image
         self.port = port
         self._hf_token = hf_token
         self.state = VLLMState()
         self._log_ring: collections.deque[str] = collections.deque(maxlen=log_ring_size)
+        self._config: VLLMConfig = config if config is not None else VLLMConfig()
+        self.media_url: str | None = None
 
     def get_logs(self) -> list[str]:
         """Snapshot of the container-log ring buffer."""
@@ -368,12 +372,15 @@ class VLLMOrchestrator:
                 recovery_hint="Stop other services or change config.vllm.port.",
             )
 
+        cfg = self._config
         cmd = [
             "docker",
             "run",
             "-d",
             "--gpus",
             "all",
+            "--add-host",
+            "host.docker.internal:host-gateway",
             "-v",
             "cognithor-hf-cache:/root/.cache/huggingface",
             "-e",
@@ -382,10 +389,33 @@ class VLLMOrchestrator:
             f"{port}:8000",
             "--label",
             "cognithor.managed=true",
-            self.docker_image,
-            "--model",
-            model,
         ]
+        if self.media_url:
+            cmd.extend(["-e", f"COGNITHOR_MEDIA_URL={self.media_url}"])
+        cmd.extend(
+            [
+                self.docker_image,
+                "--model",
+                model,
+                "--max-model-len",
+                str(cfg.max_model_len),
+                "--max-num-seqs",
+                str(cfg.max_num_seqs),
+                "--max-num-batched-tokens",
+                str(cfg.max_num_batched_tokens),
+                "--gpu-memory-utilization",
+                f"{cfg.gpu_memory_utilization:g}",
+                "--reasoning-parser",
+                "qwen3",
+                "--trust-remote-code",
+                "--media-io-kwargs",
+                '{"video": {"num_frames": -1}}',
+            ]
+        )
+        if cfg.cpu_offload_gb > 0:
+            cmd.extend(["--cpu-offload-gb", str(cfg.cpu_offload_gb)])
+        if cfg.enforce_eager:
+            cmd.append("--enforce-eager")
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
         if result.returncode != 0:
             raise VLLMNotReadyError(

--- a/src/cognithor/core/vllm_orchestrator.py
+++ b/src/cognithor/core/vllm_orchestrator.py
@@ -30,6 +30,19 @@ log = get_logger(__name__)
 
 ProgressCallback = Callable[[dict[str, Any]], None] | None
 
+
+def _redact_hf_token(cmd: list[str]) -> list[str]:
+    """Return a copy of cmd with any HF_TOKEN=<value> element replaced by
+    HF_TOKEN=<redacted>. The token is never exposed in log output."""
+    redacted: list[str] = []
+    for item in cmd:
+        if item.startswith("HF_TOKEN="):
+            redacted.append("HF_TOKEN=<redacted>")
+        else:
+            redacted.append(item)
+    return redacted
+
+
 Priority = Literal["premium", "standard", "fallback"]
 Capability = Literal["vision", "text"]
 
@@ -416,8 +429,24 @@ class VLLMOrchestrator:
             cmd.extend(["--cpu-offload-gb", str(cfg.cpu_offload_gb)])
         if cfg.enforce_eager:
             cmd.append("--enforce-eager")
+
+        # Redact HF_TOKEN before logging — it's in the cmd list as "HF_TOKEN=<value>"
+        _cmd_for_log = _redact_hf_token(cmd)
+        log.info(
+            "vllm_docker_run_starting",
+            model=model,
+            image=self.docker_image,
+            port=port,
+            media_url=self.media_url,
+            cmd=_cmd_for_log,
+        )
         result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
         if result.returncode != 0:
+            log.error(
+                "vllm_docker_run_failed",
+                returncode=result.returncode,
+                stderr=result.stderr.strip()[:500],
+            )
             raise VLLMNotReadyError(
                 f"docker run failed: {result.stderr.strip()}",
                 recovery_hint="Check Docker Desktop logs.",

--- a/src/cognithor/core/vllm_orchestrator.py
+++ b/src/cognithor/core/vllm_orchestrator.py
@@ -127,7 +127,7 @@ class VLLMOrchestrator:
     def __init__(
         self,
         *,
-        docker_image: str = "vllm/vllm-openai:v0.19.1",
+        docker_image: str = "vllm/vllm-openai:cu130-nightly",
         port: int = 8000,
         hf_token: str = "",
         log_ring_size: int = 500,

--- a/src/cognithor/gateway/gateway.py
+++ b/src/cognithor/gateway/gateway.py
@@ -1100,6 +1100,16 @@ class Gateway:
                     self._vllm_orchestrator.media_url = f"http://host.docker.internal:{port}"
             except Exception:
                 log.warning("media_server_start_failed", exc_info=True)
+
+        # Bug C1-r3: publish the Gateway-owned VLLMOrchestrator (with media_url
+        # wired above) + MediaUploadServer onto every already-registered
+        # channel's FastAPI app.state. This is the defensive path for when a
+        # channel was registered BEFORE initialize(). The common path —
+        # register_channel() after initialize() — is handled by
+        # register_channel() itself via _publish_app_state.
+        for channel in self._channels.values():
+            self._publish_app_state(channel)
+
         if self._video_cleanup is not None:
             try:
                 await self._video_cleanup.start()
@@ -1334,7 +1344,27 @@ class Gateway:
         # Wire up cancel callback for channels that support it (e.g. WebUI)
         if hasattr(channel, "_cancel_callback"):
             channel._cancel_callback = self.cancel_session
+        # Bug C1-r3: expose Gateway-owned VLLMOrchestrator + MediaUploadServer
+        # onto channel.app.state so the backends_api and media_api routers see
+        # the same instances as the Gateway (media_url + media_server are
+        # already wired by initialize()). Channels are typically registered
+        # AFTER initialize(), so this is the primary wiring path; the duplicate
+        # loop in initialize() handles the reverse ordering defensively.
+        self._publish_app_state(channel)
         log.info("channel_registered", channel=channel.name)
+
+    def _publish_app_state(self, channel: Channel) -> None:
+        """Copy Gateway-owned singletons onto channel.app.state (idempotent)."""
+        app = getattr(channel, "app", None)
+        if app is None:
+            return
+        try:
+            if getattr(self, "_vllm_orchestrator", None) is not None:
+                app.state.vllm_orchestrator = self._vllm_orchestrator
+            if getattr(self, "_media_server", None) is not None:
+                app.state.media_server = self._media_server
+        except Exception:
+            log.debug("app_state_wiring_failed", channel=channel.name, exc_info=True)
 
     async def start(self) -> None:
         """Startet den Gateway und alle Channels + Cron."""

--- a/src/cognithor/gateway/gateway.py
+++ b/src/cognithor/gateway/gateway.py
@@ -262,6 +262,7 @@ class Gateway:
                 docker_image=self._config.vllm.docker_image,
                 port=self._config.vllm.port,
                 hf_token=self._config.huggingface_api_key,
+                config=self._config.vllm,
             )
             from cognithor.channels.media_server import MediaUploadServer
             from cognithor.gateway.video_cleanup import VideoCleanupWorker

--- a/src/cognithor/gateway/gateway.py
+++ b/src/cognithor/gateway/gateway.py
@@ -157,6 +157,77 @@ def _sanitize_broken_llm_output(text: str) -> str:
     return cleaned.strip()
 
 
+# ── Video attachment classification ──────────────────────────────────────────
+
+_IMAGE_EXTS = frozenset({".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp"})
+_VIDEO_EXTS = frozenset({".mp4", ".webm", ".mov", ".mkv", ".avi"})
+
+
+def _classify_attachments(
+    attachments: list[str],
+) -> tuple[list[str], str | None, list[str]]:
+    """Split an attachment list into images / one video / rejected extra videos.
+
+    Returns:
+        (image_attachments, first_video_or_None, rejected_extra_videos)
+
+    Single-video-per-turn policy (spec Decision 7): the first video in the
+    list wins; any additional videos go into ``rejected_extra_videos`` so the
+    caller can surface a user-visible validation error.
+    """
+    images: list[str] = []
+    video: str | None = None
+    rejected: list[str] = []
+    for path in attachments:
+        ext = ""
+        if "." in path:
+            ext = "." + path.rsplit(".", 1)[-1].lower()
+        if ext in _IMAGE_EXTS:
+            images.append(path)
+        elif ext in _VIDEO_EXTS:
+            if video is None:
+                video = path
+            else:
+                rejected.append(path)
+    return images, video, rejected
+
+
+def _build_video_attachment(source: str, config: CognithorConfig) -> dict[str, Any]:
+    """Turn a local path OR URL into a {'url': ..., 'sampling': ...} dict
+    suitable for WorkingMemory.video_attachment.
+
+    URLs are passed through verbatim. Local paths must already be uploaded
+    via /api/media/upload in production — the Flutter client does this.
+    But if a raw local path arrives (e.g. from a future direct-path code
+    path or a test), we still produce a sane sampling without a URL.
+    """
+    from cognithor.core.video_sampling import resolve_sampling
+
+    sampling = resolve_sampling(
+        source,
+        ffprobe_path=config.vllm.video_ffprobe_path,
+        timeout_seconds=config.vllm.video_ffprobe_timeout_seconds,
+        http_timeout_seconds=config.vllm.video_ffprobe_http_timeout_seconds,
+        override=config.vllm.video_sampling_mode,
+    )
+    return {"url": source, "sampling": sampling.as_mm_kwargs()}
+
+
+def _extract_uuid_from_path(source: str) -> str | None:
+    """Pull a UUID out of ``http://.../media/<uuid>.<ext>`` or ``<uuid>.<ext>``.
+
+    Returns None for non-matching forms (e.g. external URLs like
+    https://example.com/clip.mp4). The UUID is used to register the upload
+    with VideoCleanupWorker; external URLs don't need cleanup.
+    """
+    basename = source.rsplit("/", 1)[-1]
+    stem = basename.rsplit(".", 1)[0]
+    # UUIDs from uuid4().hex are 32 hex chars
+    if len(stem) == 32 and all(c in "0123456789abcdef" for c in stem):
+        return stem
+    return None
+
+
 class Gateway:
     """Central entry point. Connects all Cognithor subsystems. [B§9.1]"""
 
@@ -182,6 +253,8 @@ class Gateway:
         self._pattern_record_timestamps: list[float] = []
 
         # vLLM orchestrator — created lazily if enabled; lifecycle hooks use this
+        self._media_server = None
+        self._video_cleanup = None
         if self._config.vllm.enabled:
             from cognithor.core.vllm_orchestrator import VLLMOrchestrator
 
@@ -189,6 +262,14 @@ class Gateway:
                 docker_image=self._config.vllm.docker_image,
                 port=self._config.vllm.port,
                 hf_token=self._config.huggingface_api_key,
+            )
+            from cognithor.channels.media_server import MediaUploadServer
+            from cognithor.gateway.video_cleanup import VideoCleanupWorker
+
+            self._media_server = MediaUploadServer(self._config)
+            self._video_cleanup = VideoCleanupWorker(
+                media_dir=self._media_server._media_dir,
+                ttl_hours=self._config.vllm.video_upload_ttl_hours,
             )
         else:
             self._vllm_orchestrator = None
@@ -1010,6 +1091,20 @@ class Gateway:
         # V6: Wire tool registry into Gatekeeper for per-tool risk annotations
         if self._gatekeeper and hasattr(self._mcp_client, "_tool_registry"):
             self._gatekeeper.set_tool_registry(self._mcp_client._tool_registry)
+
+        # vLLM media server + cleanup worker lifecycle
+        if self._media_server is not None:
+            try:
+                port = await self._media_server.start()
+                if self._vllm_orchestrator is not None:
+                    self._vllm_orchestrator.media_url = f"http://host.docker.internal:{port}"
+            except Exception:
+                log.warning("media_server_start_failed", exc_info=True)
+        if self._video_cleanup is not None:
+            try:
+                await self._video_cleanup.start()
+            except Exception:
+                log.warning("video_cleanup_start_failed", exc_info=True)
 
         log.info(
             "gateway_init_complete",
@@ -1843,6 +1938,18 @@ class Gateway:
                 self._user_pref_store.close()
             except Exception:
                 log.debug("user_pref_store_close_skipped", exc_info=True)
+
+        # vLLM video cleanup + media server teardown
+        if self._video_cleanup is not None:
+            try:
+                await self._video_cleanup.stop()
+            except Exception:
+                log.debug("video_cleanup_stop_skipped", exc_info=True)
+        if self._media_server is not None:
+            try:
+                await self._media_server.stop()
+            except Exception:
+                log.debug("media_server_stop_skipped", exc_info=True)
 
         # MCP-Client trennen
         if self._mcp_client:
@@ -2774,13 +2881,27 @@ class Gateway:
         wm = self._get_or_create_working_memory(session)
         wm.clear_for_new_request()
 
-        # Route image attachments to the VLM for this turn. Cleared by
+        # Route image/video attachments to the VLM for this turn. Cleared by
         # clear_for_new_request() so it only affects the current turn.
-        _IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".webp", ".gif", ".bmp"}
         if msg.attachments:
-            wm.image_attachments = [
-                a for a in msg.attachments if any(a.lower().endswith(ext) for ext in _IMAGE_EXTS)
-            ]
+            images, video_path, rejected_videos = _classify_attachments(msg.attachments)
+            wm.image_attachments = images
+            if video_path is not None:
+                try:
+                    wm.video_attachment = _build_video_attachment(video_path, self._config)
+                    uuid = _extract_uuid_from_path(video_path)
+                    if uuid is not None and self._video_cleanup is not None:
+                        self._video_cleanup.register_upload(uuid, session.session_id)
+                except Exception:
+                    log.warning("video_attachment_build_failed", path=video_path, exc_info=True)
+            if rejected_videos:
+                log.warning(
+                    "video_validation_extras_rejected",
+                    session_id=session.session_id,
+                    rejected=rejected_videos,
+                )
+        else:
+            wm.image_attachments = []
 
         # Start explainability trail for this request
         _expl_trail_id: str | None = None

--- a/src/cognithor/gateway/gateway.py
+++ b/src/cognithor/gateway/gateway.py
@@ -5433,8 +5433,14 @@ class Gateway:
 
         This is called periodically (guarded by _CLEANUP_INTERVAL_SECONDS) to
         prevent unbounded growth of the in-memory session and working-memory dicts.
+
+        When a VideoCleanupWorker is configured, each evicted session_id is also
+        dispatched to :meth:`VideoCleanupWorker.on_session_close` so that any
+        uploaded video files registered against that session are deleted
+        immediately, instead of waiting for the 24 h TTL sweep.
         """
         now = time.monotonic()
+        evicted_session_ids: list[str] = []
         with self._session_lock:
             stale_keys = [
                 key
@@ -5445,9 +5451,39 @@ class Gateway:
                 session = self._sessions.pop(key, None)
                 if session:
                     self._working_memories.pop(session.session_id, None)
+                    evicted_session_ids.append(session.session_id)
                 self._session_last_accessed.pop(key, None)
         if stale_keys:
             log.info("stale_sessions_cleaned", count=len(stale_keys))
+        # Session-lifetime video cleanup: fire VideoCleanupWorker.on_session_close
+        # for each evicted session so registered uploads are deleted now rather
+        # than waiting up to 24 h for the TTL sweep. on_session_close is a
+        # coroutine; schedule it as a background task if we are on an event
+        # loop, otherwise the TTL sweep remains a safety net.
+        video_cleanup = getattr(self, "_video_cleanup", None)
+        if evicted_session_ids and video_cleanup is not None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                # Called from a thread or context with no running loop —
+                # rely on the TTL sweep to reclaim the orphaned uploads.
+                loop = None
+            if loop is not None:
+                background_tasks = getattr(self, "_background_tasks", None)
+                for sid in evicted_session_ids:
+                    try:
+                        task = loop.create_task(video_cleanup.on_session_close(sid))
+                        # Track to keep a strong reference and avoid "Task was
+                        # destroyed but it is pending" warnings.
+                        if background_tasks is not None:
+                            background_tasks.add(task)
+                            task.add_done_callback(background_tasks.discard)
+                    except Exception:
+                        log.debug(
+                            "video_cleanup_schedule_failed",
+                            session_id=sid,
+                            exc_info=True,
+                        )
         self._last_session_cleanup = now
 
     def _maybe_cleanup_sessions(self) -> None:

--- a/src/cognithor/gateway/gateway.py
+++ b/src/cognithor/gateway/gateway.py
@@ -2888,7 +2888,9 @@ class Gateway:
             wm.image_attachments = images
             if video_path is not None:
                 try:
-                    wm.video_attachment = _build_video_attachment(video_path, self._config)
+                    wm.video_attachment = await asyncio.to_thread(
+                        _build_video_attachment, video_path, self._config
+                    )
                     uuid = _extract_uuid_from_path(video_path)
                     if uuid is not None and self._video_cleanup is not None:
                         self._video_cleanup.register_upload(uuid, session.session_id)

--- a/src/cognithor/gateway/video_cleanup.py
+++ b/src/cognithor/gateway/video_cleanup.py
@@ -38,7 +38,18 @@ class VideoCleanupWorker:
         self._stop_event = asyncio.Event()
 
     async def start(self) -> None:
-        """Run TTL sweep once at start, then kick off the periodic sweep loop."""
+        """Run TTL sweep once at start, then kick off the periodic sweep loop.
+
+        Idempotent: if a sweep task is already running, skip the restart so
+        retry paths (e.g. after a partial media-server bind failure) don't
+        orphan the first task. A previous task that has already finished is
+        cleared before a fresh one is scheduled.
+        """
+        if self._sweep_task is not None and not self._sweep_task.done():
+            log.debug("video_cleanup_already_started")
+            return
+        # If there's a previous finished task, clear it before creating a new one.
+        self._sweep_task = None
         await self._sweep_once()
         self._stop_event.clear()
         self._sweep_task = asyncio.create_task(self._run_periodic())

--- a/src/cognithor/gateway/video_cleanup.py
+++ b/src/cognithor/gateway/video_cleanup.py
@@ -1,0 +1,110 @@
+"""VideoCleanupWorker — deletes uploaded videos on session close + TTL expiry.
+
+No persistent state — the 24 h filesystem-mtime-based TTL sweep is authoritative.
+Session tracking is an optimization: users who close a session before the TTL
+window get their videos deleted sooner. If Cognithor crashes mid-session and
+never fires ``on_session_close``, the TTL sweep picks up the orphans on the next
+run or within the hour.
+
+See spec: docs/superpowers/specs/2026-04-23-video-input-vllm-design.md
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+from cognithor.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+class VideoCleanupWorker:
+    """Manages per-session cleanup and a periodic TTL sweep."""
+
+    def __init__(
+        self,
+        media_dir: Path,
+        *,
+        ttl_hours: int = 24,
+        sweep_interval_sec: float = 60.0,
+    ) -> None:
+        self._media_dir = Path(media_dir)
+        self._ttl_hours = ttl_hours
+        self._sweep_interval = sweep_interval_sec
+        self._by_session: dict[str, list[str]] = {}
+        self._sweep_task: asyncio.Task[None] | None = None
+        self._stop_event = asyncio.Event()
+
+    async def start(self) -> None:
+        """Run TTL sweep once at start, then kick off the periodic sweep loop."""
+        await self._sweep_once()
+        self._stop_event.clear()
+        self._sweep_task = asyncio.create_task(self._run_periodic())
+        log.info("video_cleanup_started", media_dir=str(self._media_dir), ttl_hours=self._ttl_hours)
+
+    async def stop(self) -> None:
+        """Cancel the periodic sweep. Idempotent."""
+        if self._sweep_task is None:
+            return
+        self._stop_event.set()
+        try:
+            await asyncio.wait_for(self._sweep_task, timeout=2.0)
+        except (TimeoutError, asyncio.CancelledError):
+            self._sweep_task.cancel()
+        self._sweep_task = None
+        log.info("video_cleanup_stopped")
+
+    def register_upload(self, uuid: str, session_id: str) -> None:
+        """Track this upload so it's deleted when the session closes."""
+        self._by_session.setdefault(session_id, []).append(uuid)
+
+    async def on_session_close(self, session_id: str) -> None:
+        """Delete all uploads (and thumbnails) registered under this session."""
+        uuids = self._by_session.pop(session_id, [])
+        for uuid in uuids:
+            self._delete_upload(uuid)
+
+    def _delete_upload(self, uuid: str) -> None:
+        """Remove any file starting with ``<uuid>.`` in the media dir."""
+        if not self._media_dir.is_dir():
+            return
+        for path in self._media_dir.glob(f"{uuid}.*"):
+            try:
+                path.unlink()
+            except OSError as exc:
+                log.warning(
+                    "video_cleanup_delete_failed",
+                    uuid=uuid,
+                    path=str(path),
+                    error=str(exc),
+                )
+
+    async def _run_periodic(self) -> None:
+        """Loop: wait ``_sweep_interval`` seconds, sweep, repeat until stopped."""
+        while not self._stop_event.is_set():
+            try:
+                await asyncio.wait_for(self._stop_event.wait(), timeout=self._sweep_interval)
+                return  # stop signal arrived
+            except TimeoutError:
+                pass
+            await self._sweep_once()
+
+    async def _sweep_once(self) -> None:
+        """Delete every file in ``media_dir`` whose mtime is older than ttl_hours."""
+        if not self._media_dir.is_dir():
+            return
+        cutoff = time.time() - self._ttl_hours * 3600
+        deleted = 0
+        for path in self._media_dir.iterdir():
+            if not path.is_file():
+                continue
+            try:
+                if path.stat().st_mtime < cutoff:
+                    path.unlink()
+                    deleted += 1
+            except OSError as exc:
+                log.warning("video_ttl_sweep_failed", path=str(path), error=str(exc))
+        if deleted:
+            log.info("video_ttl_sweep_completed", deleted=deleted)

--- a/src/cognithor/models.py
+++ b/src/cognithor/models.py
@@ -496,6 +496,14 @@ class WorkingMemory(BaseModel):
     # Paths to image attachments on this turn. Routed to vision_model_detail
     # by the Planner when non-empty. Cleared by the Gateway after one turn.
     image_attachments: list[str] = Field(default_factory=list)
+    video_attachment: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Per-turn video attachment: "
+            "{'url': str, 'sampling': {'fps': float} | {'num_frames': int}}. "
+            "At most one video per chat turn (see video-input spec 2026-04-23)."
+        ),
+    )
 
     @property
     def usage_ratio(self) -> float:
@@ -571,10 +579,11 @@ class WorkingMemory(BaseModel):
         self.active_plan = None
         self.injected_memories = []
         self.injected_procedures = []
-        # image_attachments are per-turn — the Gateway sets them from the
-        # incoming message before each turn, so clearing here avoids bleed
-        # from the previous turn.
+        # image_attachments and video_attachment are per-turn — the Gateway
+        # sets them from the incoming message before each turn, so clearing
+        # here avoids bleed from the previous turn.
         self.image_attachments = []
+        self.video_attachment = None
 
 
 # ============================================================================

--- a/tests/config/test_vllm_config.py
+++ b/tests/config/test_vllm_config.py
@@ -12,7 +12,7 @@ class TestVLLMConfig:
         c = VLLMConfig()
         assert c.enabled is False
         assert c.model == ""
-        assert c.docker_image == "vllm/vllm-openai:v0.19.1"
+        assert c.docker_image == "vllm/vllm-openai:cu130-nightly"
         assert c.port == 8000
         assert c.auto_stop_on_close is False
         assert c.skip_hardware_check is False

--- a/tests/config/test_vllm_config.py
+++ b/tests/config/test_vllm_config.py
@@ -31,3 +31,65 @@ class TestVLLMConfig:
         c = CognithorConfig(vllm={"enabled": True, "port": 8042})
         assert c.vllm.enabled is True
         assert c.vllm.port == 8042
+
+
+class TestVLLMConfigVideoFields:
+    def test_video_defaults(self):
+        c = VLLMConfig()
+        assert c.video_sampling_mode == "adaptive"
+        assert c.video_ffprobe_path == "ffprobe"
+        assert c.video_ffprobe_timeout_seconds == 5
+        assert c.video_ffprobe_http_timeout_seconds == 30
+        assert c.video_max_upload_mb == 500
+        assert c.video_quota_gb == 5
+        assert c.video_upload_ttl_hours == 24
+
+    def test_video_sampling_mode_literal_rejects_garbage(self):
+        with pytest.raises(ValidationError):
+            VLLMConfig(video_sampling_mode="totally_bogus")
+
+    def test_video_sampling_mode_accepts_all_four(self):
+        for mode in ("adaptive", "fixed_32", "fixed_64", "fps_1"):
+            c = VLLMConfig(video_sampling_mode=mode)
+            assert c.video_sampling_mode == mode
+
+    def test_timeout_lower_bound(self):
+        with pytest.raises(ValidationError):
+            VLLMConfig(video_ffprobe_timeout_seconds=0)
+
+    def test_upload_mb_upper_bound(self):
+        with pytest.raises(ValidationError):
+            VLLMConfig(video_max_upload_mb=999999)
+
+
+class TestVLLMConfigLauncherFields:
+    """Flags that the spike identified as required for 32 GB-class GPUs.
+    Defaults match the spike's working RTX 5090 profile."""
+
+    def test_launcher_defaults_match_spike_profile(self):
+        c = VLLMConfig()
+        assert c.max_model_len == 16384
+        assert c.max_num_seqs == 2
+        assert c.max_num_batched_tokens == 2048
+        assert c.gpu_memory_utilization == 0.94
+        assert c.cpu_offload_gb == 4
+        assert c.enforce_eager is True
+
+    def test_gpu_util_must_be_in_open_unit_interval(self):
+        with pytest.raises(ValidationError):
+            VLLMConfig(gpu_memory_utilization=0.0)
+        with pytest.raises(ValidationError):
+            VLLMConfig(gpu_memory_utilization=1.01)
+
+    def test_larger_gpu_profile(self):
+        """User with an A100 loosens the defaults."""
+        c = VLLMConfig(
+            max_model_len=65536,
+            max_num_seqs=8,
+            gpu_memory_utilization=0.90,
+            cpu_offload_gb=0,
+            enforce_eager=False,
+        )
+        assert c.max_model_len == 65536
+        assert c.cpu_offload_gb == 0
+        assert c.enforce_eager is False

--- a/tests/test_channels/test_backends_api_orchestrator_unification.py
+++ b/tests/test_channels/test_backends_api_orchestrator_unification.py
@@ -1,0 +1,133 @@
+"""Regression for Bug C1-r3: the backends_api endpoints must use the same
+VLLMOrchestrator instance as the Gateway, so media_url set by Gateway
+propagates into the start_container call path.
+
+Without this unification there are two separate VLLMOrchestrator objects:
+one owned by the Gateway (with .media_url wired after MediaUploadServer
+startup) and one cached at module level inside backends_api. In production
+the Flutter UI hits backends_api, which launches a vLLM container without
+the -e COGNITHOR_MEDIA_URL=... flag, so the container cannot reach the
+media-upload server.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+class TestOrchestratorUnification:
+    def test_resolve_orchestrator_prefers_app_state(self):
+        """When Gateway has registered its orchestrator onto app.state, the
+        backends_api helper must return that instance, not create a new one."""
+        from cognithor.channels.backends_api import _resolve_orchestrator
+
+        gateway_orch = MagicMock(name="gateway-owned")
+        request = MagicMock()
+        request.app.state.vllm_orchestrator = gateway_orch
+        request.app.state.config = MagicMock()
+
+        resolved = _resolve_orchestrator(request)
+        assert resolved is gateway_orch
+
+    def test_resolve_orchestrator_falls_back_to_cache_when_no_gateway(self):
+        """In standalone API mode (no Gateway) the cached-creation path is used."""
+        from cognithor.channels.backends_api import _resolve_orchestrator
+        from cognithor.config import CognithorConfig
+
+        # Use a real FastAPI app so request.app.state is the real State object
+        # (not a MagicMock which auto-creates any attribute).
+        app = FastAPI()
+        app.state.config = CognithorConfig()
+        # Deliberately do NOT set app.state.vllm_orchestrator — simulates
+        # standalone API mode.
+
+        request = MagicMock()
+        request.app = app
+
+        resolved = _resolve_orchestrator(request)
+        assert resolved is not None
+
+    def test_resolve_orchestrator_falls_back_when_state_attr_is_none(self):
+        """An explicit None on app.state.vllm_orchestrator must also fall
+        through to the cached-creation path — otherwise channels that
+        tentatively reserved the slot would break standalone mode."""
+        from cognithor.channels.backends_api import _resolve_orchestrator
+        from cognithor.config import CognithorConfig
+
+        app = FastAPI()
+        app.state.config = CognithorConfig()
+        app.state.vllm_orchestrator = None
+
+        request = MagicMock()
+        request.app = app
+
+        resolved = _resolve_orchestrator(request)
+        assert resolved is not None
+
+    def test_start_endpoint_uses_app_state_orchestrator_over_cache(self):
+        """Integration: when app.state.vllm_orchestrator is registered, the
+        POST /api/backends/vllm/start endpoint must call start_container on
+        THAT instance — not on the module-level cached fallback."""
+        from cognithor.channels.backends_api import build_backends_app
+        from cognithor.config import CognithorConfig, VLLMConfig
+        from cognithor.core.vllm_orchestrator import ContainerInfo
+
+        cfg = CognithorConfig(vllm=VLLMConfig(enabled=True))
+        app = build_backends_app(config=cfg)
+
+        gateway_orch = MagicMock(name="gateway-owned")
+        gateway_orch.start_container.return_value = ContainerInfo(
+            container_id="cid-gw", port=8000, model="some-model"
+        )
+        app.state.vllm_orchestrator = gateway_orch
+
+        client = TestClient(app)
+        r = client.post("/api/backends/vllm/start", json={"model": "some-model"})
+        assert r.status_code == 200
+        assert r.json()["container_id"] == "cid-gw"
+        gateway_orch.start_container.assert_called_once_with("some-model")
+
+    def test_media_url_on_gateway_propagates_to_start_container_call(self):
+        """End-to-end: Gateway sets media_url, backends_api start endpoint uses
+        the same instance, subprocess sees -e COGNITHOR_MEDIA_URL=..."""
+        from cognithor.config import CognithorConfig, VLLMConfig
+        from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+
+        cfg = CognithorConfig(vllm=VLLMConfig(enabled=True))
+        orch = VLLMOrchestrator(config=cfg.vllm)
+        orch.media_url = "http://host.docker.internal:9999"
+
+        # Simulate the flow: we resolve orch and call start_container.
+        with (
+            patch.object(VLLMOrchestrator, "_port_available", return_value=True),
+            patch(
+                "subprocess.run",
+                return_value=MagicMock(returncode=0, stdout="cid"),
+            ) as run_mock,
+            patch.object(VLLMOrchestrator, "_wait_for_health", return_value=True),
+        ):
+            orch.start_container("mmangkad/Qwen3.6-27B-NVFP4")
+
+        args = run_mock.call_args[0][0]
+        assert any("COGNITHOR_MEDIA_URL=http://host.docker.internal:9999" in a for a in args), (
+            "Expected -e COGNITHOR_MEDIA_URL=... in docker run args when media_url is set"
+        )
+
+
+class TestGatewayRegistersOrchestratorOnAppState:
+    def test_gateway_exposes_orchestrator_on_app_state_when_vllm_enabled(self):
+        """Gateway must register self._vllm_orchestrator onto the APIChannel's
+        FastAPI app.state so backends_api can resolve it. Source-level check
+        since constructing a real Gateway requires the full init chain."""
+        import inspect
+
+        from cognithor.gateway import gateway as gw
+
+        src = inspect.getsource(gw)
+        assert "app.state.vllm_orchestrator" in src, (
+            "Gateway must set app.state.vllm_orchestrator = self._vllm_orchestrator "
+            "so backends_api endpoints see the same instance (media_url wired)."
+        )

--- a/tests/test_channels/test_media_api.py
+++ b/tests/test_channels/test_media_api.py
@@ -80,3 +80,80 @@ class TestThumbEndpoint:
     def test_thumb_returns_404_for_missing(self, client: TestClient):
         r = client.get("/api/media/thumb/not-a-real-uuid.jpg")
         assert r.status_code == 404
+
+
+class TestUploadDoesNotBlockEventLoop:
+    @pytest.mark.asyncio
+    async def test_concurrent_requests_not_serialized_by_subprocess(self, tmp_path: Path):
+        """When ffprobe/ffmpeg are slow, concurrent upload requests must
+        not serialize on the event loop.
+
+        We drive this by patching resolve_sampling to sleep (simulating
+        ffprobe hanging on a slow HTTP URL) and firing two uploads
+        concurrently. If the handler runs subprocess.run directly on the
+        loop, total wall time ~ 2*sleep. With asyncio.to_thread it's ~
+        1*sleep."""
+        import asyncio as _asyncio
+        import time
+
+        from cognithor.channels.media_server import MediaUploadServer
+        from cognithor.config import CognithorConfig, VLLMConfig
+        from cognithor.core.video_sampling import VideoSampling
+
+        cfg = CognithorConfig(
+            cognithor_home=tmp_path,
+            vllm=VLLMConfig(enabled=True, video_max_upload_mb=10, video_quota_gb=1),
+        )
+        ms = MediaUploadServer(cfg)
+        ms._port = 4711
+        from cognithor.channels.media_api import build_media_app
+
+        app = build_media_app(config=cfg, media_server=ms)
+
+        sleep_seconds = 0.5
+
+        def _slow_sampling(*args, **kwargs) -> VideoSampling:
+            time.sleep(sleep_seconds)  # blocking sync sleep - a proxy for ffprobe
+            return VideoSampling(fps=1.0, duration_sec=10.0)
+
+        with (
+            patch(
+                "cognithor.channels.media_api.resolve_sampling",
+                side_effect=_slow_sampling,
+            ),
+            patch(
+                "cognithor.channels.media_api._extract_thumbnail",
+                return_value=True,
+            ),
+        ):
+            # TestClient runs in a separate thread so we can't use it for
+            # concurrent-async testing. Instead use httpx.AsyncClient against
+            # an ASGITransport.
+            from httpx import ASGITransport, AsyncClient
+
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                start = time.perf_counter()
+                responses = await _asyncio.gather(
+                    client.post(
+                        "/api/media/upload",
+                        files={"file": ("a.mp4", b"\x00" * 2048, "video/mp4")},
+                    ),
+                    client.post(
+                        "/api/media/upload",
+                        files={"file": ("b.mp4", b"\x00" * 2048, "video/mp4")},
+                    ),
+                )
+                elapsed = time.perf_counter() - start
+
+        for r in responses:
+            assert r.status_code == 200, r.text
+
+        # With asyncio.to_thread: ~sleep_seconds (parallel) + overhead
+        # Without: ~2*sleep_seconds (serialized)
+        # Tolerance: pass if < 1.6*sleep_seconds (i.e. strictly less than
+        # serial execution, accounting for thread-pool startup).
+        assert elapsed < 1.6 * sleep_seconds, (
+            f"Upload handler appears to serialize: {elapsed:.2f}s for two 0.5s uploads "
+            f"(expected ~0.5s parallel, got {elapsed:.2f}s)"
+        )

--- a/tests/test_channels/test_media_api.py
+++ b/tests/test_channels/test_media_api.py
@@ -82,6 +82,39 @@ class TestThumbEndpoint:
         assert r.status_code == 404
 
 
+class TestThumbPathTraversal:
+    def test_thumb_rejects_absolute_path(self, client: TestClient):
+        r = client.get("/api/media/thumb//etc/passwd")
+        # The double-slash after /thumb/ does NOT collapse in Starlette
+        # routing, so this request hits no route and returns 404. If the
+        # router ever starts normalizing slashes, the filename reaching
+        # the handler would be "etc/passwd" — which must then be rejected
+        # with 400. Either outcome is an acceptable "reject".
+        assert r.status_code in (400, 404)
+
+    def test_thumb_rejects_parent_traversal(self, client: TestClient):
+        r = client.get("/api/media/thumb/..%2F..%2Fetc%2Fpasswd")
+        assert r.status_code in (400, 404)  # either path-reject or not-found
+
+    def test_thumb_rejects_backslash_on_windows(self, client: TestClient):
+        r = client.get("/api/media/thumb/..%5C..%5Csecret.txt")
+        assert r.status_code in (400, 404)
+
+    def test_thumb_rejects_absolute_windows_path(self, client: TestClient):
+        r = client.get("/api/media/thumb/C:%5CWindows%5Csystem32%5Ccmd.exe")
+        assert r.status_code in (400, 404)
+
+    def test_thumb_accepts_legitimate_uuid_filename(self, client: TestClient, tmp_path: Path):
+        """After hardening, legit {uuid}.jpg still works."""
+        # Pre-plant a thumbnail
+        uuid = "abc123def456"
+        media_dir = tmp_path / "media" / "vllm-uploads"
+        media_dir.mkdir(parents=True, exist_ok=True)
+        (media_dir / f"{uuid}.jpg").write_bytes(b"\xff\xd8\xff\xe0fake")
+        r = client.get(f"/api/media/thumb/{uuid}.jpg")
+        assert r.status_code == 200
+
+
 class TestUploadDoesNotBlockEventLoop:
     @pytest.mark.asyncio
     async def test_concurrent_requests_not_serialized_by_subprocess(self, tmp_path: Path):

--- a/tests/test_channels/test_media_api.py
+++ b/tests/test_channels/test_media_api.py
@@ -190,3 +190,36 @@ class TestUploadDoesNotBlockEventLoop:
             f"Upload handler appears to serialize: {elapsed:.2f}s for two 0.5s uploads "
             f"(expected ~0.5s parallel, got {elapsed:.2f}s)"
         )
+
+
+class TestUploadQuotaExceededSurfacesRecoveryHint:
+    def test_quota_exceeded_response_includes_recovery_hint(
+        self, client: TestClient, tmp_path: Path
+    ):
+        """Regression for Bug-4-r4: MediaUploadQuotaExceededError's
+        recovery_hint must reach the client, not be dropped by the generic
+        MediaUploadError catch branch."""
+        from cognithor.core.llm_backend import MediaUploadQuotaExceededError
+
+        # Patch save_upload on the actual media_server instance owned by the
+        # FastAPI app state — `media_api` does not re-export MediaUploadServer,
+        # and patching the class globally does not reach the live instance
+        # method lookup.
+        media_server = client.app.state.media_server
+        with patch.object(
+            media_server,
+            "save_upload",
+            side_effect=MediaUploadQuotaExceededError(
+                "Upload alone (2048.0 MB) exceeds the full quota (1.0 GB)",
+                status_code=413,
+                recovery_hint="Raise config.vllm.video_quota_gb or shrink the file.",
+            ),
+        ):
+            r = client.post(
+                "/api/media/upload",
+                files={"file": ("huge.mp4", b"\x00" * 2048, "video/mp4")},
+            )
+        assert r.status_code == 507
+        detail = r.json().get("detail", {})
+        assert "recovery_hint" in detail, f"Expected recovery_hint in detail: {detail}"
+        assert "video_quota_gb" in detail["recovery_hint"]

--- a/tests/test_channels/test_media_api.py
+++ b/tests/test_channels/test_media_api.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from pathlib import Path  # noqa: TC003
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cognithor.channels.media_api import build_media_app
+from cognithor.channels.media_server import MediaUploadServer
+from cognithor.config import CognithorConfig, VLLMConfig
+
+
+@pytest.fixture
+def client(tmp_path: Path) -> TestClient:
+    cfg = CognithorConfig(
+        cognithor_home=tmp_path,
+        vllm=VLLMConfig(enabled=True, video_max_upload_mb=10, video_quota_gb=1),
+    )
+    media_server = MediaUploadServer(cfg)
+    media_server._port = 4711  # not running, but public_url needs a port
+    app = build_media_app(config=cfg, media_server=media_server)
+    return TestClient(app)
+
+
+class TestUploadEndpoint:
+    def test_upload_valid_video_returns_metadata(self, client: TestClient):
+        from cognithor.core.video_sampling import VideoSampling
+
+        with (
+            patch(
+                "cognithor.channels.media_api.resolve_sampling",
+                return_value=VideoSampling(fps=1.0, duration_sec=93.5),
+            ),
+            patch(
+                "cognithor.channels.media_api._extract_thumbnail",
+                return_value=True,
+            ),
+        ):
+            r = client.post(
+                "/api/media/upload",
+                files={"file": ("drone.mp4", b"\x00" * 2048, "video/mp4")},
+            )
+        assert r.status_code == 200
+        data = r.json()
+        assert "uuid" in data
+        assert data["url"].startswith("http://host.docker.internal:4711/media/")
+        assert data["duration_sec"] == 93.5
+        assert data["sampling"] == {"fps": 1.0}
+        assert data["thumb_url"].startswith("/api/media/thumb/")
+
+    def test_upload_too_large_returns_413(self, client: TestClient):
+        too_big = b"\x00" * (11 * 1024 * 1024)
+        r = client.post(
+            "/api/media/upload",
+            files={"file": ("big.mp4", too_big, "video/mp4")},
+        )
+        assert r.status_code == 413
+        assert "recovery_hint" in r.json().get("detail", {})
+
+    def test_upload_unsupported_extension_returns_400(self, client: TestClient):
+        r = client.post(
+            "/api/media/upload",
+            files={"file": ("trojan.exe", b"\x00" * 1024, "application/octet-stream")},
+        )
+        assert r.status_code == 400
+
+
+class TestThumbEndpoint:
+    def test_thumb_returns_jpeg(self, client: TestClient, tmp_path: Path):
+        uuid = "test-uuid-1234"
+        media_dir = tmp_path / "media" / "vllm-uploads"
+        media_dir.mkdir(parents=True, exist_ok=True)
+        thumb = media_dir / f"{uuid}.jpg"
+        thumb.write_bytes(b"\xff\xd8\xff\xe0fake-jpeg-bytes")
+        r = client.get(f"/api/media/thumb/{uuid}.jpg")
+        assert r.status_code == 200
+        assert r.headers["content-type"].startswith("image/")
+
+    def test_thumb_returns_404_for_missing(self, client: TestClient):
+        r = client.get("/api/media/thumb/not-a-real-uuid.jpg")
+        assert r.status_code == 404

--- a/tests/test_channels/test_media_server.py
+++ b/tests/test_channels/test_media_server.py
@@ -89,3 +89,46 @@ class TestDelete:
 
     def test_delete_of_missing_is_noop(self, server: MediaUploadServer):
         server.delete("nonexistent-uuid-abc", "mp4")  # must not raise
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_binds_ephemeral_port_serves_media(self, tmp_path: Path):
+        import httpx
+
+        from cognithor.config import CognithorConfig, VLLMConfig
+
+        cfg = CognithorConfig(
+            cognithor_home=tmp_path,
+            vllm=VLLMConfig(enabled=True, video_max_upload_mb=10, video_quota_gb=1),
+        )
+        srv = MediaUploadServer(cfg)
+        port = await srv.start()
+        try:
+            assert port > 0
+            uuid = srv.save_upload(b"hello video world", "mp4")
+            url = f"http://127.0.0.1:{port}/media/{uuid}.mp4"
+            async with httpx.AsyncClient() as client:
+                r = await client.get(url, timeout=5.0)
+            assert r.status_code == 200
+            assert r.content == b"hello video world"
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_stop_is_idempotent(self, tmp_path: Path):
+        from cognithor.config import CognithorConfig, VLLMConfig
+
+        cfg = CognithorConfig(
+            cognithor_home=tmp_path,
+            vllm=VLLMConfig(enabled=True),
+        )
+        srv = MediaUploadServer(cfg)
+        await srv.start()
+        await srv.stop()
+        await srv.stop()  # second stop must not raise
+        # Restart on a fresh instance
+        srv2 = MediaUploadServer(cfg)
+        port2 = await srv2.start()
+        assert port2 > 0
+        await srv2.stop()

--- a/tests/test_channels/test_media_server.py
+++ b/tests/test_channels/test_media_server.py
@@ -132,3 +132,74 @@ class TestLifecycle:
         port2 = await srv2.start()
         assert port2 > 0
         await srv2.stop()
+
+
+class TestServePathTraversal:
+    @pytest.mark.asyncio
+    async def test_serve_rejects_parent_traversal(self, tmp_path: Path):
+        import httpx
+
+        from cognithor.config import CognithorConfig, VLLMConfig
+
+        cfg = CognithorConfig(
+            cognithor_home=tmp_path,
+            vllm=VLLMConfig(enabled=True, video_max_upload_mb=10, video_quota_gb=1),
+        )
+        srv = MediaUploadServer(cfg)
+        port = await srv.start()
+        try:
+            async with httpx.AsyncClient() as client:
+                r = await client.get(
+                    f"http://127.0.0.1:{port}/media/..%2F..%2Fetc%2Fpasswd",
+                    timeout=5.0,
+                )
+            assert r.status_code in (400, 404)
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_serve_rejects_backslash_traversal(self, tmp_path: Path):
+        import httpx
+
+        from cognithor.config import CognithorConfig, VLLMConfig
+
+        cfg = CognithorConfig(
+            cognithor_home=tmp_path,
+            vllm=VLLMConfig(enabled=True, video_max_upload_mb=10, video_quota_gb=1),
+        )
+        srv = MediaUploadServer(cfg)
+        port = await srv.start()
+        try:
+            async with httpx.AsyncClient() as client:
+                r = await client.get(
+                    f"http://127.0.0.1:{port}/media/..%5C..%5Csecret.txt",
+                    timeout=5.0,
+                )
+            assert r.status_code in (400, 404)
+        finally:
+            await srv.stop()
+
+    @pytest.mark.asyncio
+    async def test_serve_accepts_legitimate_uuid(self, tmp_path: Path):
+        """After hardening, legit {uuid}.mp4 still works."""
+        import httpx
+
+        from cognithor.config import CognithorConfig, VLLMConfig
+
+        cfg = CognithorConfig(
+            cognithor_home=tmp_path,
+            vllm=VLLMConfig(enabled=True, video_max_upload_mb=10, video_quota_gb=1),
+        )
+        srv = MediaUploadServer(cfg)
+        port = await srv.start()
+        try:
+            uuid = srv.save_upload(b"legit video bytes", "mp4")
+            async with httpx.AsyncClient() as client:
+                r = await client.get(
+                    f"http://127.0.0.1:{port}/media/{uuid}.mp4",
+                    timeout=5.0,
+                )
+            assert r.status_code == 200
+            assert r.content == b"legit video bytes"
+        finally:
+            await srv.stop()

--- a/tests/test_channels/test_media_server.py
+++ b/tests/test_channels/test_media_server.py
@@ -203,3 +203,57 @@ class TestServePathTraversal:
             assert r.content == b"legit video bytes"
         finally:
             await srv.stop()
+
+
+class TestSaveUploadConcurrency:
+    def test_many_concurrent_saves_stay_within_quota(self, tmp_path: Path):
+        """Many concurrent save_upload calls must not race past the quota
+        check. Invariant: after all threads complete, media_dir total bytes
+        is at or below quota.
+
+        Without a lock, two or more threads can each compute `current` before
+        the others write, both pass the "will fit" check, and then all write
+        their bytes — leaving the directory above quota. Ten concurrent
+        1 MB saves against a 6 MB quota reliably exercise the race.
+        """
+        import threading
+
+        from cognithor.channels.media_server import MediaUploadServer
+        from cognithor.config import CognithorConfig, VLLMConfig
+
+        cfg = CognithorConfig(
+            cognithor_home=tmp_path,
+            vllm=VLLMConfig(
+                enabled=True,
+                video_max_upload_mb=10,
+                video_quota_gb=1,
+            ),
+        )
+        srv = MediaUploadServer(cfg)
+        srv._port = 4711
+        srv._quota_bytes = 6 * 1024 * 1024  # 6 MB quota for the test
+
+        data = b"\x00" * (1 * 1024 * 1024)  # 1 MB each
+
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                srv.save_upload(data, "mp4")
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=worker) for _ in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        total = sum(
+            f.stat().st_size
+            for f in srv._media_dir.iterdir()
+            if f.is_file() and f.suffix.lower() == ".mp4"
+        )
+        assert total <= srv._quota_bytes, (
+            f"Concurrent uploads exceeded quota: {total} bytes > {srv._quota_bytes} bytes quota"
+        )

--- a/tests/test_channels/test_media_server.py
+++ b/tests/test_channels/test_media_server.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cognithor.channels.media_server import MediaUploadServer
+from cognithor.config import CognithorConfig, VLLMConfig
+from cognithor.core.llm_backend import (
+    MediaUploadTooLargeError,
+    MediaUploadUnsupportedFormatError,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def server(tmp_path: Path) -> MediaUploadServer:
+    cfg = CognithorConfig(
+        cognithor_home=tmp_path,
+        vllm=VLLMConfig(
+            enabled=True,
+            video_max_upload_mb=10,  # small cap for fast tests
+            video_quota_gb=1,
+        ),
+    )
+    srv = MediaUploadServer(cfg)
+    # Pretend we've bound to port 4711 (real start() is tested in Task 7)
+    srv._port = 4711
+    return srv
+
+
+class TestSaveUpload:
+    def test_saves_bytes_returns_uuid(self, server: MediaUploadServer):
+        data = b"\x00" * 1024  # 1 KB
+        uuid = server.save_upload(data, "mp4")
+        assert uuid
+        path = server._media_dir / f"{uuid}.mp4"
+        assert path.is_file()
+        assert path.read_bytes() == data
+
+    def test_rejects_file_over_per_file_cap(self, server: MediaUploadServer):
+        too_big = b"\x00" * (11 * 1024 * 1024)  # 11 MB > 10 MB cap
+        with pytest.raises(MediaUploadTooLargeError):
+            server.save_upload(too_big, "mp4")
+
+    def test_rejects_unsupported_extension(self, server: MediaUploadServer):
+        with pytest.raises(MediaUploadUnsupportedFormatError):
+            server.save_upload(b"\x00" * 1024, "exe")
+
+    def test_case_insensitive_extension(self, server: MediaUploadServer):
+        uuid = server.save_upload(b"\x00" * 1024, "MP4")
+        assert uuid  # accepts "MP4" / "Mp4"
+
+    def test_public_url_shape(self, server: MediaUploadServer):
+        uuid = server.save_upload(b"\x00" * 1024, "mp4")
+        url = server.public_url(uuid, "mp4")
+        assert url == f"http://host.docker.internal:4711/media/{uuid}.mp4"
+
+    def test_lru_eviction_when_quota_exceeded(self, server: MediaUploadServer, tmp_path: Path):
+        # Quota is 1 GB. Fill up with 3 files of 3 MB each.
+        # Then add a file that would push total over a (monkey-patched) 12 MB quota.
+        server._quota_bytes = 12 * 1024 * 1024  # override quota to 12 MB
+
+        import time
+
+        u1 = server.save_upload(b"\x00" * (3 * 1024 * 1024), "mp4")
+        time.sleep(0.01)  # ensure distinct mtimes
+        u2 = server.save_upload(b"\x00" * (3 * 1024 * 1024), "mp4")
+        time.sleep(0.01)
+        _ = server.save_upload(b"\x00" * (3 * 1024 * 1024), "mp4")
+
+        # Now save a 5 MB file — total would be 14 MB > 12 MB quota.
+        # Expected: u1 (oldest) gets evicted.
+        u4 = server.save_upload(b"\x00" * (5 * 1024 * 1024), "mp4")
+        assert not (server._media_dir / f"{u1}.mp4").exists()
+        assert (server._media_dir / f"{u2}.mp4").exists()
+        assert (server._media_dir / f"{u4}.mp4").exists()
+
+
+class TestDelete:
+    def test_delete_removes_file(self, server: MediaUploadServer):
+        uuid = server.save_upload(b"\x00" * 1024, "mp4")
+        path = server._media_dir / f"{uuid}.mp4"
+        assert path.exists()
+        server.delete(uuid, "mp4")
+        assert not path.exists()
+
+    def test_delete_of_missing_is_noop(self, server: MediaUploadServer):
+        server.delete("nonexistent-uuid-abc", "mp4")  # must not raise

--- a/tests/test_core/test_llm_backend_errors.py
+++ b/tests/test_core/test_llm_backend_errors.py
@@ -42,3 +42,36 @@ class TestBackendTypeEnum:
         from cognithor.core.llm_backend import LLMBackendType
 
         assert "vllm" in {t.value for t in LLMBackendType}
+
+
+class TestMediaUploadErrors:
+    def test_media_upload_error_is_llm_backend_error(self):
+        from cognithor.core.llm_backend import LLMBackendError, MediaUploadError
+
+        assert issubclass(MediaUploadError, LLMBackendError)
+
+    def test_too_large_inherits(self):
+        from cognithor.core.llm_backend import MediaUploadError, MediaUploadTooLargeError
+
+        assert issubclass(MediaUploadTooLargeError, MediaUploadError)
+        err = MediaUploadTooLargeError("file is 600 MB, max is 500 MB", status_code=413)
+        assert err.status_code == 413
+
+    def test_unsupported_format_inherits(self):
+        from cognithor.core.llm_backend import MediaUploadError, MediaUploadUnsupportedFormatError
+
+        assert issubclass(MediaUploadUnsupportedFormatError, MediaUploadError)
+
+    def test_quota_exceeded_inherits(self):
+        from cognithor.core.llm_backend import MediaUploadError, MediaUploadQuotaExceededError
+
+        assert issubclass(MediaUploadQuotaExceededError, MediaUploadError)
+
+    def test_all_carry_recovery_hint(self):
+        from cognithor.core.llm_backend import MediaUploadTooLargeError
+
+        err = MediaUploadTooLargeError(
+            "too big",
+            recovery_hint="Shorten or downscale the clip before uploading.",
+        )
+        assert err.recovery_hint == "Shorten or downscale the clip before uploading."

--- a/tests/test_core/test_models.py
+++ b/tests/test_core/test_models.py
@@ -729,6 +729,27 @@ class TestWorkingMemoryExtended:
         assert len(wm.injected_procedures) == 0
         assert len(wm.injected_memories) == 0
 
+    def test_working_memory_has_video_attachment_default_none(self) -> None:
+        from cognithor.models import WorkingMemory
+
+        wm = WorkingMemory(session_id="s1")
+        assert wm.video_attachment is None
+
+    def test_working_memory_video_attachment_accepts_dict(self) -> None:
+        from cognithor.models import WorkingMemory
+
+        wm = WorkingMemory(session_id="s1")
+        wm.video_attachment = {"url": "http://x/a.mp4", "sampling": {"fps": 2.0}}
+        assert wm.video_attachment["url"] == "http://x/a.mp4"
+
+    def test_working_memory_clear_for_new_request_resets_video(self) -> None:
+        from cognithor.models import WorkingMemory
+
+        wm = WorkingMemory(session_id="s1")
+        wm.video_attachment = {"url": "http://x/a.mp4", "sampling": {"fps": 1.0}}
+        wm.clear_for_new_request()
+        assert wm.video_attachment is None
+
 
 class TestMessageChannel:
     """Message mit optionalem Channel-Feld."""

--- a/tests/test_core/test_orchestrator_config_propagation.py
+++ b/tests/test_core/test_orchestrator_config_propagation.py
@@ -1,0 +1,53 @@
+"""Regression for Bug-3 (round 4): call sites that construct VLLMOrchestrator
+must thread the live config.vllm through, not fall back to VLLMConfig() defaults."""
+
+from __future__ import annotations
+
+from cognithor.config import CognithorConfig, VLLMConfig
+
+
+class TestConfigPropagation:
+    def test_gateway_threads_live_vllm_config(self) -> None:
+        """Gateway.__init__ must pass config=self._config.vllm to orchestrator.
+
+        Verified via source inspection: constructing a full Gateway in a unit
+        test is heavyweight, but the bug is about a literal missing kwarg at a
+        specific call site — source-level assertion is both faster and more
+        direct.
+        """
+        import inspect
+
+        from cognithor.gateway import gateway as gw
+
+        src = inspect.getsource(gw)
+        idx = src.find("self._vllm_orchestrator = VLLMOrchestrator(")
+        assert idx != -1, "Could not locate VLLMOrchestrator construction in gateway.py"
+        snippet = src[idx : idx + 400]
+        assert "config=self._config.vllm" in snippet, (
+            f"Gateway must pass config=self._config.vllm to orchestrator. Got:\n{snippet}"
+        )
+
+    def test_backends_api_get_orchestrator_threads_config(self) -> None:
+        """backends_api._get_orchestrator must pass config=config.vllm too."""
+        from cognithor.channels import backends_api
+
+        # Ensure clean cache
+        backends_api._orchestrator_cache.clear()
+        cfg = CognithorConfig(
+            vllm=VLLMConfig(
+                enabled=True,
+                max_model_len=32768,
+                cpu_offload_gb=8,
+            )
+        )
+        orch = backends_api._get_orchestrator(cfg)
+        assert orch._config.max_model_len == 32768
+        assert orch._config.cpu_offload_gb == 8
+
+    def test_orchestrator_defaults_used_when_config_omitted(self) -> None:
+        """Baseline: without config=, defaults apply (documented behaviour)."""
+        from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+
+        orch = VLLMOrchestrator(port=8000)
+        # Spike default
+        assert orch._config.max_model_len == 16384

--- a/tests/test_core/test_planner_envelope.py
+++ b/tests/test_core/test_planner_envelope.py
@@ -142,3 +142,24 @@ class TestVisionRouting:
         call = planner_with_mocks._ollama.chat.call_args
         assert call.kwargs.get("images") is None
         planner_with_mocks._router.select_model.assert_called()
+
+    async def test_video_attachment_also_routes_to_vision_model(self, planner_with_mocks):
+        from cognithor.models import WorkingMemory
+
+        planner_with_mocks._config.vision_model_detail = "mmangkad/Qwen3.6-27B-NVFP4"
+        wm = WorkingMemory(session_id="s1")
+        wm.video_attachment = {
+            "url": "http://host.docker.internal:4711/media/abc.mp4",
+            "sampling": {"fps": 1.0},
+        }
+
+        await planner_with_mocks.formulate_response(
+            user_message="Describe the video",
+            results=[],
+            working_memory=wm,
+        )
+
+        call = planner_with_mocks._ollama.chat.call_args
+        assert call.kwargs.get("model") == "mmangkad/Qwen3.6-27B-NVFP4"
+        assert call.kwargs.get("video") is not None
+        assert call.kwargs["video"]["url"].endswith("abc.mp4")

--- a/tests/test_core/test_unified_llm_circuit_breaker.py
+++ b/tests/test_core/test_unified_llm_circuit_breaker.py
@@ -127,3 +127,26 @@ class TestFailFlowDispatch:
                 messages=[{"role": "user", "content": "what is this?"}],
                 images=[str(img)],
             )
+
+    @pytest.mark.asyncio
+    async def test_video_request_hard_errors_when_vllm_degraded(
+        self, mock_vllm_backend, mock_ollama_client
+    ):
+        mock_vllm_backend.chat.side_effect = VLLMNotReadyError("down")
+        client = UnifiedLLMClient(
+            ollama_client=mock_ollama_client,
+            backend=mock_vllm_backend,
+            _breaker_recovery_timeout=60.0,
+        )
+        # Trip the breaker
+        for _ in range(3):
+            with contextlib.suppress(Exception):
+                await client.chat(model="x", messages=[{"role": "user", "content": "hi"}])
+
+        # Now a video request — no silent fallback
+        with pytest.raises(VLLMNotReadyError):
+            await client.chat(
+                model="x",
+                messages=[{"role": "user", "content": "what is this?"}],
+                video={"url": "http://x/a.mp4", "sampling": {"fps": 1.0}},
+            )

--- a/tests/test_core/test_video_sampling.py
+++ b/tests/test_core/test_video_sampling.py
@@ -28,7 +28,7 @@ class TestVideoSamplingDataclass:
 
     def test_as_mm_kwargs_raises_when_neither(self):
         s = VideoSampling()  # both None
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="neither fps nor num_frames"):
             s.as_mm_kwargs()
 
 

--- a/tests/test_core/test_video_sampling.py
+++ b/tests/test_core/test_video_sampling.py
@@ -67,3 +67,103 @@ class TestBucketForDuration:
         assert s.fps is None
         s = _bucket_for_duration(-5.0)
         assert s.num_frames == 32
+
+
+from unittest.mock import MagicMock, patch
+
+from cognithor.core.video_sampling import resolve_sampling
+
+
+class TestResolveSampling:
+    def _mk_probe_stdout(self, duration: float) -> str:
+        import json as _json
+
+        return _json.dumps({"format": {"duration": str(duration)}})
+
+    def test_adaptive_short_clip(self):
+        mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(5.0))
+        with patch("subprocess.run", return_value=mock):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.fps == 3.0
+        assert s.num_frames is None
+        assert s.duration_sec == 5.0
+
+    def test_adaptive_long_clip(self):
+        mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(1800.0))
+        with patch("subprocess.run", return_value=mock):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.num_frames == 32
+        assert s.duration_sec == 1800.0
+
+    def test_ffprobe_missing_falls_back_to_num_frames_32(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.num_frames == 32
+        assert s.fps is None
+        assert s.duration_sec is None
+
+    def test_ffprobe_timeout_falls_back(self):
+        import subprocess as _sp
+
+        with patch("subprocess.run", side_effect=_sp.TimeoutExpired(cmd="ffprobe", timeout=5)):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.num_frames == 32
+
+    def test_ffprobe_nonzero_returncode_falls_back(self):
+        mock = MagicMock(returncode=1, stdout="", stderr="file not found")
+        with patch("subprocess.run", return_value=mock):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.num_frames == 32
+
+    def test_ffprobe_unparseable_json_falls_back(self):
+        mock = MagicMock(returncode=0, stdout="not json at all")
+        with patch("subprocess.run", return_value=mock):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.num_frames == 32
+
+    def test_ffprobe_negative_duration_falls_back(self):
+        mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(-1.0))
+        with patch("subprocess.run", return_value=mock):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.num_frames == 32
+
+    def test_ffprobe_duration_over_24h_falls_back(self):
+        mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(100_000.0))
+        with patch("subprocess.run", return_value=mock):
+            s = resolve_sampling("/tmp/x.mp4")
+        assert s.num_frames == 32
+
+    def test_override_fixed_32_skips_ffprobe(self):
+        with patch("subprocess.run") as run_mock:
+            s = resolve_sampling("/tmp/x.mp4", override="fixed_32")
+        assert s.num_frames == 32
+        assert s.fps is None
+        run_mock.assert_not_called()
+
+    def test_override_fixed_64_skips_ffprobe(self):
+        with patch("subprocess.run") as run_mock:
+            s = resolve_sampling("/tmp/x.mp4", override="fixed_64")
+        assert s.num_frames == 64
+        run_mock.assert_not_called()
+
+    def test_override_fps_1_skips_ffprobe(self):
+        with patch("subprocess.run") as run_mock:
+            s = resolve_sampling("/tmp/x.mp4", override="fps_1")
+        assert s.fps == 1.0
+        run_mock.assert_not_called()
+
+    def test_http_url_uses_http_timeout(self):
+        mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(45.0))
+        with patch("subprocess.run", return_value=mock) as run_mock:
+            resolve_sampling(
+                "https://example.com/clip.mp4",
+                timeout_seconds=5,
+                http_timeout_seconds=30,
+            )
+        assert run_mock.call_args.kwargs["timeout"] == 30
+
+    def test_local_path_uses_local_timeout(self):
+        mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(45.0))
+        with patch("subprocess.run", return_value=mock) as run_mock:
+            resolve_sampling("/tmp/x.mp4", timeout_seconds=5, http_timeout_seconds=30)
+        assert run_mock.call_args.kwargs["timeout"] == 5

--- a/tests/test_core/test_video_sampling.py
+++ b/tests/test_core/test_video_sampling.py
@@ -82,7 +82,7 @@ class TestResolveSampling:
 
     def test_adaptive_short_clip(self):
         mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(5.0))
-        with patch("subprocess.run", return_value=mock):
+        with patch("cognithor.core.video_sampling.subprocess.run", return_value=mock):
             s = resolve_sampling("/tmp/x.mp4")
         assert s.fps == 3.0
         assert s.num_frames is None
@@ -90,13 +90,13 @@ class TestResolveSampling:
 
     def test_adaptive_long_clip(self):
         mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(1800.0))
-        with patch("subprocess.run", return_value=mock):
+        with patch("cognithor.core.video_sampling.subprocess.run", return_value=mock):
             s = resolve_sampling("/tmp/x.mp4")
         assert s.num_frames == 32
         assert s.duration_sec == 1800.0
 
     def test_ffprobe_missing_falls_back_to_num_frames_32(self):
-        with patch("subprocess.run", side_effect=FileNotFoundError):
+        with patch("cognithor.core.video_sampling.subprocess.run", side_effect=FileNotFoundError):
             s = resolve_sampling("/tmp/x.mp4")
         assert s.num_frames == 32
         assert s.fps is None
@@ -105,56 +105,57 @@ class TestResolveSampling:
     def test_ffprobe_timeout_falls_back(self):
         import subprocess as _sp
 
-        with patch("subprocess.run", side_effect=_sp.TimeoutExpired(cmd="ffprobe", timeout=5)):
+        exc = _sp.TimeoutExpired(cmd="ffprobe", timeout=5)
+        with patch("cognithor.core.video_sampling.subprocess.run", side_effect=exc):
             s = resolve_sampling("/tmp/x.mp4")
         assert s.num_frames == 32
 
     def test_ffprobe_nonzero_returncode_falls_back(self):
         mock = MagicMock(returncode=1, stdout="", stderr="file not found")
-        with patch("subprocess.run", return_value=mock):
+        with patch("cognithor.core.video_sampling.subprocess.run", return_value=mock):
             s = resolve_sampling("/tmp/x.mp4")
         assert s.num_frames == 32
 
     def test_ffprobe_unparseable_json_falls_back(self):
         mock = MagicMock(returncode=0, stdout="not json at all")
-        with patch("subprocess.run", return_value=mock):
+        with patch("cognithor.core.video_sampling.subprocess.run", return_value=mock):
             s = resolve_sampling("/tmp/x.mp4")
         assert s.num_frames == 32
 
     def test_ffprobe_negative_duration_falls_back(self):
         mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(-1.0))
-        with patch("subprocess.run", return_value=mock):
+        with patch("cognithor.core.video_sampling.subprocess.run", return_value=mock):
             s = resolve_sampling("/tmp/x.mp4")
         assert s.num_frames == 32
 
     def test_ffprobe_duration_over_24h_falls_back(self):
         mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(100_000.0))
-        with patch("subprocess.run", return_value=mock):
+        with patch("cognithor.core.video_sampling.subprocess.run", return_value=mock):
             s = resolve_sampling("/tmp/x.mp4")
         assert s.num_frames == 32
 
     def test_override_fixed_32_skips_ffprobe(self):
-        with patch("subprocess.run") as run_mock:
+        with patch("cognithor.core.video_sampling.subprocess.run") as run_mock:
             s = resolve_sampling("/tmp/x.mp4", override="fixed_32")
         assert s.num_frames == 32
         assert s.fps is None
         run_mock.assert_not_called()
 
     def test_override_fixed_64_skips_ffprobe(self):
-        with patch("subprocess.run") as run_mock:
+        with patch("cognithor.core.video_sampling.subprocess.run") as run_mock:
             s = resolve_sampling("/tmp/x.mp4", override="fixed_64")
         assert s.num_frames == 64
         run_mock.assert_not_called()
 
     def test_override_fps_1_skips_ffprobe(self):
-        with patch("subprocess.run") as run_mock:
+        with patch("cognithor.core.video_sampling.subprocess.run") as run_mock:
             s = resolve_sampling("/tmp/x.mp4", override="fps_1")
         assert s.fps == 1.0
         run_mock.assert_not_called()
 
     def test_http_url_uses_http_timeout(self):
         mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(45.0))
-        with patch("subprocess.run", return_value=mock) as run_mock:
+        with patch("cognithor.core.video_sampling.subprocess.run", return_value=mock) as run_mock:
             resolve_sampling(
                 "https://example.com/clip.mp4",
                 timeout_seconds=5,
@@ -164,6 +165,6 @@ class TestResolveSampling:
 
     def test_local_path_uses_local_timeout(self):
         mock = MagicMock(returncode=0, stdout=self._mk_probe_stdout(45.0))
-        with patch("subprocess.run", return_value=mock) as run_mock:
+        with patch("cognithor.core.video_sampling.subprocess.run", return_value=mock) as run_mock:
             resolve_sampling("/tmp/x.mp4", timeout_seconds=5, http_timeout_seconds=30)
         assert run_mock.call_args.kwargs["timeout"] == 5

--- a/tests/test_core/test_video_sampling.py
+++ b/tests/test_core/test_video_sampling.py
@@ -1,0 +1,69 @@
+# tests/test_core/test_video_sampling.py
+from __future__ import annotations
+
+import pytest
+
+from cognithor.core.video_sampling import VideoSampling, _bucket_for_duration
+
+
+class TestVideoSamplingDataclass:
+    def test_fps_only(self):
+        s = VideoSampling(fps=2.0, duration_sec=25.0)
+        assert s.fps == 2.0
+        assert s.num_frames is None
+        assert s.duration_sec == 25.0
+
+    def test_num_frames_only(self):
+        s = VideoSampling(num_frames=32, duration_sec=900.0)
+        assert s.num_frames == 32
+        assert s.fps is None
+
+    def test_as_mm_kwargs_fps(self):
+        s = VideoSampling(fps=3.0)
+        assert s.as_mm_kwargs() == {"fps": 3.0}
+
+    def test_as_mm_kwargs_num_frames(self):
+        s = VideoSampling(num_frames=64)
+        assert s.as_mm_kwargs() == {"num_frames": 64}
+
+    def test_as_mm_kwargs_raises_when_neither(self):
+        s = VideoSampling()  # both None
+        with pytest.raises(ValueError):
+            s.as_mm_kwargs()
+
+
+class TestBucketForDuration:
+    # Spec bucket table (see design doc § "Frame Sampling"):
+    # <10s → fps=3; 10-30s → fps=2; 30s-2min → fps=1;
+    # 2-5min → num_frames=64; 5-15min → num_frames=32; >15min → num_frames=32
+    @pytest.mark.parametrize(
+        "dur,expected_fps,expected_num",
+        [
+            (5.0, 3.0, None),
+            (9.99, 3.0, None),
+            (10.0, 2.0, None),
+            (29.99, 2.0, None),
+            (30.0, 1.0, None),
+            (119.99, 1.0, None),
+            (120.0, None, 64),
+            (299.99, None, 64),
+            (300.0, None, 32),
+            (899.99, None, 32),
+            (900.0, None, 32),  # >15min still 32
+            (3600.0, None, 32),
+        ],
+    )
+    def test_buckets(
+        self, dur: float, expected_fps: float | None, expected_num: int | None
+    ) -> None:
+        s = _bucket_for_duration(dur)
+        assert s.fps == expected_fps
+        assert s.num_frames == expected_num
+
+    def test_zero_or_negative_duration_falls_back(self):
+        # Defensive: upstream feeds us >0 but guard anyway
+        s = _bucket_for_duration(0.0)
+        assert s.num_frames == 32
+        assert s.fps is None
+        s = _bucket_for_duration(-5.0)
+        assert s.num_frames == 32

--- a/tests/test_core/test_vllm_backend.py
+++ b/tests/test_core/test_vllm_backend.py
@@ -195,3 +195,61 @@ class TestVLLMBackendEmbed:
         )
         with pytest.raises(LLMBadRequestError):
             await backend.embed(model="qwen-chat-only", text="hello")
+
+
+class TestAttachImagesWithListContent:
+    """Regression for Bug-5-r4: _attach_images_to_last_user must behave the
+    same way _attach_video_to_last_user does when the last user message
+    already has list-form content."""
+
+    def test_preserves_text_when_last_user_has_list_content(self, tmp_path):
+        from cognithor.core.vllm_backend import _attach_images_to_last_user
+
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR")
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "video_url", "video_url": {"url": "http://x/clip.mp4"}},
+                    {"type": "text", "text": "Was ist im Bild und Video?"},
+                ],
+            }
+        ]
+        result = _attach_images_to_last_user(messages, [str(img)])
+        last = result[-1]
+        assert isinstance(last["content"], list)
+        # Text must survive
+        assert any(
+            c.get("type") == "text" and c["text"] == "Was ist im Bild und Video?"
+            for c in last["content"]
+        )
+        # Pre-existing video_url must survive
+        assert any(
+            c.get("type") == "video_url" and c["video_url"]["url"] == "http://x/clip.mp4"
+            for c in last["content"]
+        )
+        # New image_url must be present
+        assert any(
+            c.get("type") == "image_url"
+            and c["image_url"]["url"].startswith("data:image/png;base64,")
+            for c in last["content"]
+        )
+
+    def test_list_without_text_does_not_inject_empty_text(self, tmp_path):
+        from cognithor.core.vllm_backend import _attach_images_to_last_user
+
+        img = tmp_path / "pic.png"
+        img.write_bytes(b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR")
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "video_url", "video_url": {"url": "http://x/clip.mp4"}},
+                ],
+            }
+        ]
+        result = _attach_images_to_last_user(messages, [str(img)])
+        last = result[-1]
+        texts = [c for c in last["content"] if c.get("type") == "text"]
+        assert texts == []

--- a/tests/test_core/test_vllm_backend_video.py
+++ b/tests/test_core/test_vllm_backend_video.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import json as _json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cognithor.core.vllm_backend import VLLMBackend, _attach_video_to_last_user
+
+if TYPE_CHECKING:
+    from pytest_httpx import HTTPXMock
+
+
+BASE_URL = "http://localhost:8000/v1"
+
+
+@pytest.fixture
+def backend() -> VLLMBackend:
+    return VLLMBackend(base_url=BASE_URL, timeout=5)
+
+
+class TestAttachVideoHelper:
+    def test_prepends_video_url_content_item_to_last_user(self):
+        messages = [
+            {"role": "system", "content": "you are helpful"},
+            {"role": "user", "content": "What is in this?"},
+        ]
+        video = {"url": "http://x/a.mp4", "sampling": {"fps": 2.0}}
+        new_messages, mm_kwargs = _attach_video_to_last_user(messages, video)
+
+        # System message untouched
+        assert new_messages[0] == messages[0]
+        # Last user message converted to content-item list
+        last = new_messages[-1]
+        assert last["role"] == "user"
+        assert isinstance(last["content"], list)
+        assert last["content"][0] == {"type": "video_url", "video_url": {"url": "http://x/a.mp4"}}
+        assert last["content"][1] == {"type": "text", "text": "What is in this?"}
+        # mm kwargs shape
+        assert mm_kwargs == {"mm_processor_kwargs": {"video": {"fps": 2.0}}}
+
+    def test_num_frames_sampling(self):
+        video = {"url": "http://x/a.mp4", "sampling": {"num_frames": 32}}
+        _, mm_kwargs = _attach_video_to_last_user([{"role": "user", "content": "hi"}], video)
+        assert mm_kwargs == {"mm_processor_kwargs": {"video": {"num_frames": 32}}}
+
+    def test_empty_text_part_not_added(self):
+        """If the user message content is already an empty string, don't
+        inject a zero-length text part."""
+        messages = [{"role": "user", "content": ""}]
+        video = {"url": "http://x/a.mp4", "sampling": {"fps": 1.0}}
+        new_messages, _ = _attach_video_to_last_user(messages, video)
+        content_items = new_messages[-1]["content"]
+        assert len(content_items) == 1  # only the video, no text
+        assert content_items[0]["type"] == "video_url"
+
+    def test_caller_messages_not_mutated(self):
+        messages = [{"role": "user", "content": "orig"}]
+        video = {"url": "http://x/a.mp4", "sampling": {"fps": 1.0}}
+        _attach_video_to_last_user(messages, video)
+        assert messages[0]["content"] == "orig"
+        assert isinstance(messages[0]["content"], str)
+
+
+class TestChatWithVideo:
+    @pytest.mark.asyncio
+    async def test_chat_with_video_sends_video_url_and_mm_kwargs(
+        self, backend: VLLMBackend, httpx_mock: HTTPXMock
+    ):
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=200,
+            json={
+                "choices": [{"message": {"content": "A drone flying over a field."}}],
+                "model": "mmangkad/Qwen3.6-27B-NVFP4",
+                "usage": {"prompt_tokens": 100, "completion_tokens": 10, "total_tokens": 110},
+            },
+        )
+        resp = await backend.chat(
+            model="mmangkad/Qwen3.6-27B-NVFP4",
+            messages=[{"role": "user", "content": "What's in this clip?"}],
+            video={
+                "url": "http://host.docker.internal:4711/media/abc.mp4",
+                "sampling": {"fps": 2.0},
+            },
+        )
+        assert resp.content == "A drone flying over a field."
+
+        request = httpx_mock.get_requests()[0]
+        body = _json.loads(request.content)
+
+        last_msg = body["messages"][-1]
+        assert last_msg["role"] == "user"
+        assert isinstance(last_msg["content"], list)
+        assert any(
+            c.get("type") == "video_url"
+            and c["video_url"]["url"] == "http://host.docker.internal:4711/media/abc.mp4"
+            for c in last_msg["content"]
+        )
+
+        assert body["extra_body"]["mm_processor_kwargs"]["video"] == {"fps": 2.0}
+
+    @pytest.mark.asyncio
+    async def test_chat_without_video_does_not_set_extra_body(
+        self, backend: VLLMBackend, httpx_mock: HTTPXMock
+    ):
+        """Regression: image-only or text-only requests must not grow an
+        extra_body.mm_processor_kwargs key they don't need."""
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=200,
+            json={"choices": [{"message": {"content": "ok"}}], "model": "x"},
+        )
+        await backend.chat(
+            model="Qwen/Qwen2.5-VL-7B-Instruct",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        body = _json.loads(httpx_mock.get_requests()[0].content)
+        assert "extra_body" not in body or "mm_processor_kwargs" not in body.get("extra_body", {})

--- a/tests/test_core/test_vllm_backend_video.py
+++ b/tests/test_core/test_vllm_backend_video.py
@@ -166,3 +166,70 @@ class TestChatWithVideo:
         )
         body = _json.loads(httpx_mock.get_requests()[0].content)
         assert "extra_body" not in body or "mm_processor_kwargs" not in body.get("extra_body", {})
+
+
+class TestChatStreamWithVideo:
+    @pytest.mark.asyncio
+    async def test_chat_stream_sends_video_url_and_mm_kwargs(
+        self, backend: VLLMBackend, httpx_mock: HTTPXMock
+    ):
+        """chat_stream must thread video kwarg into the SSE request body
+        the same way chat() does."""
+        # A minimal valid SSE response: one data chunk + [DONE]
+        sse_body = b'data: {"choices":[{"delta":{"content":"A"},"index":0}]}\n\ndata: [DONE]\n\n'
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=200,
+            content=sse_body,
+            headers={"content-type": "text/event-stream"},
+        )
+
+        chunks: list[str] = []
+        async for chunk in backend.chat_stream(
+            model="mmangkad/Qwen3.6-27B-NVFP4",
+            messages=[{"role": "user", "content": "What's in this clip?"}],
+            video={
+                "url": "http://host.docker.internal:4711/media/abc.mp4",
+                "sampling": {"fps": 2.0},
+            },
+        ):
+            chunks.append(chunk)
+
+        # Collected at least one chunk
+        assert chunks
+
+        request = httpx_mock.get_requests()[0]
+        body = _json.loads(request.content)
+
+        last_msg = body["messages"][-1]
+        assert isinstance(last_msg["content"], list)
+        assert any(
+            c.get("type") == "video_url"
+            and c["video_url"]["url"] == "http://host.docker.internal:4711/media/abc.mp4"
+            for c in last_msg["content"]
+        )
+        assert body["extra_body"]["mm_processor_kwargs"]["video"] == {"fps": 2.0}
+        assert body.get("stream") is True
+
+    @pytest.mark.asyncio
+    async def test_chat_stream_without_video_does_not_set_extra_body(
+        self, backend: VLLMBackend, httpx_mock: HTTPXMock
+    ):
+        """Regression: text-only streaming requests must not grow an extra_body
+        they don't need."""
+        sse_body = b'data: {"choices":[{"delta":{"content":"ok"},"index":0}]}\n\ndata: [DONE]\n\n'
+        httpx_mock.add_response(
+            url=f"{BASE_URL}/chat/completions",
+            status_code=200,
+            content=sse_body,
+            headers={"content-type": "text/event-stream"},
+        )
+
+        async for _ in backend.chat_stream(
+            model="x",
+            messages=[{"role": "user", "content": "hi"}],
+        ):
+            pass
+
+        body = _json.loads(httpx_mock.get_requests()[0].content)
+        assert "extra_body" not in body or "mm_processor_kwargs" not in body.get("extra_body", {})

--- a/tests/test_core/test_vllm_backend_video.py
+++ b/tests/test_core/test_vllm_backend_video.py
@@ -61,6 +61,55 @@ class TestAttachVideoHelper:
         assert messages[0]["content"] == "orig"
         assert isinstance(messages[0]["content"], str)
 
+    def test_preserves_text_when_last_user_already_has_list_content(self):
+        """Regression: a prior image in the same turn makes content a list.
+        The video helper must extract the text from that list, not drop it."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "http://x/pic.png"}},
+                    {"type": "text", "text": "Was ist auf dem Bild und im Video?"},
+                ],
+            }
+        ]
+        video = {"url": "http://x/a.mp4", "sampling": {"fps": 2.0}}
+        new_messages, mm_kwargs = _attach_video_to_last_user(messages, video)
+
+        last = new_messages[-1]
+        assert last["role"] == "user"
+        assert isinstance(last["content"], list)
+        # The video must be present
+        assert any(c.get("type") == "video_url" for c in last["content"])
+        # The text must survive
+        assert any(
+            c.get("type") == "text" and c["text"] == "Was ist auf dem Bild und im Video?"
+            for c in last["content"]
+        )
+        # The pre-existing image must survive
+        assert any(
+            c.get("type") == "image_url" and c["image_url"]["url"] == "http://x/pic.png"
+            for c in last["content"]
+        )
+
+    def test_list_content_without_text_does_not_inject_empty_text(self):
+        """If the existing list has no text item, the helper should not append
+        a zero-length text content item."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "http://x/pic.png"}},
+                ],
+            }
+        ]
+        video = {"url": "http://x/a.mp4", "sampling": {"fps": 1.0}}
+        new_messages, _ = _attach_video_to_last_user(messages, video)
+
+        last = new_messages[-1]
+        texts = [c for c in last["content"] if c.get("type") == "text"]
+        assert len(texts) == 0
+
 
 class TestChatWithVideo:
     @pytest.mark.asyncio

--- a/tests/test_core/test_vllm_orchestrator.py
+++ b/tests/test_core/test_vllm_orchestrator.py
@@ -69,11 +69,11 @@ class TestDataclasses:
 class TestOrchestratorInit:
     def test_orchestrator_constructs_with_config(self):
         orch = VLLMOrchestrator(
-            docker_image="vllm/vllm-openai:v0.19.1",
+            docker_image="vllm/vllm-openai:cu130-nightly",
             port=8000,
             hf_token="hf_test",
         )
-        assert orch.docker_image == "vllm/vllm-openai:v0.19.1"
+        assert orch.docker_image == "vllm/vllm-openai:cu130-nightly"
         assert orch.port == 8000
         assert orch._hf_token == "hf_test"
         assert orch.state.hardware_ok is False
@@ -181,7 +181,7 @@ class TestPullImage:
             '{"status":"Pulling from vllm/vllm-openai","id":"latest"}\n',
             '{"status":"Downloading","progressDetail":{"current":1000000,"total":10000000},"id":"abc123"}\n',
             '{"status":"Download complete","id":"abc123"}\n',
-            '{"status":"Status: Downloaded newer image for vllm/vllm-openai:v0.19.1"}\n',
+            '{"status":"Status: Downloaded newer image for vllm/vllm-openai:cu130-nightly"}\n',
         ]
         mock_proc = MagicMock()
         mock_proc.stdout = iter(json_lines)
@@ -194,7 +194,7 @@ class TestPullImage:
             events.append(ev)
 
         with patch("subprocess.Popen", return_value=mock_proc):
-            VLLMOrchestrator().pull_image("vllm/vllm-openai:v0.19.1", progress_callback=cb)
+            VLLMOrchestrator().pull_image("vllm/vllm-openai:cu130-nightly", progress_callback=cb)
 
         assert any(e.get("status") == "Downloading" for e in events)
         assert any("current" in (e.get("progressDetail") or {}) for e in events)
@@ -231,7 +231,7 @@ class TestStartContainer:
         ):
             run_mock.return_value = MagicMock(returncode=0, stdout="abc123def456")
             orch = VLLMOrchestrator(
-                docker_image="vllm/vllm-openai:v0.19.1", port=8000, hf_token="hf_x"
+                docker_image="vllm/vllm-openai:cu130-nightly", port=8000, hf_token="hf_x"
             )
             info = orch.start_container("Qwen/Qwen3.6-27B-FP8")
 
@@ -241,7 +241,7 @@ class TestStartContainer:
         assert "--gpus" in args and "all" in args
         assert any("HF_TOKEN=hf_x" in a for a in args)
         assert any("cognithor.managed=true" in a for a in args)
-        assert any("vllm-openai:v0.19.1" in a for a in args)
+        assert any("vllm-openai:cu130-nightly" in a for a in args)
         assert "Qwen/Qwen3.6-27B-FP8" in args
         assert info.port == 8000
         assert info.model == "Qwen/Qwen3.6-27B-FP8"
@@ -312,7 +312,8 @@ class TestStopAndReuse:
     def test_reuse_existing_returns_info(self):
         ps_stdout = (
             '{"ID":"abc123def456","Ports":"0.0.0.0:8000->8000/tcp",'
-            '"Image":"vllm/vllm-openai:v0.19.1","Command":"... --model Qwen/Qwen3.6-27B-FP8 ..."}\n'
+            '"Image":"vllm/vllm-openai:cu130-nightly",'
+            '"Command":"... --model Qwen/Qwen3.6-27B-FP8 ..."}\n'
         )
         with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout=ps_stdout)):
             info = VLLMOrchestrator().reuse_existing()

--- a/tests/test_core/test_vllm_orchestrator.py
+++ b/tests/test_core/test_vllm_orchestrator.py
@@ -338,3 +338,90 @@ class TestStatusAggregator:
         # Mutating the returned copy must not leak back into orch.state
         snapshot.hardware_ok = False
         assert orch.state.hardware_ok is True
+
+
+class TestStartContainerVideoFlags:
+    def _run_start(self, **orch_kwargs):
+        from unittest.mock import MagicMock, patch
+
+        from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+
+        with (
+            patch.object(VLLMOrchestrator, "_port_available", return_value=True),
+            patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")) as run_mock,
+            patch.object(VLLMOrchestrator, "_wait_for_health", return_value=True),
+        ):
+            orch = VLLMOrchestrator(**orch_kwargs)
+            orch.start_container("mmangkad/Qwen3.6-27B-NVFP4")
+        return run_mock.call_args[0][0]
+
+    def test_default_image_is_cu130_nightly(self):
+        args = self._run_start(port=8000)
+        assert "vllm/vllm-openai:cu130-nightly" in args
+
+    def test_docker_run_includes_media_io_kwargs(self):
+        args = self._run_start(port=8000)
+        idx = args.index("--media-io-kwargs")
+        assert '"video"' in args[idx + 1]
+        assert '"num_frames": -1' in args[idx + 1]
+
+    def test_docker_run_includes_add_host(self):
+        args = self._run_start(port=8000)
+        assert "--add-host" in args
+        idx = args.index("--add-host")
+        assert args[idx + 1] == "host.docker.internal:host-gateway"
+
+    def test_docker_run_includes_spike_stability_flags(self):
+        args = self._run_start(port=8000)
+        assert "--max-model-len" in args and args[args.index("--max-model-len") + 1] == "16384"
+        assert "--max-num-seqs" in args and args[args.index("--max-num-seqs") + 1] == "2"
+        assert (
+            "--max-num-batched-tokens" in args
+            and args[args.index("--max-num-batched-tokens") + 1] == "2048"
+        )
+        assert (
+            "--gpu-memory-utilization" in args
+            and args[args.index("--gpu-memory-utilization") + 1] == "0.94"
+        )
+        assert "--cpu-offload-gb" in args and args[args.index("--cpu-offload-gb") + 1] == "4"
+        assert "--enforce-eager" in args
+        assert (
+            "--reasoning-parser" in args and args[args.index("--reasoning-parser") + 1] == "qwen3"
+        )
+        assert "--trust-remote-code" in args
+
+    def test_docker_run_includes_media_url_env_when_port_given(self):
+        from unittest.mock import MagicMock, patch
+
+        from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+
+        with (
+            patch.object(VLLMOrchestrator, "_port_available", return_value=True),
+            patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")) as run_mock,
+            patch.object(VLLMOrchestrator, "_wait_for_health", return_value=True),
+        ):
+            orch = VLLMOrchestrator(port=8000)
+            orch.media_url = "http://host.docker.internal:4711"
+            orch.start_container("mmangkad/Qwen3.6-27B-NVFP4")
+        args = run_mock.call_args[0][0]
+        assert any("COGNITHOR_MEDIA_URL=http://host.docker.internal:4711" in a for a in args)
+
+    def test_overrides_from_vllm_config(self):
+        """A 40 GB-class GPU loosens the defaults — orchestrator reads from VLLMConfig."""
+        from cognithor.config import VLLMConfig
+
+        cfg = VLLMConfig(
+            max_model_len=65536,
+            max_num_seqs=8,
+            max_num_batched_tokens=8192,
+            gpu_memory_utilization=0.90,
+            cpu_offload_gb=0,
+            enforce_eager=False,
+        )
+        args = self._run_start(port=8000, config=cfg)
+        assert args[args.index("--max-model-len") + 1] == "65536"
+        assert args[args.index("--gpu-memory-utilization") + 1] == "0.9"
+        # --cpu-offload-gb must be OMITTED when 0 (vLLM complains if 0 is passed)
+        assert "--cpu-offload-gb" not in args
+        # --enforce-eager must be OMITTED when disabled
+        assert "--enforce-eager" not in args

--- a/tests/test_core/test_vllm_orchestrator.py
+++ b/tests/test_core/test_vllm_orchestrator.py
@@ -425,3 +425,74 @@ class TestStartContainerVideoFlags:
         assert "--cpu-offload-gb" not in args
         # --enforce-eager must be OMITTED when disabled
         assert "--enforce-eager" not in args
+
+
+class TestStartContainerLogging:
+    def test_start_container_logs_command_with_token_redacted(self):
+        """Regression for Bug I4-r3: admins must see the full docker run cmd
+        in logs when debugging a failed vLLM start — but HF_TOKEN value must
+        be redacted."""
+        from unittest.mock import MagicMock, patch
+
+        from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+
+        with (
+            patch.object(VLLMOrchestrator, "_port_available", return_value=True),
+            patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="cid")),
+            patch.object(VLLMOrchestrator, "_wait_for_health", return_value=True),
+            patch("cognithor.core.vllm_orchestrator.log") as mock_log,
+        ):
+            orch = VLLMOrchestrator(port=8000)
+            orch._hf_token = "hf_secret_very_long_token_xyz"
+            orch.start_container("mmangkad/Qwen3.6-27B-NVFP4")
+
+        # log.info must be called with the docker cmd
+        info_calls = [
+            call
+            for call in mock_log.info.call_args_list
+            if call.args and "vllm_docker_run_starting" in call.args[0]
+        ]
+        assert info_calls, "Expected log.info('vllm_docker_run_starting', ...) call"
+        call = info_calls[0]
+        cmd_kwarg = call.kwargs.get("cmd")
+        assert cmd_kwarg is not None, "Log call must include cmd= kwarg"
+        cmd_str = " ".join(cmd_kwarg)
+        # HF_TOKEN value must NOT appear in the log cmd
+        assert "hf_secret_very_long_token_xyz" not in cmd_str, (
+            f"HF_TOKEN leaked into log cmd: {cmd_str}"
+        )
+        assert "HF_TOKEN=<redacted>" in cmd_str, (
+            f"Expected HF_TOKEN=<redacted> placeholder in log cmd, got: {cmd_str}"
+        )
+
+    def test_start_container_logs_error_on_failed_run(self):
+        """A failed docker run must produce a log.error with returncode + stderr,
+        not just the bubbled-up exception."""
+        import contextlib
+        from unittest.mock import MagicMock, patch
+
+        from cognithor.core.llm_backend import VLLMNotReadyError
+        from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+
+        with (
+            patch.object(VLLMOrchestrator, "_port_available", return_value=True),
+            patch(
+                "subprocess.run",
+                return_value=MagicMock(
+                    returncode=125,
+                    stdout="",
+                    stderr="no such image: foo/bar",
+                ),
+            ),
+            patch("cognithor.core.vllm_orchestrator.log") as mock_log,
+        ):
+            orch = VLLMOrchestrator(port=8000)
+            with contextlib.suppress(VLLMNotReadyError):
+                orch.start_container("foo/bar")
+
+        error_calls = [
+            call
+            for call in mock_log.error.call_args_list
+            if call.args and "vllm_docker_run_failed" in call.args[0]
+        ]
+        assert error_calls, "Expected log.error('vllm_docker_run_failed', ...) on failed run"

--- a/tests/test_gateway/test_gateway_video_wiring.py
+++ b/tests/test_gateway/test_gateway_video_wiring.py
@@ -49,3 +49,56 @@ class TestClassifyAttachments:
         assert images == []
         assert video is None
         assert rejected == []
+
+
+class TestBuildVideoAttachmentIsNonBlocking:
+    def test_gateway_wraps_build_video_attachment_in_to_thread(self):
+        """Regression for Bug I3: the per-turn handler must offload the
+        blocking _build_video_attachment call (which runs ffprobe via
+        subprocess.run) to a thread pool, otherwise a slow remote URL
+        ties up the async event loop for up to 30 s.
+
+        This is a source-level assertion because _build_video_attachment's
+        call site is buried in the Gateway's chat handler and is hard to
+        reach via unit test without spinning up a full gateway stack.
+        """
+        import inspect
+
+        from cognithor.gateway import gateway as gw
+
+        src = inspect.getsource(gw)
+
+        # The blocking call site must be wrapped; look for the exact pattern.
+        # We accept either of these forms:
+        #   await asyncio.to_thread(_build_video_attachment, ...)
+        #   await asyncio.to_thread(self._build_video_attachment, ...)
+        # and reject the bare unwrapped form.
+        has_wrapped = "asyncio.to_thread(_build_video_attachment" in src or (
+            "asyncio.to_thread(\n" in src and "_build_video_attachment" in src
+        )
+        assert has_wrapped, (
+            "Expected _build_video_attachment to be called via "
+            "asyncio.to_thread in gateway.py - see Bug I3."
+        )
+
+        # And the bare unwrapped form must NOT appear in any active code path.
+        # (A commented-out example is fine; a genuine bare call is not.)
+        lines = [
+            line
+            for line in src.splitlines()
+            if "_build_video_attachment(" in line and not line.lstrip().startswith("#")
+        ]
+        bare_calls = [
+            line
+            for line in lines
+            if "asyncio.to_thread" not in line
+            and "def _build_video_attachment" not in line
+            and "await" not in line.split("_build_video_attachment", 1)[0][-20:]
+        ]
+        # Only the definition and the wrapped call should remain; no bare
+        # unwrapped invocations. The function definition itself counts; filter
+        # it out.
+        bare_invocations = [line for line in bare_calls if "def " not in line]
+        assert not bare_invocations, (
+            f"Found unwrapped bare call(s) to _build_video_attachment: {bare_invocations}"
+        )

--- a/tests/test_gateway/test_gateway_video_wiring.py
+++ b/tests/test_gateway/test_gateway_video_wiring.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+
+class TestClassifyAttachments:
+    def test_video_and_image_classified_correctly(self):
+        from cognithor.gateway.gateway import _classify_attachments
+
+        images, video, rejected = _classify_attachments(
+            [
+                "/tmp/pic.png",
+                "/tmp/clip.mp4",
+            ]
+        )
+        assert images == ["/tmp/pic.png"]
+        assert video == "/tmp/clip.mp4"
+        assert rejected == []
+
+    def test_second_video_is_rejected(self):
+        from cognithor.gateway.gateway import _classify_attachments
+
+        images, video, rejected = _classify_attachments(
+            [
+                "/tmp/clip1.mp4",
+                "/tmp/clip2.mp4",
+                "/tmp/clip3.webm",
+            ]
+        )
+        assert images == []
+        assert video == "/tmp/clip1.mp4"  # first wins
+        assert rejected == ["/tmp/clip2.mp4", "/tmp/clip3.webm"]
+
+    def test_no_videos_returns_none(self):
+        from cognithor.gateway.gateway import _classify_attachments
+
+        images, video, rejected = _classify_attachments(
+            [
+                "/tmp/pic.png",
+                "/tmp/doc.pdf",
+            ]
+        )
+        assert video is None
+        assert rejected == []
+        assert images == ["/tmp/pic.png"]
+
+    def test_empty_input_returns_empty(self):
+        from cognithor.gateway.gateway import _classify_attachments
+
+        images, video, rejected = _classify_attachments([])
+        assert images == []
+        assert video is None
+        assert rejected == []

--- a/tests/test_gateway/test_video_cleanup.py
+++ b/tests/test_gateway/test_video_cleanup.py
@@ -108,3 +108,30 @@ class TestStartStop:
         await worker.start()
         await worker.stop()
         await worker.stop()  # second stop must not raise
+
+
+class TestStartIdempotent:
+    @pytest.mark.asyncio
+    async def test_double_start_does_not_leak_second_task(self, tmp_path: Path):
+        """Regression for Bug C2-r3: start() called twice must not orphan the
+        first sweep task. Without the idempotency guard, the first _sweep_task
+        reference is overwritten and the task runs forever."""
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24, sweep_interval_sec=0.05)
+        await worker.start()
+        first_task = worker._sweep_task
+        assert first_task is not None
+
+        # Second start() must either return the same task or leave the first one
+        # intact and not running in parallel with a second one.
+        await worker.start()
+        second_task = worker._sweep_task
+
+        # Either the same task object OR the first task has been cleanly
+        # cancelled/replaced. The concrete invariant: no more than ONE active
+        # sweep task exists.
+        assert first_task is second_task or first_task.done(), (
+            "Second start() orphaned the first sweep task: "
+            f"first_task.done={first_task.done()}, different-object={first_task is not second_task}"
+        )
+
+        await worker.stop()

--- a/tests/test_gateway/test_video_cleanup.py
+++ b/tests/test_gateway/test_video_cleanup.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from cognithor.gateway.video_cleanup import VideoCleanupWorker
+
+
+def _touch(path: Path, size: int = 64, mtime_age_sec: float = 0.0) -> None:
+    """Create a file with optional artificially-old mtime."""
+    path.write_bytes(b"x" * size)
+    if mtime_age_sec > 0:
+        t = time.time() - mtime_age_sec
+        os.utime(path, (t, t))
+
+
+class TestRegisterAndSessionClose:
+    @pytest.mark.asyncio
+    async def test_register_upload_is_tracked_by_session(self, tmp_path: Path):
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24)
+        worker.register_upload("abc123", "session-1")
+        worker.register_upload("def456", "session-1")
+        worker.register_upload("ghi789", "session-2")
+        assert set(worker._by_session["session-1"]) == {"abc123", "def456"}
+        assert worker._by_session["session-2"] == ["ghi789"]
+
+    @pytest.mark.asyncio
+    async def test_on_session_close_deletes_only_that_sessions_files(self, tmp_path: Path):
+        _touch(tmp_path / "abc123.mp4")
+        _touch(tmp_path / "abc123.jpg")  # thumbnail sidecar
+        _touch(tmp_path / "def456.mp4")
+        _touch(tmp_path / "ghi789.mp4")
+
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24)
+        worker.register_upload("abc123", "session-1")
+        worker.register_upload("def456", "session-1")
+        worker.register_upload("ghi789", "session-2")
+
+        await worker.on_session_close("session-1")
+
+        assert not (tmp_path / "abc123.mp4").exists()
+        assert not (tmp_path / "abc123.jpg").exists()
+        assert not (tmp_path / "def456.mp4").exists()
+        assert (tmp_path / "ghi789.mp4").exists()
+        assert "session-1" not in worker._by_session
+
+    @pytest.mark.asyncio
+    async def test_on_session_close_for_unknown_session_is_noop(self, tmp_path: Path):
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24)
+        await worker.on_session_close("ghost-session")
+
+
+class TestTTLSweep:
+    @pytest.mark.asyncio
+    async def test_sweep_deletes_files_older_than_ttl(self, tmp_path: Path):
+        old = tmp_path / "old-uuid.mp4"
+        fresh = tmp_path / "fresh-uuid.mp4"
+        _touch(old, mtime_age_sec=25 * 3600)  # 25 h old
+        _touch(fresh, mtime_age_sec=1 * 3600)  # 1 h old
+
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24)
+        await worker._sweep_once()
+
+        assert not old.exists()
+        assert fresh.exists()
+
+    @pytest.mark.asyncio
+    async def test_sweep_deletes_thumbnails_too(self, tmp_path: Path):
+        old_video = tmp_path / "old.mp4"
+        old_thumb = tmp_path / "old.jpg"
+        _touch(old_video, mtime_age_sec=25 * 3600)
+        _touch(old_thumb, mtime_age_sec=25 * 3600)
+
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24)
+        await worker._sweep_once()
+
+        assert not old_video.exists()
+        assert not old_thumb.exists()
+
+    @pytest.mark.asyncio
+    async def test_sweep_ignores_missing_dir(self, tmp_path: Path):
+        missing = tmp_path / "does-not-exist"
+        worker = VideoCleanupWorker(media_dir=missing, ttl_hours=24)
+        # Must not raise
+        await worker._sweep_once()
+
+
+class TestStartStop:
+    @pytest.mark.asyncio
+    async def test_start_runs_initial_sweep(self, tmp_path: Path):
+        old = tmp_path / "old.mp4"
+        _touch(old, mtime_age_sec=25 * 3600)
+
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24, sweep_interval_sec=0.05)
+        await worker.start()
+        await asyncio.sleep(0.02)  # give the initial sweep a moment
+        await worker.stop()
+
+        assert not old.exists()
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent(self, tmp_path: Path):
+        worker = VideoCleanupWorker(media_dir=tmp_path, ttl_hours=24)
+        await worker.start()
+        await worker.stop()
+        await worker.stop()  # second stop must not raise

--- a/tests/test_gateway/test_video_cleanup_session_wiring.py
+++ b/tests/test_gateway/test_video_cleanup_session_wiring.py
@@ -1,0 +1,156 @@
+"""Regression test for Bug C1-r2: Gateway must fire VideoCleanupWorker.on_session_close
+when a session ends (stale sweep OR explicit close), otherwise videos leak until
+the 24 h TTL sweep."""
+
+from __future__ import annotations
+
+
+class TestSessionCloseFiresVideoCleanup:
+    def test_stale_cleanup_triggers_on_session_close(self):
+        """When _cleanup_stale_sessions evicts a session, the VideoCleanupWorker
+        must be told so its registered uploads get deleted immediately."""
+        import inspect
+
+        from cognithor.gateway import gateway as gw
+
+        src = inspect.getsource(gw)
+
+        # Find _cleanup_stale_sessions method body and check for a call to
+        # video_cleanup.on_session_close inside it.
+        # Accept either:
+        #   self._video_cleanup.on_session_close(...)
+        #   asyncio.ensure_future(self._video_cleanup.on_session_close(...))
+        #   await self._video_cleanup.on_session_close(...)
+        m_start = src.find("def _cleanup_stale_sessions")
+        assert m_start != -1, "Could not locate _cleanup_stale_sessions in gateway.py"
+        # Take a reasonable window after the def
+        m_end = src.find("\n    def ", m_start + 1)
+        if m_end == -1:
+            m_end = len(src)
+        body = src[m_start:m_end]
+
+        assert "on_session_close" in body, (
+            "_cleanup_stale_sessions does not call VideoCleanupWorker.on_session_close. "
+            "Session-lifetime cleanup is dead code — videos only deleted by 24h TTL sweep."
+        )
+
+
+class TestFunctionalSessionCloseWiring:
+    """Functional test: build a minimally-constructed Gateway (__new__, no __init__)
+    and verify _cleanup_stale_sessions schedules on_session_close for each evicted
+    session when a running event loop is available.
+    """
+
+    def test_cleanup_calls_video_worker_with_each_session_id(self):
+        import asyncio
+        import threading
+        import time
+        from dataclasses import dataclass
+        from unittest.mock import MagicMock
+
+        from cognithor.gateway.gateway import Gateway
+
+        # Build a bare Gateway without running __init__.
+        gw = Gateway.__new__(Gateway)
+
+        # Minimal attribute surface required by _cleanup_stale_sessions.
+        @dataclass
+        class _FakeSession:
+            session_id: str
+
+        gw._session_lock = threading.Lock()
+        gw._SESSION_TTL_SECONDS = 1  # type: ignore[attr-defined]
+        gw._last_session_cleanup = 0.0
+        # Two sessions that are definitely stale (last accessed "forever ago").
+        key_a = "channel:user-a:jarvis"
+        key_b = "channel:user-b:jarvis"
+        gw._sessions = {
+            key_a: _FakeSession(session_id="sid-a"),
+            key_b: _FakeSession(session_id="sid-b"),
+        }
+        gw._working_memories = {"sid-a": object(), "sid-b": object()}
+        # A time far enough in the past to exceed TTL.
+        past = time.monotonic() - 9999.0
+        gw._session_last_accessed = {key_a: past, key_b: past}
+
+        # Mock the video cleanup worker.
+        calls: list[str] = []
+
+        async def _fake_close(session_id: str) -> None:
+            calls.append(session_id)
+
+        mock_worker = MagicMock()
+        mock_worker.on_session_close.side_effect = _fake_close
+        gw._video_cleanup = mock_worker
+
+        async def _runner():
+            gw._cleanup_stale_sessions()
+            # Let the scheduled tasks run.
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+
+        asyncio.run(_runner())
+
+        # Each evicted session should have fired on_session_close exactly once.
+        assert mock_worker.on_session_close.call_count == 2
+        called_ids = {c.args[0] for c in mock_worker.on_session_close.call_args_list}
+        assert called_ids == {"sid-a", "sid-b"}
+
+    def test_cleanup_skips_video_worker_when_none(self):
+        """Gateway where vLLM is disabled has _video_cleanup=None — must not crash."""
+        import threading
+        import time
+        from dataclasses import dataclass
+
+        from cognithor.gateway.gateway import Gateway
+
+        gw = Gateway.__new__(Gateway)
+
+        @dataclass
+        class _FakeSession:
+            session_id: str
+
+        gw._session_lock = threading.Lock()
+        gw._SESSION_TTL_SECONDS = 1  # type: ignore[attr-defined]
+        gw._last_session_cleanup = 0.0
+        gw._sessions = {"k": _FakeSession(session_id="sid-x")}
+        gw._working_memories = {"sid-x": object()}
+        gw._session_last_accessed = {"k": time.monotonic() - 9999.0}
+        gw._video_cleanup = None
+
+        # Must not raise even without a video cleanup worker.
+        gw._cleanup_stale_sessions()
+        assert gw._sessions == {}
+        assert gw._working_memories == {}
+
+    def test_cleanup_tolerates_no_running_loop(self):
+        """If no event loop is running, we can't schedule the coroutine — must
+        not raise (TTL sweep will catch orphans later)."""
+        import threading
+        import time
+        from dataclasses import dataclass
+        from unittest.mock import MagicMock
+
+        from cognithor.gateway.gateway import Gateway
+
+        gw = Gateway.__new__(Gateway)
+
+        @dataclass
+        class _FakeSession:
+            session_id: str
+
+        gw._session_lock = threading.Lock()
+        gw._SESSION_TTL_SECONDS = 1  # type: ignore[attr-defined]
+        gw._last_session_cleanup = 0.0
+        gw._sessions = {"k": _FakeSession(session_id="sid-y")}
+        gw._working_memories = {"sid-y": object()}
+        gw._session_last_accessed = {"k": time.monotonic() - 9999.0}
+
+        mock_worker = MagicMock()
+        # Do not call — simulates no-loop path.
+        gw._video_cleanup = mock_worker
+
+        # Running synchronously outside asyncio.run() → no running loop.
+        gw._cleanup_stale_sessions()
+        # Session should still have been evicted.
+        assert gw._sessions == {}

--- a/tests/test_integration/test_v17_browser_use.py
+++ b/tests/test_integration/test_v17_browser_use.py
@@ -836,8 +836,15 @@ class TestBrowserAgentMocked:
         from cognithor.browser.agent import BrowserAgent
 
         agent = BrowserAgent()
-        with pytest.raises(RuntimeError, match="not started"):
-            asyncio.get_event_loop().run_until_complete(agent.click("#x"))
+        # Python 3.12+: asyncio.get_event_loop() without a running loop
+        # raises its own RuntimeError before reaching the agent. Create
+        # an explicit loop so the test actually exercises agent.click().
+        loop = asyncio.new_event_loop()
+        try:
+            with pytest.raises(RuntimeError, match="not started"):
+                loop.run_until_complete(agent.click("#x"))
+        finally:
+            loop.close()
 
     # ── Stats ────────────────────────────────────────────────────
 

--- a/tests/test_integration/test_vllm_fake_server.py
+++ b/tests/test_integration/test_vllm_fake_server.py
@@ -36,6 +36,25 @@ def _build_fake_vllm_app() -> FastAPI:
                 yield "data: [DONE]\n\n"
 
             return StreamingResponse(gen(), media_type="text/event-stream")
+
+        last_msg = body["messages"][-1]
+        content = last_msg.get("content")
+        if isinstance(content, list):
+            has_video = any(c.get("type") == "video_url" for c in content)
+            if has_video:
+                video_url = next(
+                    c["video_url"]["url"] for c in content if c.get("type") == "video_url"
+                )
+                extra = body.get("extra_body", {})
+                mm_video = extra.get("mm_processor_kwargs", {}).get("video", {})
+                return {
+                    "choices": [
+                        {"message": {"content": f"Saw video {video_url} with sampling {mm_video}"}}
+                    ],
+                    "model": body["model"],
+                    "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+                }
+
         return {
             "choices": [{"message": {"content": "echo: " + body["messages"][-1]["content"]}}],
             "model": body["model"],
@@ -116,5 +135,21 @@ class TestVLLMBackendEndToEnd:
         try:
             models = await backend.list_models()
             assert "fake-model" in models
+        finally:
+            await backend.close()
+
+
+class TestVLLMBackendVideoEndToEnd:
+    @pytest.mark.asyncio
+    async def test_video_roundtrip_preserves_url_and_sampling(self, fake_server):
+        backend = VLLMBackend(base_url=f"http://127.0.0.1:{fake_server}/v1")
+        try:
+            resp = await backend.chat(
+                model="fake-model",
+                messages=[{"role": "user", "content": "describe"}],
+                video={"url": "http://example.com/clip.mp4", "sampling": {"fps": 2.0}},
+            )
+            assert "http://example.com/clip.mp4" in resp.content
+            assert "fps" in resp.content
         finally:
             await backend.close()


### PR DESCRIPTION
## Summary

- **Native video input** in chat via vLLM's `video_url` content type on Qwen3.6-27B (or any video-capable VLM). No frame-extraction workarounds — rides on the protocol as designed.
- **Full upload flow**: paperclip → "Video hochladen" → local file picked → multipart upload to `/api/media/upload` → served to vLLM over 127.0.0.1 HTTP → `extra_body.mm_processor_kwargs.video` carries the adaptive sampling. URL-paste path also supported via regex detect + dedicated URL-einfügen dialog.
- **Day-1 spike** proved the `v0.19.1` tagged vLLM image crashes Qwen3.6-27B-NVFP4 at warmup on SM120 (Blackwell / RTX 50xx). Pinned default image to `cu130-nightly` which ships the `FlashInferCutlassNvFp4LinearKernel` fix.

## What's in the branch

48 commits since `0a6d6c6`:
- 1 spike commit (Day-1 findings doc)
- 22 feature commits (Tasks 2–23 of the plan)
- 1 repo-wide ruff sweep
- 20 bug-fix commits from 4 independent review rounds
- 3 documentation commits
- 1 release-prep commit (0.92.7 bump + README highlights)

## Review rounds

| Round | Real bugs | False-positives | Skips |
|------:|----------:|----------------:|------:|
| 1 | 6 | 0 | 0 |
| 2 | 6 | 0 | 0 |
| 3 | 4 | 1 | 1 |
| 4 | 4 | 1 | 0 |
| 5 | 0 | — | — |

**19 real bugs caught and fixed before merge**, including:
- Windows path-traversal exploit (`C:\...\cmd.exe` via `%5C` → would have returned 200 OK)
- Quota-TOCTOU race (8/10 concurrent writers slipped past quota pre-fix)
- Production-silent two-orchestrator bug (`media_url` never reached the container)
- Dead-code session cleanup (only the 24 h TTL sweep actually ran)
- Multi-turn text-loss in the vision helper
- Event-loop-blocking ffprobe (1.01 s serialized → 0.5 s parallel)
- Config-drift where user overrides silently fell back to defaults

Round 5 verdict: **Ready to merge** — all seven probes clean.

## Testing

- **Python:** 14,118 tests passing, 12 skipped, 0 failures (19 min regression). 149 video-specific.
- **Flutter:** 31/31 tests passing. `flutter analyze` clean.
- **Ruff:** `All checks passed!` + 1265 files formatted across the entire repo.

## Follow-ups (not blockers)

- `cu130-nightly` is a rolling tag — documented in the user guide + spike findings with mitigation steps.
- End-to-end Flutter→vLLM integration test is a layered-mock stack today, not a single connected test — noted in round-5 probe 5.

## Test plan

- [ ] CI Python regression green
- [ ] CI Flutter regression green
- [ ] CI ruff green
- [ ] Manual smoke test §9 — video upload with 30-s clip on RTX 5090
- [ ] Manual smoke test §10 — video URL paste
- [ ] Manual smoke test §11 — long-video banner appears on >15 min video
- [ ] Manual smoke test §12 — degraded vLLM surfaces red error, no Ollama fallback
- [ ] Manual smoke test §13 — session-close cleanup removes uploads immediately
- [ ] Manual smoke test §14 — TTL sweep removes orphan files on restart
- [ ] Manual smoke test §15 — second video in same turn is rejected

See `docs/vllm-manual-test.md` §9–15 for full recipes.
