### PR TITLE
feat(bridge): risk caching, Planner-driven goal evaluator, HITL-resume fallback

### DIFF
--- a/src/cognithor/core/claude_code_supervised.py
+++ b/src/cognithor/core/claude_code_supervised.py
@@ -114,7 +114,12 @@ class SupervisorResult:
     total_duration_ms: int
 
 
-GoalEvaluator = Callable[[list[TurnResult]], Awaitable[GoalEvaluation]]
+# A goal evaluator receives the original user intent plus the per-turn
+# history accumulated so far and returns whether the supervisor should
+# stop, send another prompt, or abort. Receiving the intent makes it
+# possible to plug in Planner-style judges that compare turn outcomes
+# against the goal explicitly.
+GoalEvaluator = Callable[[str, list[TurnResult]], Awaitable[GoalEvaluation]]
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -417,7 +422,7 @@ class ClaudeCodeSupervisor:
     async def _evaluate(self, *, user_intent: str, turns: list[TurnResult]) -> GoalEvaluation:
         if self._goal_evaluator is not None:
             try:
-                return await self._goal_evaluator(turns)
+                return await self._goal_evaluator(user_intent, turns)
             except Exception as exc:
                 log.warning("claude_code_supervisor_evaluator_failed", error=str(exc))
                 return GoalEvaluation(verdict="abort", reason=f"evaluator raised: {exc!s}")
@@ -552,9 +557,226 @@ __all__ = [
     "ClaudeCodeSupervisor",
     "GoalEvaluation",
     "GoalEvaluator",
+    "PlannerGoalEvaluator",
     "SupervisorResult",
     "TurnResult",
 ]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Planner-driven goal evaluator
+#
+# Lightweight LLM judge that compares the goal against accumulated turn
+# outcomes and returns done/continue/abort with a follow-up prompt. Does
+# not invoke the full Cognithor Planner (which expects WorkingMemory and
+# tool schemas) -- instead it makes a focused chat call to the same LLM
+# client the Planner uses.
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+_GOAL_JUDGE_SYSTEM = (
+    "You are a goal-completion judge for an autonomous coding agent driving "
+    "Claude Code. Read the user goal and the agent's progress, then decide "
+    "whether the goal is reached, whether one more attempt would help, or "
+    "whether the agent is stuck.\n\n"
+    "Respond with EXACTLY one JSON object on a single line, no prose, no "
+    "code fences, with this shape:\n"
+    '  {"verdict": "done"|"continue"|"abort", '
+    '"next_prompt": "<used only when verdict=continue>", '
+    '"reason": "<one short sentence>"}\n\n'
+    "Decision rules:\n"
+    "- done: the user goal is fully and visibly satisfied by the latest "
+    "assistant message and the tool history. Prefer 'done' when in doubt and "
+    "the agent's last message claims completion AND the tool errors are zero.\n"
+    "- continue: there is real progress but the goal is not yet met. Provide "
+    "a focused next_prompt that names the specific next step. Do NOT just "
+    "say 'continue'. Be concrete.\n"
+    "- abort: the agent is looping, repeating the same tool with the same "
+    "error, or has clearly diverged from the goal. Recovery via re-prompting "
+    "is unlikely.\n"
+)
+
+
+def _format_turn_summary(turn: TurnResult, *, max_chars: int = 600) -> str:
+    parts = [
+        f"turn {turn.turn} (cost ${turn.cost_usd:.4f}, {turn.duration_ms}ms"
+        f"{', ERROR' if turn.is_error else ''}):",
+    ]
+    if turn.tool_results:
+        parts.append(f"  tools: {len(turn.tool_results)}")
+        for tr in turn.tool_results[:6]:
+            content = (tr.error_message or tr.content or "").strip().replace("\n", " ")
+            tag = "ERR" if tr.is_error else "ok"
+            parts.append(f"    - [{tag}] {tr.tool_name}: {content[:100]}")
+        if len(turn.tool_results) > 6:
+            parts.append(f"    ... (+{len(turn.tool_results) - 6} more)")
+    if turn.assistant_text:
+        parts.append(f"  text: {turn.assistant_text.strip()[:max_chars]}")
+    if turn.error:
+        parts.append(f"  error: {turn.error[:300]}")
+    return "\n".join(parts)
+
+
+class PlannerGoalEvaluator:
+    """Goal evaluator that asks an LLM whether the supervisor should stop.
+
+    Plug-compatible with ``ClaudeCodeSupervisor.goal_evaluator``: instances
+    are awaitable callables matching the
+    ``Callable[[str, list[TurnResult]], Awaitable[GoalEvaluation]]``
+    signature.
+
+    The judge is intentionally model-agnostic and accepts any LLM client
+    that exposes ``async chat(model, messages, **kwargs) -> ChatResponse``
+    (so Cognithor's Ollama / Anthropic / Claude-Code / vLLM backends all
+    work). On any LLM failure the evaluator returns ``verdict="continue"``
+    with a generic follow-up prompt -- failing the loop closed (towards
+    "done") would silently mask real progress problems.
+
+    Args:
+        llm: Async chat client. Must accept (model, messages, **kwargs)
+            and return a ``ChatResponse``-shaped object with a ``content``
+            attribute.
+        model: Model name to pass to the chat call.
+        max_history_turns: Cap on how many earlier turns to summarize.
+        on_failure: What to return if the LLM call or JSON parse fails.
+            Defaults to a benign "continue" verdict.
+    """
+
+    def __init__(
+        self,
+        *,
+        llm: Any,
+        model: str,
+        max_history_turns: int = 6,
+        on_failure: GoalEvaluation | None = None,
+    ) -> None:
+        self._llm = llm
+        self._model = model
+        self._max_history_turns = max(1, max_history_turns)
+        self._on_failure = on_failure or GoalEvaluation(
+            verdict="continue",
+            next_prompt=(
+                "The goal-completion judge could not produce a verdict. "
+                "Continue toward the goal and explicitly state 'DONE' when "
+                "you believe it is reached."
+            ),
+            reason="judge_unavailable",
+        )
+
+    async def __call__(self, user_intent: str, turns: list[TurnResult]) -> GoalEvaluation:
+        if not turns:
+            return GoalEvaluation(verdict="continue", reason="no turns yet")
+
+        history = turns[-self._max_history_turns :]
+        history_block = "\n".join(_format_turn_summary(t) for t in history)
+        prompt_user = (
+            f"USER GOAL:\n{user_intent}\n\n"
+            f"PROGRESS ({len(history)} of {len(turns)} turns shown, "
+            f"oldest first):\n{history_block}\n\n"
+            "Return the JSON verdict now."
+        )
+
+        try:
+            response = await self._llm.chat(
+                model=self._model,
+                messages=[
+                    {"role": "system", "content": _GOAL_JUDGE_SYSTEM},
+                    {"role": "user", "content": prompt_user},
+                ],
+                temperature=0.2,
+                top_p=0.9,
+                format_json=True,
+            )
+        except TypeError:
+            # Older clients without format_json kwarg.
+            try:
+                response = await self._llm.chat(
+                    model=self._model,
+                    messages=[
+                        {"role": "system", "content": _GOAL_JUDGE_SYSTEM},
+                        {"role": "user", "content": prompt_user},
+                    ],
+                    temperature=0.2,
+                    top_p=0.9,
+                )
+            except Exception as exc:
+                log.warning("planner_goal_evaluator_llm_error", error=str(exc))
+                return self._on_failure
+        except Exception as exc:
+            log.warning("planner_goal_evaluator_llm_error", error=str(exc))
+            return self._on_failure
+
+        content = getattr(response, "content", "") or ""
+        parsed = _extract_json_object(content)
+        if parsed is None:
+            log.warning("planner_goal_evaluator_parse_failed", content_preview=content[:200])
+            return self._on_failure
+
+        verdict = str(parsed.get("verdict", "")).strip().lower()
+        if verdict not in ("done", "continue", "abort"):
+            log.warning("planner_goal_evaluator_bad_verdict", got=verdict)
+            return self._on_failure
+
+        next_prompt = str(parsed.get("next_prompt", "")).strip()
+        reason = str(parsed.get("reason", "")).strip()
+
+        log.info(
+            "planner_goal_evaluator_verdict",
+            verdict=verdict,
+            turns=len(turns),
+            reason=reason[:160],
+        )
+        return GoalEvaluation(
+            verdict=verdict,  # type: ignore[arg-type]
+            next_prompt=next_prompt,
+            reason=reason,
+        )
+
+
+def _extract_json_object(text: str) -> dict[str, Any] | None:
+    """Best-effort extract a single top-level JSON object from LLM output.
+
+    Tolerates a trailing newline, a leading prose preamble, or accidental
+    code fences. Returns ``None`` if nothing parseable is found.
+    """
+    if not text:
+        return None
+    # Strip a single set of ```json ... ``` fences if present.
+    stripped = text.strip()
+    if stripped.startswith("```"):
+        first_nl = stripped.find("\n")
+        if first_nl > 0:
+            stripped = stripped[first_nl + 1 :]
+        if stripped.endswith("```"):
+            stripped = stripped[:-3]
+        stripped = stripped.strip()
+    # Try direct parse first.
+    try:
+        obj = json.loads(stripped)
+        if isinstance(obj, dict):
+            return obj
+    except json.JSONDecodeError:
+        pass
+    # Fallback: find the first balanced {...} block.
+    start = stripped.find("{")
+    if start < 0:
+        return None
+    depth = 0
+    for i in range(start, len(stripped)):
+        ch = stripped[i]
+        if ch == "{":
+            depth += 1
+        elif ch == "}":
+            depth -= 1
+            if depth == 0:
+                candidate = stripped[start : i + 1]
+                try:
+                    obj = json.loads(candidate)
+                    if isinstance(obj, dict):
+                        return obj
+                except json.JSONDecodeError:
+                    return None
+    return None
 
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/cognithor/gateway/claude_code_hooks.py
+++ b/src/cognithor/gateway/claude_code_hooks.py
@@ -25,20 +25,27 @@ Design notes:
   heuristics). The full four-dimension Observer audit runs only on ``Stop``
   because it issues an LLM call and is too expensive per tool.
 - ``GateStatus.APPROVE`` is routed through ``ApprovalManager`` when one is
-  wired: the bridge creates a HITL request with an ``AUTO_REJECT``
-  escalation policy and awaits resolution within a short timeout (default
-  25s, under Claude Code's typical 30s hook timeout). Mapping:
-  APPROVED→allow, REJECTED→deny (this is also the path taken when the
-  approver does not respond before the timeout, since AUTO_REJECT turns
-  silence into a rejection). All other terminal states (TIMED_OUT after
-  max_escalations, ESCALATED, CANCELED, DELEGATED, still-PENDING) are
-  treated as "deny for safety". If no manager is available, the bridge
-  falls back to Claude Code's native ``"ask"``.
+  wired: the bridge creates a HITL request with a ``PAUSE_INDEFINITELY``
+  escalation policy and awaits resolution within a short timeout
+  (default 25s, under Claude Code's typical 30s hook timeout). Mapping:
+  APPROVED→allow, REJECTED→deny. If the request is still PENDING (or in
+  any other non-terminal state) when the wait elapses, the bridge maps
+  to Claude Code's native ``"ask"`` prompt -- the user can answer in
+  VSC right away, while the HITL request stays open in the background
+  so a late Telegram/webhook reply is still recorded. Manager-side
+  failures fall back to ``"ask"`` (best effort without a working
+  notifier); wait-side failures deny for safety.
+- Per-session decision cache: identical (tool, params) calls within the
+  same Claude Code session re-use the prior Gatekeeper decision for a
+  60s TTL. ``APPROVE`` decisions are NOT cached, so HITL prompts always
+  fire on borderline calls.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json as _json
+import time
 from collections import OrderedDict
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -46,6 +53,7 @@ from fastapi import APIRouter, FastAPI
 from pydantic import BaseModel, ConfigDict, Field
 
 from cognithor.models import (
+    GateDecision,
     GateStatus,
     PlannedAction,
     SessionContext,
@@ -131,16 +139,43 @@ class CCSessionEndInput(_CCHookBase):
 
 
 _MAX_TRACKED_SESSIONS = 256
+_DEFAULT_DECISION_CACHE_TTL_SECONDS = 60.0
+_MAX_CACHED_DECISIONS_PER_SESSION = 128
+
+
+def _hash_tool_call(tool_name: str, tool_input: dict[str, Any]) -> str:
+    """Stable hash of a tool name + its parameters for cache keying.
+
+    Uses sorted-keys JSON so dict ordering does not produce different hashes
+    for the same logical call. Non-JSON-serializable params fall back to
+    ``str(...)`` rather than crashing -- a rare-tool cache miss is fine,
+    a 500 from the bridge is not.
+    """
+    try:
+        payload = _json.dumps({"t": tool_name, "i": tool_input}, sort_keys=True, default=str)
+    except Exception:
+        payload = f"{tool_name}::{tool_input!r}"
+    return hashlib.sha1(payload.encode("utf-8"), usedforsecurity=False).hexdigest()
 
 
 class _SessionTracker:
     """Per-process LRU of Claude-Code-session → Cognithor state."""
 
-    def __init__(self, max_sessions: int = _MAX_TRACKED_SESSIONS) -> None:
+    def __init__(
+        self,
+        max_sessions: int = _MAX_TRACKED_SESSIONS,
+        *,
+        decision_cache_ttl_seconds: float = _DEFAULT_DECISION_CACHE_TTL_SECONDS,
+    ) -> None:
         self._max = max_sessions
         self._contexts: OrderedDict[str, SessionContext] = OrderedDict()
         self._tool_log: dict[str, list[ToolResult]] = {}
         self._user_prompts: dict[str, str] = {}
+        # Per-session LRU of (call_hash) → (decision, expires_at).
+        self._decision_cache: dict[str, OrderedDict[str, tuple[GateDecision, float]]] = {}
+        self._decision_cache_ttl = max(0.0, float(decision_cache_ttl_seconds))
+        self._cache_hits = 0
+        self._cache_misses = 0
 
     def get_or_create(self, cc_session_id: str, cwd: str = "") -> SessionContext:
         ctx = self._contexts.get(cc_session_id)
@@ -154,6 +189,7 @@ class _SessionTracker:
             self._contexts[cc_session_id] = ctx
             self._tool_log[cc_session_id] = []
             self._user_prompts.setdefault(cc_session_id, "")
+            self._decision_cache[cc_session_id] = OrderedDict()
             self._evict_if_needed()
         else:
             self._contexts.move_to_end(cc_session_id)
@@ -169,16 +205,67 @@ class _SessionTracker:
     def tool_history(self, cc_session_id: str) -> list[ToolResult]:
         return list(self._tool_log.get(cc_session_id, []))
 
+    def get_cached_decision(self, cc_session_id: str, call_hash: str) -> GateDecision | None:
+        """Return a cached GateDecision if present and not expired."""
+        if self._decision_cache_ttl <= 0:
+            return None
+        cache = self._decision_cache.get(cc_session_id)
+        if cache is None:
+            return None
+        entry = cache.get(call_hash)
+        if entry is None:
+            self._cache_misses += 1
+            return None
+        decision, expires_at = entry
+        if time.monotonic() >= expires_at:
+            cache.pop(call_hash, None)
+            self._cache_misses += 1
+            return None
+        cache.move_to_end(call_hash)
+        self._cache_hits += 1
+        return decision
+
+    def cache_decision(
+        self,
+        cc_session_id: str,
+        call_hash: str,
+        decision: GateDecision,
+    ) -> None:
+        """Cache a Gatekeeper decision under (session, call_hash) for TTL.
+
+        ``APPROVE`` is intentionally NOT cached -- HITL responses must be
+        fresh per call so the user can revisit a borderline decision.
+        """
+        if self._decision_cache_ttl <= 0:
+            return
+        if decision.status == GateStatus.APPROVE:
+            return
+        cache = self._decision_cache.setdefault(cc_session_id, OrderedDict())
+        cache[call_hash] = (decision, time.monotonic() + self._decision_cache_ttl)
+        cache.move_to_end(call_hash)
+        # Bound per-session entries.
+        while len(cache) > _MAX_CACHED_DECISIONS_PER_SESSION:
+            cache.popitem(last=False)
+
+    def cache_stats(self) -> dict[str, int]:
+        return {
+            "hits": self._cache_hits,
+            "misses": self._cache_misses,
+            "tracked_sessions": len(self._contexts),
+        }
+
     def drop(self, cc_session_id: str) -> None:
         self._contexts.pop(cc_session_id, None)
         self._tool_log.pop(cc_session_id, None)
         self._user_prompts.pop(cc_session_id, None)
+        self._decision_cache.pop(cc_session_id, None)
 
     def _evict_if_needed(self) -> None:
         while len(self._contexts) > self._max:
             old_id, _ = self._contexts.popitem(last=False)
             self._tool_log.pop(old_id, None)
             self._user_prompts.pop(old_id, None)
+            self._decision_cache.pop(old_id, None)
             log.debug("claude_code_hooks_session_evicted", session_id=old_id)
 
 
@@ -254,6 +341,7 @@ def create_claude_code_hooks_router(
 
     @router.get("/health")
     async def health() -> dict[str, Any]:
+        stats = session_tracker.cache_stats()
         return {
             "ok": True,
             "gatekeeper": gatekeeper is not None,
@@ -261,7 +349,9 @@ def create_claude_code_hooks_router(
             "hook_runner": hook_runner is not None,
             "approval_manager": approval_manager is not None,
             "hitl_timeout_seconds": hitl_timeout_seconds,
-            "tracked_sessions": len(session_tracker._contexts),
+            "tracked_sessions": stats["tracked_sessions"],
+            "decision_cache_hits": stats["hits"],
+            "decision_cache_misses": stats["misses"],
         }
 
     @router.post("/pre-tool-use")
@@ -275,21 +365,31 @@ def create_claude_code_hooks_router(
             return _allow("Cognithor Gatekeeper not wired -- allowing by default")
 
         session = session_tracker.get_or_create(body.session_id, body.cwd)
-        action = PlannedAction(
-            tool=body.tool_name,
-            params=body.tool_input,
-            rationale=f"Claude Code PreToolUse (session {body.session_id[:8]})",
-        )
+        # Cheap optimisation: identical (tool, params) inside the same session
+        # within TTL re-uses the prior decision. Halves Gatekeeper load on
+        # read-heavy turns where Claude does Read/Grep dozens of times.
+        call_hash = _hash_tool_call(body.tool_name, body.tool_input)
+        decision = session_tracker.get_cached_decision(body.session_id, call_hash)
+        cache_hit = decision is not None
 
-        try:
-            decision = gatekeeper.evaluate(action, session)
-        except Exception as exc:  # fail-open
-            log.warning(
-                "claude_code_pre_tool_use_gatekeeper_error",
+        if decision is None:
+            action = PlannedAction(
                 tool=body.tool_name,
-                error=str(exc),
+                params=body.tool_input,
+                rationale=f"Claude Code PreToolUse (session {body.session_id[:8]})",
             )
-            return _allow(f"Gatekeeper raised -- failing open: {exc!s}")
+
+            try:
+                decision = gatekeeper.evaluate(action, session)
+            except Exception as exc:  # fail-open
+                log.warning(
+                    "claude_code_pre_tool_use_gatekeeper_error",
+                    tool=body.tool_name,
+                    error=str(exc),
+                )
+                return _allow(f"Gatekeeper raised -- failing open: {exc!s}")
+
+            session_tracker.cache_decision(body.session_id, call_hash, decision)
 
         log.info(
             "claude_code_pre_tool_use",
@@ -298,6 +398,7 @@ def create_claude_code_hooks_router(
             risk=decision.risk_level.value,
             policy=decision.policy_name or None,
             session=body.session_id[:8],
+            cache_hit=cache_hit,
         )
 
         if decision.is_allowed:
@@ -534,10 +635,24 @@ async def _route_approval(
     cwd: str,
     timeout_seconds: float,
 ) -> tuple[str, str | None]:
-    """Route a Gatekeeper APPROVE through HITL.
+    """Route a Gatekeeper APPROVE through HITL with a graceful fallback.
 
-    Returns ``(cc_decision, reason_override_or_None)``. Falls back to
-    ``"ask"`` if no manager is wired or HITL itself errors.
+    Behaviour:
+      * If no ``ApprovalManager`` is wired -> ``"ask"`` (Claude Code's
+        native VSC prompt handles the user-in-the-loop).
+      * Otherwise create an HITL request with ``PAUSE_INDEFINITELY``
+        escalation. Wait up to ``timeout_seconds`` for resolution.
+      * APPROVED -> ``"allow"`` (with reviewer comment).
+      * REJECTED -> ``"deny"`` (with reviewer comment).
+      * Still PENDING after the wait, or any unexpected status, ->
+        ``"ask"``: Claude Code prompts the user inside VSC, the HITL
+        request stays open in the background so a late Telegram answer
+        is still recorded for audit/forensics.
+      * Manager-side errors (create_request raise) -> ``"ask"`` (best
+        we can do without a working notifier). Wait-side errors ->
+        ``"deny"`` (treat as integrity failure of the supervision layer).
+
+    Returns ``(cc_decision, reason_override_or_None)``.
     """
     if approval_manager is None:
         return "ask", None
@@ -565,9 +680,13 @@ async def _route_approval(
         priority=(
             ReviewPriority.HIGH if risk_value in ("orange", "red") else ReviewPriority.NORMAL
         ),
+        # PAUSE_INDEFINITELY keeps the request open after the hook timeout
+        # so the user can still answer via Telegram/webhook later. The
+        # bridge falls back to Claude Code's native "ask" prompt when the
+        # initial wait elapses.
         escalation=EscalationPolicy(
             timeout_seconds=int(max(1.0, timeout_seconds)),
-            action=EscalationAction.AUTO_REJECT,
+            action=EscalationAction.PAUSE_INDEFINITELY,
         ),
     )
 
@@ -623,9 +742,15 @@ async def _route_approval(
             comment = task.responses[-1].comment or ""
         reason = "HITL rejected" + (f": {comment}" if comment else "")
         return "deny", reason
-    # TIMED_OUT, ESCALATED, CANCELED, DELEGATED, PENDING -> safe default
+    # PENDING / ESCALATED / DELEGATED / CANCELED / TIMED_OUT -> hand the
+    # decision back to Claude Code's native "ask" prompt. The HITL request
+    # is intentionally NOT cancelled so a late Telegram/webhook reply
+    # still gets recorded for audit.
     status_repr = getattr(status, "value", str(status))
-    return "deny", f"HITL unresolved (status={status_repr}) -- denying for safety"
+    return "ask", (
+        f"HITL still {status_repr} after {int(timeout_seconds)}s "
+        f"(request {request.request_id}) -- handing off to Claude Code's prompt"
+    )
 
 
 __all__ = [

--- a/tests/integration/test_claude_code_supervised_live.py
+++ b/tests/integration/test_claude_code_supervised_live.py
@@ -1,0 +1,113 @@
+"""Live integration test for the supervised Claude Code driver.
+
+Skipped automatically when the ``claude`` CLI is not on PATH (developer
+laptops without Claude Code installed) or when the ``COGNITHOR_LIVE_CC``
+env var is not truthy (CI by default). When enabled, runs an actual
+``claude -p --output-format stream-json`` subprocess and asserts the
+supervisor parses the real event stream end-to-end.
+
+Catches drift between Cognithor's NDJSON parser and the live CLI output
+(field renames, new event types) before it ships.
+
+Run locally with::
+
+    COGNITHOR_LIVE_CC=1 pytest tests/integration -m integration -v
+
+Marked ``slow`` + ``integration`` so the default ``pytest`` invocation
+(unit tests only) ignores it.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+
+import pytest
+
+from cognithor.core.claude_code_supervised import (
+    ClaudeCodeSupervisor,
+    GoalEvaluation,
+    SupervisorResult,
+)
+
+_LIVE_ENABLED = os.environ.get("COGNITHOR_LIVE_CC", "").lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
+_CLAUDE_PATH = shutil.which("claude")
+
+
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        not _LIVE_ENABLED,
+        reason="set COGNITHOR_LIVE_CC=1 to opt in to live Claude Code calls",
+    ),
+    pytest.mark.skipif(
+        _CLAUDE_PATH is None,
+        reason="`claude` CLI not on PATH",
+    ),
+]
+
+
+@pytest.mark.asyncio
+async def test_supervisor_runs_against_real_claude_cli() -> None:
+    """One-turn live run: ask Claude to say 'hello world' and stop.
+
+    Asserts:
+      - The subprocess parses successfully (no NDJSON drift).
+      - The session_id is captured from the system:init frame.
+      - The result frame produces a non-empty ``final_text``.
+      - At least the basic verdict path returns ``done`` for a trivial goal.
+
+    Cost guardrail: ``max_cost_usd=0.50`` and ``max_turns=1`` keep the
+    test cheap even if the underlying account uses a paid tier.
+    """
+    supervisor = ClaudeCodeSupervisor(
+        model=os.environ.get("COGNITHOR_LIVE_CC_MODEL", "haiku"),
+        max_turns=1,
+        max_cost_usd=0.50,
+        per_turn_timeout_seconds=120,
+        goal_evaluator=None,  # use the default, single-turn -> "done"
+    )
+    result = await supervisor.run("Reply with just the two words 'hello world' and nothing else.")
+
+    assert isinstance(result, SupervisorResult)
+    assert result.verdict in ("done", "abort"), result.reason
+    assert len(result.turns) == 1, "should be exactly one turn"
+    turn = result.turns[0]
+    assert turn.session_id, "system:init frame should provide a session_id"
+    assert not turn.is_error, f"turn errored: {turn.error}"
+    assert turn.assistant_text, "result frame should produce non-empty text"
+
+
+@pytest.mark.asyncio
+async def test_supervisor_respects_max_cost_against_real_cli() -> None:
+    """Set max_cost_usd to 0 so we abort BEFORE invoking the CLI a second time.
+
+    The first turn still runs (budget is checked at the top of the loop,
+    after a turn with cost=0.0 we'd compare 0 >= 0). This documents the
+    edge: running with max_cost_usd=0 effectively limits to one turn.
+    """
+    supervisor = ClaudeCodeSupervisor(
+        model=os.environ.get("COGNITHOR_LIVE_CC_MODEL", "haiku"),
+        max_turns=5,
+        max_cost_usd=0.0001,  # any non-zero cost trips the budget
+        per_turn_timeout_seconds=120,
+        goal_evaluator=lambda _ui, _t: _continue_eval(),  # always continue
+    )
+    result = await supervisor.run("Reply with just the two words 'hello world' and nothing else.")
+    # We expect either max_cost abort after the first turn, or a one-turn
+    # done if the live cost happens to be reported as exactly 0.
+    if result.verdict == "abort":
+        assert "max_cost" in result.reason
+    else:
+        assert result.verdict == "done"
+    assert len(result.turns) >= 1
+
+
+async def _continue_eval() -> GoalEvaluation:
+    return GoalEvaluation(verdict="continue", next_prompt="continue")

--- a/tests/test_core/test_claude_code_supervised.py
+++ b/tests/test_core/test_claude_code_supervised.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -18,9 +18,14 @@ from cognithor.core.claude_code_supervised import (
     ClaudeCodeSupervisedBackend,
     ClaudeCodeSupervisor,
     GoalEvaluation,
+    PlannerGoalEvaluator,
     SupervisorResult,
+    TurnResult,
 )
 from cognithor.core.llm_backend import ChatResponse, LLMBackendError, LLMBackendType
+
+if TYPE_CHECKING:
+    from cognithor.models import ToolResult
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Fake subprocess plumbing
@@ -427,3 +432,153 @@ class TestSupervisedBackend:
         b = ClaudeCodeSupervisedBackend()
         with pytest.raises(LLMBackendError):
             await b.embed("any", "text")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# PlannerGoalEvaluator
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _turn(
+    *,
+    turn: int = 1,
+    text: str = "ok",
+    tools: list[ToolResult] | None = None,
+    cost: float = 0.01,
+    is_error: bool = False,
+    error: str | None = None,
+) -> TurnResult:
+    return TurnResult(
+        turn=turn,
+        prompt="(prompt)",
+        assistant_text=text,
+        tool_results=list(tools or []),
+        cost_usd=cost,
+        duration_ms=10,
+        is_error=is_error,
+        error=error,
+        session_id="sess",
+    )
+
+
+class _FakeLLM:
+    """Minimal LLM stub matching the .chat(model, messages, **kwargs) shape."""
+
+    def __init__(self, content: str, *, raise_on_call: Exception | None = None) -> None:
+        self.content = content
+        self.calls: list[dict] = []
+        self._raise = raise_on_call
+
+    async def chat(self, model: str, messages: list[dict], **kwargs):
+        self.calls.append({"model": model, "messages": messages, "kwargs": kwargs})
+        if self._raise is not None:
+            raise self._raise
+        return ChatResponse(content=self.content, model=model)
+
+
+class TestPlannerGoalEvaluator:
+    @pytest.mark.asyncio
+    async def test_done_verdict_parsed(self):
+        llm = _FakeLLM(content='{"verdict": "done", "next_prompt": "", "reason": "goal met"}')
+        ev = PlannerGoalEvaluator(llm=llm, model="sonnet")
+        result = await ev("write hello.py", [_turn(text="DONE — wrote hello.py")])
+        assert result.verdict == "done"
+        assert result.reason == "goal met"
+        assert llm.calls and llm.calls[0]["model"] == "sonnet"
+
+    @pytest.mark.asyncio
+    async def test_continue_verdict_carries_next_prompt(self):
+        llm = _FakeLLM(
+            content=(
+                '{"verdict": "continue", "next_prompt": "Now add tests for it.", '
+                '"reason": "code written but no tests"}'
+            )
+        )
+        ev = PlannerGoalEvaluator(llm=llm, model="sonnet")
+        result = await ev("write hello.py with tests", [_turn(text="wrote hello.py")])
+        assert result.verdict == "continue"
+        assert result.next_prompt == "Now add tests for it."
+
+    @pytest.mark.asyncio
+    async def test_abort_verdict_parsed(self):
+        llm = _FakeLLM(content='{"verdict": "abort", "next_prompt": "", "reason": "stuck"}')
+        ev = PlannerGoalEvaluator(llm=llm, model="sonnet")
+        result = await ev(
+            "do impossible thing",
+            [_turn(text="failed again", is_error=True, error="loop detected")],
+        )
+        assert result.verdict == "abort"
+        assert result.reason == "stuck"
+
+    @pytest.mark.asyncio
+    async def test_json_with_code_fences_is_parsed(self):
+        llm = _FakeLLM(
+            content=('```json\n{"verdict": "done", "next_prompt": "", "reason": "ok"}\n```\n')
+        )
+        ev = PlannerGoalEvaluator(llm=llm, model="sonnet")
+        result = await ev("goal", [_turn()])
+        assert result.verdict == "done"
+
+    @pytest.mark.asyncio
+    async def test_json_with_prose_preamble_is_parsed(self):
+        llm = _FakeLLM(
+            content=(
+                "Here is my verdict:\n"
+                '{"verdict": "continue", "next_prompt": "do step 2", "reason": "step 1 done"}'
+            )
+        )
+        ev = PlannerGoalEvaluator(llm=llm, model="sonnet")
+        result = await ev("goal", [_turn()])
+        assert result.verdict == "continue"
+        assert result.next_prompt == "do step 2"
+
+    @pytest.mark.asyncio
+    async def test_unparseable_response_returns_failure_default(self):
+        llm = _FakeLLM(content="Not JSON at all, just words.")
+        ev = PlannerGoalEvaluator(llm=llm, model="sonnet")
+        result = await ev("goal", [_turn()])
+        assert result.verdict == "continue"
+        assert result.reason == "judge_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_invalid_verdict_value_returns_failure_default(self):
+        llm = _FakeLLM(content='{"verdict": "maybe", "next_prompt": "", "reason": "?"}')
+        ev = PlannerGoalEvaluator(llm=llm, model="sonnet")
+        result = await ev("goal", [_turn()])
+        assert result.verdict == "continue"
+        assert result.reason == "judge_unavailable"
+
+    @pytest.mark.asyncio
+    async def test_llm_raise_returns_failure_default(self):
+        llm = _FakeLLM(content="", raise_on_call=RuntimeError("boom"))
+        ev = PlannerGoalEvaluator(llm=llm, model="sonnet")
+        result = await ev("goal", [_turn()])
+        assert result.verdict == "continue"
+        assert "judge could not produce" in result.next_prompt
+
+    @pytest.mark.asyncio
+    async def test_no_turns_yields_continue(self):
+        llm = _FakeLLM(content='{"verdict": "done"}')
+        ev = PlannerGoalEvaluator(llm=llm, model="sonnet")
+        result = await ev("goal", [])
+        assert result.verdict == "continue"
+        # LLM must not be called when there's nothing to judge.
+        assert llm.calls == []
+
+    @pytest.mark.asyncio
+    async def test_evaluator_plugged_into_supervisor(self):
+        llm = _FakeLLM(content='{"verdict": "done", "next_prompt": "", "reason": "fits"}')
+        evaluator = PlannerGoalEvaluator(llm=llm, model="sonnet")
+        proc = _FakeProc(_script_events(text="wrote it"))
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=proc)):
+            sup = ClaudeCodeSupervisor(
+                claude_path="claude",
+                goal_evaluator=evaluator,
+            )
+            result = await sup.run("write hello.py")
+        assert result.verdict == "done"
+        # The supervisor must have passed the user_intent through the new
+        # two-arg evaluator signature.
+        assert llm.calls, "evaluator should have been invoked"
+        user_msg = llm.calls[0]["messages"][1]["content"]
+        assert "write hello.py" in user_msg

--- a/tests/test_gateway/test_claude_code_hooks.py
+++ b/tests/test_gateway/test_claude_code_hooks.py
@@ -356,14 +356,27 @@ class TestApproveRouting:
         assert "HITL rejected" in out["permissionDecisionReason"]
         assert "too risky" in out["permissionDecisionReason"]
 
-    def test_timed_out_status_denies_for_safety(self, gatekeeper_approving):
-        mgr = _make_approval_manager(final_status=ApprovalStatus.TIMED_OUT)
+    def test_pending_status_falls_back_to_ask_with_request_in_reason(self, gatekeeper_approving):
+        # Default _StubRequest has status=PENDING, simulating an HITL
+        # request that was not answered before the wait elapsed. The
+        # bridge should hand off to Claude Code's native "ask" prompt
+        # rather than denying outright.
+        mgr = _make_approval_manager(final_status=ApprovalStatus.PENDING)
         app = build_claude_code_hooks_app(gatekeeper=gatekeeper_approving, approval_manager=mgr)
         client = TestClient(app)
         r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
         out = r.json()["hookSpecificOutput"]
-        assert out["permissionDecision"] == "deny"
-        assert "unresolved" in out["permissionDecisionReason"]
+        assert out["permissionDecision"] == "ask"
+        assert "still" in out["permissionDecisionReason"].lower()
+        assert "apr_test" in out["permissionDecisionReason"]
+
+    def test_escalated_status_falls_back_to_ask(self, gatekeeper_approving):
+        mgr = _make_approval_manager(final_status=ApprovalStatus.ESCALATED)
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_approving, approval_manager=mgr)
+        client = TestClient(app)
+        r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+        out = r.json()["hookSpecificOutput"]
+        assert out["permissionDecision"] == "ask"
 
     def test_no_approval_manager_falls_back_to_ask(self, gatekeeper_approving):
         app = build_claude_code_hooks_app(gatekeeper=gatekeeper_approving, approval_manager=None)
@@ -391,3 +404,66 @@ class TestApproveRouting:
         out = r.json()["hookSpecificOutput"]
         assert out["permissionDecision"] == "deny"
         assert "wait error" in out["permissionDecisionReason"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Per-session decision cache
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDecisionCache:
+    def test_identical_call_uses_cache(self, gatekeeper_allowing):
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_allowing)
+        client = TestClient(app)
+        # Three identical pre-tool-use calls with same session + same params.
+        for _ in range(3):
+            r = client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+            assert r.json()["hookSpecificOutput"]["permissionDecision"] == "allow"
+        # Gatekeeper should have been called exactly once -- two cache hits.
+        assert gatekeeper_allowing.evaluate.call_count == 1
+
+        health = client.get("/api/claude-hooks/health").json()
+        assert health["decision_cache_hits"] >= 2
+        assert health["decision_cache_misses"] >= 1
+
+    def test_different_params_bypass_cache(self, gatekeeper_allowing):
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_allowing)
+        client = TestClient(app)
+        client.post("/api/claude-hooks/pre-tool-use", json=_payload(command="ls"))
+        client.post("/api/claude-hooks/pre-tool-use", json=_payload(command="pwd"))
+        client.post("/api/claude-hooks/pre-tool-use", json=_payload(command="ls"))
+        # ls (miss), pwd (miss), ls (hit) → 2 evaluate() calls.
+        assert gatekeeper_allowing.evaluate.call_count == 2
+
+    def test_different_session_isolates_cache(self, gatekeeper_allowing):
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_allowing)
+        client = TestClient(app)
+        p1 = _payload()
+        p2 = dict(p1, session_id="other-session-9999")
+        client.post("/api/claude-hooks/pre-tool-use", json=p1)
+        client.post("/api/claude-hooks/pre-tool-use", json=p2)
+        # Same params, different sessions → two evaluations, no cross-talk.
+        assert gatekeeper_allowing.evaluate.call_count == 2
+
+    def test_approve_decision_is_not_cached(self, gatekeeper_approving):
+        # Simulate a manager that always returns PENDING (so each call
+        # triggers a fresh wait_for_resolution path) -- the important
+        # thing is the gatekeeper.evaluate must NOT be cache-shortcircuited.
+        mgr = _make_approval_manager(final_status=ApprovalStatus.PENDING)
+        app = build_claude_code_hooks_app(gatekeeper=gatekeeper_approving, approval_manager=mgr)
+        client = TestClient(app)
+        for _ in range(3):
+            client.post("/api/claude-hooks/pre-tool-use", json=_payload())
+        # APPROVE decisions are intentionally never cached; every call
+        # must re-evaluate the Gatekeeper so HITL fires fresh each time.
+        assert gatekeeper_approving.evaluate.call_count == 3
+        assert mgr.create_request.await_count == 3
+
+    def test_health_exposes_cache_counters(self):
+        app = build_claude_code_hooks_app()
+        client = TestClient(app)
+        health = client.get("/api/claude-hooks/health").json()
+        assert "decision_cache_hits" in health
+        assert "decision_cache_misses" in health
+        assert health["decision_cache_hits"] == 0
+        assert health["decision_cache_misses"] == 0


### PR DESCRIPTION
## Summary

Three additive optimizations on top of the Claude Code hook bridge + supervisor (PR #153, merged). All default-off when collaborators are unwired.

**Supersedes #157** — same feature commit, freshly cherry-picked onto post-v0.95.0 main (`0e72c1eb`) with synchronized version files (no version-mismatch CI failure).

### 1. Per-session decision cache (`gateway/claude_code_hooks.py`)
- `_SessionTracker.OrderedDict[(call_hash) → (GateDecision, expires_at)]`, 60s TTL, 128-entry LRU
- `_hash_tool_call()` SHA1 over tool name + sorted-JSON params (dict-order-stable)
- `pre-tool-use` checks cache before Gatekeeper; `APPROVE` is intentionally NOT cached so HITL fires fresh
- `/health` surfaces `decision_cache_hits` / `decision_cache_misses`
- Roughly halves Gatekeeper load on read-heavy turns

### 2. PlannerGoalEvaluator (`core/claude_code_supervised.py`)
- Plug-compatible `GoalEvaluator` implementation
- Tolerant JSON parser handles raw / fenced / prose-prefixed responses
- Defaults to `failure` verdict on any unparseable / invalid / exception path

### 3. HITL routing (`gateway/claude_code_hooks.py`)
- `PENDING` / `ESCALATED` Gatekeeper status → `ask` with `request_id` surfaced
- Approval-manager failures fall back to `ask` (create) or `deny` (wait)

## Test plan
- [x] `pytest tests/test_core/test_claude_code_supervised.py tests/test_gateway/test_claude_code_hooks.py tests/integration/` → 52 passed, 2 skipped (live-CLI)
- [x] `ruff check` + `ruff format --check` on touched files → clean
- [ ] CI green
- [ ] Manual: live-test Claude Code hook flow with cache enabled