### PR TITLE
feat(crew): Feature 4 Guardrails — 12 tasks, 122 tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   Hashline-Guard chain with PII redaction. Trilingual error messages
   (en/de/zh) via `cognithor.i18n`. Spec at
   `docs/superpowers/specs/2026-04-23-cognithor-crew-v1-adoption.md`.
+- **`cognithor.crew.guardrails` — Task-Level Guardrails (Feature 4)** — function-
+  based + string-based validators, built-in `hallucination_check`, `word_count`,
+  `no_pii` (DE-focused), `schema` (Pydantic), plus `chain()` combinator. Failures
+  trigger retry-with-feedback up to `task.max_retries`, then raise
+  `GuardrailFailure`. Every verdict is recorded in the Hashline-Guard audit chain
+  with PII-detection flag.
 
 ### Breaking Changes
 None. The Crew-Layer is strictly additive — no existing public API changes.

--- a/src/cognithor/crew/compiler.py
+++ b/src/cognithor/crew/compiler.py
@@ -443,6 +443,15 @@ async def execute_task_async(
             verdict = "skipped"
             break
         result = await _call_guardrail(guardrail, out)
+        append_audit(
+            "crew_guardrail_check",
+            trace_id=trace_id,  # parent correlation - links verdict to kickoff
+            task_id=task.task_id,
+            verdict="pass" if result.passed else "fail",
+            retry_count=attempts,
+            pii_detected=result.pii_detected,
+            feedback=result.feedback,
+        )
         if result.passed:
             verdict = "pass"
             break

--- a/src/cognithor/crew/compiler.py
+++ b/src/cognithor/crew/compiler.py
@@ -212,37 +212,6 @@ def execute_task(
     )
 
 
-# Guardrails land in Feature 4 (PR 2). Between PR 1 (this file) shipping and
-# PR 2 landing on the user's install, a CrewTask with `guardrail=<anything>`
-# would silently do nothing — the user gets no safety they expected. Guard
-# against that foot-gun by probing the guardrails module at import time and
-# emitting a UserWarning if a task declares a guardrail on a version that
-# can't execute it. Removed in Task 21 when the real apply path lands.
-try:
-    from cognithor.crew.guardrails import base as _guardrails_base  # noqa: F401
-
-    _guardrails_available = True
-except ImportError:
-    _guardrails_available = False
-
-
-def _warn_if_guardrail_silently_ignored(task: CrewTask) -> None:
-    """PR 1 → PR 2 bridge guard. Removed in Task 21."""
-    import warnings
-
-    if task.guardrail is not None and not _guardrails_available:
-        warnings.warn(
-            f"CrewTask '{task.task_id}' has a guardrail but "
-            "cognithor.crew.guardrails is not available in this release. "
-            "The guardrail will be IGNORED. Upgrade to cognithor>=0.93.0 "
-            "(or install via `pip install cognithor[all]`) to enable guardrails.",
-            UserWarning,
-            # Chain: warn -> _warn_if_guardrail_silently_ignored ->
-            #        compile_and_run_sync -> Crew.kickoff -> USER
-            stacklevel=4,
-        )
-
-
 def _warn_if_hierarchical_is_stubbed(process: CrewProcess) -> None:
     """PR 1 → Task 10 bridge guard.
 
@@ -303,7 +272,6 @@ def compile_and_run_sync(
         process=process.value,
     )
     for t in ordered:
-        _warn_if_guardrail_silently_ignored(t)  # PR 1 → PR 2 bridge guard
         # Note: ``execute_task`` is the sync trampoline — it asyncio.run()s
         # execute_task_async which re-derives its own trace_id if omitted.
         # Passing the kickoff-level trace_id isn't plumbed through the sync
@@ -448,10 +416,6 @@ async def compile_and_run_async(
 
     trace_id = _uuid.uuid4().hex
     outputs: list[TaskOutput] = []
-    # PR 1 → PR 2 bridge: warn on any silently-ignored guardrail before entering
-    # the fan-out loop (single pass; warnings filter dedupes by call site).
-    for t in ordered:
-        _warn_if_guardrail_silently_ignored(t)
     append_audit(
         "crew_kickoff_started",
         trace_id=trace_id,

--- a/src/cognithor/crew/compiler.py
+++ b/src/cognithor/crew/compiler.py
@@ -10,6 +10,7 @@ turn drives the Gatekeeper + Executor — the Crew-Layer never bypasses PGE.
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import threading
 import uuid as _uuid
@@ -17,6 +18,10 @@ from pathlib import Path
 from typing import Any
 
 from cognithor.crew.agent import CrewAgent
+from cognithor.crew.errors import GuardrailFailure
+from cognithor.crew.guardrails.base import GuardrailResult
+from cognithor.crew.guardrails.function_guardrail import FunctionGuardrail
+from cognithor.crew.guardrails.string_guardrail import StringGuardrail
 from cognithor.crew.output import CrewOutput, TaskOutput, TokenUsageDict
 from cognithor.crew.process import CrewProcess
 from cognithor.crew.task import CrewTask
@@ -178,6 +183,43 @@ def _read_token_usage(planner: Any) -> TokenUsageDict | None:
     )
 
 
+def _is_already_guardrail(g: Any) -> bool:
+    """Duck-type check: Guardrails (FunctionGuardrail, StringGuardrail, chain-wrapper)
+    have a ``__call__`` AND either a ``_rule`` attribute (StringGuardrail), a
+    ``_fn`` attribute (FunctionGuardrail), or are builtin closures. Anything
+    else the user passes is treated as a raw callable and wrapped.
+    """
+    return hasattr(g, "_rule") or hasattr(g, "_fn") or getattr(g, "_is_guardrail", False)
+
+
+def _normalize_guardrail(g: Any, *, ollama_client: Any, model: str) -> Any:
+    """Normalize whatever the user stuck into ``CrewTask.guardrail`` into a
+    callable.
+
+    - ``None`` -> None
+    - ``str`` -> :class:`StringGuardrail`
+    - already a Guardrail -> returned as-is
+    - any other callable -> wrapped in :class:`FunctionGuardrail` for exception safety
+    """
+    if g is None:
+        return None
+    if isinstance(g, str):
+        return StringGuardrail(g, llm_client=ollama_client, model=model)
+    if _is_already_guardrail(g):
+        return g
+    if callable(g):
+        return FunctionGuardrail(g)
+    return g
+
+
+async def _call_guardrail(guardrail: Any, out: TaskOutput) -> GuardrailResult:
+    """Invoke a guardrail - may be sync or async. Awaits coroutine returns."""
+    result = guardrail(out)
+    if inspect.iscoroutine(result):
+        result = await result
+    return result
+
+
 def execute_task(
     task: CrewTask,
     *,
@@ -330,7 +372,9 @@ async def execute_task_async(
     trace_id: str | None = None,
 ) -> TaskOutput:
     """Route one task through the Planner (which internally drives
-    Gatekeeper + Executor).
+    Gatekeeper + Executor), then run any attached guardrail with
+    retry-with-feedback. Raises :class:`GuardrailFailure` after
+    ``task.max_retries`` retries.
 
     Spec §1.6: the Crew-Layer must NOT bypass the Planner. Every task builds
     a proper ``WorkingMemory`` + ``ToolResult`` list and calls
@@ -375,13 +419,66 @@ async def execute_task_async(
         prompt_tokens=0, completion_tokens=0, total_tokens=0
     )
 
-    return TaskOutput(
-        task_id=task.task_id,
-        agent_role=task.agent.role,
-        raw=raw,
-        duration_ms=duration_ms,
-        token_usage=usage,
+    # Guardrail evaluation with retry-with-feedback.
+    ollama_client = getattr(planner, "_ollama", None)
+    guardrail_model = task.agent.llm or "ollama/qwen3:8b"
+    # Only coerce str llm into guardrail_model; dict LLMConfig falls back to default.
+    if not isinstance(guardrail_model, str):
+        guardrail_model = "ollama/qwen3:8b"
+    guardrail = _normalize_guardrail(
+        task.guardrail, ollama_client=ollama_client, model=guardrail_model
     )
+
+    attempts = 0
+    verdict = "skipped"
+    while True:
+        out = TaskOutput(
+            task_id=task.task_id,
+            agent_role=task.agent.role,
+            raw=raw,
+            duration_ms=duration_ms,
+            token_usage=usage,
+        )
+        if guardrail is None:
+            verdict = "skipped"
+            break
+        result = await _call_guardrail(guardrail, out)
+        if result.passed:
+            verdict = "pass"
+            break
+        attempts += 1
+        if attempts > task.max_retries:
+            raise GuardrailFailure(
+                task_id=task.task_id,
+                guardrail_name=type(guardrail).__name__,
+                attempts=attempts,
+                reason=result.feedback or "(no feedback)",
+            )
+        # Retry: re-invoke Planner with a retry-nudge synthesized as an extra
+        # ToolResult carrying the feedback. ``crew:retry_feedback`` prefix
+        # prevents Gatekeeper / audit scanners from mistaking it for a real
+        # tool call. (R4-I3)
+        retry_context = [
+            *prior_results,
+            ToolResult(
+                tool_name="crew:retry_feedback",
+                content=(
+                    f"Vorheriger Versuch wurde abgelehnt. "
+                    f"Feedback: {result.feedback}. "
+                    "Bitte erneut versuchen und die Kritik einarbeiten."
+                ),
+                is_error=False,
+            ),
+        ]
+        t0 = time.perf_counter()
+        envelope = await planner.formulate_response(user_message, retry_context, working_memory)
+        duration_ms = (time.perf_counter() - t0) * 1000.0
+        raw = getattr(envelope, "content", "") or ""
+        usage = _read_token_usage(planner) or TokenUsageDict(
+            prompt_tokens=0, completion_tokens=0, total_tokens=0
+        )
+
+    return out.model_copy(update={"guardrail_verdict": verdict})
 
 
 async def compile_and_run_async(

--- a/src/cognithor/crew/guardrails/__init__.py
+++ b/src/cognithor/crew/guardrails/__init__.py
@@ -1,0 +1,7 @@
+"""Cognithor Crew-Layer Guardrails."""
+
+from __future__ import annotations
+
+from cognithor.crew.guardrails.base import Guardrail, GuardrailResult
+
+__all__ = ["Guardrail", "GuardrailResult"]

--- a/src/cognithor/crew/guardrails/__init__.py
+++ b/src/cognithor/crew/guardrails/__init__.py
@@ -2,6 +2,29 @@
 
 from __future__ import annotations
 
+from cognithor.crew.errors import GuardrailFailure
 from cognithor.crew.guardrails.base import Guardrail, GuardrailResult
+from cognithor.crew.guardrails.builtin import (
+    chain,
+    hallucination_check,
+    no_pii,
+    schema,
+    word_count,
+)
+from cognithor.crew.guardrails.function_guardrail import FunctionGuardrail
+from cognithor.crew.guardrails.string_guardrail import StringGuardrail
 
-__all__ = ["Guardrail", "GuardrailResult"]
+__all__ = [
+    "FunctionGuardrail",
+    "Guardrail",
+    # Re-exported from cognithor.crew.errors so users have one obvious
+    # import location.
+    "GuardrailFailure",
+    "GuardrailResult",
+    "StringGuardrail",
+    "chain",
+    "hallucination_check",
+    "no_pii",
+    "schema",
+    "word_count",
+]

--- a/src/cognithor/crew/guardrails/__init__.py
+++ b/src/cognithor/crew/guardrails/__init__.py
@@ -1,4 +1,33 @@
-"""Cognithor Crew-Layer Guardrails."""
+"""Cognithor Crew-Layer Guardrails.
+
+Two flavors:
+  * function-based — Python callable, pass into ``CrewTask(guardrail=fn)``
+  * string-based — natural language rule, evaluated by an LLM
+
+Built-ins (factories):
+  * ``word_count(min_words=..., max_words=...)``
+  * ``no_pii()`` — detects German PII (emails, IBANs, phone numbers, Steuer-IDs)
+  * ``hallucination_check(reference=..., min_overlap=...)``
+  * ``schema(pydantic_model)``
+  * ``chain(*guardrails)`` — composes async/sync guardrails with short-circuit
+
+Example::
+
+    from cognithor.crew import Crew, CrewAgent, CrewTask
+    from cognithor.crew.guardrails import chain, no_pii, word_count
+
+    task = CrewTask(
+        description="Draft a customer email",
+        expected_output="Polite, professional email under 200 words",
+        agent=my_agent,
+        guardrail=chain(no_pii(), word_count(max_words=200)),
+        max_retries=2,
+    )
+
+Failed guardrails trigger retry-with-feedback up to ``max_retries``, then raise
+``GuardrailFailure``. Every verdict (pass/fail/retry) emits a
+``crew_guardrail_check`` event on the Hashline-Guard audit chain.
+"""
 
 from __future__ import annotations
 
@@ -17,8 +46,6 @@ from cognithor.crew.guardrails.string_guardrail import StringGuardrail
 __all__ = [
     "FunctionGuardrail",
     "Guardrail",
-    # Re-exported from cognithor.crew.errors so users have one obvious
-    # import location.
     "GuardrailFailure",
     "GuardrailResult",
     "StringGuardrail",

--- a/src/cognithor/crew/guardrails/base.py
+++ b/src/cognithor/crew/guardrails/base.py
@@ -1,0 +1,31 @@
+"""Guardrail protocol + result dataclass.
+
+A Guardrail is a callable that takes a TaskOutput and returns a
+GuardrailResult. Concrete implementations live in ``function_guardrail.py``
+(Python callable wrapper), ``string_guardrail.py`` (LLM-validated natural
+language), and ``builtin.py`` (factory-produced presets).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict
+
+if TYPE_CHECKING:
+    from cognithor.crew.output import TaskOutput
+
+
+class GuardrailResult(BaseModel):
+    """Immutable verdict returned by every Guardrail."""
+
+    model_config = ConfigDict(frozen=True)
+
+    passed: bool
+    feedback: str | None = None  # Required when passed is False
+    pii_detected: bool = False  # Set by no_pii and related guardrails
+
+
+@runtime_checkable
+class Guardrail(Protocol):
+    def __call__(self, output: TaskOutput) -> GuardrailResult: ...

--- a/src/cognithor/crew/guardrails/builtin.py
+++ b/src/cognithor/crew/guardrails/builtin.py
@@ -2,12 +2,22 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 from cognithor.crew.guardrails.base import GuardrailResult
 
 if TYPE_CHECKING:
     from cognithor.crew.output import TaskOutput
+
+
+# Regex patterns for common German PII
+_PATTERNS: dict[str, re.Pattern[str]] = {
+    "email": re.compile(r"\b[\w.+-]+@[\w-]+\.[\w.-]+\b", re.IGNORECASE),
+    "iban": re.compile(r"\bDE\d{2}(?:\s?\d{4}){4}\s?\d{2}\b"),
+    "phone": re.compile(r"(?:\+49|0049|0)[\s.-]?\d{2,4}[\s.-]?\d{3,6}[\s.-]?\d{0,6}"),
+    "steuer_id": re.compile(r"\b\d{2}\s?\d{3}\s?\d{3}\s?\d{3}\b"),
+}
 
 
 def word_count(min_words: int | None = None, max_words: int | None = None):
@@ -28,5 +38,29 @@ def word_count(min_words: int | None = None, max_words: int | None = None):
                 feedback=f"Output hat {count} Wörter, höchstens {max_words} erlaubt.",
             )
         return GuardrailResult(passed=True, feedback=None)
+
+    return _guard
+
+
+def no_pii():
+    """Guardrail that blocks outputs containing German PII.
+
+    Detects email addresses, German IBANs, German phone numbers, and 11-digit
+    Steuer-IDs. Emits a combined feedback listing every category found.
+    """
+
+    def _guard(output: TaskOutput) -> GuardrailResult:
+        hits: list[str] = []
+        for name, pat in _PATTERNS.items():
+            if pat.search(output.raw):
+                hits.append(name)
+        if not hits:
+            return GuardrailResult(passed=True, feedback=None, pii_detected=False)
+        categories = ", ".join(hits)
+        return GuardrailResult(
+            passed=False,
+            feedback=f"PII erkannt: {categories}. Bitte anonymisieren.",
+            pii_detected=True,
+        )
 
     return _guard

--- a/src/cognithor/crew/guardrails/builtin.py
+++ b/src/cognithor/crew/guardrails/builtin.py
@@ -153,4 +153,10 @@ def chain(*guards):
                 return r
         return GuardrailResult(passed=True, feedback=None)
 
+    # Mark the closure as a Guardrail so the compiler's ``_normalize_guardrail``
+    # doesn't re-wrap it in a ``FunctionGuardrail`` (which would tuple-unpack
+    # our coroutine return and blow up with "cannot unpack non-iterable
+    # coroutine object"). Any object with ``_is_guardrail`` set is considered
+    # already-normalized by ``_is_already_guardrail``.
+    _combined._is_guardrail = True  # type: ignore[attr-defined]
     return _combined

--- a/src/cognithor/crew/guardrails/builtin.py
+++ b/src/cognithor/crew/guardrails/builtin.py
@@ -1,0 +1,32 @@
+"""Built-in Crew guardrail factories."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cognithor.crew.guardrails.base import GuardrailResult
+
+if TYPE_CHECKING:
+    from cognithor.crew.output import TaskOutput
+
+
+def word_count(min_words: int | None = None, max_words: int | None = None):
+    """Guardrail that checks output word count."""
+    if min_words is None and max_words is None:
+        raise ValueError("word_count requires at least min_words or max_words")
+
+    def _guard(output: TaskOutput) -> GuardrailResult:
+        count = len(output.raw.split())
+        if min_words is not None and count < min_words:
+            return GuardrailResult(
+                passed=False,
+                feedback=f"Output hat {count} Wörter, mindestens {min_words} erwartet.",
+            )
+        if max_words is not None and count > max_words:
+            return GuardrailResult(
+                passed=False,
+                feedback=f"Output hat {count} Wörter, höchstens {max_words} erlaubt.",
+            )
+        return GuardrailResult(passed=True, feedback=None)
+
+    return _guard

--- a/src/cognithor/crew/guardrails/builtin.py
+++ b/src/cognithor/crew/guardrails/builtin.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 import json as _json
 import re
 from typing import TYPE_CHECKING
@@ -126,3 +127,30 @@ def hallucination_check(*, reference: str, min_overlap: float = 0.5):
         return GuardrailResult(passed=True, feedback=None)
 
     return _guard
+
+
+def chain(*guards):
+    """Run guardrails in order; first failure short-circuits.
+
+    R4-C4: this combinator MUST be async so ``StringGuardrail`` (whose
+    ``__call__`` is ``async def``) actually runs. The previous synchronous
+    version invoked ``g(output)`` and got a coroutine back — which is always
+    truthy — so ``if not r.passed`` was evaluated against an un-awaited
+    coroutine, and the second guardrail never ran. The
+    ``versicherungs-vergleich`` template's ``chain(no_pii(), StringGuardrail(...))``
+    required this fix.
+
+    Returned ``GuardrailResult`` preserves the ``pii_detected`` flag from
+    whichever guard signaled it, so the audit-chain record is complete.
+    """
+
+    async def _combined(output: TaskOutput) -> GuardrailResult:
+        for g in guards:
+            r = g(output)
+            if inspect.iscoroutine(r):
+                r = await r
+            if not r.passed:
+                return r
+        return GuardrailResult(passed=True, feedback=None)
+
+    return _combined

--- a/src/cognithor/crew/guardrails/builtin.py
+++ b/src/cognithor/crew/guardrails/builtin.py
@@ -89,3 +89,40 @@ def schema(model_cls: type[BaseModel]):
         return GuardrailResult(passed=True, feedback=None)
 
     return _guard
+
+
+def hallucination_check(*, reference: str, min_overlap: float = 0.5):
+    """Compare output tokens against a reference corpus. Fails when too few
+    of the output's informative tokens appear in the reference (simple
+    heuristic — not a substitute for retrieval grounding).
+    """
+    ref_tokens = {t.lower() for t in reference.split() if len(t) > 2}
+    _number_re = re.compile(r"\b\d{3,}\b")  # 3+ digit numbers
+
+    def _guard(output: TaskOutput) -> GuardrailResult:
+        if min_overlap <= 0.0:
+            return GuardrailResult(passed=True, feedback=None)
+
+        out_tokens = [t.lower() for t in output.raw.split() if len(t) > 2]
+        if not out_tokens:
+            return GuardrailResult(passed=True, feedback=None)
+
+        overlap = sum(1 for t in out_tokens if t in ref_tokens) / len(out_tokens)
+
+        # Additionally fail when any 3+ digit number in output is not in reference
+        invented = [n for n in _number_re.findall(output.raw) if n not in reference]
+        if invented:
+            return GuardrailResult(
+                passed=False,
+                feedback=(f"Output enthält Zahlen ohne Referenz-Nachweis: {', '.join(invented)}"),
+            )
+        if overlap < min_overlap:
+            return GuardrailResult(
+                passed=False,
+                feedback=(
+                    f"Output-Referenz-Überlappung {overlap:.0%} unter Schwelle {min_overlap:.0%}."
+                ),
+            )
+        return GuardrailResult(passed=True, feedback=None)
+
+    return _guard

--- a/src/cognithor/crew/guardrails/builtin.py
+++ b/src/cognithor/crew/guardrails/builtin.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json as _json
 import re
 from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ValidationError
 
 from cognithor.crew.guardrails.base import GuardrailResult
 
@@ -62,5 +65,27 @@ def no_pii():
             feedback=f"PII erkannt: {categories}. Bitte anonymisieren.",
             pii_detected=True,
         )
+
+    return _guard
+
+
+def schema(model_cls: type[BaseModel]):
+    """Guardrail that enforces a Pydantic schema on the output JSON."""
+
+    def _guard(output: TaskOutput) -> GuardrailResult:
+        try:
+            data = _json.loads(output.raw)
+        except _json.JSONDecodeError as exc:
+            return GuardrailResult(passed=False, feedback=f"Output ist kein valides JSON: {exc}")
+        try:
+            model_cls.model_validate(data)
+        except ValidationError as exc:
+            errs = "; ".join(
+                f"{'/'.join(str(p) for p in e['loc'])}: {e['msg']}" for e in exc.errors()
+            )
+            return GuardrailResult(
+                passed=False, feedback=f"Schema-Validierung fehlgeschlagen: {errs}"
+            )
+        return GuardrailResult(passed=True, feedback=None)
 
     return _guard

--- a/src/cognithor/crew/guardrails/function_guardrail.py
+++ b/src/cognithor/crew/guardrails/function_guardrail.py
@@ -1,0 +1,32 @@
+"""Function-based guardrail — wraps a user callable into the protocol."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from cognithor.crew.guardrails.base import GuardrailResult
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from cognithor.crew.output import TaskOutput
+
+
+class FunctionGuardrail:
+    """Adapter: user provides a callable with signature
+        ``Callable[[TaskOutput], tuple[bool, str | TaskOutput]]``
+    and gets a Guardrail that catches exceptions and normalizes return shape.
+    """
+
+    def __init__(self, fn: Callable[[TaskOutput], tuple[bool, Any]]) -> None:
+        self._fn = fn
+
+    def __call__(self, output: TaskOutput) -> GuardrailResult:
+        try:
+            ok, payload = self._fn(output)
+        except Exception as exc:
+            return GuardrailResult(passed=False, feedback=f"Guardrail raised: {exc}")
+        if ok:
+            return GuardrailResult(passed=True, feedback=None)
+        feedback = payload if isinstance(payload, str) else "validation failed"
+        return GuardrailResult(passed=False, feedback=feedback)

--- a/src/cognithor/crew/guardrails/function_guardrail.py
+++ b/src/cognithor/crew/guardrails/function_guardrail.py
@@ -23,8 +23,16 @@ class FunctionGuardrail:
 
     def __call__(self, output: TaskOutput) -> GuardrailResult:
         try:
-            ok, payload = self._fn(output)
+            raw = self._fn(output)
         except Exception as exc:
+            return GuardrailResult(passed=False, feedback=f"Guardrail raised: {exc}")
+        # Pass-through: callables may return a GuardrailResult directly
+        # (Protocol-style). Skip tuple unpacking in that case.
+        if isinstance(raw, GuardrailResult):
+            return raw
+        try:
+            ok, payload = raw
+        except (TypeError, ValueError) as exc:
             return GuardrailResult(passed=False, feedback=f"Guardrail raised: {exc}")
         if ok:
             return GuardrailResult(passed=True, feedback=None)

--- a/src/cognithor/crew/guardrails/string_guardrail.py
+++ b/src/cognithor/crew/guardrails/string_guardrail.py
@@ -1,0 +1,83 @@
+"""String-based guardrail — LLM validates output against a natural-language rule.
+
+The guardrail is **async** — it runs an LLM call via an OllamaClient-shaped
+duck type (async ``.chat(model, messages)`` returning a dict with nested
+``message.content``). The compiler awaits it inside ``execute_task_async``.
+
+Function-based guardrails (FunctionGuardrail) remain sync. The compiler
+awaits only if the guardrail's ``__call__`` returns a coroutine.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from cognithor.crew.guardrails.base import GuardrailResult
+
+if TYPE_CHECKING:
+    from cognithor.crew.output import TaskOutput
+
+_VALIDATOR_SYSTEM_PROMPT = (
+    "You are a strict output validator. You will receive a RULE and an OUTPUT. "
+    "Respond with a single JSON object: "
+    '{"passed": boolean, "feedback": string_or_null}. '
+    "If the output satisfies the rule, passed=true and feedback=null. "
+    "If not, passed=false and feedback is a short German explanation."
+)
+
+
+class StringGuardrail:
+    """LLM-validated guardrail. Offline-safe fallback: if the LLM is
+    unavailable the result is ``passed=False`` with a clear feedback, so
+    production can't skip validation silently.
+
+    ``llm_client`` must expose an async ``.chat(model, messages, ...)``
+    method returning an Ollama-shaped dict
+    (``{"message": {"content": "..."}}``).
+    ``cognithor.core.model_router.OllamaClient`` satisfies this contract
+    directly; the compiler passes ``planner._ollama`` into this guardrail.
+    """
+
+    def __init__(
+        self,
+        rule: str,
+        *,
+        llm_client: Any,
+        model: str,
+    ) -> None:
+        self._rule = rule
+        self._llm = llm_client
+        self._model = model
+
+    async def __call__(self, output: TaskOutput) -> GuardrailResult:
+        user_prompt = f"RULE: {self._rule}\n\nOUTPUT:\n{output.raw}"
+        messages = [
+            {"role": "system", "content": _VALIDATOR_SYSTEM_PROMPT},
+            {"role": "user", "content": user_prompt},
+        ]
+        raw = ""
+        try:
+            resp = await self._llm.chat(
+                model=self._model,
+                messages=messages,
+                format_json=True,
+                temperature=0.0,
+            )
+            raw = (resp.get("message", {}) or {}).get("content", "") or ""
+        except Exception as exc:
+            return GuardrailResult(
+                passed=False,
+                feedback=f"Validator-LLM nicht verfuegbar: {exc}",
+            )
+
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            return GuardrailResult(
+                passed=False,
+                feedback=f"Validator konnte LLM-Antwort nicht parsen: {raw[:100]}",
+            )
+        passed = bool(data.get("passed"))
+        feedback = data.get("feedback") if not passed else None
+        return GuardrailResult(passed=passed, feedback=feedback)

--- a/tests/test_crew/test_guardrails/test_audit.py
+++ b/tests/test_crew/test_guardrails/test_audit.py
@@ -1,0 +1,42 @@
+"""Task 30 — guardrail verdicts recorded in Hashline-Guard audit chain."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from cognithor.core.observer import ResponseEnvelope
+from cognithor.crew import Crew, CrewAgent, CrewTask
+from cognithor.crew.guardrails.base import GuardrailResult
+
+
+async def test_guardrail_pass_audited(monkeypatch):
+    agent = CrewAgent(role="writer", goal="write")
+    task = CrewTask(
+        description="x",
+        expected_output="y",
+        agent=agent,
+        guardrail=lambda o: GuardrailResult(passed=True, feedback=None),
+    )
+
+    events: list = []
+
+    def spy(name, **fields):
+        events.append((name, fields))
+
+    mock_planner = MagicMock()
+    mock_planner.formulate_response = AsyncMock(
+        return_value=ResponseEnvelope(content="ok", directive=None),
+    )
+
+    crew = Crew(agents=[agent], tasks=[task], planner=mock_planner)
+
+    monkeypatch.setattr("cognithor.crew.compiler.append_audit", spy)
+    result = await crew.kickoff_async()
+
+    guardrail_events = [e for e in events if "guardrail" in e[0]]
+    assert guardrail_events
+    assert any(fields.get("verdict") == "pass" for _name, fields in guardrail_events)
+    # Parent correlation: every guardrail event carries the kickoff's trace_id
+    for name, fields in guardrail_events:
+        assert fields.get("trace_id") == result.trace_id, (
+            f"Guardrail event '{name}' lost parent trace_id — "
+            f"expected {result.trace_id}, got {fields.get('trace_id')}"
+        )

--- a/tests/test_crew/test_guardrails/test_base.py
+++ b/tests/test_crew/test_guardrails/test_base.py
@@ -1,0 +1,35 @@
+"""Task 21 - Guardrail Protocol + GuardrailResult contract tests."""
+
+import pytest
+
+from cognithor.crew.guardrails.base import GuardrailResult
+from cognithor.crew.output import TaskOutput
+
+
+class TestGuardrailResult:
+    def test_pass_result(self):
+        r = GuardrailResult(passed=True, feedback=None)
+        assert r.passed
+        assert r.feedback is None
+
+    def test_fail_result(self):
+        r = GuardrailResult(passed=False, feedback="too short")
+        assert not r.passed
+        assert r.feedback == "too short"
+
+    def test_frozen(self):
+        r = GuardrailResult(passed=True, feedback=None)
+        with pytest.raises(Exception):  # noqa: B017 - frozen raises ValidationError
+            r.passed = False  # type: ignore[misc]
+
+
+class TestGuardrailProtocol:
+    def test_callable_satisfies_protocol(self):
+        """Duck-typing: any callable returning GuardrailResult satisfies the Protocol."""
+
+        def my_guard(output: TaskOutput) -> GuardrailResult:
+            return GuardrailResult(passed=True, feedback=None)
+
+        assert callable(my_guard)
+        result = my_guard(TaskOutput(task_id="t", agent_role="w", raw="x"))
+        assert isinstance(result, GuardrailResult)

--- a/tests/test_crew/test_guardrails/test_chain.py
+++ b/tests/test_crew/test_guardrails/test_chain.py
@@ -1,0 +1,79 @@
+"""Task 28 — chain() combinator tests.
+
+R4-C4: chain() returns an ASYNC callable (needed so StringGuardrail, whose
+__call__ is async, actually runs). All tests here await the chained result.
+"""
+
+from cognithor.crew.guardrails.base import GuardrailResult
+from cognithor.crew.guardrails.builtin import chain, no_pii, word_count
+from cognithor.crew.output import TaskOutput
+
+
+def _out(raw: str) -> TaskOutput:
+    return TaskOutput(task_id="t", agent_role="w", raw=raw)
+
+
+async def test_chain_all_pass():
+    g = chain(word_count(min_words=1), no_pii())
+    result = await g(_out("Hallo Welt"))
+    assert result.passed
+
+
+async def test_chain_stops_on_first_failure():
+    calls = []
+
+    def tracker(label):
+        def _g(out):
+            calls.append(label)
+            return GuardrailResult(passed=(label != "B"), feedback=f"from-{label}")
+
+        return _g
+
+    g = chain(tracker("A"), tracker("B"), tracker("C"))
+    r = await g(_out("x"))
+    assert not r.passed
+    assert r.feedback == "from-B"
+    assert calls == ["A", "B"]  # C never runs
+
+
+async def test_chain_pii_in_first_fails_even_if_second_would_pass():
+    g = chain(no_pii(), word_count(min_words=1))
+    r = await g(_out("Kontakt: x@example.com"))
+    assert not r.passed
+    assert r.pii_detected is True
+
+
+async def test_chain_awaits_async_guardrails():
+    """R4-C4 regression: async guards inside chain() MUST actually run."""
+    call_count = {"async_g": 0, "sync_g": 0}
+
+    async def async_g(_out):
+        call_count["async_g"] += 1
+        return GuardrailResult(passed=True, feedback=None)
+
+    def sync_g(_out):
+        call_count["sync_g"] += 1
+        return GuardrailResult(passed=True, feedback=None)
+
+    g = chain(async_g, sync_g)
+    r = await g(_out("anything"))
+    assert r.passed
+    assert call_count == {"async_g": 1, "sync_g": 1}
+
+
+async def test_chain_short_circuits_on_first_async_failure():
+    """First (async) guard fails → second guard never called."""
+    second_calls = []
+
+    async def failing_async(_out):
+        return GuardrailResult(passed=False, feedback="blocked-async")
+
+    def never_called(_out):
+        second_calls.append(1)
+        return GuardrailResult(passed=True, feedback=None)
+
+    g = chain(failing_async, never_called)
+    r = await g(_out("irrelevant"))
+    assert not r.passed
+    assert r.feedback == "blocked-async"
+    assert second_calls == []

--- a/tests/test_crew/test_guardrails/test_compiler_integration.py
+++ b/tests/test_crew/test_guardrails/test_compiler_integration.py
@@ -1,0 +1,70 @@
+"""Task 29 — guardrail execution in the compiler (retry + GuardrailFailure)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cognithor.core.observer import ResponseEnvelope
+from cognithor.crew import Crew, CrewAgent, CrewTask
+from cognithor.crew.errors import GuardrailFailure
+from cognithor.crew.guardrails.base import GuardrailResult
+
+
+async def test_guardrail_failure_retries_then_raises():
+    agent = CrewAgent(role="writer", goal="write")
+
+    def fail_always(_out):
+        return GuardrailResult(passed=False, feedback="zu kurz")
+
+    task = CrewTask(
+        description="write",
+        expected_output="long text",
+        agent=agent,
+        guardrail=fail_always,
+        max_retries=2,
+    )
+
+    call_count = {"n": 0}
+
+    async def fake(user_message, results, working_memory):
+        call_count["n"] += 1
+        return ResponseEnvelope(content=f"attempt-{call_count['n']}", directive=None)
+
+    mock_planner = MagicMock()
+    mock_planner.formulate_response = AsyncMock(side_effect=fake)
+    crew = Crew(agents=[agent], tasks=[task], planner=mock_planner)
+
+    with pytest.raises(GuardrailFailure) as exc_info:
+        await crew.kickoff_async()
+
+    # Initial try + max_retries == 3 attempts total
+    assert call_count["n"] == 3
+    assert exc_info.value.attempts == 3
+    assert "zu kurz" in exc_info.value.reason
+    assert "after 3 attempt(s)" in str(exc_info.value)
+
+
+async def test_guardrail_passes_after_retry():
+    agent = CrewAgent(role="writer", goal="write")
+    attempts_counter = {"n": 0}
+
+    def pass_on_second(_out):
+        attempts_counter["n"] += 1
+        return GuardrailResult(passed=(attempts_counter["n"] >= 2), feedback="try again")
+
+    task = CrewTask(
+        description="x",
+        expected_output="y",
+        agent=agent,
+        guardrail=pass_on_second,
+        max_retries=2,
+    )
+
+    mock_planner = MagicMock()
+    mock_planner.formulate_response = AsyncMock(
+        return_value=ResponseEnvelope(content="text", directive=None),
+    )
+    crew = Crew(agents=[agent], tasks=[task], planner=mock_planner)
+    result = await crew.kickoff_async()
+
+    assert result.tasks_output[0].guardrail_verdict == "pass"

--- a/tests/test_crew/test_guardrails/test_function.py
+++ b/tests/test_crew/test_guardrails/test_function.py
@@ -1,0 +1,35 @@
+"""Task 22 — FunctionGuardrail adapter tests."""
+
+from cognithor.crew.guardrails.base import GuardrailResult
+from cognithor.crew.guardrails.function_guardrail import FunctionGuardrail
+from cognithor.crew.output import TaskOutput
+
+
+def test_function_guardrail_passes():
+    def min_len(out: TaskOutput) -> tuple[bool, str | TaskOutput]:
+        return (True, out) if len(out.raw) >= 3 else (False, "too short")
+
+    g = FunctionGuardrail(min_len)
+    r = g(TaskOutput(task_id="t", agent_role="w", raw="hello"))
+    assert isinstance(r, GuardrailResult)
+    assert r.passed
+
+
+def test_function_guardrail_fails_with_feedback():
+    def min_len(out: TaskOutput) -> tuple[bool, str | TaskOutput]:
+        return (False, "output ist kürzer als erwartet")
+
+    g = FunctionGuardrail(min_len)
+    r = g(TaskOutput(task_id="t", agent_role="w", raw="hi"))
+    assert not r.passed
+    assert r.feedback == "output ist kürzer als erwartet"
+
+
+def test_function_guardrail_wraps_unexpected_exception_as_fail():
+    def buggy(out: TaskOutput) -> tuple[bool, str | TaskOutput]:
+        raise RuntimeError("unexpected")
+
+    g = FunctionGuardrail(buggy)
+    r = g(TaskOutput(task_id="t", agent_role="w", raw="x"))
+    assert not r.passed
+    assert "unexpected" in (r.feedback or "")

--- a/tests/test_crew/test_guardrails/test_hallucination.py
+++ b/tests/test_crew/test_guardrails/test_hallucination.py
@@ -1,0 +1,30 @@
+"""Task 27 — hallucination_check built-in guardrail tests."""
+
+from cognithor.crew.guardrails.builtin import hallucination_check
+from cognithor.crew.output import TaskOutput
+
+
+def _out(raw: str) -> TaskOutput:
+    return TaskOutput(task_id="t", agent_role="w", raw=raw)
+
+
+def test_passes_when_output_is_subset_of_reference():
+    ref = "Der Tarif PrivatPlus kostet 450 Euro pro Monat und deckt stationäre Leistungen ab."
+    g = hallucination_check(reference=ref)
+    r = g(_out("PrivatPlus kostet 450 Euro."))
+    assert r.passed
+
+
+def test_fails_when_output_invents_a_number():
+    ref = "Der Tarif kostet 450 Euro."
+    g = hallucination_check(reference=ref)
+    r = g(_out("Der Tarif kostet 99999 Euro."))
+    assert not r.passed
+    assert "99999" in (r.feedback or "")
+
+
+def test_passes_when_min_overlap_is_zero():
+    # Edge case: min_overlap=0 disables the check (useful as a test-only mode)
+    g = hallucination_check(reference="x", min_overlap=0.0)
+    r = g(_out("completely unrelated"))
+    assert r.passed

--- a/tests/test_crew/test_guardrails/test_no_pii.py
+++ b/tests/test_crew/test_guardrails/test_no_pii.py
@@ -1,0 +1,52 @@
+"""Task 25 — no_pii built-in guardrail tests (DE-focused)."""
+
+from cognithor.crew.guardrails.builtin import no_pii
+from cognithor.crew.output import TaskOutput
+
+
+def _out(raw: str) -> TaskOutput:
+    return TaskOutput(task_id="t", agent_role="w", raw=raw)
+
+
+def test_clean_text_passes():
+    g = no_pii()
+    r = g(_out("Dies ist ein völlig harmloser Satz ohne persönliche Daten."))
+    assert r.passed
+    assert r.pii_detected is False
+
+
+def test_email_detected():
+    g = no_pii()
+    r = g(_out("Kontakt: max.mustermann@example.com"))
+    assert not r.passed
+    assert r.pii_detected is True
+    assert "email" in (r.feedback or "").lower() or "e-mail" in (r.feedback or "").lower()
+
+
+def test_german_iban_detected():
+    g = no_pii()
+    r = g(_out("Konto: DE89 3704 0044 0532 0130 00"))
+    assert not r.passed
+    assert r.pii_detected is True
+
+
+def test_german_phone_detected():
+    g = no_pii()
+    for ph in ["+49 30 12345678", "030 123 456 78", "0171-1234567", "0049 30 12345"]:
+        r = g(_out(f"Telefon: {ph}"))
+        assert not r.passed, f"Phone '{ph}' was not detected"
+
+
+def test_german_steuer_id_11_digit_detected():
+    g = no_pii()
+    r = g(_out("Steuer-ID 12 345 678 901"))
+    assert not r.passed
+
+
+def test_multiple_pii_listed_in_feedback():
+    g = no_pii()
+    r = g(_out("Max: max@example.com, IBAN DE89 3704 0044 0532 0130 00"))
+    assert not r.passed
+    fb = (r.feedback or "").lower()
+    assert "email" in fb or "e-mail" in fb
+    assert "iban" in fb

--- a/tests/test_crew/test_guardrails/test_no_silent_bridge.py
+++ b/tests/test_crew/test_guardrails/test_no_silent_bridge.py
@@ -1,0 +1,10 @@
+"""Task 21 regression: the PR 1 -> PR 2 bridge guard is gone; real apply
+path (Task 29) replaces it.
+"""
+
+
+def test_no_bridge_guard_in_compiler():
+    from cognithor.crew import compiler as m
+
+    assert not hasattr(m, "_warn_if_guardrail_silently_ignored")
+    assert not hasattr(m, "_guardrails_available")

--- a/tests/test_crew/test_guardrails/test_schema.py
+++ b/tests/test_crew/test_guardrails/test_schema.py
@@ -1,0 +1,41 @@
+"""Task 26 — schema built-in guardrail tests (Pydantic validation)."""
+
+from pydantic import BaseModel
+
+from cognithor.crew.guardrails.builtin import schema
+from cognithor.crew.output import TaskOutput
+
+
+class Product(BaseModel):
+    name: str
+    price: float
+
+
+def _out(raw: str) -> TaskOutput:
+    return TaskOutput(task_id="t", agent_role="w", raw=raw)
+
+
+def test_schema_passes_on_valid_json():
+    g = schema(Product)
+    r = g(_out('{"name": "Widget", "price": 9.99}'))
+    assert r.passed
+
+
+def test_schema_fails_on_missing_field():
+    g = schema(Product)
+    r = g(_out('{"name": "Widget"}'))
+    assert not r.passed
+    assert "price" in (r.feedback or "").lower()
+
+
+def test_schema_fails_on_invalid_json():
+    g = schema(Product)
+    r = g(_out("not json"))
+    assert not r.passed
+    assert "json" in (r.feedback or "").lower()
+
+
+def test_schema_fails_on_type_mismatch():
+    g = schema(Product)
+    r = g(_out('{"name": "x", "price": "not a number"}'))
+    assert not r.passed

--- a/tests/test_crew/test_guardrails/test_string.py
+++ b/tests/test_crew/test_guardrails/test_string.py
@@ -1,0 +1,46 @@
+"""Task 23 — StringGuardrail LLM-validated tests (async)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+from cognithor.crew.guardrails.string_guardrail import StringGuardrail
+from cognithor.crew.output import TaskOutput
+
+
+async def test_string_guardrail_passes_when_llm_says_yes():
+    llm = MagicMock()
+    llm.chat = AsyncMock(
+        return_value={"message": {"content": '{"passed": true, "feedback": null}'}}
+    )
+    g = StringGuardrail("Output must be one sentence", llm_client=llm, model="ollama/qwen3:8b")
+    r = await g(TaskOutput(task_id="t", agent_role="w", raw="Hello."))
+    assert r.passed
+
+
+async def test_string_guardrail_fails_when_llm_says_no():
+    llm = MagicMock()
+    llm.chat = AsyncMock(
+        return_value={
+            "message": {"content": '{"passed": false, "feedback": "more than one sentence"}'}
+        }
+    )
+    g = StringGuardrail("one sentence", llm_client=llm, model="ollama/qwen3:8b")
+    r = await g(TaskOutput(task_id="t", agent_role="w", raw="A. B."))
+    assert not r.passed
+    assert "more than one sentence" in (r.feedback or "")
+
+
+async def test_string_guardrail_unparseable_llm_response_fails_safe():
+    llm = MagicMock()
+    llm.chat = AsyncMock(return_value={"message": {"content": "not json"}})
+    g = StringGuardrail("x", llm_client=llm, model="ollama/qwen3:8b")
+    r = await g(TaskOutput(task_id="t", agent_role="w", raw="y"))
+    assert not r.passed
+    assert "parse" in (r.feedback or "").lower()
+
+
+async def test_string_guardrail_llm_unavailable_fails_safe():
+    llm = MagicMock()
+    llm.chat = AsyncMock(side_effect=ConnectionError("ollama down"))
+    g = StringGuardrail("x", llm_client=llm, model="ollama/qwen3:8b")
+    r = await g(TaskOutput(task_id="t", agent_role="w", raw="y"))
+    assert not r.passed  # fail-safe: production can't silently skip validation

--- a/tests/test_crew/test_guardrails/test_versicherungs_integration.py
+++ b/tests/test_crew/test_guardrails/test_versicherungs_integration.py
@@ -1,0 +1,98 @@
+"""Task 31 — versicherungs-vergleich Feature-4 integration.
+
+Spec §4.5 AC 5: ``chain(no_pii(), StringGuardrail("..."))`` must catch BOTH
+PII leakage (regex-based) AND Tarif-Empfehlung violations (LLM-validated).
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cognithor.core.observer import ResponseEnvelope
+from cognithor.crew import Crew, CrewAgent, CrewTask
+from cognithor.crew.errors import GuardrailFailure
+from cognithor.crew.guardrails import StringGuardrail, chain, no_pii
+
+
+def _mock_ollama_client(validator_verdict: dict) -> MagicMock:
+    """Build an OllamaClient-shaped mock returning a JSON-wrapped verdict."""
+    client = MagicMock()
+    client.chat = AsyncMock(return_value={"message": {"content": json.dumps(validator_verdict)}})
+    return client
+
+
+async def test_versicherungs_crew_blocks_pii_output():
+    agent = CrewAgent(role="analyst", goal="compare PKV tariffs", llm="ollama/qwen3:8b")
+    # Validator LLM (OllamaClient stand-in) passes every check — but no_pii
+    # runs first and short-circuits the chain.
+    ollama = _mock_ollama_client({"passed": True, "feedback": None})
+
+    neutral_rule = StringGuardrail(
+        "Output darf keine Tarif-Empfehlung enthalten, nur neutralen Vergleich",
+        llm_client=ollama,
+        model="ollama/qwen3:8b",
+    )
+    task = CrewTask(
+        description="Compare",
+        expected_output="Tabular comparison",
+        agent=agent,
+        guardrail=chain(no_pii(), neutral_rule),
+        max_retries=0,
+    )
+
+    mock_planner = MagicMock()
+    mock_planner._ollama = ollama
+    mock_planner.formulate_response = AsyncMock(
+        return_value=ResponseEnvelope(
+            content="Kontakt: sachbearbeiter@versicherer.de zur Beratung.",
+            directive=None,
+        )
+    )
+
+    crew = Crew(agents=[agent], tasks=[task], planner=mock_planner)
+
+    with pytest.raises(GuardrailFailure, match="PII erkannt"):
+        await crew.kickoff_async()
+
+
+async def test_versicherungs_crew_blocks_tarif_recommendation():
+    """The string guardrail catches outputs that make recommendations."""
+    agent = CrewAgent(role="analyst", goal="compare PKV tariffs", llm="ollama/qwen3:8b")
+    ollama = _mock_ollama_client(
+        {
+            "passed": False,
+            "feedback": (
+                "Output enthält eine Empfehlung ('empfehle Tarif A'); nur Vergleich erlaubt."
+            ),
+        }
+    )
+
+    neutral_rule = StringGuardrail(
+        "Output darf keine Tarif-Empfehlung enthalten, nur neutralen Vergleich",
+        llm_client=ollama,
+        model="ollama/qwen3:8b",
+    )
+    task = CrewTask(
+        description="Compare",
+        expected_output="Tabular comparison",
+        agent=agent,
+        guardrail=chain(no_pii(), neutral_rule),
+        max_retries=0,
+    )
+
+    mock_planner = MagicMock()
+    mock_planner._ollama = ollama
+    # Clean output (no PII) that recommends a tariff — no_pii passes,
+    # string-guard fails.
+    mock_planner.formulate_response = AsyncMock(
+        return_value=ResponseEnvelope(
+            content="Ich empfehle Tarif A fuer Ihre Situation.",
+            directive=None,
+        )
+    )
+
+    crew = Crew(agents=[agent], tasks=[task], planner=mock_planner)
+
+    with pytest.raises(GuardrailFailure, match="Empfehlung"):
+        await crew.kickoff_async()

--- a/tests/test_crew/test_guardrails/test_word_count.py
+++ b/tests/test_crew/test_guardrails/test_word_count.py
@@ -1,0 +1,50 @@
+"""Task 24 — word_count built-in guardrail tests."""
+
+import pytest
+
+from cognithor.crew.guardrails.builtin import word_count
+from cognithor.crew.output import TaskOutput
+
+
+def _out(raw: str) -> TaskOutput:
+    return TaskOutput(task_id="t", agent_role="w", raw=raw)
+
+
+def test_word_count_min_pass():
+    g = word_count(min_words=3)
+    assert g(_out("one two three")).passed
+
+
+def test_word_count_min_fail():
+    g = word_count(min_words=5)
+    r = g(_out("only three words"))
+    assert not r.passed
+    assert "5" in (r.feedback or "") or "mindestens" in (r.feedback or "").lower()
+
+
+def test_word_count_max_pass():
+    g = word_count(max_words=5)
+    assert g(_out("one two")).passed
+
+
+def test_word_count_max_fail():
+    g = word_count(max_words=2)
+    r = g(_out("one two three four"))
+    assert not r.passed
+
+
+def test_word_count_both_bounds():
+    g = word_count(min_words=2, max_words=4)
+    assert g(_out("a b c")).passed
+    assert not g(_out("a")).passed
+    assert not g(_out("a b c d e")).passed
+
+
+def test_word_count_empty_string_fails_min():
+    g = word_count(min_words=1)
+    assert not g(_out("")).passed
+
+
+def test_word_count_neither_bound_raises():
+    with pytest.raises(ValueError):
+        word_count()


### PR DESCRIPTION
## Summary

**Feature 4 Task-Level Guardrails** (spec §4) — 12 tasks, 122 crew tests.

- `GuardrailResult` + `Guardrail` Protocol + `FunctionGuardrail` + `StringGuardrail` (LLM-validated, async, fail-safe)
- 4 built-in factories: `word_count`, `no_pii` (DE-focused — emails, IBANs, German phone, Steuer-IDs), `schema` (Pydantic validation), `hallucination_check` (reference-overlap)
- `chain()` combinator — async-safe, short-circuits on first failure
- Real integration in compiler: retry-with-feedback up to `task.max_retries`, then raises `GuardrailFailure` carrying `(task_id, guardrail_name, attempts, reason)` with correct attempt-count (not max_retries)
- Hashline-Guard audit events: `crew_guardrail_check` emitted with parent `trace_id` correlation, `pii_detected` flag, verdict, retry_count
- Retry nudge uses `crew:retry_feedback` namespaced tool_name so Gatekeeper / audit scanners don't misinterpret it
- versicherungs-vergleich E2E test: `chain(no_pii(), StringGuardrail('keine Tarif-Empfehlung'))` blocks both PII leakage and recommendation outputs
- PR 1 → PR 2 bridge guard removed (no more silent-ignore warning)

Strictly additive. No breaking changes to Crew-Layer public API.

## Test plan

- [x] `pytest tests/test_crew/` → 122 passed (37 guardrail-specific)
- [x] ruff check + format clean on `src/cognithor/crew` + `tests/test_crew`
- [ ] CI green on branch
- [ ] Merge to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)