### PR TITLE
docs(audit): benchmark/ archive recommendation (closes last VERIFY-WIRING item)

### DIFF
--- a/docs/audits/2026-04-27-stale-module-triage.md
+++ b/docs/audits/2026-04-27-stale-module-triage.md
@@ -22,13 +22,13 @@ Audit of 14 backend modules under `src/cognithor/` with no commits since 2026-04
 - **Test coverage:** 11 test refs.
 - **Recommendation:** No action. Module is stable and integrated within the security layer.
 
-### `benchmark` — **VERIFY-WIRING**
+### `benchmark` — **VERIFY-WIRING** → see [2026-04-28 archive recommendation](2026-04-28-benchmark-archive-recommendation.md)
 
 - **Purpose:** Performance benchmarking & profiling utilities (2 files, 863 LOC).
 - **External import count:** 0 (only test refs).
 - **Test coverage:** 1 test ref.
-- **Runtime relevance:** Mentioned in CLI flags but not instantiated at runtime.
-- **Question for the user:** *Archive now, or keep seeded for future ARC-AGI-3 integration?* If kept, document the intended consumer.
+- **Runtime relevance:** None — not wired into CLI / gateway / channels.
+- **Recommendation:** Archive. The canonical benchmark home is the top-level `cognithor_bench/` package (own `pyproject.toml`, `cognithor-bench` CLI, Cognithor + AutoGen adapters). The internal `src/cognithor/benchmark/` is a parallel implementation with zero callers. See the linked recommendation doc for details + decision options.
 
 ### `documents` — **KEEP-DOCUMENTED**
 
@@ -121,7 +121,7 @@ green post-deletion (14 454 passed).
 - [x] ~~Resolve `kanban/` (7 TODOs) and `proactive/` (2 TODOs) hot-spots~~ — false positive, the "TODOs" were enum members named `TODO`, not work markers.
 - [x] ~~Decide `ui/`~~ — deleted (PR #162).
 - [x] ~~Add brief sections to `docs/ARCHITECTURE.md` for `forensics/` and `hitl/`~~ — done (`adcd6314`).
-- [ ] Decide `benchmark/`: archive vs. keep-for-ARC-AGI-3 (still pending — user judgment call).
+- [ ] Decide `benchmark/`: archive vs. keep-and-wire — see [2026-04-28 archive recommendation](2026-04-28-benchmark-archive-recommendation.md). Recommended: archive. Pending User confirmation.
 
 ## Notes
 

--- a/docs/audits/2026-04-28-benchmark-archive-recommendation.md
+++ b/docs/audits/2026-04-28-benchmark-archive-recommendation.md
@@ -1,0 +1,60 @@
+# `src/cognithor/benchmark/` — archive recommendation — 2026-04-28
+
+Closes the last open VERIFY-WIRING item from `docs/audits/2026-04-27-stale-module-triage.md`.
+
+## TL;DR
+
+**Archive `src/cognithor/benchmark/` (~863 LOC).** It's a sophisticated benchmark framework that no production code calls; the canonical benchmark home is the top-level `cognithor_bench/` package, which already has its own `pyproject.toml`, console-script `cognithor-bench`, and Cognithor + AutoGen adapters.
+
+## Evidence
+
+### `src/cognithor/benchmark/`
+
+- 2 files, 863 LOC: `__init__.py` (4 lines), `suite.py` (859 LOC).
+- Defines 7 classes — `BenchmarkTask`, `BenchmarkResult`, `BenchmarkScorer`, `BenchmarkRunner`, `BenchmarkReport`, `RegressionEntry`, `RegressionDetector` — and the `TaskCategory` / `TaskDifficulty` / `ResultStatus` enums.
+- Architecture reference: §18.1.
+- **Live import count outside its own package:** 0.
+- **Test references:** 1 — `tests/test_benchmark/test_suite.py`.
+- **Wired into:** nothing — not the CLI (`__main__.py`), not the gateway, not any channel, not a workflow.
+- **Last commit:** 2026-04-10 (≥ 18 days stale).
+
+### `cognithor_bench/` (top-level)
+
+- Has its own `pyproject.toml` with version 0.1.0 and the CLI entry point `cognithor-bench = "cognithor_bench.cli:main"`.
+- Lives outside the published `cognithor` PyPI package on purpose (per the dev-deps comment in the root `pyproject.toml`: "Local sub-packages are NOT listed here because direct file references are forbidden in PyPI metadata").
+- Already has Cognithor + AutoGen adapters: `cognithor_bench/src/cognithor_bench/adapters/autogen_adapter.py` (lazy import per pyproject comment).
+- Memory entry confirms: "in-monorepo benchmark scaffold with own pyproject.toml + console-script cognithor-bench."
+
+## Why archive instead of rewire
+
+1. **Duplication risk** — keeping both invites confusion about which is the canonical benchmark home. `cognithor_bench/` is the one with publishable artefacts and adapters; the internal one is a duplicated implementation.
+2. **No callers** — 0 production imports in 18+ days means there's no migration cost on archival.
+3. **The framework is genuinely fancy** — `RegressionDetector`, `BenchmarkReport` markdown + JSON, scoring across 7 categories. If we ever want any of this, we should backport the *useful pieces* into `cognithor_bench/`, not keep two parallel implementations.
+4. **Test count is weak** — 1 test file. Tests can be archived alongside the source.
+
+## Recommended action
+
+```bash
+# Move source to archive (keeps git history)
+git mv src/cognithor/benchmark archive/cognithor_internal_benchmark
+git mv tests/test_benchmark archive/cognithor_internal_benchmark_tests
+
+# Or just delete if no historical value:
+git rm -r src/cognithor/benchmark tests/test_benchmark
+```
+
+If a piece of the internal framework is actually useful (e.g. `RegressionDetector`'s diff format, the markdown report shape), copy that ONE piece into `cognithor_bench/` first — don't preserve the entire 863-LOC parallel impl just for one nice class.
+
+## Counter-argument (for completeness)
+
+If there's a use case for an *in-process* benchmark runner (i.e. one that runs INSIDE a live `cognithor` instance for self-evaluation, rather than as an external CLI), then keep `src/cognithor/benchmark/` — but actually wire it up to something (e.g. expose via `cognithor benchmark run` subcommand or via a gateway endpoint). Right now it's a dead module dressed as a feature.
+
+## Decision required
+
+This is a User-judgment call — pick one:
+
+- [ ] **Archive** (`git mv` to `archive/`) — recommended.
+- [ ] **Delete** (`git rm`) — also fine; git history preserves recoverability.
+- [ ] **Keep + wire up** — only if there's a concrete in-process benchmark use case. Specify what consumer would call it.
+
+Once decided, the relevant action is one PR; ~10 minutes either way. This doc doesn't decide for you — it surfaces the case clearly enough to decide quickly.


### PR DESCRIPTION
Pure docs commit. Closes the last open VERIFY-WIRING item from the 2026-04-27 stale-module triage (which was: "benchmark/: archive or keep-for-ARC-AGI-3?").

## Investigation

`src/cognithor/benchmark/` is 863 LOC across 2 files (`__init__.py` 4 lines + `suite.py` 859 lines). It defines 7 production-ready classes (`BenchmarkTask`, `BenchmarkResult`, `BenchmarkScorer`, `BenchmarkRunner`, `BenchmarkReport`, `RegressionEntry`, `RegressionDetector`) plus 3 enums.

**Live import count outside its own package: 0.** Test refs: 1. Wired into nothing — not the CLI, not the gateway, not any channel.

The canonical benchmark home is the top-level `cognithor_bench/` package, which has its own `pyproject.toml` (v0.1.0), `cognithor-bench` console script, and Cognithor + AutoGen adapters. That's the one used. The internal `src/cognithor/benchmark/` is a parallel implementation that never got wired up.

## Recommendation

**Archive it** (`git mv src/cognithor/benchmark archive/cognithor_internal_benchmark`). The 18-day staleness + zero callers + duplicate-of-cognithor_bench evidence make this the obvious call. If any specific class (e.g. `RegressionDetector`) has reuse value, copy it INTO `cognithor_bench/` first.

## What this PR contains

- New `docs/audits/2026-04-28-benchmark-archive-recommendation.md` — full evidence + decision options + counter-argument.
- Updates `docs/audits/2026-04-27-stale-module-triage.md` to point to the new recommendation doc and mark `benchmark/` as decided-pending-confirmation.

This PR does NOT execute the archival. That's a separate PR after User confirmation.

## Test plan

- [x] No code change → CI exercise via lint + test legs only
- [ ] CI green