### PR TITLE
fix: v0.94.1 hotfix — autogen-ext pin, sevdesk catalog filter, Windows UTF-8 stdio

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.94.1] — 2026-04-26
+
+### Fixed — v0.94.0 hotfix
+
+- `[autogen]` extra (root + `cognithor_bench`) now also pins
+  `autogen-ext[openai]==0.7.5`. Without it, `cognithor-bench --adapter autogen`
+  raised a misleading ImportError because `OpenAIChatCompletionClient` lives
+  in `autogen-ext`, not `autogen-agentchat`. Updated the adapter's error hint
+  accordingly. Surfaced by post-release dry-run audit (`docs/superpowers/reports/2026-04-26-v094-dry-run-audit.md` — BUG-1, HIGH).
+- `docs/integrations/catalog.json` no longer lists `sevdesk_get_invoice` and
+  `sevdesk_list_contacts`. The sevDesk MCP module uses a no-op `@mcp_tool`
+  marker decorator and is not yet wired into the live MCP server, so the
+  catalog over-promised capability. The generator script
+  (`scripts/generate_integrations_catalog.py`) now has an explicit
+  `NOT_YET_REGISTERED_PREFIXES` filter — re-add `cognithor.mcp.sevdesk` to
+  the catalog automatically when the connector lands. (BUG-2, MEDIUM.)
+- `insurance-agent-pack run --interview` no longer renders `§34d` as
+  mojibake on Windows consoles. CLI now reconfigures `sys.stdout`/`sys.stderr`
+  to UTF-8 on `win32` at entry. (BUG-3, LOW.)
+
 ## [0.94.0] — 2026-04-25
 
 ### Added — AutoGen Strategy Adoption

--- a/cognithor_bench/pyproject.toml
+++ b/cognithor_bench/pyproject.toml
@@ -33,8 +33,12 @@ dev = [
     "pytest-cov>=6.0,<7",
 ]
 # Mirrors the root cognithor[autogen] extra so cognithor_bench can pull
-# autogen-agentchat for the optional AutoGenAdapter without re-pinning.
-autogen = ["autogen-agentchat==0.7.5"]
+# autogen-agentchat AND autogen-ext for the optional AutoGenAdapter
+# (autogen-ext provides OpenAIChatCompletionClient).
+autogen = [
+    "autogen-agentchat==0.7.5",
+    "autogen-ext[openai]==0.7.5",
+]
 
 [project.scripts]
 cognithor-bench = "cognithor_bench.cli:main"

--- a/cognithor_bench/src/cognithor_bench/adapters/autogen_adapter.py
+++ b/cognithor_bench/src/cognithor_bench/adapters/autogen_adapter.py
@@ -13,7 +13,9 @@ from cognithor_bench.adapters.base import ScenarioInput, ScenarioResult
 
 _AUTOGEN_IMPORT_ERROR_HINT = (
     "AutoGenAdapter requires `pip install cognithor[autogen]` "
-    "(or `pip install autogen-agentchat==0.7.5`)."
+    "which installs both `autogen-agentchat==0.7.5` and "
+    "`autogen-ext[openai]==0.7.5` "
+    "(autogen-ext supplies OpenAIChatCompletionClient)."
 )
 
 

--- a/docs/integrations/catalog.json
+++ b/docs/integrations/catalog.json
@@ -1,20 +1,5 @@
 {
-  "generated_at": "2026-04-24T18:23:51.198452+00:00",
-  "tool_count": 2,
-  "tools": [
-    {
-      "name": "sevdesk_get_invoice",
-      "module": "cognithor.mcp.sevdesk.tools",
-      "category": "sevdesk",
-      "description": "DACH accounting: fetch a single sevDesk invoice (Rechnung) by id.",
-      "dach_specific": true
-    },
-    {
-      "name": "sevdesk_list_contacts",
-      "module": "cognithor.mcp.sevdesk.tools",
-      "category": "sevdesk",
-      "description": "DACH accounting: list sevDesk contacts (Kunden/Lieferanten).",
-      "dach_specific": true
-    }
-  ]
+  "generated_at": "2026-04-26T12:13:31.047907+00:00",
+  "tool_count": 0,
+  "tools": []
 }

--- a/docs/superpowers/reports/2026-04-26-v094-dry-run-audit.md
+++ b/docs/superpowers/reports/2026-04-26-v094-dry-run-audit.md
@@ -1,0 +1,164 @@
+# v0.94.0 End-to-End Dry-Run Audit
+
+**Date:** 2026-04-26
+**Branch / HEAD:** `main` @ `0abb9d26` (recovery commit on top of 655fe704)
+**Auditor:** Claude (Opus 4.7, 1M ctx)
+
+## Verdict: WARNING
+
+The v0.94.0 release surface is **functionally green** (imports OK, tests OK, lint/format/mypy clean, console-scripts wired correctly in `pyproject.toml`, all cross-refs resolve, all CI YAMLs parse), but the audit surfaced **two real wiring concerns** that ship to users:
+
+1. **HIGH** — `cognithor_bench` AutoGenAdapter has a missing-runtime-dep / misleading error.
+2. **MEDIUM** — sevDesk MCP tools appear in the integrations catalog but are not actually registered with the live MCP server.
+
+Plus one local-env issue (LOW) for the developer machine. Details below.
+
+---
+
+## A. Package metadata correctness
+
+- [x] [OK] `pyproject.toml` `version = "0.94.0"`.
+- [x] [OK] `src/cognithor/__init__.py` `__version__ = "0.94.0"`.
+- [x] [OK] `flutter_app/pubspec.yaml` `version: 0.94.0+1`.
+- [x] [OK] `flutter_app/lib/providers/connection_provider.dart` `kFrontendVersion = '0.94.0'`.
+- [x] [OK] `[project.optional-dependencies] dev` contains no `@ file:` refs (verified via `tomllib`). Comment block explains why.
+- [x] [OK] `[project.optional-dependencies] autogen = ["autogen-agentchat==0.7.5"]` — single pin-point, exactly as spec §6.
+- [x] [OK] `all` and `full` parse cleanly; no `[tool.hatch.metadata] allow-direct-references` block (correctly removed in `0abb9d26`).
+
+## B. Public-API surface correctness
+
+- [x] [OK] `from cognithor import __version__` returns `"0.94.0"`.
+- [x] [OK] `from cognithor.crew import Crew, CrewAgent, CrewTask, CrewProcess` resolves.
+- [x] [OK] `from cognithor.compat.autogen import …` (all 9 names) resolves; emits one `DeprecationWarning` on import as designed.
+- [x] [OK] `inspect.signature(AssistantAgent.__init__)` has 18 parameters (17 fields + `self`), matching upstream `autogen-agentchat==0.7.5`.
+- [x] [OK] `from cognithor_bench …` (3 imports) all resolve; `__version__ == "0.1.0"`.
+- [x] [OK] `from insurance_agent_pack …` (3 imports) all resolve; `__version__ == "0.1.0"`.
+
+## C. Console-script entry points
+
+- [⚠️] [WARN] `cognithor --version` from the dev shell hits a **stale console-script binary** at `C:/Users/ArtiCall/AppData/Roaming/Python/Python313/Scripts/cognithor.exe`. It crashes with `ModuleNotFoundError: No module named 'jarvis.__main__'`. Root cause: the user's last `pip install -e .` was at v0.52.0 (when the entry point was `jarvis.__main__:main`). `pip show cognithor` confirms `Version: 0.52.0`. **The pyproject.toml is correct** (`cognithor.__main__:main`); only the local install is stale. `python -m cognithor --version` correctly prints `Cognithor v0.94.0`. Recommended fix on dev box: `pip install -e .` to refresh metadata + console-script.
+- [x] [OK] `cognithor-bench --help` prints usage with `run` and `tabulate` subcommands.
+- [x] [OK] `insurance-agent-pack --help` prints usage with `run` subcommand. (Description has one mojibake char `�34d` — German `§34d` corrupted to cp1252; cosmetic only, **LOW severity**.)
+
+## D. Targeted regression test subsets
+
+- [x] [OK] `tests/test_compat/test_autogen/` — 45 passed, 1 expected DeprecationWarning.
+- [x] [OK] `cognithor_bench/tests/` — 30 passed, 4 xpassed.
+- [x] [OK] `examples/insurance-agent-pack/tests/` — 58 passed, 1 skipped (slow marker).
+- [x] [OK] `tests/test_docs/` — 6 passed.
+- [x] [OK] `tests/test_crew/` — 166 passed, 1 skipped.
+
+Total: 305 passed, 2 skipped, 4 xpassed across v0.94.0-relevant subsets. No regressions vs. 655fe704's green run.
+
+## E. Lint + type-check
+
+- [x] [OK] `ruff check` — *All checks passed!* (compat + tests/test_compat + cognithor_bench + insurance-agent-pack).
+- [x] [OK] `ruff format --check` — 67 files already formatted.
+- [x] [OK] `mypy --strict src/cognithor/compat` — Success: no issues found in 11 source files.
+
+## F. Wiring sweep
+
+1. **MCP tool registration — sevDesk** [⚠️ MEDIUM]
+   `docs/integrations/catalog.json` lists `sevdesk_get_invoice` and `sevdesk_list_contacts`. They are decorated with `@mcp_tool`, but per `src/cognithor/mcp/sevdesk/tools.py:18-23`, **`mcp_tool` is a no-op marker decorator** for AST-based catalog scanning only. The module is also **not imported anywhere** except inside its own folder (verified via grep). So a running MCP server will not expose these tools. The module's own docstring admits this: *"actual runtime registration with the Cognithor MCP server happens via the existing `register_*` convention in sibling modules; hook those up when the connector is wired into a live Gateway."* The catalog over-promises capability.
+2. **Channel registrations** [OK] 3 bundled `LeadSource` subclasses (`DiscordLeadSource`, `HnLeadSource`, `RssLeadSource`) — match the 3 bundled packs (`discord-lead-hunter`, `hn-lead-hunter`, `rss-lead-hunter`). No orphans, no missing translations.
+3. **`@agent` / `@task` / `@crew` decorators** [OK] Defined in `src/cognithor/crew/decorators.py`. Templates correctly import them as `from cognithor.crew.decorators import agent, crew, task`. They are NOT re-exported in `cognithor.crew.__init__`, but no doc claims they are. Decorators import OK at runtime.
+4. **PGE-Trinity wiring** [OK] `from cognithor.gateway.gateway import Gateway`, `Planner`, `Gatekeeper`, `Executor` all import without error. Gateway class resolves.
+5. **`cognithor.compat.autogen → cognithor.crew` bridge** [OK] `_bridge.py` imports `from cognithor.crew import Crew, CrewAgent, CrewTask`; `run_single_task()` constructs a real `Crew(agents=[...], tasks=[...])` and awaits `kickoff_async`. End-to-end mock-LLM smoke test passes (covered by `test_hello_world_search_replace.py`).
+6. **Insurance pack → cognithor.crew** [OK] `build_team()` returns a `Crew` with 4 `CrewAgent`s + 4 `CrewTask`s, `process=CrewProcess.SEQUENTIAL`. Verified by instantiating live: `team built: Crew agents: 4 tasks: 4 process: CrewProcess.SEQUENTIAL`.
+7. **`cognithor-bench` AutoGen adapter ImportError path** [❌ HIGH] **BUG**. See "Bugs found" below.
+
+## G. Documentation cross-references
+
+- [x] [OK] README → `src/cognithor/compat/autogen/README.md` ✓ exists.
+- [x] [OK] `docs/competitive-analysis/autogen.md` → `docs/adr/0001-pge-trinity-vs-group-chat.md` ✓ exists.
+- [x] [OK] `docs/adr/0001-pge-trinity-vs-group-chat.md` → `docs/hashline-guard.md` ✓ exists.
+- [x] [OK] `examples/insurance-agent-pack/README.md` → `docs/adr/0001-pge-trinity-vs-group-chat.md` ✓ exists.
+- [x] [OK] `cognithor_bench/README.md` exists (cross-refs not exhaustively checked, but file is present).
+- [x] [OK] `NOTICE` lines 87-94 contain BOTH CrewAI MIT attribution AND AutoGen MIT attribution + the `autogen-agentchat==0.7.5` reference.
+
+## H. CI workflow correctness
+
+- [x] [OK] `.github/workflows/ci.yml:74-77` installs `pip install -e ".[dev]"` first, then `pip install -e ./cognithor_bench` and `pip install -e ./examples/insurance-agent-pack` — exactly the fix from `0abb9d26`.
+- [x] [OK] No leftover `@ file:` refs anywhere in `*.toml` (verified via `tomllib` introspection AND repo-wide grep).
+- [x] [OK] All 12 workflow files (`ci.yml`, `publish.yml`, `release.yml`, `build-*.yml`, etc.) parse as valid YAML.
+
+## I. Pre-existing dirty state (informational)
+
+- 11 modified `skills/*` files (backup, gmail_sync, test, test_skill, wetter_abfrage) — user's local WIP, untouched.
+- Untracked `docs/superpowers/plans/2026-04-25-cognithor-autogen-strategy.md` and `results/` — left in place.
+
+---
+
+## Bugs found
+
+### BUG-1 — `cognithor[autogen]` extra is incomplete (HIGH)
+
+**File:** `cognithor_bench/src/cognithor_bench/adapters/autogen_adapter.py:35`
+**Also affects:** `cognithor_bench/pyproject.toml:34` and root `pyproject.toml:180-187` (`[autogen]` extra).
+
+**Symptom:** A user follows the docs:
+```bash
+pip install cognithor[autogen]
+cognithor-bench run --adapter autogen scenarios.jsonl
+```
+…and gets `ImportError: AutoGenAdapter requires pip install cognithor[autogen] (or pip install autogen-agentchat==0.7.5)` — even though `autogen-agentchat==0.7.5` IS installed.
+
+**Reproduction (verified on this dev machine):**
+```bash
+pip show autogen-agentchat   # Version: 0.7.5  (installed)
+pip show autogen-ext         # WARNING: Package(s) not found
+python -c "from cognithor_bench.adapters.autogen_adapter import AutoGenAdapter; ..."
+# → ImportError ... line 35: from autogen_ext.models.openai import (OpenAIChatCompletionClient, ...)
+```
+
+**Root cause:** `OpenAIChatCompletionClient` lives in the **`autogen-ext`** PyPI package, not in `autogen-agentchat`. Both `[autogen]` extras (root + bench sub-package) only pin `autogen-agentchat==0.7.5`. The `try/except ImportError` block in `autogen_adapter.py` catches the missing-`autogen_ext` ImportError but raises with a misleading "install autogen-agentchat" hint.
+
+**Fix paths (any one):**
+1. Add `"autogen-ext[openai]>=0.7,<0.8"` to the `[autogen]` extra in BOTH `pyproject.toml` files.
+2. OR: change the adapter to use `cognithor.compat.autogen.OpenAIChatCompletionClient` (the local shim) instead of importing from `autogen_ext` directly. This eliminates the second dep but means the bench adapter is no longer a "pure AutoGen" comparison.
+3. AND: update the error message to mention `autogen-ext` so future users can self-diagnose.
+
+**Why tests didn't catch this:** `test_autogen_adapter_runs_when_import_succeeds` patches `sys.modules["autogen_ext.models.openai"]` with a `MagicMock`, so the test passes regardless of whether `autogen-ext` is actually installable. Recommend a lightweight integration check `pip install cognithor[autogen] && python -c "from autogen_ext.models.openai import OpenAIChatCompletionClient"` in CI.
+
+### BUG-2 — sevDesk MCP tools listed in catalog but not registered (MEDIUM)
+
+**Files:** `src/cognithor/mcp/sevdesk/tools.py`, `docs/integrations/catalog.json`.
+
+**Symptom:** `docs/integrations/catalog.json` advertises 2 sevDesk tools with `dach_specific: true`. They appear on the `/integrations` site page (per memory). However, the `@mcp_tool` decorator they use is a **local no-op marker**, not the real `register_tool` mechanism used by other MCP modules. Nothing in `cognithor/gateway/`, `cognithor/mcp/server.py`, or `cognithor/mcp/bridge.py` imports `cognithor.mcp.sevdesk`, so a running MCP server will not expose these tools to the planner.
+
+**Reproduction:**
+```bash
+grep -rn "from cognithor.mcp.sevdesk" src/cognithor/  # only the module's own internal imports
+```
+
+**Severity rationale:** Not a runtime crash; the tools are just silently absent. But the catalog promises capability the running server cannot fulfil — false advertising for the integrations page.
+
+**Fix path:** Add `register_tool` calls in `src/cognithor/mcp/sevdesk/__init__.py` (currently empty) wired through whatever sibling module pattern (`tasks.py`, `email.py`, etc.) actually registers tools at server start. Alternative: remove the entries from `docs/integrations/catalog.json` until the connector is wired.
+
+### BUG-3 — Mojibake in insurance-agent-pack CLI description (LOW)
+
+**File:** `examples/insurance-agent-pack/src/insurance_agent_pack/cli.py` (or wherever `parser.description` is set).
+**Symptom:** `insurance-agent-pack --help` prints `Reference Cognithor pack: �34d-NEUTRAL DACH insurance pre-advisory.` — `§34d` got encoded as `�34d` because Windows console default cp1252. Other DE strings inside the package render correctly (German backstories work), so this is just a CLI metadata string that needs an `\u00a7` escape or a `# -*- coding: utf-8 -*-` header / explicit UTF-8 stream wrap.
+
+---
+
+## Wiring concerns (not bugs)
+
+1. **Stale local pip install (LOW)** — The dev's `Python313/Scripts/cognithor.exe` still points at `jarvis.__main__:main` because `pip install -e .` was last run at v0.52.0. `python -m cognithor` works, but the bare `cognithor` console script doesn't. Cosmetic for development; not a release defect.
+2. **Decorators not re-exported** — `cognithor.crew.{agent, task, crew}` decorators are NOT in the public `__all__` of `cognithor.crew`. Templates import them via `cognithor.crew.decorators`, which is fine. Suggestion: add to `cognithor.crew.__init__.__all__` for symmetry with the rest of the crew surface, or don't.
+
+---
+
+## Recommended action list (sorted by severity)
+
+1. **HIGH** — Fix BUG-1: either add `autogen-ext[openai]>=0.7,<0.8` to `[autogen]` extras (root + bench) **OR** rewire `AutoGenAdapter` to use `cognithor.compat.autogen.OpenAIChatCompletionClient`. Update the error message either way. Add a CI step that does a real `pip install cognithor[autogen] && python -c "from autogen_ext.models.openai import OpenAIChatCompletionClient"` to prevent regression.
+2. **MEDIUM** — Fix BUG-2: wire sevDesk tools into the live MCP server **OR** remove from `docs/integrations/catalog.json` until v0.95.0 ships a real connector. Add a test that asserts every tool in `catalog.json` is actually returned by the live MCP server's tool-list endpoint.
+3. **LOW** — Fix BUG-3: replace `§34d` in CLI description with `\u00a7 34d` or wrap stdout in UTF-8 on Windows.
+4. **LOW** (dev box only) — `pip install -e .` to refresh stale 0.52.0 console-script. Not a release blocker.
+5. **Optional** — Re-export `agent/task/crew` decorators in `cognithor.crew.__all__` for ergonomics.
+
+---
+
+## Summary
+
+v0.94.0 is **shippable**. No CRITICAL bugs. The HIGH bug (`cognithor[autogen]` extra missing `autogen-ext`) only affects users who actively choose the optional `autogen` adapter, and the failure is a clean ImportError (not data loss / corruption / silent wrong behavior). The MEDIUM sevDesk catalog mismatch is documentation drift that affects the marketing `/integrations` page, not core agent behavior. Both are addressable in a v0.94.1 patch.

--- a/examples/insurance-agent-pack/src/insurance_agent_pack/cli.py
+++ b/examples/insurance-agent-pack/src/insurance_agent_pack/cli.py
@@ -48,7 +48,20 @@ def _cmd_run(args: argparse.Namespace) -> int:
     return 0
 
 
+def _ensure_utf8_stdio() -> None:
+    """On Windows, default console encoding is cp1252 — German § becomes mojibake.
+
+    This reconfigures stdout/stderr to UTF-8 so e.g. "§34d" in argparse
+    descriptions and prompt text renders correctly. No-op on POSIX.
+    """
+    if sys.platform == "win32":
+        for stream in (sys.stdout, sys.stderr):
+            if hasattr(stream, "reconfigure"):
+                stream.reconfigure(encoding="utf-8", errors="replace")
+
+
 def main(argv: list[str] | None = None) -> int:
+    _ensure_utf8_stdio()
     args = _build_parser().parse_args(argv)
     if args.cmd == "run":
         return _cmd_run(args)

--- a/flutter_app/lib/providers/connection_provider.dart
+++ b/flutter_app/lib/providers/connection_provider.dart
@@ -13,7 +13,7 @@ enum CognithorConnectionState { disconnected, connecting, connected, error }
 /// Frontend version — must match backend `__version__` (major.minor).
 /// See issue #111: version mismatch between Flutter and Python backend
 /// should block entry to the app.
-const String kFrontendVersion = '0.94.0';
+const String kFrontendVersion = '0.94.1';
 
 /// Extracts "major.minor" from a semver-ish string like "0.91.0" or "0.91.0+1".
 String? _majorMinor(String? v) {

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.94.0+1
+version: 0.94.1+1
 
 environment:
   sdk: ^3.11.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cognithor"
-version = "0.94.0"
+version = "0.94.1"
 description = "Cognithor · Agent OS — Local-first autonomous agent operating system"
 readme = "README.md"
 license = "Apache-2.0"
@@ -184,6 +184,10 @@ autogen = [
     #   - cognithor_bench/src/cognithor_bench/adapters/autogen_adapter.py (lazy import)
     # See spec §6 (Single Pin-Point) and §8.4 acceptance criteria.
     "autogen-agentchat==0.7.5",
+    # autogen-ext provides OpenAIChatCompletionClient which the bench-adapter
+    # imports directly. Without it, `cognithor-bench --adapter autogen` raises
+    # a misleading ImportError. Pinned to the same minor as autogen-agentchat.
+    "autogen-ext[openai]==0.7.5",
 ]
 all = [
     "cognithor[memory,vector,mcp,telegram,web,search,cron,documents,identity,desktop,arc,encryption]",

--- a/scripts/generate_integrations_catalog.py
+++ b/scripts/generate_integrations_catalog.py
@@ -30,6 +30,17 @@ MCP_DIR = REPO_ROOT / "src" / "cognithor" / "mcp"
 
 DACH_MARKERS = {"datev", "lexware", "sevdesk", "elster", "schufa"}
 
+# Modules that carry @mcp_tool-decorated functions but are NOT yet wired into
+# the live MCP server (no register_tool calls, module not imported by the
+# server boot path). Excluded from the public catalog so the cognithor.ai
+# /integrations page doesn't over-promise capability.
+#
+# When wiring a module into the live server, remove its prefix from this set
+# AND add the appropriate register_tool calls in the module's __init__.
+NOT_YET_REGISTERED_PREFIXES: set[str] = {
+    "cognithor.mcp.sevdesk",
+}
+
 
 def extract_tools(py_file: Path) -> list[dict]:
     """Parse a Python file and return any @mcp_tool-decorated function metadata."""
@@ -112,6 +123,12 @@ def main() -> int:
     tools: list[dict] = []
     for py in MCP_DIR.rglob("*.py"):
         tools.extend(extract_tools(py))
+
+    # Filter out tools from modules that aren't wired into the live server yet.
+    # See NOT_YET_REGISTERED_PREFIXES at top of file.
+    tools = [
+        t for t in tools if not any(t["module"].startswith(p) for p in NOT_YET_REGISTERED_PREFIXES)
+    ]
 
     seen: set[tuple[str, str]] = set()
     deduped: list[dict] = []

--- a/src/cognithor/__init__.py
+++ b/src/cognithor/__init__.py
@@ -1,6 +1,6 @@
 """Cognithor · Agent OS -- Local-first autonomous agent operating system."""
 
-__version__ = "0.94.0"
+__version__ = "0.94.1"
 __author__ = "Alexander Söllner"
 
 # ── Centralized branding — single source of truth for banner + version ──


### PR DESCRIPTION
## Summary
Post-release dry-run audit (`docs/superpowers/reports/2026-04-26-v094-dry-run-audit.md`) found 3 fixable issues in v0.94.0. Patched all in this hotfix release.

## Bugs fixed

**HIGH (BUG-1):** `[autogen]` extra now also pins `autogen-ext[openai]==0.7.5`. `OpenAIChatCompletionClient` lives in `autogen-ext` not `autogen-agentchat`; previous extra was incomplete and `cognithor-bench --adapter autogen` raised a misleading ImportError. Fixed in both root + `cognithor_bench/pyproject.toml`. Adapter error message updated.

**MEDIUM (BUG-2):** `docs/integrations/catalog.json` no longer lists sevDesk tools. They use a no-op `@mcp_tool` marker decorator and are not wired into the live MCP server (the catalog over-promised capability that the server cannot deliver). Generator script `scripts/generate_integrations_catalog.py` now has explicit `NOT_YET_REGISTERED_PREFIXES` filter — re-add `cognithor.mcp.sevdesk` automatically when the connector lands.

**LOW (BUG-3):** `insurance-agent-pack run --interview` now reconfigures stdio to UTF-8 on Windows. `§34d` no longer renders as mojibake in cp1252 console.

## Files
- `pyproject.toml`, `cognithor_bench/pyproject.toml` — `[autogen]` extra adds autogen-ext pin
- `cognithor_bench/src/cognithor_bench/adapters/autogen_adapter.py` — error hint updated
- `examples/insurance-agent-pack/src/insurance_agent_pack/cli.py` — `_ensure_utf8_stdio()` on Windows
- `scripts/generate_integrations_catalog.py` — `NOT_YET_REGISTERED_PREFIXES` filter
- `docs/integrations/catalog.json` — regenerated (now empty; no false-positive entries)
- 4 version files: 0.94.0 → 0.94.1
- `CHANGELOG.md` — `[0.94.1] — 2026-04-26` entry
- `docs/superpowers/reports/2026-04-26-v094-dry-run-audit.md` — full audit report (committed for history)

## Test plan
- [x] `pip install --dry-run autogen-ext[openai]==0.7.5` resolves
- [x] `pytest tests/test_compat/test_autogen/ -q` → 45 passed
- [x] `pytest cognithor_bench/tests/ -q` → 30 passed, 4 xpassed
- [x] `pytest examples/insurance-agent-pack/tests/ -q` → 58 passed, 1 skipped
- [x] `pytest tests/test_docs/ -q` → 6 passed
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] catalog regen produces empty list (sevDesk filtered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)