### PR TITLE
feat(bench): WP4 cognithor-bench scaffold + [autogen] extra (v0.94.0 PR 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ flutter_app/build/web/canvaskit/wimp*
 .hypothesis/
 environment_files/
 arc_agi3_validation.json
+
+# cognithor-bench result artifacts
+cognithor_bench/results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 - `docs/competitive-analysis/` — comparison docs for AutoGen, MAF, LangGraph, CrewAI (WP1).
 - `docs/adr/0001-pge-trinity-vs-group-chat.md` — first Architecture Decision Record (WP5).
+- `cognithor_bench/` — reproducible Multi-Agent benchmark scaffold (WP4).
+  CLI: `cognithor-bench run|tabulate`. Default adapter: Cognithor; opt-in
+  AutoGen adapter via `pip install cognithor[autogen]`. Bundled smoke
+  scenarios under `cognithor_bench/src/cognithor_bench/scenarios/`.
+- `pyproject.toml` — new `[autogen]` extra (`autogen-agentchat==0.7.5`)
+  as the single pin-point for v0.94.0's source-compat shim and bench adapter.
 
 ## [0.93.0] -- 2026-04-24
 

--- a/cognithor_bench/README.md
+++ b/cognithor_bench/README.md
@@ -1,0 +1,67 @@
+# cognithor-bench — Reproducible Multi-Agent Benchmark Scaffold
+
+In-monorepo benchmark harness for Cognithor. Independent of `agbench`;
+focuses on Cognithor-native scenarios with the option to compare against
+AutoGen via the source-compat shim from `cognithor.compat.autogen`.
+
+## Status
+
+`v0.1.0` ships **scaffold + smoke-test only** with Cognithor v0.94.0.
+GAIA / WebArena / AssistantBench scenario adapters are post-v0.94.0.
+
+## Install
+
+```bash
+pip install -e .
+# Optional: pull the AutoGen adapter dependency
+pip install -e ".[autogen]"
+```
+
+## Usage
+
+```bash
+# Run the default smoke-test (3 trivial tasks)
+cognithor-bench run src/cognithor_bench/scenarios/smoke_test.jsonl
+
+# With repetition + sub-sampling
+cognithor-bench run scenarios/foo.jsonl --repeat 5 --subsample 0.5
+
+# Pick the AutoGen adapter (requires [autogen] extra)
+cognithor-bench run scenarios/foo.jsonl --adapter autogen
+
+# Pick a specific Ollama model
+cognithor-bench run scenarios/foo.jsonl --model ollama/qwen3:8b
+
+# Native execution (default) vs Docker isolation (opt-in)
+cognithor-bench run scenarios/foo.jsonl --native     # default
+cognithor-bench run scenarios/foo.jsonl --docker     # opt-in
+
+# Aggregate a results directory into a Markdown table
+cognithor-bench tabulate results/
+```
+
+## Scenario format (JSONL — one task per line)
+
+```json
+{"id": "smoke-001", "task": "Was ist 2+2?", "expected": "4", "timeout_sec": 30, "requires": ["no_network"]}
+```
+
+Fields:
+- `id` — short identifier (used for result aggregation).
+- `task` — natural-language prompt.
+- `expected` — exact-match string OR substring (matched case-insensitively).
+- `timeout_sec` — per-task timeout.
+- `requires` — list of capability tags (`no_network`, `ollama`, `pdf-tools`, ...).
+
+## Adding a new scenario file
+
+Drop a JSONL file under `src/cognithor_bench/scenarios/`. Each line is a
+discrete task. Run:
+
+```bash
+cognithor-bench run src/cognithor_bench/scenarios/my_new_set.jsonl
+```
+
+## License
+
+Apache 2.0. See repo-root `LICENSE`.

--- a/cognithor_bench/pyproject.toml
+++ b/cognithor_bench/pyproject.toml
@@ -18,7 +18,10 @@ classifiers = [
 ]
 
 dependencies = [
-    "cognithor>=0.94.0",
+    # cognithor.crew (used by CognithorAdapter) ships in 0.93.0+, so >=0.93.0
+    # is the true minimum. Tighten to >=0.94.0 once v0.94.0 makes the [autogen]
+    # extra available on PyPI for users running `cognithor-bench --adapter autogen`.
+    "cognithor>=0.93.0",
     "anyio>=4.0,<5",
     "structlog>=25.4,<26",
 ]

--- a/cognithor_bench/pyproject.toml
+++ b/cognithor_bench/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "cognithor-bench"
+version = "0.1.0"
+description = "Reproducible Multi-Agent benchmark scaffold for Cognithor"
+readme = "README.md"
+license = "Apache-2.0"
+requires-python = ">=3.12"
+authors = [{ name = "Alexander Söllner" }]
+keywords = ["ai", "agent", "benchmark", "cognithor"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+]
+
+dependencies = [
+    "cognithor>=0.94.0",
+    "anyio>=4.0,<5",
+    "structlog>=25.4,<26",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0,<9",
+    "pytest-asyncio>=0.24,<1",
+    "pytest-cov>=6.0,<7",
+]
+# Mirrors the root cognithor[autogen] extra so cognithor_bench can pull
+# autogen-agentchat for the optional AutoGenAdapter without re-pinning.
+autogen = ["autogen-agentchat==0.7.5"]
+
+[project.scripts]
+cognithor-bench = "cognithor_bench.cli:main"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/cognithor_bench"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "W", "F", "I", "N", "UP", "B", "SIM", "TCH", "RUF"]
+ignore = ["RUF001", "RUF002", "RUF003", "RUF012"]

--- a/cognithor_bench/src/cognithor_bench/__init__.py
+++ b/cognithor_bench/src/cognithor_bench/__init__.py
@@ -1,0 +1,7 @@
+"""cognithor-bench — reproducible Multi-Agent benchmark scaffold."""
+
+from __future__ import annotations
+
+__version__ = "0.1.0"
+
+__all__ = ["__version__"]

--- a/cognithor_bench/src/cognithor_bench/adapters/__init__.py
+++ b/cognithor_bench/src/cognithor_bench/adapters/__init__.py
@@ -1,0 +1,7 @@
+"""Benchmark adapters — wrappers over multi-agent frameworks."""
+
+from __future__ import annotations
+
+from cognithor_bench.adapters.base import Adapter, ScenarioInput, ScenarioResult
+
+__all__ = ["Adapter", "ScenarioInput", "ScenarioResult"]

--- a/cognithor_bench/src/cognithor_bench/adapters/autogen_adapter.py
+++ b/cognithor_bench/src/cognithor_bench/adapters/autogen_adapter.py
@@ -1,0 +1,66 @@
+"""AutoGenAdapter — opt-in via [autogen] extra.
+
+Imports `autogen_agentchat` LAZILY inside .run(). If the extra isn't installed,
+the adapter raises a helpful ImportError pointing at the install command.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from cognithor_bench.adapters.base import ScenarioInput, ScenarioResult
+
+_AUTOGEN_IMPORT_ERROR_HINT = (
+    "AutoGenAdapter requires `pip install cognithor[autogen]` "
+    "(or `pip install autogen-agentchat==0.7.5`)."
+)
+
+
+class AutoGenAdapter:
+    """Run a scenario through autogen-agentchat AssistantAgent."""
+
+    name = "autogen"
+
+    def __init__(self, *, model: str = "ollama/qwen3:8b") -> None:
+        self.model = model
+
+    async def run(self, scenario: ScenarioInput) -> ScenarioResult:
+        start = time.perf_counter()
+        try:
+            try:
+                from autogen_agentchat.agents import AssistantAgent  # type: ignore[import-not-found]
+                from autogen_ext.models.openai import OpenAIChatCompletionClient  # type: ignore[import-not-found]
+            except ImportError as e:
+                raise ImportError(_AUTOGEN_IMPORT_ERROR_HINT) from e
+
+            client = OpenAIChatCompletionClient(model=self.model)
+            agent = AssistantAgent(
+                name="bench-agent",
+                model_client=client,
+                description="Answers benchmark questions with one short string.",
+            )
+            result = await asyncio.wait_for(
+                agent.run(task=scenario.task),
+                timeout=scenario.timeout_sec,
+            )
+            messages = getattr(result, "messages", []) or []
+            raw = str(messages[-1].content) if messages else ""
+            success = scenario.expected.lower() in raw.lower()
+            return ScenarioResult(
+                id=scenario.id,
+                output=raw,
+                success=success,
+                duration_sec=time.perf_counter() - start,
+                error=None,
+            )
+        except ImportError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            return ScenarioResult(
+                id=scenario.id,
+                output="",
+                success=False,
+                duration_sec=time.perf_counter() - start,
+                error=f"{type(exc).__name__}: {exc}",
+            )

--- a/cognithor_bench/src/cognithor_bench/adapters/autogen_adapter.py
+++ b/cognithor_bench/src/cognithor_bench/adapters/autogen_adapter.py
@@ -29,8 +29,12 @@ class AutoGenAdapter:
         start = time.perf_counter()
         try:
             try:
-                from autogen_agentchat.agents import AssistantAgent  # type: ignore[import-not-found]
-                from autogen_ext.models.openai import OpenAIChatCompletionClient  # type: ignore[import-not-found]
+                from autogen_agentchat.agents import (
+                    AssistantAgent,  # type: ignore[import-not-found]
+                )
+                from autogen_ext.models.openai import (
+                    OpenAIChatCompletionClient,  # type: ignore[import-not-found]
+                )
             except ImportError as e:
                 raise ImportError(_AUTOGEN_IMPORT_ERROR_HINT) from e
 
@@ -56,7 +60,7 @@ class AutoGenAdapter:
             )
         except ImportError:
             raise
-        except Exception as exc:  # noqa: BLE001
+        except Exception as exc:
             return ScenarioResult(
                 id=scenario.id,
                 output="",

--- a/cognithor_bench/src/cognithor_bench/adapters/base.py
+++ b/cognithor_bench/src/cognithor_bench/adapters/base.py
@@ -1,0 +1,45 @@
+"""Adapter Protocol + scenario types."""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ScenarioInput(BaseModel):
+    """One scenario row from a JSONL file."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(..., min_length=1)
+    task: str = Field(..., min_length=1)
+    expected: str = Field(...)
+    timeout_sec: int = Field(default=60, ge=1, le=3600)
+    requires: tuple[str, ...] = Field(default_factory=tuple)
+
+
+class ScenarioResult(BaseModel):
+    """One adapter execution result."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    output: str
+    success: bool
+    duration_sec: float
+    error: str | None = None
+
+
+@runtime_checkable
+class Adapter(Protocol):
+    """Pluggable benchmark adapter.
+
+    Implementations:
+      - cognithor_bench.adapters.cognithor_adapter.CognithorAdapter (default)
+      - cognithor_bench.adapters.autogen_adapter.AutoGenAdapter (opt-in)
+    """
+
+    name: str
+
+    async def run(self, scenario: ScenarioInput) -> ScenarioResult: ...

--- a/cognithor_bench/src/cognithor_bench/adapters/cognithor_adapter.py
+++ b/cognithor_bench/src/cognithor_bench/adapters/cognithor_adapter.py
@@ -1,0 +1,58 @@
+"""Default CognithorAdapter — wraps cognithor.crew.Crew."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+from cognithor.crew import Crew, CrewAgent, CrewTask  # type: ignore[attr-defined]
+
+from cognithor_bench.adapters.base import ScenarioInput, ScenarioResult
+
+
+class CognithorAdapter:
+    """Run a scenario through a single-agent, single-task Cognithor Crew."""
+
+    name = "cognithor"
+
+    def __init__(self, *, model: str = "ollama/qwen3:8b") -> None:
+        self.model = model
+
+    async def run(self, scenario: ScenarioInput) -> ScenarioResult:
+        start = time.perf_counter()
+        try:
+            agent = CrewAgent(
+                role="bench-agent",
+                goal=f"Answer the user's task accurately: {scenario.task}",
+                backstory="You answer benchmark questions with one short string.",
+                llm=self.model,
+                verbose=False,
+            )
+            task = CrewTask(
+                description=scenario.task,
+                expected_output=scenario.expected,
+                agent=agent,
+            )
+            crew = Crew(agents=[agent], tasks=[task])
+
+            output = await asyncio.wait_for(
+                crew.kickoff_async({}),
+                timeout=scenario.timeout_sec,
+            )
+            raw = str(getattr(output, "raw", "") or "")
+            success = scenario.expected.lower() in raw.lower()
+            return ScenarioResult(
+                id=scenario.id,
+                output=raw,
+                success=success,
+                duration_sec=time.perf_counter() - start,
+                error=None,
+            )
+        except Exception as exc:  # noqa: BLE001 — adapter must capture all errors
+            return ScenarioResult(
+                id=scenario.id,
+                output="",
+                success=False,
+                duration_sec=time.perf_counter() - start,
+                error=f"{type(exc).__name__}: {exc}",
+            )

--- a/cognithor_bench/src/cognithor_bench/adapters/cognithor_adapter.py
+++ b/cognithor_bench/src/cognithor_bench/adapters/cognithor_adapter.py
@@ -48,7 +48,7 @@ class CognithorAdapter:
                 duration_sec=time.perf_counter() - start,
                 error=None,
             )
-        except Exception as exc:  # noqa: BLE001 — adapter must capture all errors
+        except Exception as exc:
             return ScenarioResult(
                 id=scenario.id,
                 output="",

--- a/cognithor_bench/src/cognithor_bench/cli.py
+++ b/cognithor_bench/src/cognithor_bench/cli.py
@@ -1,0 +1,102 @@
+"""cognithor-bench CLI — `run` and `tabulate` subcommands."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from cognithor_bench.adapters.autogen_adapter import AutoGenAdapter
+from cognithor_bench.adapters.base import ScenarioResult
+from cognithor_bench.adapters.cognithor_adapter import CognithorAdapter
+from cognithor_bench.reporter import tabulate_results
+from cognithor_bench.runner import BenchRunner
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="cognithor-bench",
+        description="Reproducible Multi-Agent benchmark scaffold for Cognithor.",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    run = sub.add_parser("run", help="Run a JSONL scenario file through an adapter.")
+    run.add_argument("scenario", type=Path, help="Path to a .jsonl scenario file.")
+    run.add_argument("--repeat", type=int, default=1, help="Repetitions per scenario.")
+    run.add_argument("--subsample", type=float, default=1.0, help="Fraction of rows to sample.")
+    run.add_argument("--adapter", choices=("cognithor", "autogen"), default="cognithor")
+    run.add_argument(
+        "--model", default="ollama/qwen3:8b", help="Model spec (e.g. ollama/qwen3:8b)."
+    )
+    run.add_argument("--output-dir", type=Path, default=Path("results"))
+    run.add_argument("--seed", type=int, default=None)
+    iso = run.add_mutually_exclusive_group()
+    iso.add_argument("--native", action="store_true", help="Run in-process (default).")
+    iso.add_argument("--docker", action="store_true", help="Run inside Docker (opt-in).")
+
+    tab = sub.add_parser("tabulate", help="Aggregate a results directory into Markdown.")
+    tab.add_argument("results_dir", type=Path)
+    return p
+
+
+def _run_under_docker(args: argparse.Namespace) -> int:
+    """Stub for opt-in Docker execution. Real implementation is post-v0.94.0."""
+    print(
+        "[cognithor-bench] --docker isolation is post-v0.94.0; falling back to --native",
+        file=sys.stderr,
+    )
+    return _run_native(args)
+
+
+def _run_native(args: argparse.Namespace) -> int:
+    adapter = (
+        AutoGenAdapter(model=args.model)
+        if args.adapter == "autogen"
+        else CognithorAdapter(model=args.model)
+    )
+    runner = BenchRunner(adapter=adapter, seed=args.seed)
+    results = asyncio.run(
+        runner.run_file(
+            args.scenario,
+            repeat=args.repeat,
+            subsample=args.subsample,
+            output_dir=args.output_dir,
+        )
+    )
+    print(tabulate_results(results))
+    return 0
+
+
+def _cmd_run(args: argparse.Namespace) -> int:
+    if not args.scenario.exists():
+        print(f"error: scenario file not found: {args.scenario}", file=sys.stderr)
+        sys.exit(2)
+    if args.docker:
+        return _run_under_docker(args)
+    return _run_native(args)
+
+
+def _cmd_tabulate(args: argparse.Namespace) -> int:
+    if not args.results_dir.exists():
+        print(f"error: results directory not found: {args.results_dir}", file=sys.stderr)
+        sys.exit(2)
+    rows: list[ScenarioResult] = []
+    for path in sorted(args.results_dir.glob("*.jsonl")):
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            rows.append(ScenarioResult(**json.loads(line)))
+    print(tabulate_results(rows))
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _build_parser().parse_args(argv)
+    if args.cmd == "run":
+        return _cmd_run(args)
+    if args.cmd == "tabulate":
+        return _cmd_tabulate(args)
+    return 1

--- a/cognithor_bench/src/cognithor_bench/reporter.py
+++ b/cognithor_bench/src/cognithor_bench/reporter.py
@@ -1,0 +1,51 @@
+"""Reporter — Markdown table for ScenarioResult lists."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from statistics import mean
+
+from cognithor_bench.adapters.base import ScenarioResult
+
+
+def _format_pass_rate(passed: int, total: int) -> str:
+    if total == 0:
+        return "—"
+    if passed == total:
+        return "✅"
+    if passed == 0:
+        return "❌"
+    return f"{(passed / total) * 100.0:.0f}%"
+
+
+def tabulate_results(results: list[ScenarioResult]) -> str:
+    if not results:
+        return "_no results to report_\n"
+
+    grouped: dict[str, list[ScenarioResult]] = defaultdict(list)
+    for r in results:
+        grouped[r.id].append(r)
+
+    lines = [
+        "| Scenario | Runs | Pass-Rate | Avg Duration (s) | Sample Output |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    total_runs = 0
+    total_pass = 0
+    for sid in sorted(grouped):
+        runs = grouped[sid]
+        n = len(runs)
+        passed = sum(1 for r in runs if r.success)
+        avg = mean(r.duration_sec for r in runs)
+        sample = (runs[0].output or "")[:40].replace("\n", " ")
+        sample_md = sample if sample else (runs[0].error or "—")
+        lines.append(
+            f"| {sid} | {n} | {_format_pass_rate(passed, n)} | {avg:.3f} | {sample_md} |"
+        )
+        total_runs += n
+        total_pass += passed
+
+    lines.append(
+        f"| **Total** | **{total_runs}** | **{_format_pass_rate(total_pass, total_runs)}** | — | — |"
+    )
+    return "\n".join(lines) + "\n"

--- a/cognithor_bench/src/cognithor_bench/reporter.py
+++ b/cognithor_bench/src/cognithor_bench/reporter.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 from collections import defaultdict
 from statistics import mean
+from typing import TYPE_CHECKING
 
-from cognithor_bench.adapters.base import ScenarioResult
+if TYPE_CHECKING:
+    from cognithor_bench.adapters.base import ScenarioResult
 
 
 def _format_pass_rate(passed: int, total: int) -> str:
@@ -39,13 +41,10 @@ def tabulate_results(results: list[ScenarioResult]) -> str:
         avg = mean(r.duration_sec for r in runs)
         sample = (runs[0].output or "")[:40].replace("\n", " ")
         sample_md = sample if sample else (runs[0].error or "—")
-        lines.append(
-            f"| {sid} | {n} | {_format_pass_rate(passed, n)} | {avg:.3f} | {sample_md} |"
-        )
+        lines.append(f"| {sid} | {n} | {_format_pass_rate(passed, n)} | {avg:.3f} | {sample_md} |")
         total_runs += n
         total_pass += passed
 
-    lines.append(
-        f"| **Total** | **{total_runs}** | **{_format_pass_rate(total_pass, total_runs)}** | — | — |"
-    )
+    total_pct = _format_pass_rate(total_pass, total_runs)
+    lines.append(f"| **Total** | **{total_runs}** | **{total_pct}** | — | — |")
     return "\n".join(lines) + "\n"

--- a/cognithor_bench/src/cognithor_bench/runner.py
+++ b/cognithor_bench/src/cognithor_bench/runner.py
@@ -1,0 +1,61 @@
+"""BenchRunner — load JSONL scenarios + execute through an Adapter."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import random
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from cognithor_bench.adapters.base import Adapter, ScenarioInput, ScenarioResult
+
+
+class BenchRunner:
+    """Drives an Adapter across a JSONL scenario file."""
+
+    def __init__(self, *, adapter: Adapter, seed: int | None = None) -> None:
+        self.adapter = adapter
+        self._rng = random.Random(seed)
+
+    async def run_file(
+        self,
+        scenario_path: Path,
+        *,
+        repeat: int = 1,
+        subsample: float = 1.0,
+        output_dir: Path | None = None,
+    ) -> list[ScenarioResult]:
+        scenarios = self._load(scenario_path)
+        if subsample < 1.0:
+            n = max(1, int(round(len(scenarios) * subsample)))
+            scenarios = self._rng.sample(scenarios, n)
+
+        results: list[ScenarioResult] = []
+        for s in scenarios:
+            for _ in range(repeat):
+                results.append(await self.adapter.run(s))
+
+        if output_dir is not None:
+            output_dir.mkdir(parents=True, exist_ok=True)
+            stamp = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            out_file = output_dir / f"{self.adapter.name}-{scenario_path.stem}-{stamp}.jsonl"
+            out_file.write_text(
+                "\n".join(r.model_dump_json() for r in results) + "\n",
+                encoding="utf-8",
+            )
+        return results
+
+    @staticmethod
+    def _load(scenario_path: Path) -> list[ScenarioInput]:
+        scenarios: list[ScenarioInput] = []
+        for line in scenario_path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line or line.startswith("#"):
+                continue
+            row = json.loads(line)
+            row.setdefault("requires", [])
+            row["requires"] = tuple(row["requires"])
+            scenarios.append(ScenarioInput(**row))
+        return scenarios

--- a/cognithor_bench/src/cognithor_bench/runner.py
+++ b/cognithor_bench/src/cognithor_bench/runner.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import random
-import time
-from datetime import datetime, timezone
-from pathlib import Path
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
 
-from cognithor_bench.adapters.base import Adapter, ScenarioInput, ScenarioResult
+from cognithor_bench.adapters.base import ScenarioInput
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from cognithor_bench.adapters.base import Adapter, ScenarioResult
 
 
 class BenchRunner:
@@ -29,7 +32,7 @@ class BenchRunner:
     ) -> list[ScenarioResult]:
         scenarios = self._load(scenario_path)
         if subsample < 1.0:
-            n = max(1, int(round(len(scenarios) * subsample)))
+            n = max(1, round(len(scenarios) * subsample))
             scenarios = self._rng.sample(scenarios, n)
 
         results: list[ScenarioResult] = []
@@ -39,7 +42,7 @@ class BenchRunner:
 
         if output_dir is not None:
             output_dir.mkdir(parents=True, exist_ok=True)
-            stamp = datetime.now(tz=timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            stamp = datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%SZ")
             out_file = output_dir / f"{self.adapter.name}-{scenario_path.stem}-{stamp}.jsonl"
             out_file.write_text(
                 "\n".join(r.model_dump_json() for r in results) + "\n",

--- a/cognithor_bench/src/cognithor_bench/scenarios/__init__.py
+++ b/cognithor_bench/src/cognithor_bench/scenarios/__init__.py
@@ -1,0 +1,1 @@
+"""Bundled benchmark scenarios."""

--- a/cognithor_bench/src/cognithor_bench/scenarios/smoke_test.jsonl
+++ b/cognithor_bench/src/cognithor_bench/scenarios/smoke_test.jsonl
@@ -1,0 +1,3 @@
+{"id": "smoke-arith", "task": "Was ist 2 plus 2? Antworte mit einer einzigen Zahl.", "expected": "4", "timeout_sec": 30, "requires": ["no_network"]}
+{"id": "smoke-capital", "task": "Was ist die Hauptstadt von Frankreich? Antworte mit einer einzigen Stadt.", "expected": "Paris", "timeout_sec": 30, "requires": ["no_network"]}
+{"id": "smoke-translate", "task": "Übersetze 'hello' auf Deutsch. Antworte mit einem einzigen Wort.", "expected": "hallo", "timeout_sec": 30, "requires": ["no_network"]}

--- a/cognithor_bench/tests/test_adapters_base.py
+++ b/cognithor_bench/tests/test_adapters_base.py
@@ -1,0 +1,39 @@
+"""Adapter Protocol — runtime-checkable + minimal contract."""
+
+from __future__ import annotations
+
+import pytest
+
+from cognithor_bench.adapters.base import Adapter, ScenarioInput, ScenarioResult
+
+
+def test_adapter_is_runtime_checkable_protocol() -> None:
+    class Dummy:
+        name = "dummy"
+
+        async def run(self, scenario: ScenarioInput) -> ScenarioResult:
+            return ScenarioResult(
+                id=scenario.id, output="x", success=False,
+                duration_sec=0.0, error=None,
+            )
+
+    assert isinstance(Dummy(), Adapter)
+
+
+def test_scenario_input_required_fields() -> None:
+    s = ScenarioInput(id="s1", task="2+2", expected="4", timeout_sec=10, requires=())
+    assert s.id == "s1"
+    assert s.task == "2+2"
+    assert s.expected == "4"
+
+
+def test_scenario_result_required_fields() -> None:
+    r = ScenarioResult(id="s1", output="4", success=True, duration_sec=0.1, error=None)
+    assert r.id == "s1"
+    assert r.success is True
+
+
+def test_scenario_input_is_frozen() -> None:
+    s = ScenarioInput(id="s1", task="2+2", expected="4", timeout_sec=10, requires=())
+    with pytest.raises(Exception):
+        s.id = "modified"  # type: ignore[misc]

--- a/cognithor_bench/tests/test_adapters_base.py
+++ b/cognithor_bench/tests/test_adapters_base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import pytest
+from pydantic import ValidationError
 
 from cognithor_bench.adapters.base import Adapter, ScenarioInput, ScenarioResult
 
@@ -13,8 +14,11 @@ def test_adapter_is_runtime_checkable_protocol() -> None:
 
         async def run(self, scenario: ScenarioInput) -> ScenarioResult:
             return ScenarioResult(
-                id=scenario.id, output="x", success=False,
-                duration_sec=0.0, error=None,
+                id=scenario.id,
+                output="x",
+                success=False,
+                duration_sec=0.0,
+                error=None,
             )
 
     assert isinstance(Dummy(), Adapter)
@@ -35,5 +39,5 @@ def test_scenario_result_required_fields() -> None:
 
 def test_scenario_input_is_frozen() -> None:
     s = ScenarioInput(id="s1", task="2+2", expected="4", timeout_sec=10, requires=())
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         s.id = "modified"  # type: ignore[misc]

--- a/cognithor_bench/tests/test_autogen_adapter.py
+++ b/cognithor_bench/tests/test_autogen_adapter.py
@@ -1,0 +1,65 @@
+"""AutoGenAdapter — opt-in via [autogen] extra; ImportError-safe."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cognithor_bench.adapters.autogen_adapter import AutoGenAdapter, _AUTOGEN_IMPORT_ERROR_HINT
+from cognithor_bench.adapters.base import ScenarioInput
+
+
+def test_autogen_adapter_name() -> None:
+    a = AutoGenAdapter(model="ollama/qwen3:8b")
+    assert a.name == "autogen"
+
+
+@pytest.mark.asyncio
+async def test_autogen_adapter_raises_when_import_missing(monkeypatch) -> None:
+    """If autogen_agentchat is not installed, .run raises a helpful ImportError."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fail_import(name: str, *args, **kwargs):
+        if name.startswith("autogen_agentchat"):
+            raise ImportError(f"No module named {name!r}")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fail_import)
+
+    a = AutoGenAdapter(model="ollama/qwen3:8b")
+    scenario = ScenarioInput(id="s1", task="2+2", expected="4", timeout_sec=10, requires=())
+    with pytest.raises(ImportError) as exc:
+        await a.run(scenario)
+    assert _AUTOGEN_IMPORT_ERROR_HINT in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_autogen_adapter_runs_when_import_succeeds() -> None:
+    """When autogen_agentchat is importable, adapter runs and reports success."""
+    fake_msg = MagicMock()
+    fake_msg.content = "4"
+    fake_result = MagicMock()
+    fake_result.messages = [fake_msg]
+
+    fake_agent = MagicMock()
+    fake_agent.run = AsyncMock(return_value=fake_result)
+
+    fake_agents_module = MagicMock()
+    fake_agents_module.AssistantAgent = MagicMock(return_value=fake_agent)
+
+    fake_models_module = MagicMock()
+    fake_models_module.OpenAIChatCompletionClient = MagicMock(return_value=MagicMock())
+
+    with patch.dict(sys.modules, {
+        "autogen_agentchat.agents": fake_agents_module,
+        "autogen_ext.models.openai": fake_models_module,
+    }):
+        a = AutoGenAdapter(model="ollama/qwen3:8b")
+        scenario = ScenarioInput(id="s1", task="2+2", expected="4", timeout_sec=10, requires=())
+        result = await a.run(scenario)
+        assert result.success is True
+        assert "4" in result.output

--- a/cognithor_bench/tests/test_autogen_adapter.py
+++ b/cognithor_bench/tests/test_autogen_adapter.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from cognithor_bench.adapters.autogen_adapter import AutoGenAdapter, _AUTOGEN_IMPORT_ERROR_HINT
+from cognithor_bench.adapters.autogen_adapter import _AUTOGEN_IMPORT_ERROR_HINT, AutoGenAdapter
 from cognithor_bench.adapters.base import ScenarioInput
 
 
@@ -54,10 +54,13 @@ async def test_autogen_adapter_runs_when_import_succeeds() -> None:
     fake_models_module = MagicMock()
     fake_models_module.OpenAIChatCompletionClient = MagicMock(return_value=MagicMock())
 
-    with patch.dict(sys.modules, {
-        "autogen_agentchat.agents": fake_agents_module,
-        "autogen_ext.models.openai": fake_models_module,
-    }):
+    with patch.dict(
+        sys.modules,
+        {
+            "autogen_agentchat.agents": fake_agents_module,
+            "autogen_ext.models.openai": fake_models_module,
+        },
+    ):
         a = AutoGenAdapter(model="ollama/qwen3:8b")
         scenario = ScenarioInput(id="s1", task="2+2", expected="4", timeout_sec=10, requires=())
         result = await a.run(scenario)

--- a/cognithor_bench/tests/test_cli.py
+++ b/cognithor_bench/tests/test_cli.py
@@ -3,13 +3,16 @@
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from cognithor_bench.adapters.base import ScenarioResult
 from cognithor_bench.cli import main
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _scenarios(tmp_path: Path) -> Path:
@@ -45,9 +48,15 @@ def test_cli_run_invokes_adapter(tmp_path: Path) -> None:
     with patch("cognithor_bench.cli.CognithorAdapter") as ca:
         instance = MagicMock()
         instance.name = "cognithor"
-        instance.run = AsyncMock(return_value=ScenarioResult(
-            id="a", output="x", success=True, duration_sec=0.01, error=None,
-        ))
+        instance.run = AsyncMock(
+            return_value=ScenarioResult(
+                id="a",
+                output="x",
+                success=True,
+                duration_sec=0.01,
+                error=None,
+            )
+        )
         ca.return_value = instance
 
         rc = main(["run", str(p), "--repeat", "1", "--output-dir", str(out)])
@@ -57,13 +66,21 @@ def test_cli_run_invokes_adapter(tmp_path: Path) -> None:
 
 def test_cli_run_picks_autogen_adapter_when_flag_set(tmp_path: Path) -> None:
     p = _scenarios(tmp_path)
-    with patch("cognithor_bench.cli.AutoGenAdapter") as aa, \
-         patch("cognithor_bench.cli.CognithorAdapter") as ca:
+    with (
+        patch("cognithor_bench.cli.AutoGenAdapter") as aa,
+        patch("cognithor_bench.cli.CognithorAdapter") as ca,
+    ):
         instance = MagicMock()
         instance.name = "autogen"
-        instance.run = AsyncMock(return_value=ScenarioResult(
-            id="a", output="x", success=True, duration_sec=0.01, error=None,
-        ))
+        instance.run = AsyncMock(
+            return_value=ScenarioResult(
+                id="a",
+                output="x",
+                success=True,
+                duration_sec=0.01,
+                error=None,
+            )
+        )
         aa.return_value = instance
 
         rc = main(["run", str(p), "--adapter", "autogen"])
@@ -76,9 +93,16 @@ def test_cli_tabulate_aggregates_directory(tmp_path: Path, capsys) -> None:
     out = tmp_path / "results"
     out.mkdir()
     (out / "x.jsonl").write_text(
-        json.dumps(ScenarioResult(
-            id="a", output="x", success=True, duration_sec=0.1, error=None,
-        ).model_dump()) + "\n",
+        json.dumps(
+            ScenarioResult(
+                id="a",
+                output="x",
+                success=True,
+                duration_sec=0.1,
+                error=None,
+            ).model_dump()
+        )
+        + "\n",
         encoding="utf-8",
     )
     rc = main(["tabulate", str(out)])
@@ -90,13 +114,21 @@ def test_cli_tabulate_aggregates_directory(tmp_path: Path, capsys) -> None:
 def test_cli_run_native_is_default_no_docker_invoked(tmp_path: Path) -> None:
     """Spec: --native is default, --docker is opt-in. No docker call without flag."""
     p = _scenarios(tmp_path)
-    with patch("cognithor_bench.cli.CognithorAdapter") as ca, \
-         patch("cognithor_bench.cli._run_under_docker") as docker:
+    with (
+        patch("cognithor_bench.cli.CognithorAdapter") as ca,
+        patch("cognithor_bench.cli._run_under_docker") as docker,
+    ):
         instance = MagicMock()
         instance.name = "cognithor"
-        instance.run = AsyncMock(return_value=ScenarioResult(
-            id="a", output="x", success=True, duration_sec=0.01, error=None,
-        ))
+        instance.run = AsyncMock(
+            return_value=ScenarioResult(
+                id="a",
+                output="x",
+                success=True,
+                duration_sec=0.01,
+                error=None,
+            )
+        )
         ca.return_value = instance
 
         rc = main(["run", str(p)])

--- a/cognithor_bench/tests/test_cli.py
+++ b/cognithor_bench/tests/test_cli.py
@@ -1,0 +1,104 @@
+"""CLI — argparse, run / tabulate subcommands."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cognithor_bench.adapters.base import ScenarioResult
+from cognithor_bench.cli import main
+
+
+def _scenarios(tmp_path: Path) -> Path:
+    p = tmp_path / "scen.jsonl"
+    p.write_text(
+        json.dumps({"id": "a", "task": "ta", "expected": "x", "timeout_sec": 5, "requires": []})
+        + "\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_cli_help_exits_zero(capsys) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["--help"])
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert "cognithor-bench" in captured.out
+    assert "run" in captured.out
+    assert "tabulate" in captured.out
+
+
+def test_cli_run_missing_scenario_exits_nonzero(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as exc:
+        main(["run", str(tmp_path / "doesnotexist.jsonl")])
+    assert exc.value.code != 0
+
+
+def test_cli_run_invokes_adapter(tmp_path: Path) -> None:
+    p = _scenarios(tmp_path)
+    out = tmp_path / "results"
+
+    with patch("cognithor_bench.cli.CognithorAdapter") as ca:
+        instance = MagicMock()
+        instance.name = "cognithor"
+        instance.run = AsyncMock(return_value=ScenarioResult(
+            id="a", output="x", success=True, duration_sec=0.01, error=None,
+        ))
+        ca.return_value = instance
+
+        rc = main(["run", str(p), "--repeat", "1", "--output-dir", str(out)])
+        assert rc == 0
+        assert any(out.glob("*.jsonl"))
+
+
+def test_cli_run_picks_autogen_adapter_when_flag_set(tmp_path: Path) -> None:
+    p = _scenarios(tmp_path)
+    with patch("cognithor_bench.cli.AutoGenAdapter") as aa, \
+         patch("cognithor_bench.cli.CognithorAdapter") as ca:
+        instance = MagicMock()
+        instance.name = "autogen"
+        instance.run = AsyncMock(return_value=ScenarioResult(
+            id="a", output="x", success=True, duration_sec=0.01, error=None,
+        ))
+        aa.return_value = instance
+
+        rc = main(["run", str(p), "--adapter", "autogen"])
+        assert rc == 0
+        aa.assert_called_once()
+        ca.assert_not_called()
+
+
+def test_cli_tabulate_aggregates_directory(tmp_path: Path, capsys) -> None:
+    out = tmp_path / "results"
+    out.mkdir()
+    (out / "x.jsonl").write_text(
+        json.dumps(ScenarioResult(
+            id="a", output="x", success=True, duration_sec=0.1, error=None,
+        ).model_dump()) + "\n",
+        encoding="utf-8",
+    )
+    rc = main(["tabulate", str(out)])
+    assert rc == 0
+    captured = capsys.readouterr()
+    assert "| a |" in captured.out
+
+
+def test_cli_run_native_is_default_no_docker_invoked(tmp_path: Path) -> None:
+    """Spec: --native is default, --docker is opt-in. No docker call without flag."""
+    p = _scenarios(tmp_path)
+    with patch("cognithor_bench.cli.CognithorAdapter") as ca, \
+         patch("cognithor_bench.cli._run_under_docker") as docker:
+        instance = MagicMock()
+        instance.name = "cognithor"
+        instance.run = AsyncMock(return_value=ScenarioResult(
+            id="a", output="x", success=True, duration_sec=0.01, error=None,
+        ))
+        ca.return_value = instance
+
+        rc = main(["run", str(p)])
+        assert rc == 0
+        docker.assert_not_called()

--- a/cognithor_bench/tests/test_cognithor_adapter.py
+++ b/cognithor_bench/tests/test_cognithor_adapter.py
@@ -1,0 +1,74 @@
+"""CognithorAdapter — wraps cognithor.crew.Crew for benchmark execution."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cognithor_bench.adapters.base import ScenarioInput
+from cognithor_bench.adapters.cognithor_adapter import CognithorAdapter
+
+
+@pytest.mark.asyncio
+async def test_cognithor_adapter_name() -> None:
+    a = CognithorAdapter(model="ollama/qwen3:8b")
+    assert a.name == "cognithor"
+
+
+@pytest.mark.asyncio
+async def test_cognithor_adapter_runs_scenario_success() -> None:
+    """A passing scenario produces ScenarioResult(success=True) with output."""
+    fake_output = MagicMock()
+    fake_output.raw = "4"
+    fake_output.tasks_outputs = []
+
+    with patch("cognithor_bench.adapters.cognithor_adapter.Crew") as crew_cls:
+        crew = MagicMock()
+        crew.kickoff_async = AsyncMock(return_value=fake_output)
+        crew_cls.return_value = crew
+
+        a = CognithorAdapter(model="ollama/qwen3:8b")
+        scenario = ScenarioInput(id="s1", task="2+2", expected="4", timeout_sec=10, requires=())
+        result = await a.run(scenario)
+
+        assert result.id == "s1"
+        assert result.output == "4"
+        assert result.success is True
+        assert result.error is None
+
+
+@pytest.mark.asyncio
+async def test_cognithor_adapter_failure_reports_error() -> None:
+    """An exception inside kickoff_async produces ScenarioResult(success=False, error)."""
+    with patch("cognithor_bench.adapters.cognithor_adapter.Crew") as crew_cls:
+        crew = MagicMock()
+        crew.kickoff_async = AsyncMock(side_effect=RuntimeError("boom"))
+        crew_cls.return_value = crew
+
+        a = CognithorAdapter(model="ollama/qwen3:8b")
+        scenario = ScenarioInput(id="s1", task="x", expected="y", timeout_sec=10, requires=())
+        result = await a.run(scenario)
+
+        assert result.success is False
+        assert result.error is not None
+        assert "boom" in result.error
+
+
+@pytest.mark.asyncio
+async def test_cognithor_adapter_substring_match_is_case_insensitive() -> None:
+    """Expected '4' matched against 'The answer is 4.' counts as success."""
+    fake_output = MagicMock()
+    fake_output.raw = "The answer is 4."
+    fake_output.tasks_outputs = []
+
+    with patch("cognithor_bench.adapters.cognithor_adapter.Crew") as crew_cls:
+        crew = MagicMock()
+        crew.kickoff_async = AsyncMock(return_value=fake_output)
+        crew_cls.return_value = crew
+
+        a = CognithorAdapter(model="ollama/qwen3:8b")
+        scenario = ScenarioInput(id="s1", task="2+2", expected="4", timeout_sec=10, requires=())
+        result = await a.run(scenario)
+
+        assert result.success is True

--- a/cognithor_bench/tests/test_e2e_smoke.py
+++ b/cognithor_bench/tests/test_e2e_smoke.py
@@ -12,7 +12,10 @@ from cognithor_bench.cli import main
 def test_full_smoke_run_with_mock_adapter(tmp_path: Path, capsys) -> None:
     smoke = (
         Path(__file__).resolve().parent.parent
-        / "src" / "cognithor_bench" / "scenarios" / "smoke_test.jsonl"
+        / "src"
+        / "cognithor_bench"
+        / "scenarios"
+        / "smoke_test.jsonl"
     )
 
     # Stub CognithorAdapter to deterministic outputs (no LLM call).
@@ -22,10 +25,15 @@ def test_full_smoke_run_with_mock_adapter(tmp_path: Path, capsys) -> None:
 
         async def _run(s):
             from cognithor_bench.adapters.base import ScenarioResult
+
             return ScenarioResult(
-                id=s.id, output=s.expected, success=True,
-                duration_sec=0.001, error=None,
+                id=s.id,
+                output=s.expected,
+                success=True,
+                duration_sec=0.001,
+                error=None,
             )
+
         instance.run = AsyncMock(side_effect=_run)
         ca.return_value = instance
 
@@ -35,6 +43,10 @@ def test_full_smoke_run_with_mock_adapter(tmp_path: Path, capsys) -> None:
 
         files = list(out_dir.glob("*.jsonl"))
         assert len(files) == 1
-        rows = [json.loads(l) for l in files[0].read_text(encoding="utf-8").splitlines() if l.strip()]
+        rows = [
+            json.loads(line)
+            for line in files[0].read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
         assert len(rows) == 3
         assert all(r["success"] for r in rows)

--- a/cognithor_bench/tests/test_e2e_smoke.py
+++ b/cognithor_bench/tests/test_e2e_smoke.py
@@ -1,0 +1,40 @@
+"""End-to-end smoke run — uses MockAdapter so CI never hits an LLM."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from cognithor_bench.cli import main
+
+
+def test_full_smoke_run_with_mock_adapter(tmp_path: Path, capsys) -> None:
+    smoke = (
+        Path(__file__).resolve().parent.parent
+        / "src" / "cognithor_bench" / "scenarios" / "smoke_test.jsonl"
+    )
+
+    # Stub CognithorAdapter to deterministic outputs (no LLM call).
+    with patch("cognithor_bench.cli.CognithorAdapter") as ca:
+        instance = MagicMock()
+        instance.name = "cognithor"
+
+        async def _run(s):
+            from cognithor_bench.adapters.base import ScenarioResult
+            return ScenarioResult(
+                id=s.id, output=s.expected, success=True,
+                duration_sec=0.001, error=None,
+            )
+        instance.run = AsyncMock(side_effect=_run)
+        ca.return_value = instance
+
+        out_dir = tmp_path / "results"
+        rc = main(["run", str(smoke), "--output-dir", str(out_dir)])
+        assert rc == 0
+
+        files = list(out_dir.glob("*.jsonl"))
+        assert len(files) == 1
+        rows = [json.loads(l) for l in files[0].read_text(encoding="utf-8").splitlines() if l.strip()]
+        assert len(rows) == 3
+        assert all(r["success"] for r in rows)

--- a/cognithor_bench/tests/test_package_install.py
+++ b/cognithor_bench/tests/test_package_install.py
@@ -10,19 +10,23 @@ pytestmark = pytest.mark.xfail(
 
 def test_package_imports() -> None:
     import cognithor_bench
+
     assert hasattr(cognithor_bench, "__version__")
 
 
 def test_runner_module_imports() -> None:
     from cognithor_bench import runner
+
     assert hasattr(runner, "BenchRunner")
 
 
 def test_cli_module_imports() -> None:
     from cognithor_bench import cli
+
     assert hasattr(cli, "main")
 
 
 def test_cognithor_adapter_imports() -> None:
     from cognithor_bench.adapters import cognithor_adapter
+
     assert hasattr(cognithor_adapter, "CognithorAdapter")

--- a/cognithor_bench/tests/test_package_install.py
+++ b/cognithor_bench/tests/test_package_install.py
@@ -1,0 +1,28 @@
+"""Verify cognithor_bench installs and exposes its public surface."""
+
+import pytest
+
+pytestmark = pytest.mark.xfail(
+    reason="runner / cli / adapters arrive in Tasks 11-13",
+    strict=False,
+)
+
+
+def test_package_imports() -> None:
+    import cognithor_bench
+    assert hasattr(cognithor_bench, "__version__")
+
+
+def test_runner_module_imports() -> None:
+    from cognithor_bench import runner
+    assert hasattr(runner, "BenchRunner")
+
+
+def test_cli_module_imports() -> None:
+    from cognithor_bench import cli
+    assert hasattr(cli, "main")
+
+
+def test_cognithor_adapter_imports() -> None:
+    from cognithor_bench.adapters import cognithor_adapter
+    assert hasattr(cognithor_adapter, "CognithorAdapter")

--- a/cognithor_bench/tests/test_reporter.py
+++ b/cognithor_bench/tests/test_reporter.py
@@ -1,0 +1,42 @@
+"""Reporter — aggregate ScenarioResult lists into Markdown tables."""
+
+from __future__ import annotations
+
+from cognithor_bench.adapters.base import ScenarioResult
+from cognithor_bench.reporter import tabulate_results
+
+
+def test_tabulate_empty() -> None:
+    md = tabulate_results([])
+    assert "no results" in md.lower()
+
+
+def test_tabulate_single_result() -> None:
+    results = [
+        ScenarioResult(id="s1", output="4", success=True, duration_sec=0.12, error=None),
+    ]
+    md = tabulate_results(results)
+    assert "| s1 |" in md
+    assert "| ✅ |" in md or "| pass |" in md
+
+
+def test_tabulate_aggregates_repeated_ids() -> None:
+    """Two runs of the same id show as one row with pass-rate 50%."""
+    results = [
+        ScenarioResult(id="s1", output="4", success=True, duration_sec=0.1, error=None),
+        ScenarioResult(id="s1", output="x", success=False, duration_sec=0.2, error=None),
+    ]
+    md = tabulate_results(results)
+    # Pass rate column shows 50% (1/2)
+    assert "50" in md
+    # Average duration ~0.15s appears (rounded)
+    assert "0.15" in md or "0.150" in md
+
+
+def test_tabulate_includes_summary_row() -> None:
+    results = [
+        ScenarioResult(id="s1", output="4", success=True, duration_sec=0.1, error=None),
+        ScenarioResult(id="s2", output="x", success=False, duration_sec=0.2, error=None),
+    ]
+    md = tabulate_results(results)
+    assert "Total" in md or "Overall" in md

--- a/cognithor_bench/tests/test_runner.py
+++ b/cognithor_bench/tests/test_runner.py
@@ -1,0 +1,98 @@
+"""BenchRunner — core async loop with repetition + sub-sampling."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cognithor_bench.adapters.base import ScenarioInput, ScenarioResult
+from cognithor_bench.runner import BenchRunner
+
+
+def _scenario_file(tmp_path: Path, rows: list[dict]) -> Path:
+    p = tmp_path / "scen.jsonl"
+    p.write_text("\n".join(json.dumps(r) for r in rows) + "\n", encoding="utf-8")
+    return p
+
+
+@pytest.mark.asyncio
+async def test_runner_executes_each_scenario(tmp_path: Path) -> None:
+    rows = [
+        {"id": "a", "task": "ta", "expected": "x", "timeout_sec": 10, "requires": []},
+        {"id": "b", "task": "tb", "expected": "y", "timeout_sec": 10, "requires": []},
+    ]
+    path = _scenario_file(tmp_path, rows)
+
+    adapter = MagicMock()
+    adapter.name = "test"
+    adapter.run = AsyncMock(side_effect=[
+        ScenarioResult(id="a", output="x", success=True, duration_sec=0.1, error=None),
+        ScenarioResult(id="b", output="z", success=False, duration_sec=0.2, error=None),
+    ])
+
+    runner = BenchRunner(adapter=adapter)
+    results = await runner.run_file(path, repeat=1, subsample=1.0)
+
+    assert len(results) == 2
+    assert results[0].id == "a"
+    assert results[1].success is False
+
+
+@pytest.mark.asyncio
+async def test_runner_repeats_scenarios(tmp_path: Path) -> None:
+    rows = [{"id": "a", "task": "ta", "expected": "x", "timeout_sec": 10, "requires": []}]
+    path = _scenario_file(tmp_path, rows)
+
+    adapter = MagicMock()
+    adapter.name = "test"
+    adapter.run = AsyncMock(return_value=ScenarioResult(
+        id="a", output="x", success=True, duration_sec=0.05, error=None,
+    ))
+
+    runner = BenchRunner(adapter=adapter)
+    results = await runner.run_file(path, repeat=3, subsample=1.0)
+    assert len(results) == 3
+
+
+@pytest.mark.asyncio
+async def test_runner_subsample_reduces_count(tmp_path: Path) -> None:
+    rows = [
+        {"id": str(i), "task": "t", "expected": "x", "timeout_sec": 10, "requires": []}
+        for i in range(10)
+    ]
+    path = _scenario_file(tmp_path, rows)
+
+    adapter = MagicMock()
+    adapter.name = "test"
+    adapter.run = AsyncMock(side_effect=lambda s: ScenarioResult(
+        id=s.id, output="x", success=True, duration_sec=0.01, error=None,
+    ))
+
+    runner = BenchRunner(adapter=adapter, seed=42)
+    results = await runner.run_file(path, repeat=1, subsample=0.5)
+    assert len(results) == 5  # 10 * 0.5
+
+
+@pytest.mark.asyncio
+async def test_runner_writes_results_to_dir(tmp_path: Path) -> None:
+    rows = [{"id": "a", "task": "t", "expected": "x", "timeout_sec": 10, "requires": []}]
+    path = _scenario_file(tmp_path, rows)
+
+    adapter = MagicMock()
+    adapter.name = "test"
+    adapter.run = AsyncMock(return_value=ScenarioResult(
+        id="a", output="x", success=True, duration_sec=0.01, error=None,
+    ))
+
+    out_dir = tmp_path / "results"
+    runner = BenchRunner(adapter=adapter)
+    await runner.run_file(path, repeat=1, subsample=1.0, output_dir=out_dir)
+
+    files = list(out_dir.glob("*.jsonl"))
+    assert len(files) == 1
+    body = files[0].read_text(encoding="utf-8")
+    assert json.loads(body.splitlines()[0])["id"] == "a"

--- a/cognithor_bench/tests/test_runner.py
+++ b/cognithor_bench/tests/test_runner.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import json
-import tempfile
-from pathlib import Path
+from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from cognithor_bench.adapters.base import ScenarioInput, ScenarioResult
+from cognithor_bench.adapters.base import ScenarioResult
 from cognithor_bench.runner import BenchRunner
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _scenario_file(tmp_path: Path, rows: list[dict]) -> Path:
@@ -29,10 +31,12 @@ async def test_runner_executes_each_scenario(tmp_path: Path) -> None:
 
     adapter = MagicMock()
     adapter.name = "test"
-    adapter.run = AsyncMock(side_effect=[
-        ScenarioResult(id="a", output="x", success=True, duration_sec=0.1, error=None),
-        ScenarioResult(id="b", output="z", success=False, duration_sec=0.2, error=None),
-    ])
+    adapter.run = AsyncMock(
+        side_effect=[
+            ScenarioResult(id="a", output="x", success=True, duration_sec=0.1, error=None),
+            ScenarioResult(id="b", output="z", success=False, duration_sec=0.2, error=None),
+        ]
+    )
 
     runner = BenchRunner(adapter=adapter)
     results = await runner.run_file(path, repeat=1, subsample=1.0)
@@ -49,9 +53,15 @@ async def test_runner_repeats_scenarios(tmp_path: Path) -> None:
 
     adapter = MagicMock()
     adapter.name = "test"
-    adapter.run = AsyncMock(return_value=ScenarioResult(
-        id="a", output="x", success=True, duration_sec=0.05, error=None,
-    ))
+    adapter.run = AsyncMock(
+        return_value=ScenarioResult(
+            id="a",
+            output="x",
+            success=True,
+            duration_sec=0.05,
+            error=None,
+        )
+    )
 
     runner = BenchRunner(adapter=adapter)
     results = await runner.run_file(path, repeat=3, subsample=1.0)
@@ -68,9 +78,15 @@ async def test_runner_subsample_reduces_count(tmp_path: Path) -> None:
 
     adapter = MagicMock()
     adapter.name = "test"
-    adapter.run = AsyncMock(side_effect=lambda s: ScenarioResult(
-        id=s.id, output="x", success=True, duration_sec=0.01, error=None,
-    ))
+    adapter.run = AsyncMock(
+        side_effect=lambda s: ScenarioResult(
+            id=s.id,
+            output="x",
+            success=True,
+            duration_sec=0.01,
+            error=None,
+        )
+    )
 
     runner = BenchRunner(adapter=adapter, seed=42)
     results = await runner.run_file(path, repeat=1, subsample=0.5)
@@ -84,9 +100,15 @@ async def test_runner_writes_results_to_dir(tmp_path: Path) -> None:
 
     adapter = MagicMock()
     adapter.name = "test"
-    adapter.run = AsyncMock(return_value=ScenarioResult(
-        id="a", output="x", success=True, duration_sec=0.01, error=None,
-    ))
+    adapter.run = AsyncMock(
+        return_value=ScenarioResult(
+            id="a",
+            output="x",
+            success=True,
+            duration_sec=0.01,
+            error=None,
+        )
+    )
 
     out_dir = tmp_path / "results"
     runner = BenchRunner(adapter=adapter)

--- a/cognithor_bench/tests/test_smoke_scenarios.py
+++ b/cognithor_bench/tests/test_smoke_scenarios.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-import pytest
-
 from cognithor_bench.adapters.base import ScenarioInput
 
-SMOKE = Path(__file__).resolve().parent.parent / "src" / "cognithor_bench" / "scenarios" / "smoke_test.jsonl"
+SMOKE = (
+    Path(__file__).resolve().parent.parent
+    / "src"
+    / "cognithor_bench"
+    / "scenarios"
+    / "smoke_test.jsonl"
+)
 
 
 def test_smoke_file_exists() -> None:
@@ -17,7 +21,11 @@ def test_smoke_file_exists() -> None:
 
 
 def test_smoke_file_has_three_to_five_rows() -> None:
-    lines = [l for l in SMOKE.read_text(encoding="utf-8").splitlines() if l.strip() and not l.startswith("#")]
+    lines = [
+        line
+        for line in SMOKE.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.startswith("#")
+    ]
     assert 3 <= len(lines) <= 5
 
 

--- a/cognithor_bench/tests/test_smoke_scenarios.py
+++ b/cognithor_bench/tests/test_smoke_scenarios.py
@@ -1,0 +1,42 @@
+"""Verify the bundled smoke_test.jsonl is well-formed."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cognithor_bench.adapters.base import ScenarioInput
+
+SMOKE = Path(__file__).resolve().parent.parent / "src" / "cognithor_bench" / "scenarios" / "smoke_test.jsonl"
+
+
+def test_smoke_file_exists() -> None:
+    assert SMOKE.exists(), f"missing smoke scenarios at {SMOKE}"
+
+
+def test_smoke_file_has_three_to_five_rows() -> None:
+    lines = [l for l in SMOKE.read_text(encoding="utf-8").splitlines() if l.strip() and not l.startswith("#")]
+    assert 3 <= len(lines) <= 5
+
+
+def test_smoke_rows_are_valid_scenario_inputs() -> None:
+    for line in SMOKE.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        row = json.loads(line)
+        row.setdefault("requires", [])
+        row["requires"] = tuple(row["requires"])
+        ScenarioInput(**row)
+
+
+def test_smoke_ids_are_unique() -> None:
+    ids = []
+    for line in SMOKE.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        ids.append(json.loads(line)["id"])
+    assert len(ids) == len(set(ids))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ dev = [
     "hypothesis>=6.0,<7",
     "ruff>=0.9,<1",
     "mypy>=1.14,<2",
+    # WP4: Local cognithor-bench submodule, shipped as a separate package
+    # but installed editable for tests. See cognithor_bench/pyproject.toml.
+    "cognithor-bench @ file:./cognithor_bench",
 ]
 memory = [
     "numpy>=2.0,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,14 @@ arc-gpu = [
     "cognithor[arc]",
     "torch>=2.2.0",
 ]
+autogen = [
+    # Single pin-point for AutoGen-source-compat shim.
+    # Referenced by:
+    #   - tests/test_compat/test_autogen/ (signature parity, behaviour tests)
+    #   - cognithor_bench/src/cognithor_bench/adapters/autogen_adapter.py (lazy import)
+    # See spec §6 (Single Pin-Point) and §8.4 acceptance criteria.
+    "autogen-agentchat==0.7.5",
+]
 all = [
     "cognithor[memory,vector,mcp,telegram,web,search,cron,documents,identity,desktop,arc,encryption]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,12 @@ Repository = "https://github.com/Alex8791-cyber/cognithor"
 cognithor = "cognithor.__main__:main"
 jarvis = "cognithor.__main__:main"
 
+[tool.hatch.metadata]
+# Allow `cognithor-bench @ file:./cognithor_bench` direct-reference in [dev]
+# extra. Hatch refuses direct refs by default since they are not PyPI-installable;
+# `cognithor-bench` is intentionally a local-only dev dependency, never published.
+allow-direct-references = true
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/cognithor"]
 # Templates (.jinja / .yaml / non-.py files) are shipped automatically by the


### PR DESCRIPTION
## Summary
- New monorepo submodule `cognithor_bench/` with own `pyproject.toml`, console-script `cognithor-bench`.
- `BenchRunner`, `Adapter` Protocol, `CognithorAdapter` (default), `AutoGenAdapter` (opt-in, ImportError-safe).
- `run` + `tabulate` subcommands; `--native` default, `--docker` placeholder for post-v0.94.0.
- Bundled `smoke_test.jsonl` (3 trivial DACH scenarios for CI).
- Root `pyproject.toml`: new `[autogen]` extra with `autogen-agentchat==0.7.5` (single pin-point for WP2 + WP4).
- `cognithor-bench` added to root `[dev]` extra so it installs editable in CI.

## Spec
- `docs/superpowers/specs/2026-04-25-cognithor-autogen-strategy-design.md` §8.3, §6 F7.

## Test plan
- [x] `pytest cognithor_bench/tests/ -q` green (30 passed, 4 xpassed, 0 failed)
- [x] Coverage ≥80% — actual 94.79% on `cognithor_bench/src/cognithor_bench/`
- [x] `ruff check cognithor_bench/` clean
- [x] `ruff format --check cognithor_bench/` clean
- [x] `cognithor-bench --help` prints usage
- [x] `pip install --dry-run autogen-agentchat==0.7.5` resolves (verified before commit)
- [x] AutoGenAdapter raises a helpful ImportError when `[autogen]` extra is not installed

13 commits, all targeted single-file/single-task. Pre-existing `skills/*` WIP and the v0.94.0 plan file remain unstaged in working tree (not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)