### PR TITLE
fix(identity): close two latent observations from identity-test sessions (442 total)

### DIFF
--- a/src/cognithor/identity/cognitio/vector_store.py
+++ b/src/cognithor/identity/cognitio/vector_store.py
@@ -82,6 +82,12 @@ class VectorStore:
             # ChromaDB metadata values must be string, int, float, or bool
             clean_metadata = self._clean_metadata(metadata)
 
+            # ChromaDB 1.5+ rejects empty metadata dicts with ValueError.
+            # Inject a sentinel so the call still succeeds; callers that
+            # pass {} get a single benign field instead of a 500.
+            if not clean_metadata:
+                clean_metadata = {"_meta_empty": True}
+
             # Check for existing record
             existing = self._collection.get(ids=[memory_id])
             if existing["ids"]:

--- a/src/cognithor/identity/storage/local_store.py
+++ b/src/cognithor/identity/storage/local_store.py
@@ -47,10 +47,15 @@ class LocalStore:
             dict: {'uri': str, 'filepath': str, 'hash': str}
         """
         import hashlib
+        import uuid
 
+        # Timestamp has 1-second resolution; rapid back-to-back saves with the
+        # same identity_id would collide and silently overwrite each other.
+        # Append a short uuid4 fragment to guarantee a unique filename.
         timestamp = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
+        unique_suffix = uuid.uuid4().hex[:8]
         safe_id = _SAFE_ID_RE.sub("_", identity_id[:16])
-        filename = f"{safe_id}_{timestamp}.json"
+        filename = f"{safe_id}_{timestamp}_{unique_suffix}.json"
         filepath = os.path.join(self.base_dir, filename)
 
         content = json.dumps(snapshot, ensure_ascii=False, indent=2)

--- a/tests/test_identity/cognitio/test_vector_store.py
+++ b/tests/test_identity/cognitio/test_vector_store.py
@@ -166,6 +166,26 @@ class TestGetAllIdsAndClear:
 
 
 # ---------------------------------------------------------------------------
+# TestEmptyMetadataGuard  (regression for ChromaDB 1.5+ ValueError on {})
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyMetadataGuard:
+    """ChromaDB 1.5+ rejects empty metadata dicts with ValueError.
+    The add() guard injects a sentinel so callers passing {} don't crash."""
+
+    def test_add_with_empty_metadata_does_not_raise(self, vs):
+        vs.add("m1", EMB_X, {})  # empty metadata
+        assert vs.count() == 1
+        assert vs.exists("m1")
+
+    def test_empty_metadata_record_is_queryable(self, vs):
+        vs.add("m1", EMB_X, {})
+        ids = vs.query(EMB_X, n_results=5)
+        assert "m1" in ids
+
+
+# ---------------------------------------------------------------------------
 # TestCleanMetadata  (static — no ChromaDB needed)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_identity/storage/test_local_store.py
+++ b/tests/test_identity/storage/test_local_store.py
@@ -109,6 +109,29 @@ class TestSaveLoadSnapshot:
         assert result is None
 
 
+class TestRapidSaveNoCollision:
+    """Regression: PR #168 noted that 1-second timestamp resolution caused
+    rapid same-second saves with the same identity_id to silently overwrite
+    each other. The fix appends a uuid4 fragment to the filename."""
+
+    def test_two_saves_in_same_second_produce_two_files(self, tmp_path):
+        store = LocalStore(base_dir=str(tmp_path / "store"))
+        r1 = store.save_snapshot({"n": 1}, identity_id="x")
+        r2 = store.save_snapshot({"n": 2}, identity_id="x")
+        assert r1["filepath"] != r2["filepath"]
+        assert os.path.exists(r1["filepath"])
+        assert os.path.exists(r2["filepath"])
+
+    def test_load_each_returns_its_own_payload(self, tmp_path):
+        store = LocalStore(base_dir=str(tmp_path / "store"))
+        r1 = store.save_snapshot({"n": 1}, identity_id="x")
+        r2 = store.save_snapshot({"n": 2}, identity_id="x")
+        d1 = store.load_snapshot(r1["uri"])
+        d2 = store.load_snapshot(r2["uri"])
+        assert d1["n"] == 1
+        assert d2["n"] == 2
+
+
 # ---------------------------------------------------------------------------
 # LocalStore — path traversal
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two small source-code fixes for issues that were noted as 'latent observations' during the identity test-coverage push but not blocking at the time. Both have regression tests.

## 1. `local_store.save_snapshot` timestamp collision (originally noted in PR #168)

The `%Y%m%d_%H%M%S` timestamp has 1-second resolution; rapid back-to-back saves with the same `identity_id` produced colliding filenames that silently overwrote each other. Fix: append `uuid4().hex[:8]` to the filename so each save lands at a unique destination regardless of sub-second timing.

`tests/test_identity/storage/test_local_store.py::TestRapidSaveNoCollision` (2 tests) verifies two same-second saves produce two distinct files and `load_snapshot` returns each payload independently.

## 2. `vector_store.add` empty-metadata ValueError (originally noted in PR #167)

ChromaDB 1.5+ rejects metadata dicts with zero attributes (`validate_metadata` raises `ValueError`). The cognitive engine always passes a populated dict, but defensive callers passing `{}` (or a dict that becomes empty after `_clean_metadata` strips unsupported types) would crash. Fix: inject `{"_meta_empty": True}` sentinel when `clean_metadata` is empty.

`tests/test_identity/cognitio/test_vector_store.py::TestEmptyMetadataGuard` (2 tests) verifies `add(id, emb, {})` succeeds and the record is queryable.

## Test plan

- [x] `pytest tests/test_identity/` 442 passed in 4:52 (was 438)
- [x] `ruff check` + `ruff format --check` on the four modified files clean
- [ ] CI green