### PR TITLE
feat(channels): WP3 WebSocket Live-Stream for Crew Traces (v0.95.0 PR 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 - `cognithor.security.owner.require_owner()` — owner-token gating for Trace-UI surfaces. Reads `COGNITHOR_OWNER_USER_ID` env var with `pyproject.toml` author-name fallback.
 - Three FastAPI endpoints under `/api/crew/`: `traces` (list), `trace/{id}` (full events), `trace/{id}/stats` (aggregates). Owner-gated via `X-Cognithor-User` header. Reads `~/.cognithor/logs/audit.jsonl` directly; corrupt lines are skipped with the count surfaced via `meta.skipped_lines` (WP2 of v0.95.0 Trace-UI).
 - `docs/api/crew-traces.md` — endpoint reference.
+- WebSocket message types `crew_lifecycle_subscribe`, `crew_subscribe`, `crew_unsubscribe` for live Crew event streaming. Owner-gated; non-owner subscribes receive `{type:"error", code:"owner_only"}` and are ignored. Disconnect auto-cleans all subscriptions (WP3 of v0.95.0 Trace-UI).
+- Outbound frames: `{type:"crew_lifecycle", payload:<event>}` for lifecycle stream, `{type:"crew_event", payload:<event>}` for per-trace topic stream.
 
 ## [0.94.1] — 2026-04-26
 

--- a/src/cognithor/channels/webui.py
+++ b/src/cognithor/channels/webui.py
@@ -31,6 +31,7 @@ from uuid import uuid4
 from cognithor.channels.base import Channel, MessageHandler, StatusType
 from cognithor.crew.trace_bus import SubscriptionHandle, TraceBus
 from cognithor.models import IncomingMessage, OutgoingMessage, PlannedAction
+from cognithor.security.owner import OwnerRequiredError, require_owner
 from cognithor.security.rate_limiter import RateLimiter
 from cognithor.security.token_store import get_token_store
 from cognithor.utils.logging import get_logger
@@ -103,6 +104,71 @@ class TraceSubscriberState:
         for handle in list(self.topic_handles.values()):
             bus.unsubscribe(handle)
         self.topic_handles.clear()
+
+
+# Bounded queue size for trace subscribers; matches TraceBus default.
+_TRACE_QUEUE_MAXSIZE = 1000
+
+
+async def handle_trace_subscribe_message(
+    *,
+    message: dict[str, Any],
+    state: TraceSubscriberState,
+    bus: TraceBus,
+    user_id: str | None,
+    sender: Any,
+) -> str | None:
+    """Handle a crew_*_subscribe / crew_unsubscribe message.
+
+    Returns None on success, or a short error code string on failure
+    (also sent to the client via `sender` as an error frame).
+    """
+    msg_type = message.get("type")
+    if msg_type not in {
+        "crew_lifecycle_subscribe",
+        "crew_subscribe",
+        "crew_unsubscribe",
+    }:
+        return "unknown_message_type"
+
+    # Owner-gate every trace WS message.
+    try:
+        require_owner(user_id)
+    except OwnerRequiredError:
+        await sender(
+            {"type": "error", "code": "owner_only", "context": msg_type}
+        )
+        return "owner_only"
+
+    if msg_type == "crew_lifecycle_subscribe":
+        if state.lifecycle_handle is None:
+            queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(
+                maxsize=_TRACE_QUEUE_MAXSIZE
+            )
+            state.lifecycle_handle = bus.subscribe_lifecycle(queue)
+        return None
+
+    if msg_type == "crew_subscribe":
+        trace_id = message.get("trace_id")
+        if not isinstance(trace_id, str) or not trace_id:
+            await sender({"type": "error", "code": "invalid_trace_id"})
+            return "invalid_trace_id"
+        if trace_id in state.topic_handles:
+            return None  # idempotent
+        queue = asyncio.Queue(maxsize=_TRACE_QUEUE_MAXSIZE)
+        state.topic_handles[trace_id] = bus.subscribe(trace_id, queue)
+        return None
+
+    if msg_type == "crew_unsubscribe":
+        trace_id = message.get("trace_id")
+        if not isinstance(trace_id, str) or not trace_id:
+            return None  # silently ignore
+        handle = state.topic_handles.pop(trace_id, None)
+        if handle is not None:
+            bus.unsubscribe(handle)
+        return None
+
+    return "unknown_message_type"  # unreachable
 
 
 # ============================================================================

--- a/src/cognithor/channels/webui.py
+++ b/src/cognithor/channels/webui.py
@@ -171,6 +171,34 @@ async def handle_trace_subscribe_message(
     return "unknown_message_type"  # unreachable
 
 
+async def pump_queue_to_websocket(
+    queue: asyncio.Queue[dict[str, Any]],
+    sender: Any,
+    frame_type: str,
+) -> None:
+    """Drain a subscriber queue, wrap each record in `{type, payload}`, and send.
+
+    Runs as an asyncio Task; cancel to stop. On send-error, logs and
+    continues — the pump should outlive transient WebSocket hiccups
+    (the outer connection-handler will cancel us if the WS is truly dead).
+    """
+    while True:
+        try:
+            record = await queue.get()
+        except asyncio.CancelledError:
+            raise
+        try:
+            await sender({"type": frame_type, "payload": record})
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — pump must survive
+            log.warning(
+                "trace_ws_send_failed type=%s err=%s",
+                frame_type,
+                type(exc).__name__,
+            )
+
+
 # ============================================================================
 # WebUI Channel
 # ============================================================================

--- a/src/cognithor/channels/webui.py
+++ b/src/cognithor/channels/webui.py
@@ -29,7 +29,7 @@ from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from cognithor.channels.base import Channel, MessageHandler, StatusType
-from cognithor.crew.trace_bus import SubscriptionHandle, TraceBus
+from cognithor.crew.trace_bus import SubscriptionHandle, TraceBus, get_trace_bus
 from cognithor.models import IncomingMessage, OutgoingMessage, PlannedAction
 from cognithor.security.owner import OwnerRequiredError, require_owner
 from cognithor.security.rate_limiter import RateLimiter
@@ -574,10 +574,62 @@ class WebUIChannel(Channel):
                 self._connections[session_id] = websocket
                 log.info("ws_connected", session_id=session_id)
 
+                trace_state = TraceSubscriberState()
+                trace_pumps: list[asyncio.Task[None]] = []
+                trace_bus = get_trace_bus()
+                # Owner identity for WS auth: WebUI uses a shared API token,
+                # so all sessions share user_id="web_user". Operators wanting
+                # access to live Crew traces must set COGNITHOR_OWNER_USER_ID=web_user.
+                trace_user_id = "web_user"
+
                 try:
                     while True:
                         data = await websocket.receive_text()
                         msg = json.loads(data)
+                        msg_type = msg.get("type", "")
+                        if msg_type in {
+                            "crew_lifecycle_subscribe",
+                            "crew_subscribe",
+                            "crew_unsubscribe",
+                        }:
+                            err = await handle_trace_subscribe_message(
+                                message=msg,
+                                state=trace_state,
+                                bus=trace_bus,
+                                user_id=trace_user_id,
+                                sender=websocket.send_json,
+                            )
+                            if err is None and msg_type == "crew_lifecycle_subscribe":
+                                if trace_state.lifecycle_handle is not None and not any(
+                                    getattr(t, "_trace_pump_topic", None) == "__lifecycle__"
+                                    for t in trace_pumps
+                                ):
+                                    queue = trace_state.lifecycle_handle.queue
+                                    task = asyncio.create_task(
+                                        pump_queue_to_websocket(
+                                            queue, websocket.send_json, "crew_lifecycle"
+                                        )
+                                    )
+                                    task._trace_pump_topic = "__lifecycle__"  # type: ignore[attr-defined]
+                                    trace_pumps.append(task)
+                            elif err is None and msg_type == "crew_subscribe":
+                                trace_id = msg.get("trace_id")
+                                if isinstance(trace_id, str) and trace_id in trace_state.topic_handles:
+                                    queue = trace_state.topic_handles[trace_id].queue
+                                    task = asyncio.create_task(
+                                        pump_queue_to_websocket(
+                                            queue, websocket.send_json, "crew_event"
+                                        )
+                                    )
+                                    task._trace_pump_topic = trace_id  # type: ignore[attr-defined]
+                                    trace_pumps.append(task)
+                            elif err is None and msg_type == "crew_unsubscribe":
+                                trace_id = msg.get("trace_id")
+                                for t in list(trace_pumps):
+                                    if getattr(t, "_trace_pump_topic", None) == trace_id:
+                                        t.cancel()
+                                        trace_pumps.remove(t)
+                            continue  # crew_* messages handled; do NOT fall through to _handle_ws_message
                         await self._handle_ws_message(websocket, session_id, msg)
                 except WebSocketDisconnect:
                     log.info("ws_disconnected", session_id=session_id)
@@ -592,6 +644,9 @@ class WebUIChannel(Channel):
                 except Exception as exc:
                     log.error("ws_error", error=str(exc), session_id=session_id)
                 finally:
+                    for task in trace_pumps:
+                        task.cancel()
+                    trace_state.clear_all(trace_bus)
                     self._connections.pop(session_id, None)
 
             # --- Config-API Routes ---

--- a/src/cognithor/channels/webui.py
+++ b/src/cognithor/channels/webui.py
@@ -614,7 +614,17 @@ class WebUIChannel(Channel):
                                     trace_pumps.append(task)
                             elif err is None and msg_type == "crew_subscribe":
                                 trace_id = msg.get("trace_id")
-                                if isinstance(trace_id, str) and trace_id in trace_state.topic_handles:
+                                # Pump-existence check mirrors the lifecycle branch above:
+                                # handle_trace_subscribe_message is idempotent on re-subscribe, so
+                                # we must not spawn a second pump for the same topic.
+                                if (
+                                    isinstance(trace_id, str)
+                                    and trace_id in trace_state.topic_handles
+                                    and not any(
+                                        getattr(t, "_trace_pump_topic", None) == trace_id
+                                        for t in trace_pumps
+                                    )
+                                ):
                                     queue = trace_state.topic_handles[trace_id].queue
                                     task = asyncio.create_task(
                                         pump_queue_to_websocket(

--- a/src/cognithor/channels/webui.py
+++ b/src/cognithor/channels/webui.py
@@ -22,12 +22,14 @@ import contextlib
 import json
 import os
 import time
+from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
 from cognithor.channels.base import Channel, MessageHandler, StatusType
+from cognithor.crew.trace_bus import SubscriptionHandle, TraceBus
 from cognithor.models import IncomingMessage, OutgoingMessage, PlannedAction
 from cognithor.security.rate_limiter import RateLimiter
 from cognithor.security.token_store import get_token_store
@@ -75,6 +77,32 @@ class WSMessageType:
     ERROR = "error"
     PONG = "pong"
     IDENTITY_STATE = "identity_state"
+
+
+# ============================================================================
+# Trace-UI subscription state
+# ============================================================================
+
+
+@dataclass
+class TraceSubscriberState:
+    """Per-WebSocket-session state tracking active TraceBus subscriptions.
+
+    Stored on the session object so we can cleanly unsubscribe everything
+    when the WebSocket disconnects.
+    """
+
+    lifecycle_handle: SubscriptionHandle | None = None
+    topic_handles: dict[str, SubscriptionHandle] = field(default_factory=dict)
+
+    def clear_all(self, bus: TraceBus) -> None:
+        """Unsubscribe everything this session is subscribed to."""
+        if self.lifecycle_handle is not None:
+            bus.unsubscribe(self.lifecycle_handle)
+            self.lifecycle_handle = None
+        for handle in list(self.topic_handles.values()):
+            bus.unsubscribe(handle)
+        self.topic_handles.clear()
 
 
 # ============================================================================

--- a/src/cognithor/channels/webui.py
+++ b/src/cognithor/channels/webui.py
@@ -135,16 +135,12 @@ async def handle_trace_subscribe_message(
     try:
         require_owner(user_id)
     except OwnerRequiredError:
-        await sender(
-            {"type": "error", "code": "owner_only", "context": msg_type}
-        )
+        await sender({"type": "error", "code": "owner_only", "context": msg_type})
         return "owner_only"
 
     if msg_type == "crew_lifecycle_subscribe":
         if state.lifecycle_handle is None:
-            queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(
-                maxsize=_TRACE_QUEUE_MAXSIZE
-            )
+            queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=_TRACE_QUEUE_MAXSIZE)
             state.lifecycle_handle = bus.subscribe_lifecycle(queue)
         return None
 
@@ -191,7 +187,7 @@ async def pump_queue_to_websocket(
             await sender({"type": frame_type, "payload": record})
         except asyncio.CancelledError:
             raise
-        except Exception as exc:  # noqa: BLE001 — pump must survive
+        except Exception as exc:  # pump must survive sender errors
             log.warning(
                 "trace_ws_send_failed type=%s err=%s",
                 frame_type,
@@ -639,7 +635,8 @@ class WebUIChannel(Channel):
                                     if getattr(t, "_trace_pump_topic", None) == trace_id:
                                         t.cancel()
                                         trace_pumps.remove(t)
-                            continue  # crew_* messages handled; do NOT fall through to _handle_ws_message
+                            # crew_* handled — do NOT fall through to _handle_ws_message
+                            continue
                         await self._handle_ws_message(websocket, session_id, msg)
                 except WebSocketDisconnect:
                     log.info("ws_disconnected", session_id=session_id)

--- a/tests/test_channels/test_trace_ws.py
+++ b/tests/test_channels/test_trace_ws.py
@@ -211,3 +211,46 @@ async def test_pump_queue_to_websocket_forwards_lifecycle_events() -> None:
     sent_frame = sender.call_args.args[0]
     assert sent_frame["type"] == "crew_lifecycle"
     assert sent_frame["payload"]["trace_id"] == "abc"
+
+
+@pytest.mark.asyncio
+async def test_clear_all_after_subscribes_releases_bus_subscriptions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify TraceSubscriberState.clear_all() removes all bus subscriptions
+    so a disconnect doesn't leak."""
+    from cognithor.channels.webui import (
+        TraceSubscriberState,
+        handle_trace_subscribe_message,
+    )
+    from cognithor.crew.trace_bus import get_trace_bus
+
+    monkeypatch.setenv("COGNITHOR_OWNER_USER_ID", "owner")
+    bus = get_trace_bus()
+    state = TraceSubscriberState()
+    sender = AsyncMock()
+
+    # Subscribe to lifecycle + 2 topics
+    await handle_trace_subscribe_message(
+        message={"type": "crew_lifecycle_subscribe"},
+        state=state, bus=bus, user_id="owner", sender=sender,
+    )
+    await handle_trace_subscribe_message(
+        message={"type": "crew_subscribe", "trace_id": "t1"},
+        state=state, bus=bus, user_id="owner", sender=sender,
+    )
+    await handle_trace_subscribe_message(
+        message={"type": "crew_subscribe", "trace_id": "t2"},
+        state=state, bus=bus, user_id="owner", sender=sender,
+    )
+
+    # Confirm bus has 3 distinct topic entries.
+    assert "__lifecycle__" in bus._subscribers  # noqa: SLF001
+    assert "t1" in bus._subscribers  # noqa: SLF001
+    assert "t2" in bus._subscribers  # noqa: SLF001
+
+    # Simulate WebSocket disconnect cleanup.
+    state.clear_all(bus)
+
+    # Bus should now have no subscribers in any of these topics.
+    assert "__lifecycle__" not in bus._subscribers  # noqa: SLF001
+    assert "t1" not in bus._subscribers  # noqa: SLF001
+    assert "t2" not in bus._subscribers  # noqa: SLF001

--- a/tests/test_channels/test_trace_ws.py
+++ b/tests/test_channels/test_trace_ws.py
@@ -17,3 +17,32 @@ import pytest
 def test_webui_module_imports() -> None:
     """Sanity: webui module imports without error after our additions."""
     import cognithor.channels.webui  # noqa: F401
+
+
+@pytest.mark.asyncio
+async def test_trace_subscriber_state_creates_handles_dict() -> None:
+    """A WebSocket session that opts into trace events gets a per-session handle dict."""
+    from cognithor.channels.webui import TraceSubscriberState
+
+    state = TraceSubscriberState()
+    assert state.lifecycle_handle is None
+    assert state.topic_handles == {}
+
+
+@pytest.mark.asyncio
+async def test_trace_subscriber_state_clear_unsubscribes_everything() -> None:
+    """clear_all() should unsubscribe lifecycle + every topic from the bus."""
+    from cognithor.channels.webui import TraceSubscriberState
+    from cognithor.crew.trace_bus import TraceBus, get_trace_bus
+
+    bus = get_trace_bus()
+    state = TraceSubscriberState()
+    queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=10)
+
+    state.lifecycle_handle = bus.subscribe_lifecycle(queue)
+    state.topic_handles["trace-x"] = bus.subscribe("trace-x", queue)
+    assert len(bus._subscribers) == 2  # noqa: SLF001 — internal check
+
+    state.clear_all(bus)
+    assert state.lifecycle_handle is None
+    assert state.topic_handles == {}

--- a/tests/test_channels/test_trace_ws.py
+++ b/tests/test_channels/test_trace_ws.py
@@ -180,3 +180,34 @@ async def test_handle_unknown_subscribe_type_returns_error(monkeypatch: pytest.M
         sender=sender,
     )
     assert err == "unknown_message_type"
+
+
+@pytest.mark.asyncio
+async def test_pump_queue_to_websocket_forwards_lifecycle_events() -> None:
+    """The pump task drains a subscriber queue and sends formatted frames."""
+    from cognithor.channels.webui import (
+        TraceSubscriberState,
+        pump_queue_to_websocket,
+    )
+    from cognithor.crew.trace_bus import get_trace_bus
+
+    bus = get_trace_bus()
+    state = TraceSubscriberState()
+    queue: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=10)
+    state.lifecycle_handle = bus.subscribe_lifecycle(queue)
+    sender = AsyncMock()
+
+    pump_task = asyncio.create_task(pump_queue_to_websocket(queue, sender, "crew_lifecycle"))
+    bus.publish({"event_type": "crew_kickoff_started", "trace_id": "abc", "n_tasks": 3})
+    await asyncio.sleep(0.05)
+    pump_task.cancel()
+    try:
+        await pump_task
+    except asyncio.CancelledError:
+        pass
+
+    state.clear_all(bus)
+    assert sender.call_count >= 1
+    sent_frame = sender.call_args.args[0]
+    assert sent_frame["type"] == "crew_lifecycle"
+    assert sent_frame["payload"]["trace_id"] == "abc"

--- a/tests/test_channels/test_trace_ws.py
+++ b/tests/test_channels/test_trace_ws.py
@@ -46,3 +46,137 @@ async def test_trace_subscriber_state_clear_unsubscribes_everything() -> None:
     state.clear_all(bus)
     assert state.lifecycle_handle is None
     assert state.topic_handles == {}
+
+
+@pytest.mark.asyncio
+async def test_handle_lifecycle_subscribe_for_owner_creates_handle(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cognithor.channels.webui import (
+        TraceSubscriberState,
+        handle_trace_subscribe_message,
+    )
+    from cognithor.crew.trace_bus import get_trace_bus
+
+    monkeypatch.setenv("COGNITHOR_OWNER_USER_ID", "owner")
+    bus = get_trace_bus()
+    state = TraceSubscriberState()
+    sender = AsyncMock()
+
+    err = await handle_trace_subscribe_message(
+        message={"type": "crew_lifecycle_subscribe"},
+        state=state,
+        bus=bus,
+        user_id="owner",
+        sender=sender,
+    )
+    assert err is None
+    assert state.lifecycle_handle is not None
+    state.clear_all(bus)
+
+
+@pytest.mark.asyncio
+async def test_handle_topic_subscribe_creates_topic_handle(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cognithor.channels.webui import (
+        TraceSubscriberState,
+        handle_trace_subscribe_message,
+    )
+    from cognithor.crew.trace_bus import get_trace_bus
+
+    monkeypatch.setenv("COGNITHOR_OWNER_USER_ID", "owner")
+    bus = get_trace_bus()
+    state = TraceSubscriberState()
+    sender = AsyncMock()
+
+    err = await handle_trace_subscribe_message(
+        message={"type": "crew_subscribe", "trace_id": "abc"},
+        state=state,
+        bus=bus,
+        user_id="owner",
+        sender=sender,
+    )
+    assert err is None
+    assert "abc" in state.topic_handles
+    state.clear_all(bus)
+
+
+@pytest.mark.asyncio
+async def test_handle_topic_unsubscribe_removes_handle(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cognithor.channels.webui import (
+        TraceSubscriberState,
+        handle_trace_subscribe_message,
+    )
+    from cognithor.crew.trace_bus import get_trace_bus
+
+    monkeypatch.setenv("COGNITHOR_OWNER_USER_ID", "owner")
+    bus = get_trace_bus()
+    state = TraceSubscriberState()
+    sender = AsyncMock()
+
+    await handle_trace_subscribe_message(
+        message={"type": "crew_subscribe", "trace_id": "xyz"},
+        state=state,
+        bus=bus,
+        user_id="owner",
+        sender=sender,
+    )
+    assert "xyz" in state.topic_handles
+
+    err = await handle_trace_subscribe_message(
+        message={"type": "crew_unsubscribe", "trace_id": "xyz"},
+        state=state,
+        bus=bus,
+        user_id="owner",
+        sender=sender,
+    )
+    assert err is None
+    assert "xyz" not in state.topic_handles
+
+
+@pytest.mark.asyncio
+async def test_handle_subscribe_rejects_non_owner(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cognithor.channels.webui import (
+        TraceSubscriberState,
+        handle_trace_subscribe_message,
+    )
+    from cognithor.crew.trace_bus import get_trace_bus
+
+    monkeypatch.setenv("COGNITHOR_OWNER_USER_ID", "real-owner")
+    bus = get_trace_bus()
+    state = TraceSubscriberState()
+    sender = AsyncMock()
+
+    err = await handle_trace_subscribe_message(
+        message={"type": "crew_subscribe", "trace_id": "abc"},
+        state=state,
+        bus=bus,
+        user_id="guest",
+        sender=sender,
+    )
+    assert err == "owner_only"
+    assert state.topic_handles == {}
+    sender.assert_called_once()
+    sent = sender.call_args.args[0]
+    assert sent["type"] == "error"
+    assert sent["code"] == "owner_only"
+
+
+@pytest.mark.asyncio
+async def test_handle_unknown_subscribe_type_returns_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    from cognithor.channels.webui import (
+        TraceSubscriberState,
+        handle_trace_subscribe_message,
+    )
+    from cognithor.crew.trace_bus import get_trace_bus
+
+    monkeypatch.setenv("COGNITHOR_OWNER_USER_ID", "owner")
+    bus = get_trace_bus()
+    state = TraceSubscriberState()
+    sender = AsyncMock()
+
+    err = await handle_trace_subscribe_message(
+        message={"type": "crew_unknown_action"},
+        state=state,
+        bus=bus,
+        user_id="owner",
+        sender=sender,
+    )
+    assert err == "unknown_message_type"

--- a/tests/test_channels/test_trace_ws.py
+++ b/tests/test_channels/test_trace_ws.py
@@ -1,0 +1,19 @@
+"""Tests for cognithor.channels.webui Trace-UI WebSocket additions.
+
+These tests use the in-memory TraceBus + a mock WebSocket session to
+verify subscribe/unsubscribe/cleanup behaviour without actually starting
+a uvicorn server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def test_webui_module_imports() -> None:
+    """Sanity: webui module imports without error after our additions."""
+    import cognithor.channels.webui  # noqa: F401

--- a/tests/test_channels/test_trace_ws.py
+++ b/tests/test_channels/test_trace_ws.py
@@ -8,8 +8,9 @@ a uvicorn server.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -33,7 +34,7 @@ async def test_trace_subscriber_state_creates_handles_dict() -> None:
 async def test_trace_subscriber_state_clear_unsubscribes_everything() -> None:
     """clear_all() should unsubscribe lifecycle + every topic from the bus."""
     from cognithor.channels.webui import TraceSubscriberState
-    from cognithor.crew.trace_bus import TraceBus, get_trace_bus
+    from cognithor.crew.trace_bus import get_trace_bus
 
     bus = get_trace_bus()
     state = TraceSubscriberState()
@@ -41,7 +42,7 @@ async def test_trace_subscriber_state_clear_unsubscribes_everything() -> None:
 
     state.lifecycle_handle = bus.subscribe_lifecycle(queue)
     state.topic_handles["trace-x"] = bus.subscribe("trace-x", queue)
-    assert len(bus._subscribers) == 2  # noqa: SLF001 — internal check
+    assert len(bus._subscribers) == 2  # internal check — SLF001 not enabled
 
     state.clear_all(bus)
     assert state.lifecycle_handle is None
@@ -49,7 +50,9 @@ async def test_trace_subscriber_state_clear_unsubscribes_everything() -> None:
 
 
 @pytest.mark.asyncio
-async def test_handle_lifecycle_subscribe_for_owner_creates_handle(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_handle_lifecycle_subscribe_for_owner_creates_handle(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from cognithor.channels.webui import (
         TraceSubscriberState,
         handle_trace_subscribe_message,
@@ -201,10 +204,8 @@ async def test_pump_queue_to_websocket_forwards_lifecycle_events() -> None:
     bus.publish({"event_type": "crew_kickoff_started", "trace_id": "abc", "n_tasks": 3})
     await asyncio.sleep(0.05)
     pump_task.cancel()
-    try:
+    with contextlib.suppress(asyncio.CancelledError):
         await pump_task
-    except asyncio.CancelledError:
-        pass
 
     state.clear_all(bus)
     assert sender.call_count >= 1
@@ -214,7 +215,9 @@ async def test_pump_queue_to_websocket_forwards_lifecycle_events() -> None:
 
 
 @pytest.mark.asyncio
-async def test_clear_all_after_subscribes_releases_bus_subscriptions(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_clear_all_after_subscribes_releases_bus_subscriptions(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Verify TraceSubscriberState.clear_all() removes all bus subscriptions
     so a disconnect doesn't leak."""
     from cognithor.channels.webui import (
@@ -231,26 +234,35 @@ async def test_clear_all_after_subscribes_releases_bus_subscriptions(monkeypatch
     # Subscribe to lifecycle + 2 topics
     await handle_trace_subscribe_message(
         message={"type": "crew_lifecycle_subscribe"},
-        state=state, bus=bus, user_id="owner", sender=sender,
+        state=state,
+        bus=bus,
+        user_id="owner",
+        sender=sender,
     )
     await handle_trace_subscribe_message(
         message={"type": "crew_subscribe", "trace_id": "t1"},
-        state=state, bus=bus, user_id="owner", sender=sender,
+        state=state,
+        bus=bus,
+        user_id="owner",
+        sender=sender,
     )
     await handle_trace_subscribe_message(
         message={"type": "crew_subscribe", "trace_id": "t2"},
-        state=state, bus=bus, user_id="owner", sender=sender,
+        state=state,
+        bus=bus,
+        user_id="owner",
+        sender=sender,
     )
 
     # Confirm bus has 3 distinct topic entries.
-    assert "__lifecycle__" in bus._subscribers  # noqa: SLF001
-    assert "t1" in bus._subscribers  # noqa: SLF001
-    assert "t2" in bus._subscribers  # noqa: SLF001
+    assert "__lifecycle__" in bus._subscribers
+    assert "t1" in bus._subscribers
+    assert "t2" in bus._subscribers
 
     # Simulate WebSocket disconnect cleanup.
     state.clear_all(bus)
 
     # Bus should now have no subscribers in any of these topics.
-    assert "__lifecycle__" not in bus._subscribers  # noqa: SLF001
-    assert "t1" not in bus._subscribers  # noqa: SLF001
-    assert "t2" not in bus._subscribers  # noqa: SLF001
+    assert "__lifecycle__" not in bus._subscribers
+    assert "t1" not in bus._subscribers
+    assert "t2" not in bus._subscribers


### PR DESCRIPTION
## Summary
- Three new WebSocket message types: `crew_lifecycle_subscribe`, `crew_subscribe`, `crew_unsubscribe`.
- `TraceSubscriberState` per-session dataclass tracks active TraceBus subscriptions; `clear_all()` releases everything on disconnect.
- `handle_trace_subscribe_message()` is owner-gated (uses `cognithor.security.owner.require_owner` from PR 1).
- `pump_queue_to_websocket()` drains subscriber queues into outbound `{type, payload}` frames.

## Spec
- `docs/superpowers/specs/2026-04-26-trace-ui-v095-design.md` §8.3

## Test plan
- [x] `pytest tests/test_channels/test_trace_ws.py -q` green (10 tests)
- [x] Coverage on new functions ≥85%
- [x] Owner-gating: non-owner gets error frame, no subscription
- [x] Disconnect cleanup: clear_all() removes all topics from TraceBus
- [x] Full regression `pytest tests/ -x -q` green