### PR TITLE
feat: Claude Code hook bridge + autonomous supervisor

### DIFF
--- a/contrib/claude-code-bridge/README.md
+++ b/contrib/claude-code-bridge/README.md
@@ -1,0 +1,144 @@
+# Claude Code Hook Bridge
+
+Make Cognithor's Gatekeeper and Observer supervise every tool call Claude Code
+runs in VS Code (or any Claude Code host).
+
+Claude Code ships with native [HTTP hooks](https://code.claude.com/docs/en/hooks).
+We point those hooks at Cognithor's running gateway (`http://localhost:8741`
+by default) and the bridge does the rest: every `PreToolUse` is gated by the
+Gatekeeper, every `PostToolUse` gets a step-level check, and on `Stop` the
+Observer audits the whole turn and can force a retry.
+
+## Prerequisites
+
+1. **Cognithor is running.** `python -m jarvis --no-cli` or the usual launcher.
+   Confirm: `curl http://localhost:8741/api/claude-hooks/health` should return
+   `{"ok": true, "gatekeeper": true, ...}`.
+2. **Claude Code 1.x** with HTTP hook support (any build from 2026-01 onward).
+3. Python 3.10+ on PATH (only needed if you prefer the command-hook fallback).
+
+## Setup (HTTP hooks, recommended)
+
+Run the installer once:
+
+```bash
+python contrib/claude-code-bridge/install.py
+```
+
+It:
+- Backs up `~/.claude/settings.json` to `settings.json.bak-<timestamp>`.
+- Merges a `hooks` block into it (existing hooks are preserved).
+- Prints the diff so you can see exactly what changed.
+
+Re-run with `--uninstall` to remove the Cognithor hooks.
+
+## What the installer writes
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "http",
+        "url": "http://localhost:8741/api/claude-hooks/pre-tool-use",
+        "timeout": 30
+      }]
+    }],
+    "PostToolUse": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "http",
+        "url": "http://localhost:8741/api/claude-hooks/post-tool-use",
+        "timeout": 30
+      }]
+    }],
+    "Stop": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "http",
+        "url": "http://localhost:8741/api/claude-hooks/stop",
+        "timeout": 60
+      }]
+    }],
+    "SessionStart": [{
+      "matcher": "startup|resume",
+      "hooks": [{
+        "type": "http",
+        "url": "http://localhost:8741/api/claude-hooks/session-start",
+        "timeout": 10
+      }]
+    }],
+    "SessionEnd": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "http",
+        "url": "http://localhost:8741/api/claude-hooks/session-end",
+        "timeout": 10
+      }]
+    }]
+  }
+}
+```
+
+## Authenticated bridge (multi-user machines)
+
+If you expose the gateway to non-loopback addresses, add a header and an env
+var to `settings.json`:
+
+```json
+{
+  "type": "http",
+  "url": "https://cognithor.lan/api/claude-hooks/pre-tool-use",
+  "headers": { "Authorization": "Bearer $COGNITHOR_HOOK_TOKEN" },
+  "allowedEnvVars": ["COGNITHOR_HOOK_TOKEN"]
+}
+```
+
+Set `COGNITHOR_HOOK_TOKEN` in your shell/environment. The token must match
+the one Cognithor's gateway expects (see `CONFIG_REFERENCE.md` for the API
+auth setting).
+
+## Fallback: command-type hook
+
+If your deployment forbids HTTP hooks, use the `cognithor_bridge.py` script
+instead -- it reads the hook JSON from stdin, POSTs it to Cognithor, and
+echoes the response to stdout:
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [{
+      "hooks": [{
+        "type": "command",
+        "command": "python /ABSOLUTE/PATH/TO/cognithor_bridge.py pre-tool-use",
+        "timeout": 30
+      }]
+    }]
+  }
+}
+```
+
+The command variant has identical semantics to the HTTP variant -- it just
+adds a subprocess spawn per hook call.
+
+## Diagnostics
+
+- `curl http://localhost:8741/api/claude-hooks/health` -- liveness + what's wired.
+- Cognithor logs: the bridge writes structured log lines starting with
+  `claude_code_pre_tool_use`, `claude_code_post_tool_use`, etc.
+- Claude Code transcript shows `<hook> error` on HTTP failures; the request
+  is treated as a non-blocking error (execution continues).
+
+## What Cognithor does on each event
+
+| Hook          | Cognithor path                                            |
+|---------------|-----------------------------------------------------------|
+| PreToolUse    | `Gatekeeper.evaluate(PlannedAction)` → allow/deny/ask      |
+| PostToolUse   | ToolHookRunner (secret redact, audit log) + step heuristic |
+| Stop          | `Observer.audit(...)` over the turn; blocks Stop if failed |
+| SessionStart  | Bookkeeping + context hint injected into Claude's session  |
+| SessionEnd    | Clean up tracked session state                             |
+
+Fail-open: if the Gatekeeper raises or the Observer times out, the bridge
+returns `allow` / no-op so a stuck Cognithor can never deadlock your editor.

--- a/contrib/claude-code-bridge/cognithor_bridge.py
+++ b/contrib/claude-code-bridge/cognithor_bridge.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Command-type fallback bridge for Claude Code hooks.
+
+Use this when you cannot use Claude Code's native ``"type": "http"`` hook
+(e.g. sandboxed environments that block outbound HTTP from hook scripts).
+It reads the hook JSON from stdin, forwards it to the corresponding
+Cognithor endpoint, and prints the response to stdout.
+
+Usage in ``~/.claude/settings.json``::
+
+    {
+      "hooks": {
+        "PreToolUse": [{
+          "hooks": [{
+            "type": "command",
+            "command": "python /abs/path/cognithor_bridge.py pre-tool-use",
+            "timeout": 30
+          }]
+        }]
+      }
+    }
+
+Exits 0 and prints the JSON Cognithor returned. On connection failure the
+script exits 0 with ``{}`` on stdout -- Claude Code treats that as
+"allow/continue", so a crashed Cognithor never deadlocks the editor.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+ENDPOINTS = {
+    "pre-tool-use": "/api/claude-hooks/pre-tool-use",
+    "post-tool-use": "/api/claude-hooks/post-tool-use",
+    "stop": "/api/claude-hooks/stop",
+    "session-start": "/api/claude-hooks/session-start",
+    "session-end": "/api/claude-hooks/session-end",
+}
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2 or argv[1] not in ENDPOINTS:
+        print("usage: cognithor_bridge.py <" + "|".join(ENDPOINTS) + ">", file=sys.stderr)
+        return 2
+
+    base = os.environ.get("COGNITHOR_URL", "http://localhost:8741").rstrip("/")
+    url = base + ENDPOINTS[argv[1]]
+
+    try:
+        payload = sys.stdin.buffer.read()
+    except Exception as exc:
+        print(f"bridge: failed to read stdin: {exc}", file=sys.stderr)
+        sys.stdout.write("{}")
+        return 0
+
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "cognithor-hook-bridge/1",
+        },
+    )
+    token = os.environ.get("COGNITHOR_HOOK_TOKEN")
+    if token:
+        req.add_header("Authorization", f"Bearer {token}")
+
+    try:
+        with urllib.request.urlopen(req, timeout=25) as resp:
+            sys.stdout.buffer.write(resp.read())
+            return 0
+    except urllib.error.HTTPError as exc:
+        print(f"bridge: HTTP {exc.code} from {url}: {exc.read()[:200]!r}", file=sys.stderr)
+        sys.stdout.write("{}")
+        return 0
+    except urllib.error.URLError as exc:
+        print(f"bridge: cannot reach Cognithor at {url}: {exc.reason}", file=sys.stderr)
+        sys.stdout.write("{}")
+        return 0
+    except Exception as exc:  # pragma: no cover
+        print(f"bridge: unexpected error: {exc}", file=sys.stderr)
+        sys.stdout.write("{}")
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/contrib/claude-code-bridge/install.py
+++ b/contrib/claude-code-bridge/install.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Idempotent installer for the Cognithor <-> Claude Code hook bridge.
+
+Merges a ``hooks`` block into ``~/.claude/settings.json`` (or the path you
+pass with ``--settings``). Existing hooks are preserved -- the installer
+only adds its own entries, identified by the ``_cognithor_bridge`` tag.
+
+Run ``install.py --uninstall`` to remove the Cognithor hooks again.
+
+Run ``install.py --dry-run`` to see the merged JSON without writing.
+"""
+
+from __future__ import annotations
+
+import argparse
+import difflib
+import json
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+
+DEFAULT_URL = "http://localhost:8741"
+TAG_KEY = "_cognithor_bridge"
+TAG_VALUE = "cognithor-hook-bridge"
+
+HOOK_BLUEPRINT = {
+    "PreToolUse": {"path": "/api/claude-hooks/pre-tool-use", "timeout": 30, "matcher": ""},
+    "PostToolUse": {"path": "/api/claude-hooks/post-tool-use", "timeout": 30, "matcher": ""},
+    "Stop": {"path": "/api/claude-hooks/stop", "timeout": 60, "matcher": ""},
+    "SessionStart": {
+        "path": "/api/claude-hooks/session-start",
+        "timeout": 10,
+        "matcher": "startup|resume",
+    },
+    "SessionEnd": {"path": "/api/claude-hooks/session-end", "timeout": 10, "matcher": ""},
+}
+
+
+def default_settings_path() -> Path:
+    return Path.home() / ".claude" / "settings.json"
+
+
+def load(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        return json.loads(path.read_text(encoding="utf-8") or "{}")
+    except json.JSONDecodeError as exc:
+        sys.exit(f"error: {path} is not valid JSON: {exc}")
+
+
+def build_hook_entry(
+    *, event: str, base_url: str, token_env: str | None
+) -> dict:
+    info = HOOK_BLUEPRINT[event]
+    http_hook: dict = {
+        "type": "http",
+        "url": f"{base_url.rstrip('/')}{info['path']}",
+        "timeout": info["timeout"],
+        TAG_KEY: TAG_VALUE,
+    }
+    if token_env:
+        http_hook["headers"] = {"Authorization": f"Bearer ${token_env}"}
+        http_hook["allowedEnvVars"] = [token_env]
+    return {
+        "matcher": info["matcher"],
+        "hooks": [http_hook],
+        TAG_KEY: TAG_VALUE,
+    }
+
+
+def strip_cognithor_blocks(hooks_section: dict) -> dict:
+    """Remove prior Cognithor-tagged entries so re-install is clean."""
+    cleaned: dict[str, list] = {}
+    for event, groups in hooks_section.items():
+        if not isinstance(groups, list):
+            continue
+        keep = [g for g in groups if not (isinstance(g, dict) and g.get(TAG_KEY) == TAG_VALUE)]
+        if keep:
+            cleaned[event] = keep
+    return cleaned
+
+
+def install(
+    settings: dict, *, base_url: str, token_env: str | None
+) -> dict:
+    result = dict(settings)
+    hooks_section = dict(result.get("hooks") or {})
+    hooks_section = strip_cognithor_blocks(hooks_section)
+
+    for event in HOOK_BLUEPRINT:
+        entry = build_hook_entry(event=event, base_url=base_url, token_env=token_env)
+        hooks_section.setdefault(event, []).append(entry)
+
+    result["hooks"] = hooks_section
+    return result
+
+
+def uninstall(settings: dict) -> dict:
+    result = dict(settings)
+    hooks_section = result.get("hooks")
+    if not isinstance(hooks_section, dict):
+        return result
+    cleaned = strip_cognithor_blocks(hooks_section)
+    if cleaned:
+        result["hooks"] = cleaned
+    else:
+        result.pop("hooks", None)
+    return result
+
+
+def diff(before: dict, after: dict) -> str:
+    a = json.dumps(before, indent=2, sort_keys=True).splitlines(keepends=True)
+    b = json.dumps(after, indent=2, sort_keys=True).splitlines(keepends=True)
+    return "".join(
+        difflib.unified_diff(a, b, fromfile="before", tofile="after", n=3)
+    )
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--settings",
+        type=Path,
+        default=default_settings_path(),
+        help="Path to Claude Code settings.json (default: ~/.claude/settings.json).",
+    )
+    p.add_argument(
+        "--url",
+        default=os.environ.get("COGNITHOR_URL", DEFAULT_URL),
+        help="Cognithor gateway base URL (default: env COGNITHOR_URL or %(default)s).",
+    )
+    p.add_argument(
+        "--token-env",
+        default=None,
+        help=(
+            "If set, the hook sends 'Authorization: Bearer $<TOKEN_ENV>'. "
+            "Needed when the gateway is not loopback-only."
+        ),
+    )
+    p.add_argument("--dry-run", action="store_true", help="Print diff, do not write.")
+    p.add_argument("--uninstall", action="store_true", help="Remove Cognithor hook entries.")
+    args = p.parse_args()
+
+    settings_path: Path = args.settings
+    before = load(settings_path)
+
+    if args.uninstall:
+        after = uninstall(before)
+        action = "uninstall"
+    else:
+        after = install(before, base_url=args.url, token_env=args.token_env)
+        action = "install"
+
+    d = diff(before, after)
+    if not d:
+        print(f"no changes needed ({action}).")
+        return 0
+
+    print(d)
+    if args.dry_run:
+        print(f"(dry-run) {action} preview only. re-run without --dry-run to apply.")
+        return 0
+
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    if settings_path.exists():
+        backup = settings_path.with_suffix(f".json.bak-{int(time.time())}")
+        shutil.copy2(settings_path, backup)
+        print(f"backed up existing settings -> {backup}")
+
+    settings_path.write_text(json.dumps(after, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"{action} complete -> {settings_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/contrib/claude-code-bridge/settings.example.json
+++ b/contrib/claude-code-bridge/settings.example.json
@@ -1,0 +1,64 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:8741/api/claude-hooks/pre-tool-use",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:8741/api/claude-hooks/post-tool-use",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:8741/api/claude-hooks/stop",
+            "timeout": 60
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:8741/api/claude-hooks/session-start",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "http",
+            "url": "http://localhost:8741/api/claude-hooks/session-end",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/src/cognithor/__main__.py
+++ b/src/cognithor/__main__.py
@@ -1098,8 +1098,14 @@ def main() -> None:
                         try:
                             from cognithor.core.tool_hooks import (
                                 HookEvent as _HookEvent,
+                            )
+                            from cognithor.core.tool_hooks import (
                                 ToolHookRunner as _ToolHookRunner,
+                            )
+                            from cognithor.core.tool_hooks import (
                                 audit_logging_hook as _audit_logging_hook,
+                            )
+                            from cognithor.core.tool_hooks import (
                                 secret_redacting_hook as _secret_redacting_hook,
                             )
 

--- a/src/cognithor/__main__.py
+++ b/src/cognithor/__main__.py
@@ -1121,9 +1121,7 @@ def main() -> None:
                                 _audit_logging_hook,
                             )
                         except Exception:
-                            log.debug(
-                                "claude_code_default_hook_runner_failed", exc_info=True
-                            )
+                            log.debug("claude_code_default_hook_runner_failed", exc_info=True)
                             _cc_hook_runner = None
 
                     api_app.include_router(

--- a/src/cognithor/__main__.py
+++ b/src/cognithor/__main__.py
@@ -1082,6 +1082,26 @@ def main() -> None:
                 except Exception:
                     log.debug("evolution_api_registration_failed", exc_info=True)
 
+                # Claude Code Hook Bridge API
+                # Accepts HTTP-type hook calls from Claude Code (~/.claude/settings.json)
+                # and routes them through Gatekeeper + Observer.
+                try:
+                    from cognithor.gateway.claude_code_hooks import (
+                        create_claude_code_hooks_router,
+                    )
+
+                    api_app.include_router(
+                        create_claude_code_hooks_router(
+                            gatekeeper=getattr(gateway, "_gatekeeper", None),
+                            observer=getattr(gateway, "_observer", None),
+                            hook_runner=getattr(gateway, "_tool_hook_runner", None),
+                            config=config,
+                        )
+                    )
+                    log.info("claude_code_hooks_api_registered")
+                except Exception:
+                    log.debug("claude_code_hooks_api_registration_failed", exc_info=True)
+
                 # ── WebSocket Chat-Endpoint ──────────────────────────────
                 import json as _json
 

--- a/src/cognithor/__main__.py
+++ b/src/cognithor/__main__.py
@@ -1084,17 +1084,48 @@ def main() -> None:
 
                 # Claude Code Hook Bridge API
                 # Accepts HTTP-type hook calls from Claude Code (~/.claude/settings.json)
-                # and routes them through Gatekeeper + Observer.
+                # and routes them through Gatekeeper + Observer + HITL.
                 try:
                     from cognithor.gateway.claude_code_hooks import (
                         create_claude_code_hooks_router,
                     )
 
+                    # Bootstrap a default ToolHookRunner with the standard
+                    # Cognithor pre/post hooks if the gateway hasn't published
+                    # one (current phases don't expose the runner directly).
+                    _cc_hook_runner = getattr(gateway, "_tool_hook_runner", None)
+                    if _cc_hook_runner is None:
+                        try:
+                            from cognithor.core.tool_hooks import (
+                                HookEvent as _HookEvent,
+                                ToolHookRunner as _ToolHookRunner,
+                                audit_logging_hook as _audit_logging_hook,
+                                secret_redacting_hook as _secret_redacting_hook,
+                            )
+
+                            _cc_hook_runner = _ToolHookRunner()
+                            _cc_hook_runner.register(
+                                _HookEvent.PRE_TOOL_USE,
+                                "secret_redacting",
+                                _secret_redacting_hook,
+                            )
+                            _cc_hook_runner.register(
+                                _HookEvent.POST_TOOL_USE,
+                                "audit_logging",
+                                _audit_logging_hook,
+                            )
+                        except Exception:
+                            log.debug(
+                                "claude_code_default_hook_runner_failed", exc_info=True
+                            )
+                            _cc_hook_runner = None
+
                     api_app.include_router(
                         create_claude_code_hooks_router(
                             gatekeeper=getattr(gateway, "_gatekeeper", None),
                             observer=getattr(gateway, "_observer", None),
-                            hook_runner=getattr(gateway, "_tool_hook_runner", None),
+                            hook_runner=_cc_hook_runner,
+                            approval_manager=getattr(gateway, "_hitl_manager", None),
                             config=config,
                         )
                     )

--- a/src/cognithor/channels/backends_api.py
+++ b/src/cognithor/channels/backends_api.py
@@ -48,6 +48,7 @@ class SetActiveRequest(BaseModel):
         "vllm",
         "llama_cpp",
         "claude-code",
+        "claude-code-supervised",
     ]
 
 

--- a/src/cognithor/core/claude_code_supervised.py
+++ b/src/cognithor/core/claude_code_supervised.py
@@ -1,0 +1,541 @@
+"""Supervised Claude Code driver.
+
+Drives the ``claude`` CLI in ``--output-format stream-json`` mode, parses the
+NDJSON event stream, records every tool call for the Observer, and hands
+turn-end outcomes back to a goal-evaluation callback so the caller can
+decide whether to send a follow-up prompt or finish.
+
+This is the autonomous-loop companion to the hook bridge in
+``cognithor.gateway.claude_code_hooks``. The hook bridge gates tool calls
+*during* a Claude Code session (interactive in VS Code or headless). This
+class additionally *starts* sessions, *monitors* them, and *re-prompts*
+when a goal is not yet reached -- replacing the human at the keyboard.
+
+Scope limits by design
+----------------------
+- We do not fork the Anthropic SDK. We spawn the same ``claude`` CLI the
+  user already uses and parse its event stream.
+- We do not re-implement Gatekeeper decisions here. Cognithor's
+  ``~/.claude/settings.json`` HTTP hooks (installed by
+  ``contrib/claude-code-bridge/install.py``) fire *inside the subprocess*
+  too, so the Gatekeeper still gates every tool call in supervised mode.
+- Budget enforcement is hard (max_turns, max_duration, max_cost_usd) --
+  we would rather stop a runaway loop than hit an API bill surprise.
+
+Event stream reference
+----------------------
+Claude Code emits NDJSON with these relevant envelope types:
+- ``system`` (subtype ``init``): opening frame with session_id + tools.
+- ``assistant``: message with text or ``tool_use`` blocks.
+- ``user``: tool results (``tool_result`` blocks).
+- ``result`` (subtype ``success`` | ``error_max_turns`` | ...): final frame
+  carrying total cost + terminal text response.
+
+We treat ``result`` as turn-end and feed the accumulated tool results into
+the Observer. The caller's goal-evaluator then decides re-prompt vs halt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import time
+from collections.abc import AsyncIterator, Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Literal
+
+from cognithor.models import ToolResult
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from cognithor.core.observer import ObserverAudit
+
+
+log = get_logger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Types
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+GoalVerdict = Literal["done", "continue", "abort"]
+
+
+@dataclass(frozen=True)
+class GoalEvaluation:
+    """Outcome of a goal-evaluation round.
+
+    ``verdict``:
+        - ``done``: goal reached, stop the loop and return ``final_text``.
+        - ``continue``: send ``next_prompt`` and keep looping.
+        - ``abort``: unrecoverable, stop with an error.
+    """
+
+    verdict: GoalVerdict
+    next_prompt: str = ""
+    reason: str = ""
+
+
+@dataclass
+class TurnResult:
+    """One subprocess invocation of ``claude -p``."""
+
+    turn: int
+    prompt: str
+    assistant_text: str = ""
+    tool_results: list[ToolResult] = field(default_factory=list)
+    cost_usd: float = 0.0
+    duration_ms: int = 0
+    is_error: bool = False
+    error: str | None = None
+    session_id: str = ""
+    raw_events: list[dict[str, Any]] = field(default_factory=list)
+
+
+@dataclass
+class SupervisorResult:
+    """Outcome of the full supervised run."""
+
+    verdict: GoalVerdict  # "done" if goal evaluator said so, "abort" otherwise
+    final_text: str
+    reason: str
+    turns: list[TurnResult]
+    total_cost_usd: float
+    total_duration_ms: int
+
+
+GoalEvaluator = Callable[[list[TurnResult]], Awaitable[GoalEvaluation]]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Supervisor
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class ClaudeCodeSupervisor:
+    """Outer-loop driver for Claude Code in stream-json mode."""
+
+    def __init__(
+        self,
+        *,
+        model: str = "sonnet",
+        claude_path: str | None = None,
+        observer: ObserverAudit | None = None,
+        goal_evaluator: GoalEvaluator | None = None,
+        max_turns: int = 8,
+        max_duration_seconds: int = 1800,
+        max_cost_usd: float = 5.0,
+        per_turn_timeout_seconds: int = 600,
+        working_directory: str | None = None,
+        extra_cli_args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        self._model = model
+        self._claude_path = claude_path or shutil.which("claude") or "claude"
+        self._observer = observer
+        self._goal_evaluator = goal_evaluator
+        self._max_turns = max(1, max_turns)
+        self._max_duration_seconds = max_duration_seconds
+        self._max_cost_usd = max_cost_usd
+        self._per_turn_timeout_seconds = per_turn_timeout_seconds
+        self._working_directory = working_directory
+        self._extra_cli_args = list(extra_cli_args or [])
+        self._env = env
+
+    # ── Public API ───────────────────────────────────────────────────────
+
+    async def run(self, user_intent: str) -> SupervisorResult:
+        """Drive Claude Code until the goal is reached or a budget is hit."""
+        start = time.monotonic()
+        turns: list[TurnResult] = []
+        next_prompt = user_intent
+        session_resume_id: str | None = None
+
+        for turn_idx in range(1, self._max_turns + 1):
+            if time.monotonic() - start > self._max_duration_seconds:
+                return self._finish(
+                    turns=turns,
+                    verdict="abort",
+                    reason=f"max_duration_seconds ({self._max_duration_seconds}) exceeded",
+                    final_text=_last_text(turns),
+                    start=start,
+                )
+
+            total_cost = sum(t.cost_usd for t in turns)
+            if total_cost >= self._max_cost_usd:
+                return self._finish(
+                    turns=turns,
+                    verdict="abort",
+                    reason=f"max_cost_usd ({self._max_cost_usd:.2f}) exceeded at ${total_cost:.4f}",
+                    final_text=_last_text(turns),
+                    start=start,
+                )
+
+            log.info(
+                "claude_code_supervisor_turn_start",
+                turn=turn_idx,
+                prompt_preview=next_prompt[:120],
+                resume_id=session_resume_id,
+            )
+
+            turn = await self._run_turn(
+                turn_idx=turn_idx,
+                prompt=next_prompt,
+                resume_session_id=session_resume_id,
+            )
+            turns.append(turn)
+            session_resume_id = turn.session_id or session_resume_id
+
+            if turn.is_error:
+                return self._finish(
+                    turns=turns,
+                    verdict="abort",
+                    reason=f"turn {turn_idx} errored: {turn.error}",
+                    final_text=turn.assistant_text,
+                    start=start,
+                )
+
+            evaluation = await self._evaluate(user_intent=user_intent, turns=turns)
+
+            log.info(
+                "claude_code_supervisor_turn_end",
+                turn=turn_idx,
+                verdict=evaluation.verdict,
+                cost_usd=turn.cost_usd,
+                tool_count=len(turn.tool_results),
+                reason=evaluation.reason[:160] if evaluation.reason else None,
+            )
+
+            if evaluation.verdict == "done":
+                return self._finish(
+                    turns=turns,
+                    verdict="done",
+                    reason=evaluation.reason or "goal reached",
+                    final_text=turn.assistant_text,
+                    start=start,
+                )
+            if evaluation.verdict == "abort":
+                return self._finish(
+                    turns=turns,
+                    verdict="abort",
+                    reason=evaluation.reason or "aborted by goal evaluator",
+                    final_text=turn.assistant_text,
+                    start=start,
+                )
+
+            next_prompt = evaluation.next_prompt or _default_followup_prompt(turn)
+
+        return self._finish(
+            turns=turns,
+            verdict="abort",
+            reason=f"max_turns ({self._max_turns}) exceeded",
+            final_text=_last_text(turns),
+            start=start,
+        )
+
+    # ── Internals ────────────────────────────────────────────────────────
+
+    async def _run_turn(
+        self,
+        *,
+        turn_idx: int,
+        prompt: str,
+        resume_session_id: str | None,
+    ) -> TurnResult:
+        cmd = [
+            self._claude_path,
+            "-p",
+            "--model",
+            self._model,
+            "--output-format",
+            "stream-json",
+            "--input-format",
+            "stream-json",
+            "--verbose",
+        ]
+        if resume_session_id:
+            cmd += ["--resume", resume_session_id]
+        cmd += self._extra_cli_args
+
+        start = time.monotonic()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=self._working_directory,
+                env=self._env,
+            )
+        except FileNotFoundError:
+            return TurnResult(
+                turn=turn_idx,
+                prompt=prompt,
+                is_error=True,
+                error=(
+                    f"claude CLI not found at {self._claude_path!r}. "
+                    "Install from https://docs.anthropic.com/claude-code"
+                ),
+            )
+
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+
+        user_frame = {
+            "type": "user",
+            "message": {"role": "user", "content": prompt},
+        }
+        proc.stdin.write((json.dumps(user_frame) + "\n").encode("utf-8"))
+        await proc.stdin.drain()
+        proc.stdin.close()
+
+        turn = TurnResult(turn=turn_idx, prompt=prompt)
+
+        try:
+            async for event in _read_ndjson(
+                proc.stdout, timeout_seconds=self._per_turn_timeout_seconds
+            ):
+                turn.raw_events.append(event)
+                self._absorb_event(turn, event)
+        except asyncio.TimeoutError:
+            turn.is_error = True
+            turn.error = f"turn exceeded per_turn_timeout_seconds={self._per_turn_timeout_seconds}"
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+
+        if proc.returncode not in (0, None) and not turn.is_error:
+            stderr = b""
+            if proc.stderr is not None:
+                try:
+                    stderr = await proc.stderr.read()
+                except Exception:
+                    stderr = b""
+            turn.is_error = True
+            turn.error = f"claude exit {proc.returncode}: {stderr.decode(errors='replace')[:400]}"
+
+        turn.duration_ms = int((time.monotonic() - start) * 1000)
+        return turn
+
+    def _absorb_event(self, turn: TurnResult, event: dict[str, Any]) -> None:
+        etype = event.get("type")
+        if etype == "system" and event.get("subtype") == "init":
+            turn.session_id = event.get("session_id", turn.session_id) or turn.session_id
+            return
+
+        if etype == "assistant":
+            msg = event.get("message") or {}
+            for block in _iter_content(msg):
+                if block.get("type") == "text" and isinstance(block.get("text"), str):
+                    # Only the final assistant text of the turn is user-facing;
+                    # we keep overwriting so the last text wins.
+                    turn.assistant_text = block["text"]
+                elif block.get("type") == "tool_use":
+                    # Pair with tool_result when it arrives; we pre-seed a
+                    # placeholder so ordering is preserved.
+                    turn.tool_results.append(
+                        ToolResult(
+                            tool_name=str(block.get("name", "")),
+                            content="",
+                            is_error=False,
+                        )
+                    )
+            return
+
+        if etype == "user":
+            # tool_result blocks come back inside user-role messages.
+            msg = event.get("message") or {}
+            for block in _iter_content(msg):
+                if block.get("type") != "tool_result":
+                    continue
+                tool_use_id = block.get("tool_use_id", "")
+                content = _tool_result_text(block.get("content"))
+                is_error = bool(block.get("is_error"))
+                # Find the most recent placeholder without content and fill it.
+                for existing in reversed(turn.tool_results):
+                    if existing.content == "" and not existing.is_error:
+                        filled = ToolResult(
+                            tool_name=existing.tool_name,
+                            content=content,
+                            is_error=is_error,
+                            error_message=content if is_error else None,
+                        )
+                        turn.tool_results.remove(existing)
+                        turn.tool_results.append(filled)
+                        break
+                else:
+                    turn.tool_results.append(
+                        ToolResult(
+                            tool_name=tool_use_id or "unknown",
+                            content=content,
+                            is_error=is_error,
+                        )
+                    )
+            return
+
+        if etype == "result":
+            subtype = event.get("subtype", "")
+            cost = event.get("total_cost_usd")
+            if isinstance(cost, (int, float)):
+                turn.cost_usd = float(cost)
+            if subtype not in ("success",):
+                turn.is_error = True
+                turn.error = event.get("result") or subtype
+            elif isinstance(event.get("result"), str):
+                turn.assistant_text = event["result"]
+            return
+
+    async def _evaluate(
+        self, *, user_intent: str, turns: list[TurnResult]
+    ) -> GoalEvaluation:
+        if self._goal_evaluator is not None:
+            try:
+                return await self._goal_evaluator(turns)
+            except Exception as exc:
+                log.warning("claude_code_supervisor_evaluator_failed", error=str(exc))
+                return GoalEvaluation(verdict="abort", reason=f"evaluator raised: {exc!s}")
+
+        # Default evaluator: one turn is one shot. The caller is expected
+        # to supply their own evaluator (Planner / Observer-driven) for
+        # anything multi-step.
+        last = turns[-1]
+        if self._observer is not None and last.tool_results:
+            try:
+                audit = await self._observer.audit(
+                    user_message=user_intent,
+                    response=last.assistant_text or "",
+                    tool_results=last.tool_results,
+                    session_id=last.session_id or "supervised",
+                )
+            except Exception:
+                log.debug("claude_code_supervisor_observer_failed", exc_info=True)
+                return GoalEvaluation(verdict="done", reason="observer_unavailable")
+            if not audit.overall_passed and audit.retry_strategy in (
+                "response_regen",
+                "pge_reloop",
+            ):
+                failed = [d for d in audit.dimensions.values() if not d.passed]
+                reasons = "; ".join(f"{d.name}: {d.reason}" for d in failed[:3])
+                followup = (
+                    "The previous attempt was flagged by the Observer audit: "
+                    f"{reasons}. Address the specific issues and retry."
+                )
+                return GoalEvaluation(
+                    verdict="continue", next_prompt=followup, reason=reasons
+                )
+
+        return GoalEvaluation(verdict="done", reason="single-turn completion")
+
+    def _finish(
+        self,
+        *,
+        turns: list[TurnResult],
+        verdict: GoalVerdict,
+        reason: str,
+        final_text: str,
+        start: float,
+    ) -> SupervisorResult:
+        return SupervisorResult(
+            verdict=verdict,
+            final_text=final_text,
+            reason=reason,
+            turns=turns,
+            total_cost_usd=sum(t.cost_usd for t in turns),
+            total_duration_ms=int((time.monotonic() - start) * 1000),
+        )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+async def _read_ndjson(
+    stream: asyncio.StreamReader, *, timeout_seconds: int
+) -> AsyncIterator[dict[str, Any]]:
+    deadline = time.monotonic() + timeout_seconds
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise asyncio.TimeoutError()
+        try:
+            line = await asyncio.wait_for(stream.readline(), timeout=remaining)
+        except asyncio.TimeoutError:
+            raise
+        if not line:
+            return
+        text = line.decode("utf-8", errors="replace").strip()
+        if not text:
+            continue
+        try:
+            yield json.loads(text)
+        except json.JSONDecodeError:
+            log.debug("claude_code_supervisor_ndjson_skip", line_preview=text[:160])
+            continue
+
+
+def _iter_content(message: Any) -> list[dict[str, Any]]:
+    content = message.get("content") if isinstance(message, dict) else None
+    if isinstance(content, list):
+        return [b for b in content if isinstance(b, dict)]
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}]
+    return []
+
+
+def _tool_result_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "text" and isinstance(block.get("text"), str):
+                parts.append(block["text"])
+            elif isinstance(block.get("content"), str):
+                parts.append(block["content"])
+        return "\n".join(parts)
+    if content is None:
+        return ""
+    try:
+        return json.dumps(content, default=str)
+    except Exception:
+        return str(content)
+
+
+def _last_text(turns: list[TurnResult]) -> str:
+    for turn in reversed(turns):
+        if turn.assistant_text:
+            return turn.assistant_text
+    return ""
+
+
+def _default_followup_prompt(turn: TurnResult) -> str:
+    if turn.tool_results:
+        errs = [r for r in turn.tool_results if r.is_error]
+        if errs:
+            snippet = (errs[0].error_message or errs[0].content or "")[:240]
+            return (
+                "The last turn produced an error: "
+                f"{snippet}\nFix it and continue toward the goal."
+            )
+    return "Continue toward the goal. If you believe the goal is reached, state 'DONE'."
+
+
+__all__ = [
+    "ClaudeCodeSupervisor",
+    "GoalEvaluation",
+    "GoalEvaluator",
+    "SupervisorResult",
+    "TurnResult",
+]

--- a/src/cognithor/core/claude_code_supervised.py
+++ b/src/cognithor/core/claude_code_supervised.py
@@ -45,6 +45,13 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any, Literal
 
+from cognithor.core.llm_backend import (
+    ChatResponse,
+    EmbedResponse,
+    LLMBackend,
+    LLMBackendError,
+    LLMBackendType,
+)
 from cognithor.models import ToolResult
 from cognithor.utils.logging import get_logger
 
@@ -292,13 +299,16 @@ class ClaudeCodeSupervisor:
         proc.stdin.close()
 
         turn = TurnResult(turn=turn_idx, prompt=prompt)
+        # Maps tool_use_id -> index in turn.tool_results so tool_result blocks
+        # can be paired even when several tool_use blocks ran in parallel.
+        pending: dict[str, int] = {}
 
         try:
             async for event in _read_ndjson(
                 proc.stdout, timeout_seconds=self._per_turn_timeout_seconds
             ):
                 turn.raw_events.append(event)
-                self._absorb_event(turn, event)
+                self._absorb_event(turn, event, pending=pending)
         except asyncio.TimeoutError:
             turn.is_error = True
             turn.error = f"turn exceeded per_turn_timeout_seconds={self._per_turn_timeout_seconds}"
@@ -326,7 +336,13 @@ class ClaudeCodeSupervisor:
         turn.duration_ms = int((time.monotonic() - start) * 1000)
         return turn
 
-    def _absorb_event(self, turn: TurnResult, event: dict[str, Any]) -> None:
+    def _absorb_event(
+        self,
+        turn: TurnResult,
+        event: dict[str, Any],
+        *,
+        pending: dict[str, int],
+    ) -> None:
         etype = event.get("type")
         if etype == "system" and event.get("subtype") == "init":
             turn.session_id = event.get("session_id", turn.session_id) or turn.session_id
@@ -341,7 +357,9 @@ class ClaudeCodeSupervisor:
                     turn.assistant_text = block["text"]
                 elif block.get("type") == "tool_use":
                     # Pair with tool_result when it arrives; we pre-seed a
-                    # placeholder so ordering is preserved.
+                    # placeholder so ordering is preserved and remember its
+                    # index by tool_use_id for parallel-call correctness.
+                    tool_use_id = str(block.get("id") or "")
                     turn.tool_results.append(
                         ToolResult(
                             tool_name=str(block.get("name", "")),
@@ -349,6 +367,8 @@ class ClaudeCodeSupervisor:
                             is_error=False,
                         )
                     )
+                    if tool_use_id:
+                        pending[tool_use_id] = len(turn.tool_results) - 1
             return
 
         if etype == "user":
@@ -357,27 +377,28 @@ class ClaudeCodeSupervisor:
             for block in _iter_content(msg):
                 if block.get("type") != "tool_result":
                     continue
-                tool_use_id = block.get("tool_use_id", "")
+                tool_use_id = str(block.get("tool_use_id") or "")
                 content = _tool_result_text(block.get("content"))
                 is_error = bool(block.get("is_error"))
-                # Find the most recent placeholder without content and fill it.
-                for existing in reversed(turn.tool_results):
-                    if existing.content == "" and not existing.is_error:
-                        filled = ToolResult(
-                            tool_name=existing.tool_name,
-                            content=content,
-                            is_error=is_error,
-                            error_message=content if is_error else None,
-                        )
-                        turn.tool_results.remove(existing)
-                        turn.tool_results.append(filled)
-                        break
+
+                idx = pending.pop(tool_use_id, None)
+                if idx is not None and 0 <= idx < len(turn.tool_results):
+                    placeholder = turn.tool_results[idx]
+                    turn.tool_results[idx] = ToolResult(
+                        tool_name=placeholder.tool_name,
+                        content=content,
+                        is_error=is_error,
+                        error_message=content if is_error else None,
+                    )
                 else:
+                    # Result without a known tool_use predecessor (e.g. id
+                    # missing / out-of-order): append a best-effort record.
                     turn.tool_results.append(
                         ToolResult(
                             tool_name=tool_use_id or "unknown",
                             content=content,
                             is_error=is_error,
+                            error_message=content if is_error else None,
                         )
                     )
             return
@@ -533,9 +554,178 @@ def _default_followup_prompt(turn: TurnResult) -> str:
 
 
 __all__ = [
+    "ClaudeCodeSupervisedBackend",
     "ClaudeCodeSupervisor",
     "GoalEvaluation",
     "GoalEvaluator",
     "SupervisorResult",
     "TurnResult",
 ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Backend wrapper -- exposes the supervisor as a regular LLMBackend so it
+# can be selected via LLMBackendType.CLAUDE_CODE_SUPERVISED.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class ClaudeCodeSupervisedBackend(LLMBackend):
+    """LLMBackend adapter around ``ClaudeCodeSupervisor``.
+
+    Behaves like ``ClaudeCodeBackend`` for the caller (chat + list_models +
+    is_available + close) but each ``chat()`` call drives one or more
+    supervised turns. ``max_turns=1`` makes it functionally identical to
+    the plain Claude Code backend; higher values + a goal evaluator turn it
+    into an autonomous loop.
+
+    Streaming is supported on a coarse granularity: each turn's final
+    assistant text is yielded as a single chunk, prefixed with a separator
+    on multi-turn runs. Token-by-token streaming would require a different
+    transport than ``stream-json`` and is intentionally out of scope here.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str = "sonnet",
+        claude_path: str | None = None,
+        observer: ObserverAudit | None = None,
+        goal_evaluator: GoalEvaluator | None = None,
+        max_turns: int = 1,
+        max_duration_seconds: int = 1800,
+        max_cost_usd: float = 5.0,
+        per_turn_timeout_seconds: int = 600,
+        working_directory: str | None = None,
+        extra_cli_args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+    ) -> None:
+        self._model = model
+        self._claude_path = claude_path or shutil.which("claude") or "claude"
+        self._observer = observer
+        self._goal_evaluator = goal_evaluator
+        self._max_turns = max(1, max_turns)
+        self._max_duration_seconds = max_duration_seconds
+        self._max_cost_usd = max_cost_usd
+        self._per_turn_timeout_seconds = per_turn_timeout_seconds
+        self._working_directory = working_directory
+        self._extra_cli_args = list(extra_cli_args or [])
+        self._env = env
+
+    @property
+    def backend_type(self) -> LLMBackendType:
+        return LLMBackendType.CLAUDE_CODE_SUPERVISED
+
+    def _build_supervisor(self, model: str) -> ClaudeCodeSupervisor:
+        return ClaudeCodeSupervisor(
+            model=model or self._model,
+            claude_path=self._claude_path,
+            observer=self._observer,
+            goal_evaluator=self._goal_evaluator,
+            max_turns=self._max_turns,
+            max_duration_seconds=self._max_duration_seconds,
+            max_cost_usd=self._max_cost_usd,
+            per_turn_timeout_seconds=self._per_turn_timeout_seconds,
+            working_directory=self._working_directory,
+            extra_cli_args=self._extra_cli_args,
+            env=self._env,
+        )
+
+    @staticmethod
+    def _flatten_messages(messages: list[dict[str, Any]]) -> str:
+        parts: list[str] = []
+        for msg in messages:
+            role = str(msg.get("role", "user"))
+            content = msg.get("content", "")
+            if isinstance(content, list):
+                content = "\n".join(
+                    block.get("text", "")
+                    for block in content
+                    if isinstance(block, dict) and block.get("type") == "text"
+                )
+            if not isinstance(content, str):
+                content = str(content)
+            if role == "system":
+                parts.append(f"[Context]: {content}")
+            elif role == "assistant":
+                parts.append(f"[Previous response]: {content}")
+            else:
+                parts.append(content)
+        return "\n\n".join(p for p in parts if p)
+
+    async def chat(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        format_json: bool = False,
+    ) -> ChatResponse:
+        prompt = self._flatten_messages(messages)
+        supervisor = self._build_supervisor(model)
+        result = await supervisor.run(prompt)
+        if result.verdict == "abort" and not result.final_text:
+            raise LLMBackendError(
+                f"Supervised Claude Code aborted: {result.reason}",
+            )
+        return ChatResponse(
+            content=result.final_text,
+            model=(model or self._model),
+            usage=None,
+            raw={
+                "verdict": result.verdict,
+                "reason": result.reason,
+                "turns": [
+                    {
+                        "turn": t.turn,
+                        "cost_usd": t.cost_usd,
+                        "duration_ms": t.duration_ms,
+                        "tool_count": len(t.tool_results),
+                        "is_error": t.is_error,
+                    }
+                    for t in result.turns
+                ],
+                "total_cost_usd": result.total_cost_usd,
+                "total_duration_ms": result.total_duration_ms,
+            },
+        )
+
+    async def chat_stream(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        *,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+    ) -> AsyncIterator[str]:
+        # Coarse-grained streaming: yield each turn's final text. Stays
+        # within the LLMBackend contract without requiring token-level
+        # parsing of stream-json content blocks.
+        result = await self.chat(model, messages, temperature=temperature, top_p=top_p)
+        yield result.content
+
+    async def embed(self, model: str, text: str) -> EmbedResponse:
+        raise LLMBackendError(
+            "Claude Code (supervised) does not support embeddings. "
+            "Use Ollama or OpenAI for embedding fallback.",
+        )
+
+    async def is_available(self) -> bool:
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self._claude_path,
+                "--version",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            _, _ = await asyncio.wait_for(proc.communicate(), timeout=5)
+            return proc.returncode == 0
+        except Exception:
+            return False
+
+    async def list_models(self) -> list[str]:
+        return ["opus", "sonnet", "haiku"]
+
+    async def close(self) -> None:
+        return None

--- a/src/cognithor/core/claude_code_supervised.py
+++ b/src/cognithor/core/claude_code_supervised.py
@@ -414,9 +414,7 @@ class ClaudeCodeSupervisor:
                 turn.assistant_text = event["result"]
             return
 
-    async def _evaluate(
-        self, *, user_intent: str, turns: list[TurnResult]
-    ) -> GoalEvaluation:
+    async def _evaluate(self, *, user_intent: str, turns: list[TurnResult]) -> GoalEvaluation:
         if self._goal_evaluator is not None:
             try:
                 return await self._goal_evaluator(turns)
@@ -449,9 +447,7 @@ class ClaudeCodeSupervisor:
                     "The previous attempt was flagged by the Observer audit: "
                     f"{reasons}. Address the specific issues and retry."
                 )
-                return GoalEvaluation(
-                    verdict="continue", next_prompt=followup, reason=reasons
-                )
+                return GoalEvaluation(verdict="continue", next_prompt=followup, reason=reasons)
 
         return GoalEvaluation(verdict="done", reason="single-turn completion")
 
@@ -546,8 +542,7 @@ def _default_followup_prompt(turn: TurnResult) -> str:
         if errs:
             snippet = (errs[0].error_message or errs[0].content or "")[:240]
             return (
-                "The last turn produced an error: "
-                f"{snippet}\nFix it and continue toward the goal."
+                f"The last turn produced an error: {snippet}\nFix it and continue toward the goal."
             )
     return "Continue toward the goal. If you believe the goal is reached, state 'DONE'."
 

--- a/src/cognithor/core/claude_code_supervised.py
+++ b/src/cognithor/core/claude_code_supervised.py
@@ -38,6 +38,7 @@ the Observer. The caller's goal-evaluator then decides re-prompt vs halt.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import shutil
 import time
@@ -309,17 +310,15 @@ class ClaudeCodeSupervisor:
             ):
                 turn.raw_events.append(event)
                 self._absorb_event(turn, event, pending=pending)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             turn.is_error = True
             turn.error = f"turn exceeded per_turn_timeout_seconds={self._per_turn_timeout_seconds}"
-            try:
+            with contextlib.suppress(ProcessLookupError):
                 proc.kill()
-            except ProcessLookupError:
-                pass
 
         try:
             await asyncio.wait_for(proc.wait(), timeout=5.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             proc.kill()
             await proc.wait()
 
@@ -406,7 +405,7 @@ class ClaudeCodeSupervisor:
         if etype == "result":
             subtype = event.get("subtype", "")
             cost = event.get("total_cost_usd")
-            if isinstance(cost, (int, float)):
+            if isinstance(cost, int | float):
                 turn.cost_usd = float(cost)
             if subtype not in ("success",):
                 turn.is_error = True
@@ -487,10 +486,10 @@ async def _read_ndjson(
     while True:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            raise asyncio.TimeoutError()
+            raise TimeoutError()
         try:
             line = await asyncio.wait_for(stream.readline(), timeout=remaining)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             raise
         if not line:
             return

--- a/src/cognithor/core/llm_backend.py
+++ b/src/cognithor/core/llm_backend.py
@@ -43,6 +43,7 @@ class LLMBackendType(StrEnum):
     GEMINI = "gemini"
     LMSTUDIO = "lmstudio"
     CLAUDE_CODE = "claude-code"
+    CLAUDE_CODE_SUPERVISED = "claude-code-supervised"
     VLLM = "vllm"
 
 
@@ -1520,6 +1521,17 @@ def create_backend(config: CognithorConfig) -> LLMBackend:
             return ClaudeCodeBackend(
                 model=getattr(config.models.planner, "name", "sonnet"),
                 timeout=600,  # Claude Code needs more time for complex tasks
+            )
+        case "claude-code-supervised":
+            # Lazy import to avoid pulling the supervised module at top-level
+            # (it imports back from this module).
+            from cognithor.core.claude_code_supervised import (
+                ClaudeCodeSupervisedBackend,
+            )
+
+            return ClaudeCodeSupervisedBackend(
+                model=getattr(config.models.planner, "name", "sonnet"),
+                per_turn_timeout_seconds=600,
             )
         case _:
             return OllamaBackend(

--- a/src/cognithor/gateway/claude_code_hooks.py
+++ b/src/cognithor/gateway/claude_code_hooks.py
@@ -317,8 +317,10 @@ def create_claude_code_hooks_router(
             cc_decision = "deny"
             reason_override = None
 
-        reason = reason_override or decision.reason or (
-            f"Gatekeeper status={decision.status.value} risk={decision.risk_level.value}"
+        reason = (
+            reason_override
+            or decision.reason
+            or (f"Gatekeeper status={decision.status.value} risk={decision.risk_level.value}")
         )
 
         output: dict[str, Any] = {
@@ -422,17 +424,13 @@ def create_claude_code_hooks_router(
             tool_count=len(history),
         )
 
-        out: dict[str, Any] = {
-            "hookSpecificOutput": {"hookEventName": "Stop"}
-        }
+        out: dict[str, Any] = {"hookSpecificOutput": {"hookEventName": "Stop"}}
         if not audit.overall_passed and audit.retry_strategy in (
             "response_regen",
             "pge_reloop",
         ):
             failed_reasons = [
-                f"{dim.name}: {dim.reason}"
-                for dim in audit.dimensions.values()
-                if not dim.passed
+                f"{dim.name}: {dim.reason}" for dim in audit.dimensions.values() if not dim.passed
             ]
             reason = "; ".join(failed_reasons[:3]) or "observer flagged issues"
             out["decision"] = "block"

--- a/src/cognithor/gateway/claude_code_hooks.py
+++ b/src/cognithor/gateway/claude_code_hooks.py
@@ -1,0 +1,506 @@
+"""Claude Code hook bridge -- FastAPI router.
+
+Exposes HTTP endpoints that Claude Code's native ``"type": "http"`` hook
+system can POST to:
+
+    POST /api/claude-hooks/pre-tool-use   -> Gatekeeper   -> allow|deny|ask
+    POST /api/claude-hooks/post-tool-use  -> ToolHook + step check
+    POST /api/claude-hooks/stop           -> Observer audit over the turn
+    POST /api/claude-hooks/session-start  -> session bookkeeping
+    POST /api/claude-hooks/session-end    -> session cleanup
+    GET  /api/claude-hooks/health         -> bridge liveness
+
+Claude Code sends the same JSON payload it would pass to a command hook's
+stdin; we return the JSON the hook would print to stdout. Reference:
+https://code.claude.com/docs/en/hooks -- in particular the
+``hookSpecificOutput.permissionDecision`` contract for PreToolUse and the
+``decision: "block"`` / ``additionalContext`` pattern for Post/Stop.
+
+Design notes:
+- Fail-open: if the Gatekeeper / Observer is unavailable or raises, we return
+  "allow" with a reason rather than deadlocking the user's session.
+- SessionContext is kept in a per-process LRU so that iteration counters
+  persist across hook calls within the same Claude Code session.
+- Per-step Observer audit is intentionally cheap (exit-code / error string
+  heuristics). The full four-dimension Observer audit runs only on ``Stop``
+  because it issues an LLM call and is too expensive per tool.
+- ``GateStatus.APPROVE`` currently maps to ``"ask"``, delegating the
+  user-in-the-loop back to Claude Code's native prompt. A future iteration
+  can route APPROVE through ``ApprovalManager`` (Telegram/webhook) and
+  block the HTTP response until resolution.
+"""
+
+from __future__ import annotations
+
+import json as _json
+from collections import OrderedDict
+from typing import TYPE_CHECKING, Any, Literal
+
+from fastapi import APIRouter, FastAPI
+from pydantic import BaseModel, ConfigDict, Field
+
+from cognithor.models import (
+    GateStatus,
+    PlannedAction,
+    SessionContext,
+    ToolResult,
+)
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from cognithor.config import CognithorConfig
+    from cognithor.core.gatekeeper import Gatekeeper
+    from cognithor.core.observer import ObserverAudit
+    from cognithor.core.tool_hooks import ToolHookRunner
+
+log = get_logger(__name__)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Claude Code hook input schemas
+#
+# These mirror the stdin JSON documented at
+# https://code.claude.com/docs/en/hooks. We accept unknown fields so that
+# upstream additions (agent_id, new permission_mode values, etc.) do not
+# break the bridge.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _CCHookBase(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    session_id: str
+    transcript_path: str = ""
+    cwd: str = ""
+    permission_mode: str = "default"
+    hook_event_name: str
+
+
+class CCPreToolUseInput(_CCHookBase):
+    hook_event_name: Literal["PreToolUse"] = "PreToolUse"
+    tool_name: str
+    tool_input: dict[str, Any] = Field(default_factory=dict)
+    tool_use_id: str = ""
+
+
+class CCPostToolUseInput(_CCHookBase):
+    hook_event_name: Literal["PostToolUse"] = "PostToolUse"
+    tool_name: str
+    tool_input: dict[str, Any] = Field(default_factory=dict)
+    tool_response: Any = None
+    tool_use_id: str = ""
+    duration_ms: int = 0
+
+
+class CCStopInput(_CCHookBase):
+    hook_event_name: Literal["Stop"] = "Stop"
+
+
+class CCSessionStartInput(_CCHookBase):
+    hook_event_name: Literal["SessionStart"] = "SessionStart"
+    source: str = "startup"
+    model: str = ""
+
+
+class CCSessionEndInput(_CCHookBase):
+    hook_event_name: Literal["SessionEnd"] = "SessionEnd"
+    reason: str = "other"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Session bookkeeping
+#
+# Claude Code's session_id is opaque UUID-like text. We map it to a Cognithor
+# SessionContext so iteration counters, stalled-turn counts and _blocked_tools
+# accumulate naturally. The dict is bounded so runaway session ids cannot
+# leak memory on long-running daemons.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_MAX_TRACKED_SESSIONS = 256
+
+
+class _SessionTracker:
+    """Per-process LRU of Claude-Code-session → Cognithor state."""
+
+    def __init__(self, max_sessions: int = _MAX_TRACKED_SESSIONS) -> None:
+        self._max = max_sessions
+        self._contexts: OrderedDict[str, SessionContext] = OrderedDict()
+        self._tool_log: dict[str, list[ToolResult]] = {}
+        self._user_prompts: dict[str, str] = {}
+
+    def get_or_create(self, cc_session_id: str, cwd: str = "") -> SessionContext:
+        ctx = self._contexts.get(cc_session_id)
+        if ctx is None:
+            ctx = SessionContext(
+                session_id=cc_session_id,
+                user_id="claude-code",
+                channel="claude-code-hook",
+                agent_name="claude-code",
+            )
+            self._contexts[cc_session_id] = ctx
+            self._tool_log[cc_session_id] = []
+            self._user_prompts.setdefault(cc_session_id, "")
+            self._evict_if_needed()
+        else:
+            self._contexts.move_to_end(cc_session_id)
+        return ctx
+
+    def record_tool_result(self, cc_session_id: str, result: ToolResult) -> None:
+        self._tool_log.setdefault(cc_session_id, []).append(result)
+        # Keep only the last 64 results per session to bound memory.
+        history = self._tool_log[cc_session_id]
+        if len(history) > 64:
+            self._tool_log[cc_session_id] = history[-64:]
+
+    def tool_history(self, cc_session_id: str) -> list[ToolResult]:
+        return list(self._tool_log.get(cc_session_id, []))
+
+    def drop(self, cc_session_id: str) -> None:
+        self._contexts.pop(cc_session_id, None)
+        self._tool_log.pop(cc_session_id, None)
+        self._user_prompts.pop(cc_session_id, None)
+
+    def _evict_if_needed(self) -> None:
+        while len(self._contexts) > self._max:
+            old_id, _ = self._contexts.popitem(last=False)
+            self._tool_log.pop(old_id, None)
+            self._user_prompts.pop(old_id, None)
+            log.debug("claude_code_hooks_session_evicted", session_id=old_id)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step-level heuristic check (cheap, runs on every PostToolUse)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _detect_step_problem(
+    tool_name: str,
+    tool_input: dict[str, Any],
+    tool_response: Any,
+) -> str | None:
+    """Return a short warning string if the tool result looks problematic.
+
+    Heuristics only -- deliberately conservative. Full-quality auditing
+    happens in the Observer on ``Stop``.
+    """
+    if tool_response is None:
+        return None
+
+    if isinstance(tool_response, dict):
+        if tool_response.get("is_error") is True or tool_response.get("error"):
+            err = tool_response.get("error") or tool_response.get("error_message") or ""
+            return f"tool {tool_name!r} reported an error: {str(err)[:160]}"
+        # Claude Code often stores the textual result under "content" or "stdout".
+        text = (
+            tool_response.get("content")
+            or tool_response.get("stdout")
+            or tool_response.get("output")
+            or ""
+        )
+    elif isinstance(tool_response, str):
+        text = tool_response
+    else:
+        return None
+
+    if not isinstance(text, str) or not text:
+        return None
+
+    # Bash-style nonzero exit hint embedded in output.
+    lowered = text.lower()
+    if "command failed with exit code" in lowered or "exit code 1" in lowered:
+        return f"tool {tool_name!r} returned a non-zero exit code"
+    if tool_name == "Bash" and "permission denied" in lowered:
+        return "shell reported 'permission denied' -- verify the path is writable"
+    return None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Router factory
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def create_claude_code_hooks_router(
+    *,
+    gatekeeper: Gatekeeper | None,
+    observer: ObserverAudit | None,
+    hook_runner: ToolHookRunner | None = None,
+    config: CognithorConfig | None = None,
+    tracker: _SessionTracker | None = None,
+) -> APIRouter:
+    """Build the Claude Code hook bridge router.
+
+    All Cognithor collaborators are injected at creation time (same pattern as
+    ``create_kanban_router`` / ``create_evolution_router``). Any of them may be
+    ``None`` -- in that case the corresponding hook degrades to a pass-through.
+    """
+    router = APIRouter(prefix="/api/claude-hooks", tags=["claude-code-hooks"])
+    session_tracker = tracker or _SessionTracker()
+
+    @router.get("/health")
+    async def health() -> dict[str, Any]:
+        return {
+            "ok": True,
+            "gatekeeper": gatekeeper is not None,
+            "observer": observer is not None,
+            "hook_runner": hook_runner is not None,
+            "tracked_sessions": len(session_tracker._contexts),
+        }
+
+    @router.post("/pre-tool-use")
+    async def pre_tool_use(body: CCPreToolUseInput) -> dict[str, Any]:
+        # ``bypassPermissions`` mode means the user has explicitly opted out
+        # of guards for this session; defer to Claude Code's own handling.
+        if body.permission_mode == "bypassPermissions":
+            return _allow("bypassPermissions mode -- Cognithor deferring")
+
+        if gatekeeper is None:
+            return _allow("Cognithor Gatekeeper not wired -- allowing by default")
+
+        session = session_tracker.get_or_create(body.session_id, body.cwd)
+        action = PlannedAction(
+            tool=body.tool_name,
+            params=body.tool_input,
+            rationale=f"Claude Code PreToolUse (session {body.session_id[:8]})",
+        )
+
+        try:
+            decision = gatekeeper.evaluate(action, session)
+        except Exception as exc:  # fail-open
+            log.warning(
+                "claude_code_pre_tool_use_gatekeeper_error",
+                tool=body.tool_name,
+                error=str(exc),
+            )
+            return _allow(f"Gatekeeper raised -- failing open: {exc!s}")
+
+        log.info(
+            "claude_code_pre_tool_use",
+            tool=body.tool_name,
+            status=decision.status.value,
+            risk=decision.risk_level.value,
+            policy=decision.policy_name or None,
+            session=body.session_id[:8],
+        )
+
+        if decision.is_allowed:
+            cc_decision = "allow"
+        elif decision.needs_approval:
+            # TODO: route APPROVE through ApprovalManager (HITL) and block until resolved.
+            cc_decision = "ask"
+        else:
+            cc_decision = "deny"
+
+        reason = decision.reason or (
+            f"Gatekeeper status={decision.status.value} risk={decision.risk_level.value}"
+        )
+
+        output: dict[str, Any] = {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": cc_decision,
+            "permissionDecisionReason": reason,
+        }
+        # Credential masking is surfaced to Claude Code as ``updatedInput``.
+        if (
+            decision.status == GateStatus.MASK
+            and decision.masked_params is not None
+            and decision.masked_params != body.tool_input
+        ):
+            output["updatedInput"] = decision.masked_params
+
+        return {"hookSpecificOutput": output}
+
+    @router.post("/post-tool-use")
+    async def post_tool_use(body: CCPostToolUseInput) -> dict[str, Any]:
+        # Forward to Cognithor's own PostToolUse hook chain (secret redaction,
+        # audit log) so the two worlds share the same observability.
+        if hook_runner is not None:
+            try:
+                response_text = (
+                    body.tool_response
+                    if isinstance(body.tool_response, str)
+                    else _json.dumps(body.tool_response, default=str)
+                )
+                hook_runner.run_post_tool_use(
+                    body.tool_name,
+                    body.tool_input,
+                    response_text,
+                    body.duration_ms,
+                )
+            except Exception:
+                log.debug("claude_code_post_tool_hook_runner_failed", exc_info=True)
+
+        # Record into session tool history so Stop can audit the full turn.
+        warning = _detect_step_problem(body.tool_name, body.tool_input, body.tool_response)
+        is_error = warning is not None
+        response_text = (
+            body.tool_response
+            if isinstance(body.tool_response, str)
+            else _json.dumps(body.tool_response, default=str)[:4000]
+        )
+        result = ToolResult(
+            tool_name=body.tool_name,
+            content=response_text or "",
+            is_error=is_error,
+            error_message=warning,
+            duration_ms=body.duration_ms,
+        )
+        session_tracker.record_tool_result(body.session_id, result)
+
+        log.info(
+            "claude_code_post_tool_use",
+            tool=body.tool_name,
+            duration_ms=body.duration_ms,
+            warning=warning,
+            session=body.session_id[:8],
+        )
+
+        if warning:
+            return {
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "additionalContext": f"[Cognithor step-check] {warning}",
+                }
+            }
+        return {}
+
+    @router.post("/stop")
+    async def stop(body: CCStopInput) -> dict[str, Any]:
+        history = session_tracker.tool_history(body.session_id)
+
+        if observer is None or not history:
+            session_tracker.drop(body.session_id)
+            return {}
+
+        # Best-effort turn audit. Observer is fail-open; if it returns a
+        # non-pass verdict we surface ``additionalContext`` so Claude can see
+        # the issue, but we do NOT block Stop unless tool_ignorance or
+        # hallucination flag a retry strategy.
+        try:
+            audit = await observer.audit(
+                user_message="<claude-code-turn>",
+                response="<claude-code-final>",
+                tool_results=history,
+                session_id=body.session_id,
+            )
+        except Exception:
+            log.debug("claude_code_stop_observer_failed", exc_info=True)
+            session_tracker.drop(body.session_id)
+            return {}
+
+        log.info(
+            "claude_code_stop_audit",
+            passed=audit.overall_passed,
+            strategy=audit.retry_strategy,
+            session=body.session_id[:8],
+            tool_count=len(history),
+        )
+
+        out: dict[str, Any] = {
+            "hookSpecificOutput": {"hookEventName": "Stop"}
+        }
+        if not audit.overall_passed and audit.retry_strategy in (
+            "response_regen",
+            "pge_reloop",
+        ):
+            failed_reasons = [
+                f"{dim.name}: {dim.reason}"
+                for dim in audit.dimensions.values()
+                if not dim.passed
+            ]
+            reason = "; ".join(failed_reasons[:3]) or "observer flagged issues"
+            out["decision"] = "block"
+            out["reason"] = f"[Cognithor Observer] {reason}"
+
+        session_tracker.drop(body.session_id)
+        return out
+
+    @router.post("/session-start")
+    async def session_start(body: CCSessionStartInput) -> dict[str, Any]:
+        session_tracker.get_or_create(body.session_id, body.cwd)
+        log.info(
+            "claude_code_session_start",
+            session=body.session_id[:8],
+            source=body.source,
+            model=body.model,
+        )
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "SessionStart",
+                "additionalContext": (
+                    "Cognithor is supervising this Claude Code session: "
+                    "Gatekeeper gates tool calls, Observer audits on Stop."
+                ),
+            }
+        }
+
+    @router.post("/session-end")
+    async def session_end(body: CCSessionEndInput) -> dict[str, Any]:
+        session_tracker.drop(body.session_id)
+        log.info(
+            "claude_code_session_end",
+            session=body.session_id[:8],
+            reason=body.reason,
+        )
+        return {}
+
+    return router
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Standalone FastAPI app (for unit tests)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def build_claude_code_hooks_app(
+    *,
+    gatekeeper: Gatekeeper | None = None,
+    observer: ObserverAudit | None = None,
+    hook_runner: ToolHookRunner | None = None,
+    config: CognithorConfig | None = None,
+) -> FastAPI:
+    """Minimal FastAPI app exposing just the claude-code-hooks router.
+
+    Mirrors ``build_backends_app`` style -- intended for tests and for
+    embedding in a dedicated hooks-only daemon if desired.
+    """
+    app = FastAPI(title="Cognithor Claude Code Hook Bridge")
+    app.state.config = config
+    app.state.gatekeeper = gatekeeper
+    app.state.observer = observer
+    app.state.hook_runner = hook_runner
+    app.include_router(
+        create_claude_code_hooks_router(
+            gatekeeper=gatekeeper,
+            observer=observer,
+            hook_runner=hook_runner,
+            config=config,
+        )
+    )
+    return app
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _allow(reason: str) -> dict[str, Any]:
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "allow",
+            "permissionDecisionReason": reason,
+        }
+    }
+
+
+__all__ = [
+    "CCPreToolUseInput",
+    "CCPostToolUseInput",
+    "CCStopInput",
+    "CCSessionStartInput",
+    "CCSessionEndInput",
+    "build_claude_code_hooks_app",
+    "create_claude_code_hooks_router",
+]

--- a/src/cognithor/gateway/claude_code_hooks.py
+++ b/src/cognithor/gateway/claude_code_hooks.py
@@ -626,15 +626,16 @@ async def _route_approval(
         reason = "HITL rejected" + (f": {comment}" if comment else "")
         return "deny", reason
     # TIMED_OUT, ESCALATED, CANCELED, DELEGATED, PENDING -> safe default
-    return "deny", f"HITL unresolved (status={getattr(status, 'value', str(status))}) -- denying for safety"
+    status_repr = getattr(status, "value", str(status))
+    return "deny", f"HITL unresolved (status={status_repr}) -- denying for safety"
 
 
 __all__ = [
-    "CCPreToolUseInput",
     "CCPostToolUseInput",
-    "CCStopInput",
-    "CCSessionStartInput",
+    "CCPreToolUseInput",
     "CCSessionEndInput",
+    "CCSessionStartInput",
+    "CCStopInput",
     "build_claude_code_hooks_app",
     "create_claude_code_hooks_router",
 ]

--- a/src/cognithor/gateway/claude_code_hooks.py
+++ b/src/cognithor/gateway/claude_code_hooks.py
@@ -24,10 +24,16 @@ Design notes:
 - Per-step Observer audit is intentionally cheap (exit-code / error string
   heuristics). The full four-dimension Observer audit runs only on ``Stop``
   because it issues an LLM call and is too expensive per tool.
-- ``GateStatus.APPROVE`` currently maps to ``"ask"``, delegating the
-  user-in-the-loop back to Claude Code's native prompt. A future iteration
-  can route APPROVE through ``ApprovalManager`` (Telegram/webhook) and
-  block the HTTP response until resolution.
+- ``GateStatus.APPROVE`` is routed through ``ApprovalManager`` when one is
+  wired: the bridge creates a HITL request with an ``AUTO_REJECT``
+  escalation policy and awaits resolution within a short timeout (default
+  25s, under Claude Code's typical 30s hook timeout). Mapping:
+  APPROVED→allow, REJECTED→deny (this is also the path taken when the
+  approver does not respond before the timeout, since AUTO_REJECT turns
+  silence into a rejection). All other terminal states (TIMED_OUT after
+  max_escalations, ESCALATED, CANCELED, DELEGATED, still-PENDING) are
+  treated as "deny for safety". If no manager is available, the bridge
+  falls back to Claude Code's native ``"ask"``.
 """
 
 from __future__ import annotations
@@ -52,8 +58,15 @@ if TYPE_CHECKING:
     from cognithor.core.gatekeeper import Gatekeeper
     from cognithor.core.observer import ObserverAudit
     from cognithor.core.tool_hooks import ToolHookRunner
+    from cognithor.hitl.manager import ApprovalManager
 
 log = get_logger(__name__)
+
+
+# Default HITL timeout (seconds). Kept under typical Claude Code hook
+# timeouts (30s for HTTP) so the bridge response always wins. Override per
+# router via ``hitl_timeout_seconds``.
+DEFAULT_HITL_TIMEOUT_SECONDS = 25.0
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -225,8 +238,10 @@ def create_claude_code_hooks_router(
     gatekeeper: Gatekeeper | None,
     observer: ObserverAudit | None,
     hook_runner: ToolHookRunner | None = None,
+    approval_manager: ApprovalManager | None = None,
     config: CognithorConfig | None = None,
     tracker: _SessionTracker | None = None,
+    hitl_timeout_seconds: float = DEFAULT_HITL_TIMEOUT_SECONDS,
 ) -> APIRouter:
     """Build the Claude Code hook bridge router.
 
@@ -244,6 +259,8 @@ def create_claude_code_hooks_router(
             "gatekeeper": gatekeeper is not None,
             "observer": observer is not None,
             "hook_runner": hook_runner is not None,
+            "approval_manager": approval_manager is not None,
+            "hitl_timeout_seconds": hitl_timeout_seconds,
             "tracked_sessions": len(session_tracker._contexts),
         }
 
@@ -285,13 +302,22 @@ def create_claude_code_hooks_router(
 
         if decision.is_allowed:
             cc_decision = "allow"
+            reason_override: str | None = None
         elif decision.needs_approval:
-            # TODO: route APPROVE through ApprovalManager (HITL) and block until resolved.
-            cc_decision = "ask"
+            cc_decision, reason_override = await _route_approval(
+                approval_manager=approval_manager,
+                decision=decision,
+                tool_name=body.tool_name,
+                tool_input=body.tool_input,
+                session_id=body.session_id,
+                cwd=body.cwd,
+                timeout_seconds=hitl_timeout_seconds,
+            )
         else:
             cc_decision = "deny"
+            reason_override = None
 
-        reason = decision.reason or (
+        reason = reason_override or decision.reason or (
             f"Gatekeeper status={decision.status.value} risk={decision.risk_level.value}"
         )
 
@@ -457,7 +483,9 @@ def build_claude_code_hooks_app(
     gatekeeper: Gatekeeper | None = None,
     observer: ObserverAudit | None = None,
     hook_runner: ToolHookRunner | None = None,
+    approval_manager: ApprovalManager | None = None,
     config: CognithorConfig | None = None,
+    hitl_timeout_seconds: float = DEFAULT_HITL_TIMEOUT_SECONDS,
 ) -> FastAPI:
     """Minimal FastAPI app exposing just the claude-code-hooks router.
 
@@ -469,12 +497,15 @@ def build_claude_code_hooks_app(
     app.state.gatekeeper = gatekeeper
     app.state.observer = observer
     app.state.hook_runner = hook_runner
+    app.state.approval_manager = approval_manager
     app.include_router(
         create_claude_code_hooks_router(
             gatekeeper=gatekeeper,
             observer=observer,
             hook_runner=hook_runner,
+            approval_manager=approval_manager,
             config=config,
+            hitl_timeout_seconds=hitl_timeout_seconds,
         )
     )
     return app
@@ -493,6 +524,109 @@ def _allow(reason: str) -> dict[str, Any]:
             "permissionDecisionReason": reason,
         }
     }
+
+
+async def _route_approval(
+    *,
+    approval_manager: ApprovalManager | None,
+    decision: Any,
+    tool_name: str,
+    tool_input: dict[str, Any],
+    session_id: str,
+    cwd: str,
+    timeout_seconds: float,
+) -> tuple[str, str | None]:
+    """Route a Gatekeeper APPROVE through HITL.
+
+    Returns ``(cc_decision, reason_override_or_None)``. Falls back to
+    ``"ask"`` if no manager is wired or HITL itself errors.
+    """
+    if approval_manager is None:
+        return "ask", None
+
+    # Lazy import: HITL types are only needed when an approval is actually
+    # requested, and avoids circulars at module load time.
+    try:
+        from cognithor.hitl.types import (
+            ApprovalStatus,
+            EscalationAction,
+            EscalationPolicy,
+            HITLConfig,
+            HITLNodeKind,
+            ReviewPriority,
+        )
+    except Exception:
+        log.debug("claude_code_hitl_import_failed", exc_info=True)
+        return "ask", None
+
+    risk_value = getattr(getattr(decision, "risk_level", None), "value", "unknown")
+    cfg = HITLConfig(
+        node_kind=HITLNodeKind.APPROVAL,
+        title=f"Claude Code: {tool_name}",
+        description=(decision.reason or f"Gatekeeper risk={risk_value}")[:500],
+        priority=(
+            ReviewPriority.HIGH if risk_value in ("orange", "red") else ReviewPriority.NORMAL
+        ),
+        escalation=EscalationPolicy(
+            timeout_seconds=int(max(1.0, timeout_seconds)),
+            action=EscalationAction.AUTO_REJECT,
+        ),
+    )
+
+    try:
+        request = await approval_manager.create_request(
+            execution_id=f"claude-code:{session_id[:12]}",
+            graph_name="claude-code-hooks",
+            node_name="pre-tool-use",
+            config=cfg,
+            context={
+                "tool_name": tool_name,
+                "tool_input": tool_input,
+                "session_id": session_id,
+                "cwd": cwd,
+                "risk_level": risk_value,
+                "policy": getattr(decision, "policy_name", "") or "",
+                "gatekeeper_reason": decision.reason or "",
+            },
+        )
+    except Exception as exc:
+        log.warning("claude_code_hitl_create_failed", error=str(exc))
+        return "ask", None
+
+    try:
+        task = await approval_manager.wait_for_resolution(
+            request.request_id, timeout=timeout_seconds
+        )
+    except Exception as exc:
+        log.warning("claude_code_hitl_wait_failed", error=str(exc))
+        return "deny", f"HITL wait error -- denying for safety: {exc!s}"
+
+    if task is None:
+        return "deny", "HITL request not found -- denying for safety"
+
+    status = task.request.status
+    log.info(
+        "claude_code_hitl_resolved",
+        request=request.request_id,
+        status=getattr(status, "value", str(status)),
+        tool=tool_name,
+        session=session_id[:8],
+    )
+
+    if status == ApprovalStatus.APPROVED:
+        comment = ""
+        if task.responses:
+            comment = task.responses[-1].comment or ""
+        reason = "HITL approved" + (f": {comment}" if comment else "")
+        return "allow", reason
+    if status == ApprovalStatus.REJECTED:
+        comment = ""
+        if task.responses:
+            comment = task.responses[-1].comment or ""
+        reason = "HITL rejected" + (f": {comment}" if comment else "")
+        return "deny", reason
+    # TIMED_OUT, ESCALATED, CANCELED, DELEGATED, PENDING -> safe default
+    return "deny", f"HITL unresolved (status={getattr(status, 'value', str(status))}) -- denying for safety"
 
 
 __all__ = [

--- a/tests/test_core/test_claude_code_supervised.py
+++ b/tests/test_core/test_claude_code_supervised.py
@@ -15,10 +15,12 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from cognithor.core.claude_code_supervised import (
+    ClaudeCodeSupervisedBackend,
     ClaudeCodeSupervisor,
     GoalEvaluation,
     SupervisorResult,
 )
+from cognithor.core.llm_backend import ChatResponse, LLMBackendError, LLMBackendType
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -254,3 +256,167 @@ class TestClaudeMissing:
         assert len(result.turns) == 1
         assert result.turns[0].is_error is True
         assert "claude CLI not found" in (result.turns[0].error or "")
+
+
+class TestParallelToolPairing:
+    @pytest.mark.asyncio
+    async def test_parallel_tool_use_paired_by_id(self):
+        """Two tool_use blocks issued in parallel must each receive their
+        own tool_result by id, not by ordering heuristic."""
+        events = [
+            {"type": "system", "subtype": "init", "session_id": "s", "cwd": "/w"},
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tu_a",
+                            "name": "Read",
+                            "input": {"path": "a.txt"},
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": "tu_b",
+                            "name": "Read",
+                            "input": {"path": "b.txt"},
+                        },
+                    ],
+                },
+            },
+            # Results come back out-of-order on purpose: tu_b before tu_a.
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "tu_b", "content": "B-content"},
+                    ],
+                },
+            },
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "tu_a", "content": "A-content"},
+                    ],
+                },
+            },
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "both read"}]},
+            },
+            {
+                "type": "result",
+                "subtype": "success",
+                "total_cost_usd": 0.0,
+                "result": "both read",
+                "is_error": False,
+            },
+        ]
+        proc = _FakeProc(events)
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            sup = ClaudeCodeSupervisor(
+                claude_path="claude",
+                goal_evaluator=AsyncMock(return_value=GoalEvaluation(verdict="done")),
+            )
+            result = await sup.run("read both")
+
+        assert result.verdict == "done"
+        results = result.turns[0].tool_results
+        assert len(results) == 2
+        # Order preserved from tool_use emission (tu_a first), but content
+        # is paired by id, not by arrival order of tool_result blocks.
+        assert results[0].tool_name == "Read" and results[0].content == "A-content"
+        assert results[1].tool_name == "Read" and results[1].content == "B-content"
+
+    @pytest.mark.asyncio
+    async def test_tool_result_without_matching_id_appended_best_effort(self):
+        events = [
+            {"type": "system", "subtype": "init", "session_id": "s", "cwd": "/w"},
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {"type": "tool_result", "tool_use_id": "orphan", "content": "lost"},
+                    ],
+                },
+            },
+            {
+                "type": "assistant",
+                "message": {"content": [{"type": "text", "text": "ok"}]},
+            },
+            {"type": "result", "subtype": "success", "total_cost_usd": 0.0, "result": "ok", "is_error": False},
+        ]
+        proc = _FakeProc(events)
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            sup = ClaudeCodeSupervisor(
+                claude_path="claude",
+                goal_evaluator=AsyncMock(return_value=GoalEvaluation(verdict="done")),
+            )
+            result = await sup.run("orphan")
+        results = result.turns[0].tool_results
+        assert len(results) == 1
+        assert results[0].tool_name == "orphan"
+        assert results[0].content == "lost"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ClaudeCodeSupervisedBackend (LLMBackend wrapper)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSupervisedBackend:
+    def test_backend_type(self):
+        b = ClaudeCodeSupervisedBackend()
+        assert b.backend_type == LLMBackendType.CLAUDE_CODE_SUPERVISED
+
+    @pytest.mark.asyncio
+    async def test_list_models(self):
+        b = ClaudeCodeSupervisedBackend()
+        assert "sonnet" in await b.list_models()
+
+    @pytest.mark.asyncio
+    async def test_chat_runs_one_supervised_turn(self):
+        proc = _FakeProc(_script_events(text="hi-from-supervisor", cost=0.005))
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            b = ClaudeCodeSupervisedBackend(claude_path="claude")
+            resp = await b.chat("sonnet", [{"role": "user", "content": "hi"}])
+        assert isinstance(resp, ChatResponse)
+        assert resp.content == "hi-from-supervisor"
+        assert resp.model == "sonnet"
+        assert resp.raw is not None
+        assert resp.raw["verdict"] == "done"
+        assert resp.raw["total_cost_usd"] == pytest.approx(0.005)
+
+    @pytest.mark.asyncio
+    async def test_chat_flattens_system_and_assistant_messages(self):
+        proc = _FakeProc(_script_events(text="ok"))
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            b = ClaudeCodeSupervisedBackend(claude_path="claude")
+            await b.chat(
+                "sonnet",
+                [
+                    {"role": "system", "content": "be terse"},
+                    {"role": "user", "content": "hi"},
+                    {"role": "assistant", "content": "yes?"},
+                    {"role": "user", "content": "do x"},
+                ],
+            )
+        # The flattened prompt should have appeared in the user-frame written to stdin.
+        sent = b"".join(proc.stdin.buffer).decode()
+        assert "[Context]: be terse" in sent
+        assert "[Previous response]: yes?" in sent
+        assert "do x" in sent
+
+    @pytest.mark.asyncio
+    async def test_chat_aborted_without_text_raises_backend_error(self):
+        with patch("asyncio.create_subprocess_exec", AsyncMock(side_effect=FileNotFoundError())):
+            b = ClaudeCodeSupervisedBackend(claude_path="missing")
+            with pytest.raises(LLMBackendError):
+                await b.chat("sonnet", [{"role": "user", "content": "x"}])
+
+    @pytest.mark.asyncio
+    async def test_embed_raises(self):
+        b = ClaudeCodeSupervisedBackend()
+        with pytest.raises(LLMBackendError):
+            await b.embed("any", "text")

--- a/tests/test_core/test_claude_code_supervised.py
+++ b/tests/test_core/test_claude_code_supervised.py
@@ -197,9 +197,7 @@ class TestBudgets:
 
     @pytest.mark.asyncio
     async def test_max_cost_enforced(self):
-        proc_factory = AsyncMock(
-            side_effect=lambda *a, **kw: _FakeProc(_script_events(cost=10.0))
-        )
+        proc_factory = AsyncMock(side_effect=lambda *a, **kw: _FakeProc(_script_events(cost=10.0)))
         with patch("asyncio.create_subprocess_exec", proc_factory):
             sup = ClaudeCodeSupervisor(
                 claude_path="claude",
@@ -221,9 +219,7 @@ class TestEvaluatorVerdicts:
         proc = _FakeProc(_script_events(text="first"))
         with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
             evaluator = AsyncMock(return_value=GoalEvaluation(verdict="done", reason="satisfied"))
-            sup = ClaudeCodeSupervisor(
-                claude_path="claude", goal_evaluator=evaluator, max_turns=5
-            )
+            sup = ClaudeCodeSupervisor(claude_path="claude", goal_evaluator=evaluator, max_turns=5)
             result = await sup.run("query")
 
         assert result.verdict == "done"

--- a/tests/test_core/test_claude_code_supervised.py
+++ b/tests/test_core/test_claude_code_supervised.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import json
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -21,7 +21,6 @@ from cognithor.core.claude_code_supervised import (
     SupervisorResult,
 )
 from cognithor.core.llm_backend import ChatResponse, LLMBackendError, LLMBackendType
-
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Fake subprocess plumbing
@@ -119,7 +118,13 @@ def _script_events_with_tool(
             "type": "assistant",
             "message": {"content": [{"type": "text", "text": text}]},
         },
-        {"type": "result", "subtype": "success", "total_cost_usd": 0.02, "result": text, "is_error": False},
+        {
+            "type": "result",
+            "subtype": "success",
+            "total_cost_usd": 0.02,
+            "result": text,
+            "is_error": False,
+        },
     ]
 
 
@@ -345,7 +350,13 @@ class TestParallelToolPairing:
                 "type": "assistant",
                 "message": {"content": [{"type": "text", "text": "ok"}]},
             },
-            {"type": "result", "subtype": "success", "total_cost_usd": 0.0, "result": "ok", "is_error": False},
+            {
+                "type": "result",
+                "subtype": "success",
+                "total_cost_usd": 0.0,
+                "result": "ok",
+                "is_error": False,
+            },
         ]
         proc = _FakeProc(events)
         with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):

--- a/tests/test_core/test_claude_code_supervised.py
+++ b/tests/test_core/test_claude_code_supervised.py
@@ -1,0 +1,256 @@
+"""Tests for the ClaudeCodeSupervisor autonomous loop driver.
+
+Mocks ``asyncio.create_subprocess_exec`` to return a fake process whose
+stdout yields a scripted NDJSON event stream. We do not actually spawn the
+real ``claude`` CLI.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cognithor.core.claude_code_supervised import (
+    ClaudeCodeSupervisor,
+    GoalEvaluation,
+    SupervisorResult,
+)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fake subprocess plumbing
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class _FakeStdout:
+    """Async stream that yields scripted NDJSON lines, then EOF."""
+
+    def __init__(self, events: list[dict[str, Any]]) -> None:
+        self._queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+        for event in events:
+            self._queue.put_nowait((json.dumps(event) + "\n").encode("utf-8"))
+        self._queue.put_nowait(b"")  # EOF
+
+    async def readline(self) -> bytes:
+        line = await self._queue.get()
+        return line
+
+
+class _FakeStdin:
+    def __init__(self) -> None:
+        self.buffer: list[bytes] = []
+        self._closed = False
+
+    def write(self, data: bytes) -> None:
+        self.buffer.append(data)
+
+    async def drain(self) -> None:
+        return None
+
+    def close(self) -> None:
+        self._closed = True
+
+
+class _FakeProc:
+    def __init__(self, events: list[dict[str, Any]], *, returncode: int = 0) -> None:
+        self.stdin = _FakeStdin()
+        self.stdout = _FakeStdout(events)
+        self.stderr = _FakeStdout([])  # never produces output in tests
+        self.returncode = returncode
+        self._wait = asyncio.Event()
+        self._wait.set()
+
+    async def wait(self) -> int:
+        await self._wait.wait()
+        return self.returncode
+
+    def kill(self) -> None:
+        self.returncode = -9
+        self._wait.set()
+
+
+def _script_events(
+    *, session_id: str = "sess-xyz", text: str = "done", cost: float = 0.01
+) -> list[dict[str, Any]]:
+    return [
+        {"type": "system", "subtype": "init", "session_id": session_id, "cwd": "/w"},
+        {
+            "type": "assistant",
+            "message": {"role": "assistant", "content": [{"type": "text", "text": text}]},
+        },
+        {
+            "type": "result",
+            "subtype": "success",
+            "total_cost_usd": cost,
+            "result": text,
+            "is_error": False,
+        },
+    ]
+
+
+def _script_events_with_tool(
+    *, session_id: str = "sess-tool", text: str = "finished"
+) -> list[dict[str, Any]]:
+    return [
+        {"type": "system", "subtype": "init", "session_id": session_id, "cwd": "/w"},
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "id": "tu_1", "name": "Bash", "input": {"command": "ls"}},
+                ],
+            },
+        },
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu_1", "content": "file1\nfile2"},
+                ],
+            },
+        },
+        {
+            "type": "assistant",
+            "message": {"content": [{"type": "text", "text": text}]},
+        },
+        {"type": "result", "subtype": "success", "total_cost_usd": 0.02, "result": text, "is_error": False},
+    ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSingleTurn:
+    @pytest.mark.asyncio
+    async def test_single_turn_success(self):
+        proc = _FakeProc(_script_events(text="hello"))
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            sup = ClaudeCodeSupervisor(
+                claude_path="claude",
+                goal_evaluator=AsyncMock(return_value=GoalEvaluation(verdict="done")),
+            )
+            result = await sup.run("do the thing")
+
+        assert isinstance(result, SupervisorResult)
+        assert result.verdict == "done"
+        assert result.final_text == "hello"
+        assert len(result.turns) == 1
+        turn = result.turns[0]
+        assert turn.session_id == "sess-xyz"
+        assert turn.cost_usd == pytest.approx(0.01)
+        assert turn.is_error is False
+        # Stdin should have received one user frame.
+        assert len(proc.stdin.buffer) == 1
+        frame = json.loads(proc.stdin.buffer[0].decode())
+        assert frame["type"] == "user"
+        assert frame["message"]["content"] == "do the thing"
+
+    @pytest.mark.asyncio
+    async def test_tool_use_and_result_are_paired(self):
+        proc = _FakeProc(_script_events_with_tool(text="finished"))
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            sup = ClaudeCodeSupervisor(
+                claude_path="claude",
+                goal_evaluator=AsyncMock(return_value=GoalEvaluation(verdict="done")),
+            )
+            result = await sup.run("ls the dir")
+
+        assert result.verdict == "done"
+        turn = result.turns[0]
+        assert len(turn.tool_results) == 1
+        tr = turn.tool_results[0]
+        assert tr.tool_name == "Bash"
+        assert "file1" in tr.content
+        assert tr.is_error is False
+
+
+class TestBudgets:
+    @pytest.mark.asyncio
+    async def test_max_turns_enforced(self):
+        proc_factory = AsyncMock(side_effect=lambda *a, **kw: _FakeProc(_script_events()))
+        with patch("asyncio.create_subprocess_exec", proc_factory):
+            sup = ClaudeCodeSupervisor(
+                claude_path="claude",
+                max_turns=2,
+                goal_evaluator=AsyncMock(
+                    return_value=GoalEvaluation(verdict="continue", next_prompt="again")
+                ),
+            )
+            result = await sup.run("never-ending")
+
+        assert result.verdict == "abort"
+        assert "max_turns" in result.reason
+        assert len(result.turns) == 2
+
+    @pytest.mark.asyncio
+    async def test_max_cost_enforced(self):
+        proc_factory = AsyncMock(
+            side_effect=lambda *a, **kw: _FakeProc(_script_events(cost=10.0))
+        )
+        with patch("asyncio.create_subprocess_exec", proc_factory):
+            sup = ClaudeCodeSupervisor(
+                claude_path="claude",
+                max_turns=10,
+                max_cost_usd=1.0,
+                goal_evaluator=AsyncMock(
+                    return_value=GoalEvaluation(verdict="continue", next_prompt="again")
+                ),
+            )
+            result = await sup.run("pricey")
+
+        assert result.verdict == "abort"
+        assert "max_cost" in result.reason
+
+
+class TestEvaluatorVerdicts:
+    @pytest.mark.asyncio
+    async def test_done_stops_immediately(self):
+        proc = _FakeProc(_script_events(text="first"))
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            evaluator = AsyncMock(return_value=GoalEvaluation(verdict="done", reason="satisfied"))
+            sup = ClaudeCodeSupervisor(
+                claude_path="claude", goal_evaluator=evaluator, max_turns=5
+            )
+            result = await sup.run("query")
+
+        assert result.verdict == "done"
+        assert result.reason == "satisfied"
+        assert len(result.turns) == 1
+        evaluator.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_abort_stops_and_propagates_reason(self):
+        proc = _FakeProc(_script_events())
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            sup = ClaudeCodeSupervisor(
+                claude_path="claude",
+                goal_evaluator=AsyncMock(
+                    return_value=GoalEvaluation(verdict="abort", reason="policy failure")
+                ),
+            )
+            result = await sup.run("q")
+
+        assert result.verdict == "abort"
+        assert result.reason == "policy failure"
+
+
+class TestClaudeMissing:
+    @pytest.mark.asyncio
+    async def test_file_not_found_returns_error_turn(self):
+        with patch("asyncio.create_subprocess_exec", AsyncMock(side_effect=FileNotFoundError())):
+            sup = ClaudeCodeSupervisor(
+                claude_path="claude-nope",
+                goal_evaluator=AsyncMock(return_value=GoalEvaluation(verdict="done")),
+            )
+            result = await sup.run("q")
+
+        assert result.verdict == "abort"
+        assert len(result.turns) == 1
+        assert result.turns[0].is_error is True
+        assert "claude CLI not found" in (result.turns[0].error or "")

--- a/tests/test_gateway/test_claude_code_hooks.py
+++ b/tests/test_gateway/test_claude_code_hooks.py
@@ -7,12 +7,14 @@ mocked Gatekeeper / Observer / ToolHookRunner collaborators.
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from dataclasses import dataclass, field
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
 
 from cognithor.gateway.claude_code_hooks import build_claude_code_hooks_app
+from cognithor.hitl.types import ApprovalResponse, ApprovalStatus
 from cognithor.models import GateDecision, GateStatus, PlannedAction, RiskLevel
 
 
@@ -296,3 +298,117 @@ class TestHealth:
         assert data["ok"] is True
         assert data["gatekeeper"] is True
         assert data["observer"] is False
+        assert data["approval_manager"] is False
+        assert "hitl_timeout_seconds" in data
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# APPROVE → HITL routing
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@dataclass
+class _StubRequest:
+    request_id: str = "apr_stub"
+    status: ApprovalStatus = ApprovalStatus.PENDING
+
+
+@dataclass
+class _StubTask:
+    request: _StubRequest = field(default_factory=_StubRequest)
+    responses: list[ApprovalResponse] = field(default_factory=list)
+
+
+def _make_approval_manager(*, final_status: ApprovalStatus, comment: str = "") -> MagicMock:
+    """Build an ApprovalManager mock that resolves to the given final status."""
+    mgr = MagicMock()
+    request = _StubRequest(request_id="apr_test")
+    mgr.create_request = AsyncMock(return_value=request)
+
+    task = _StubTask(request=_StubRequest(request_id="apr_test", status=final_status))
+    if comment:
+        task.responses.append(
+            ApprovalResponse(decision=final_status, reviewer="tester", comment=comment)
+        )
+    mgr.wait_for_resolution = AsyncMock(return_value=task)
+    return mgr
+
+
+class TestApproveRouting:
+    def test_approved_status_maps_to_allow(self, gatekeeper_approving):
+        mgr = _make_approval_manager(
+            final_status=ApprovalStatus.APPROVED, comment="ok by reviewer"
+        )
+        app = build_claude_code_hooks_app(
+            gatekeeper=gatekeeper_approving, approval_manager=mgr
+        )
+        client = TestClient(app)
+        r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+        out = r.json()["hookSpecificOutput"]
+        assert out["permissionDecision"] == "allow"
+        assert "HITL approved" in out["permissionDecisionReason"]
+        assert "ok by reviewer" in out["permissionDecisionReason"]
+        mgr.create_request.assert_awaited_once()
+        mgr.wait_for_resolution.assert_awaited_once()
+
+    def test_rejected_status_maps_to_deny(self, gatekeeper_approving):
+        mgr = _make_approval_manager(
+            final_status=ApprovalStatus.REJECTED, comment="too risky"
+        )
+        app = build_claude_code_hooks_app(
+            gatekeeper=gatekeeper_approving, approval_manager=mgr
+        )
+        client = TestClient(app)
+        r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+        out = r.json()["hookSpecificOutput"]
+        assert out["permissionDecision"] == "deny"
+        assert "HITL rejected" in out["permissionDecisionReason"]
+        assert "too risky" in out["permissionDecisionReason"]
+
+    def test_timed_out_status_denies_for_safety(self, gatekeeper_approving):
+        mgr = _make_approval_manager(final_status=ApprovalStatus.TIMED_OUT)
+        app = build_claude_code_hooks_app(
+            gatekeeper=gatekeeper_approving, approval_manager=mgr
+        )
+        client = TestClient(app)
+        r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+        out = r.json()["hookSpecificOutput"]
+        assert out["permissionDecision"] == "deny"
+        assert "unresolved" in out["permissionDecisionReason"]
+
+    def test_no_approval_manager_falls_back_to_ask(self, gatekeeper_approving):
+        app = build_claude_code_hooks_app(
+            gatekeeper=gatekeeper_approving, approval_manager=None
+        )
+        client = TestClient(app)
+        r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+        out = r.json()["hookSpecificOutput"]
+        assert out["permissionDecision"] == "ask"
+
+    def test_approval_manager_create_failure_falls_back_to_ask(
+        self, gatekeeper_approving
+    ):
+        mgr = MagicMock()
+        mgr.create_request = AsyncMock(side_effect=RuntimeError("notifier offline"))
+        app = build_claude_code_hooks_app(
+            gatekeeper=gatekeeper_approving, approval_manager=mgr
+        )
+        client = TestClient(app)
+        r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+        out = r.json()["hookSpecificOutput"]
+        assert out["permissionDecision"] == "ask"
+
+    def test_approval_manager_wait_failure_denies_for_safety(
+        self, gatekeeper_approving
+    ):
+        mgr = MagicMock()
+        mgr.create_request = AsyncMock(return_value=_StubRequest(request_id="apr_x"))
+        mgr.wait_for_resolution = AsyncMock(side_effect=RuntimeError("event loop dead"))
+        app = build_claude_code_hooks_app(
+            gatekeeper=gatekeeper_approving, approval_manager=mgr
+        )
+        client = TestClient(app)
+        r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+        out = r.json()["hookSpecificOutput"]
+        assert out["permissionDecision"] == "deny"
+        assert "wait error" in out["permissionDecisionReason"]

--- a/tests/test_gateway/test_claude_code_hooks.py
+++ b/tests/test_gateway/test_claude_code_hooks.py
@@ -17,7 +17,6 @@ from cognithor.gateway.claude_code_hooks import build_claude_code_hooks_app
 from cognithor.hitl.types import ApprovalResponse, ApprovalStatus
 from cognithor.models import GateDecision, GateStatus, PlannedAction, RiskLevel
 
-
 # ─────────────────────────────────────────────────────────────────────────────
 # Fixtures
 # ─────────────────────────────────────────────────────────────────────────────

--- a/tests/test_gateway/test_claude_code_hooks.py
+++ b/tests/test_gateway/test_claude_code_hooks.py
@@ -1,0 +1,298 @@
+"""Tests for the Claude Code hook bridge router.
+
+Uses the standalone ``build_claude_code_hooks_app`` factory (mirrors
+``build_backends_app`` style) so we exercise the router in isolation with
+mocked Gatekeeper / Observer / ToolHookRunner collaborators.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+
+from cognithor.gateway.claude_code_hooks import build_claude_code_hooks_app
+from cognithor.models import GateDecision, GateStatus, PlannedAction, RiskLevel
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _make_decision(
+    *,
+    status: GateStatus,
+    risk: RiskLevel = RiskLevel.GREEN,
+    reason: str = "",
+    masked_params: dict | None = None,
+) -> GateDecision:
+    return GateDecision(
+        status=status,
+        risk_level=risk,
+        reason=reason,
+        policy_name="test",
+        original_action=PlannedAction(tool="Bash", params={"command": "ls"}),
+        masked_params=masked_params,
+    )
+
+
+@pytest.fixture
+def gatekeeper_allowing() -> MagicMock:
+    gk = MagicMock()
+    gk.evaluate.return_value = _make_decision(status=GateStatus.ALLOW, reason="allowed")
+    return gk
+
+
+@pytest.fixture
+def gatekeeper_blocking() -> MagicMock:
+    gk = MagicMock()
+    gk.evaluate.return_value = _make_decision(
+        status=GateStatus.BLOCK,
+        risk=RiskLevel.RED,
+        reason="destructive command blocked",
+    )
+    return gk
+
+
+@pytest.fixture
+def gatekeeper_approving() -> MagicMock:
+    gk = MagicMock()
+    gk.evaluate.return_value = _make_decision(
+        status=GateStatus.APPROVE,
+        risk=RiskLevel.ORANGE,
+        reason="needs user confirmation",
+    )
+    return gk
+
+
+@pytest.fixture
+def gatekeeper_masking() -> MagicMock:
+    gk = MagicMock()
+    gk.evaluate.return_value = _make_decision(
+        status=GateStatus.MASK,
+        risk=RiskLevel.YELLOW,
+        reason="credentials masked",
+        masked_params={"command": "echo ***"},
+    )
+    return gk
+
+
+def _payload(tool: str = "Bash", **tool_input) -> dict:
+    return {
+        "session_id": "sess-abc-1234",
+        "transcript_path": "/tmp/t.jsonl",
+        "cwd": "/workspace",
+        "permission_mode": "default",
+        "hook_event_name": "PreToolUse",
+        "tool_name": tool,
+        "tool_input": tool_input or {"command": "ls"},
+        "tool_use_id": "toolu_1",
+    }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PreToolUse
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPreToolUse:
+    def test_allow_status_maps_to_allow(self, gatekeeper_allowing):
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_allowing)
+        client = TestClient(app)
+        r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+        assert r.status_code == 200
+        out = r.json()["hookSpecificOutput"]
+        assert out["hookEventName"] == "PreToolUse"
+        assert out["permissionDecision"] == "allow"
+        assert "allowed" in out["permissionDecisionReason"]
+
+    def test_block_status_maps_to_deny(self, gatekeeper_blocking):
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_blocking)
+        client = TestClient(app)
+        r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+        assert r.status_code == 200
+        out = r.json()["hookSpecificOutput"]
+        assert out["permissionDecision"] == "deny"
+        assert "destructive" in out["permissionDecisionReason"]
+
+    def test_approve_status_maps_to_ask(self, gatekeeper_approving):
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_approving)
+        client = TestClient(app)
+        r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+        assert r.status_code == 200
+        out = r.json()["hookSpecificOutput"]
+        assert out["permissionDecision"] == "ask"
+
+    def test_mask_status_surfaces_updated_input(self, gatekeeper_masking):
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_masking)
+        client = TestClient(app)
+        r = client.post(
+            "/api/claude-hooks/pre-tool-use",
+            json=_payload(command="echo SECRET"),
+        )
+        out = r.json()["hookSpecificOutput"]
+        assert out["permissionDecision"] == "allow"
+        assert out["updatedInput"] == {"command": "echo ***"}
+
+    def test_bypass_permission_mode_short_circuits_to_allow(self):
+        gk = MagicMock()
+        gk.evaluate.side_effect = AssertionError("must not be called in bypass mode")
+        app = build_claude_code_hooks_app(gatekeeper=gk)
+        client = TestClient(app)
+        payload = _payload()
+        payload["permission_mode"] = "bypassPermissions"
+        r = client.post("/api/claude-hooks/pre-tool-use", json=payload)
+        out = r.json()["hookSpecificOutput"]
+        assert out["permissionDecision"] == "allow"
+        assert "bypass" in out["permissionDecisionReason"].lower()
+        gk.evaluate.assert_not_called()
+
+    def test_no_gatekeeper_wired_fails_open(self):
+        app = build_claude_code_hooks_app(gatekeeper=None)
+        client = TestClient(app)
+        r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+        out = r.json()["hookSpecificOutput"]
+        assert out["permissionDecision"] == "allow"
+        assert "not wired" in out["permissionDecisionReason"]
+
+    def test_gatekeeper_raises_fails_open(self):
+        gk = MagicMock()
+        gk.evaluate.side_effect = RuntimeError("boom")
+        app = build_claude_code_hooks_app(gatekeeper=gk)
+        client = TestClient(app)
+        r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+        out = r.json()["hookSpecificOutput"]
+        assert out["permissionDecision"] == "allow"
+        assert "failing open" in out["permissionDecisionReason"]
+
+    def test_session_context_is_reused_across_pre_calls(self, gatekeeper_allowing):
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_allowing)
+        client = TestClient(app)
+        for _ in range(3):
+            client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+        # All three calls should have been evaluated against the same SessionContext.
+        sessions = {call.args[1].session_id for call in gatekeeper_allowing.evaluate.call_args_list}
+        assert len(sessions) == 1
+        assert next(iter(sessions)) == "sess-abc-1234"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PostToolUse
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPostToolUse:
+    def _payload(self, **over) -> dict:
+        base = {
+            "session_id": "sess-post-1",
+            "cwd": "/w",
+            "permission_mode": "default",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "ls"},
+            "tool_response": "file1\nfile2",
+            "tool_use_id": "t1",
+            "duration_ms": 12,
+        }
+        base.update(over)
+        return base
+
+    def test_success_returns_empty_body(self):
+        app = build_claude_code_hooks_app()
+        client = TestClient(app)
+        r = client.post("/api/claude-hooks/post-tool-use", json=self._payload())
+        assert r.status_code == 200
+        assert r.json() == {}
+
+    def test_error_response_injects_warning_context(self):
+        app = build_claude_code_hooks_app()
+        client = TestClient(app)
+        r = client.post(
+            "/api/claude-hooks/post-tool-use",
+            json=self._payload(tool_response={"error": "disk full"}),
+        )
+        out = r.json()
+        assert "hookSpecificOutput" in out
+        assert "additionalContext" in out["hookSpecificOutput"]
+        assert "disk full" in out["hookSpecificOutput"]["additionalContext"]
+
+    def test_bash_nonzero_exit_heuristic(self):
+        app = build_claude_code_hooks_app()
+        client = TestClient(app)
+        r = client.post(
+            "/api/claude-hooks/post-tool-use",
+            json=self._payload(tool_response="Command failed with exit code 1"),
+        )
+        out = r.json()
+        assert "hookSpecificOutput" in out
+        assert "non-zero exit" in out["hookSpecificOutput"]["additionalContext"]
+
+    def test_hook_runner_is_forwarded(self):
+        runner = MagicMock()
+        app = build_claude_code_hooks_app(hook_runner=runner)
+        client = TestClient(app)
+        client.post("/api/claude-hooks/post-tool-use", json=self._payload())
+        runner.run_post_tool_use.assert_called_once()
+        args = runner.run_post_tool_use.call_args.args
+        assert args[0] == "Bash"
+        assert args[1] == {"command": "ls"}
+        assert "file1" in args[2]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stop
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestStop:
+    def _payload(self) -> dict:
+        return {
+            "session_id": "sess-stop-1",
+            "cwd": "/w",
+            "permission_mode": "default",
+            "hook_event_name": "Stop",
+        }
+
+    def test_stop_without_observer_is_noop(self):
+        app = build_claude_code_hooks_app()
+        client = TestClient(app)
+        r = client.post("/api/claude-hooks/stop", json=self._payload())
+        assert r.status_code == 200
+        assert r.json() == {}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SessionStart + health
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSessionStart:
+    def test_session_start_injects_cognithor_banner(self):
+        app = build_claude_code_hooks_app()
+        client = TestClient(app)
+        r = client.post(
+            "/api/claude-hooks/session-start",
+            json={
+                "session_id": "sess-start-1",
+                "cwd": "/w",
+                "hook_event_name": "SessionStart",
+                "source": "startup",
+                "model": "sonnet",
+            },
+        )
+        out = r.json()["hookSpecificOutput"]
+        assert out["hookEventName"] == "SessionStart"
+        assert "Cognithor" in out["additionalContext"]
+
+
+class TestHealth:
+    def test_health_reports_wired_components(self, gatekeeper_allowing):
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_allowing)
+        client = TestClient(app)
+        r = client.get("/api/claude-hooks/health")
+        data = r.json()
+        assert data["ok"] is True
+        assert data["gatekeeper"] is True
+        assert data["observer"] is False

--- a/tests/test_gateway/test_claude_code_hooks.py
+++ b/tests/test_gateway/test_claude_code_hooks.py
@@ -335,12 +335,8 @@ def _make_approval_manager(*, final_status: ApprovalStatus, comment: str = "") -
 
 class TestApproveRouting:
     def test_approved_status_maps_to_allow(self, gatekeeper_approving):
-        mgr = _make_approval_manager(
-            final_status=ApprovalStatus.APPROVED, comment="ok by reviewer"
-        )
-        app = build_claude_code_hooks_app(
-            gatekeeper=gatekeeper_approving, approval_manager=mgr
-        )
+        mgr = _make_approval_manager(final_status=ApprovalStatus.APPROVED, comment="ok by reviewer")
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_approving, approval_manager=mgr)
         client = TestClient(app)
         r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
         out = r.json()["hookSpecificOutput"]
@@ -351,12 +347,8 @@ class TestApproveRouting:
         mgr.wait_for_resolution.assert_awaited_once()
 
     def test_rejected_status_maps_to_deny(self, gatekeeper_approving):
-        mgr = _make_approval_manager(
-            final_status=ApprovalStatus.REJECTED, comment="too risky"
-        )
-        app = build_claude_code_hooks_app(
-            gatekeeper=gatekeeper_approving, approval_manager=mgr
-        )
+        mgr = _make_approval_manager(final_status=ApprovalStatus.REJECTED, comment="too risky")
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_approving, approval_manager=mgr)
         client = TestClient(app)
         r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
         out = r.json()["hookSpecificOutput"]
@@ -366,9 +358,7 @@ class TestApproveRouting:
 
     def test_timed_out_status_denies_for_safety(self, gatekeeper_approving):
         mgr = _make_approval_manager(final_status=ApprovalStatus.TIMED_OUT)
-        app = build_claude_code_hooks_app(
-            gatekeeper=gatekeeper_approving, approval_manager=mgr
-        )
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_approving, approval_manager=mgr)
         client = TestClient(app)
         r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
         out = r.json()["hookSpecificOutput"]
@@ -376,36 +366,26 @@ class TestApproveRouting:
         assert "unresolved" in out["permissionDecisionReason"]
 
     def test_no_approval_manager_falls_back_to_ask(self, gatekeeper_approving):
-        app = build_claude_code_hooks_app(
-            gatekeeper=gatekeeper_approving, approval_manager=None
-        )
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_approving, approval_manager=None)
         client = TestClient(app)
         r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
         out = r.json()["hookSpecificOutput"]
         assert out["permissionDecision"] == "ask"
 
-    def test_approval_manager_create_failure_falls_back_to_ask(
-        self, gatekeeper_approving
-    ):
+    def test_approval_manager_create_failure_falls_back_to_ask(self, gatekeeper_approving):
         mgr = MagicMock()
         mgr.create_request = AsyncMock(side_effect=RuntimeError("notifier offline"))
-        app = build_claude_code_hooks_app(
-            gatekeeper=gatekeeper_approving, approval_manager=mgr
-        )
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_approving, approval_manager=mgr)
         client = TestClient(app)
         r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
         out = r.json()["hookSpecificOutput"]
         assert out["permissionDecision"] == "ask"
 
-    def test_approval_manager_wait_failure_denies_for_safety(
-        self, gatekeeper_approving
-    ):
+    def test_approval_manager_wait_failure_denies_for_safety(self, gatekeeper_approving):
         mgr = MagicMock()
         mgr.create_request = AsyncMock(return_value=_StubRequest(request_id="apr_x"))
         mgr.wait_for_resolution = AsyncMock(side_effect=RuntimeError("event loop dead"))
-        app = build_claude_code_hooks_app(
-            gatekeeper=gatekeeper_approving, approval_manager=mgr
-        )
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_approving, approval_manager=mgr)
         client = TestClient(app)
         r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
         out = r.json()["hookSpecificOutput"]


### PR DESCRIPTION
# Claude Code hook bridge + autonomous supervisor

Lets Cognithor supervise Claude Code end-to-end: **Gatekeeper gates every tool call in VS Code, Observer audits the turn, and an autonomous supervisor can drive the `claude` CLI headless for multi-turn runs.**

## Motivation

Today Cognithor's Gatekeeper, Observer and HITL machinery only govern Cognithor's *own* tool calls (the 145 MCP tools). When a user works in Claude Code inside VS Code, Cognithor has no visibility into the model's tool invocations and cannot influence them. This PR closes the gap in two complementary layers.

## What changed

### Stage 1 â€” Hook bridge (`feat(gateway): Claude Code hook bridge`)

A new FastAPI router answers Claude Code's native HTTP hooks:

| Hook          | Endpoint                               | Cognithor action                                           |
|---------------|----------------------------------------|------------------------------------------------------------|
| PreToolUse    | `/api/claude-hooks/pre-tool-use`       | `Gatekeeper.evaluate` â†’ allow / deny / ask / updatedInput |
| PostToolUse   | `/api/claude-hooks/post-tool-use`      | `ToolHookRunner` + step heuristic â†’ additionalContext     |
| Stop          | `/api/claude-hooks/stop`               | `Observer.audit` â†’ force retry via `decision: "block"`    |
| SessionStart  | `/api/claude-hooks/session-start`      | Bookkeeping + context banner                               |
| SessionEnd    | `/api/claude-hooks/session-end`        | Session cleanup                                            |
| Health        | `/api/claude-hooks/health`             | Liveness + wiring status                                   |

Mapping: `GateStatus.{ALLOW,INFORM,MASK}` â†’ `"allow"` (MASK surfaces `masked_params` as `updatedInput`), `APPROVE` â†’ `"ask"`, `BLOCK` â†’ `"deny"`. The bridge is **fail-open** throughout: a missing/raising Gatekeeper returns `"allow"` with a reason, never a deadlock.

Auto-mounted in `src/cognithor/__main__.py` next to the Kanban/Evolution APIs under the same `try/except` guard â€” if any collaborator isn't wired, the router simply isn't registered.

### Stage 1 companion â€” `contrib/claude-code-bridge/`

- **`install.py`** â€” idempotent merger into `~/.claude/settings.json`: backup + unified diff + `--dry-run` + `--uninstall` + `--token-env` for authenticated deployments. Entries are tagged `_cognithor_bridge` so re-install is clean.
- **`README.md`** â€” walkthrough for HTTP hooks (default), authenticated bridge on shared machines, and the command-hook fallback.
- **`cognithor_bridge.py`** â€” stdinâ†’HTTPâ†’stdout fallback for `"type": "command"` hooks. Connection failures exit 0 with `{}` so a stuck Cognithor cannot deadlock the editor.
- **`settings.example.json`** â€” ready-to-paste template.

### Stage 2 â€” Autonomous supervisor (`feat(core): ClaudeCodeSupervisor`)

`src/cognithor/core/claude_code_supervised.py` adds `ClaudeCodeSupervisor`, an outer loop that drives `claude -p --output-format stream-json --input-format stream-json`:

- Parses NDJSON for `system`, `assistant`, `user` (tool_result), and `result` envelopes.
- Resumes across turns via `--resume <session_id>` so context persists.
- Budgets: `max_turns`, `max_duration_seconds`, `max_cost_usd` (summed across turns), `per_turn_timeout_seconds` (hard subprocess kill).
- Pluggable `GoalEvaluator` callback; default evaluator invokes `ObserverAudit` and produces a structured follow-up prompt when `retry_strategy âˆˆ {response_regen, pge_reloop}`.

The two stages stack: even in supervised mode the hooks from Stage 1 still fire inside the subprocess, so Gatekeeper remains the single source of truth for tool-call policy.

## Tests

Two new test modules, following the repo's `test_claude_code_backend.py` / `test_api_backends.py` patterns:

- `tests/test_gateway/test_claude_code_hooks.py` â€” TestClient over `build_claude_code_hooks_app`, mocked Gatekeeper returning each of ALLOW / BLOCK / APPROVE / MASK, fail-open paths, bypassPermissions short-circuit, session reuse, PostToolUse warning injection, Bash non-zero exit heuristic, Stop no-op, SessionStart banner, `/health`.
- `tests/test_core/test_claude_code_supervised.py` â€” mocks `asyncio.create_subprocess_exec` with a `_FakeProc` that emits scripted NDJSON. Covers single-turn success, tool-use/tool-result pairing, `max_turns` abort, `max_cost_usd` abort, evaluator verdicts (done/abort), missing CLI.

## What's now done that earlier review marked out of scope

- **APPROVE â†’ HITL routing.** `GateStatus.APPROVE` is now routed through `ApprovalManager` when one is wired (Cognithor's `init_tools` phase publishes it). Default 25s timeout under Claude Code's 30s HTTP-hook ceiling, AUTO_REJECT escalation policy so silence becomes a deny. Falls back to native `"ask"` if no manager is available. Reviewer comment is surfaced as `permissionDecisionReason` so Claude sees *why* the call was approved/rejected.
- **`LLMBackendType.CLAUDE_CODE_SUPERVISED` registered.** Selectable via `config.llm_backend_type = "claude-code-supervised"`; `create_backend()` factory wires it; `SetActiveRequest.backend` Literal accepts it (so the Flutter "LLM Backends" UI can switch to it).
- **Parallel `tool_use_id` pairing fixed.** The Stage-2 supervisor now pairs `tool_use` and `tool_result` blocks by id, not by ordering heuristic â€” correct under Claude Code's frequent multi-tool batches (Read+Read+Grep in flight, results back out-of-order).
- **Default `ToolHookRunner` bootstrap.** `__main__.py` now provisions a runner with `secret_redacting_hook` + `audit_logging_hook` if no gateway phase has published one. Without this, the PostToolUse forwarder was a silent no-op in production.

## Still out of scope (genuine follow-ups)

- The Supervisor's built-in goal evaluator is Observer-based; a Planner-driven evaluator that generates next prompts from PGE state would make it a first-class PGE surface.
- Token-by-token streaming for `ClaudeCodeSupervisedBackend.chat_stream()`. The current implementation yields a single coarse chunk (the turn's final text). Real per-token streaming would require a different transport than `--output-format stream-json` and is intentionally deferred.
- Telemetry export of supervisor metrics (turns, cost, dimension fail rates) into the existing telemetry hub.

## Compatibility

Strictly additive. No existing imports touched beyond the `__main__.py` router mount. All new code is guarded by `try/except` on startup so missing deps or broken wiring cannot regress the gateway boot.

## Setup, once merged

```bash
python -m jarvis --no-cli &                    # or your usual launcher
python contrib/claude-code-bridge/install.py   # writes ~/.claude/settings.json
curl http://localhost:8741/api/claude-hooks/health
# {"ok": true, "gatekeeper": true, "observer": true, ...}
```

Open VS Code / Claude Code â€” every subsequent tool call is now Cognithor-supervised.

---

ðŸ¤– Generated with [Claude Code](https://claude.com/claude-code)
