### PR TITLE
chore(tooling): pre-commit auto-install + verify_readme in CI + JARVIS_HOME fallback fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,19 @@ jobs:
           PYTHONIOENCODING: "utf-8"
           PYTHONUTF8: "1"
 
+      - name: verify_readme_claims.py (README drift detection)
+        # Non-blocking informational drift check: counts MCP tools, channels,
+        # LLM providers, and test functions, then compares against the values
+        # claimed in README.md. Drift surfaces in the build log but does NOT
+        # fail the job — README updates are usually informational.
+        # `continue-on-error: true` ensures any genuine drift gets seen
+        # without blocking unrelated PRs.
+        continue-on-error: true
+        run: python scripts/verify_readme_claims.py
+        env:
+          PYTHONIOENCODING: "utf-8"
+          PYTHONUTF8: "1"
+
       - name: smoke_test.py (import + bootstrap checks)
         # Skips Ollama/models; only imports, config load, directory scaffold.
         # If the script changes shape, this step catches it before release.

--- a/scripts/bootstrap_windows.py
+++ b/scripts/bootstrap_windows.py
@@ -175,13 +175,13 @@ def _download_flutter_web(repo_root: str) -> bool:
 
 
 # ── Pfade ──────────────────────────────────────────────────────────────────
-# Cognithor home: prefer COGNITHOR_HOME, fall back to legacy COGNITHOR_HOME
-# (older installs), then default to ~/.cognithor/. Variable name stays
-# `COGNITHOR_HOME` everywhere downstream — old `COGNITHOR_HOME` was a
-# pre-rebrand artefact.
+# Cognithor home: prefer COGNITHOR_HOME env var, fall back to legacy
+# JARVIS_HOME (older installs), then default to ~/.cognithor/.
+# Variable name stays `COGNITHOR_HOME` everywhere downstream — old
+# `JARVIS_HOME` was a pre-rebrand artefact kept for backwards-compat only.
 COGNITHOR_HOME = Path(
     os.environ.get("COGNITHOR_HOME")
-    or os.environ.get("COGNITHOR_HOME")
+    or os.environ.get("JARVIS_HOME")
     or (Path.home() / ".cognithor")
 )
 MARKER_FILE = COGNITHOR_HOME / ".cognithor_initialized"
@@ -952,6 +952,39 @@ def first_start(repo_root: str, *, skip_models: bool = False) -> bool:
                     )
         except Exception as e:
             warn(f"Venv sync check failed: {e}")
+
+    # Dev-mode: auto-install pre-commit hooks if running from source repo.
+    # Only fires when `.git/` exists alongside `.pre-commit-config.yaml`.
+    # End-user wheel installs skip this silently (no .git in site-packages).
+    _precommit_cfg = Path(repo_root) / ".pre-commit-config.yaml"
+    _git_dir = Path(repo_root) / ".git"
+    if _precommit_cfg.exists() and _git_dir.exists():
+        try:
+            _pc_check = subprocess.run(
+                [sys.executable, "-m", "pre_commit", "--version"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+            if _pc_check.returncode == 0:
+                _pc_install = subprocess.run(
+                    [sys.executable, "-m", "pre_commit", "install"],
+                    capture_output=True,
+                    text=True,
+                    timeout=15,
+                    cwd=repo_root,
+                )
+                if _pc_install.returncode == 0:
+                    ok("pre-commit hooks installed (dev repo)")
+                else:
+                    info(f"pre-commit install non-fatal: {_pc_install.stderr.strip()[:100]}")
+            else:
+                info(
+                    "pre-commit not installed — dev contributors should run "
+                    "`pip install pre-commit && pre-commit install`"
+                )
+        except Exception as exc:
+            info(f"pre-commit auto-install skipped: {exc}")
 
     # ── 6. Flutter Web UI ──────────────────────────────────────────────
     header("6/14  Flutter Web UI")

--- a/scripts/preflight_check.py
+++ b/scripts/preflight_check.py
@@ -26,12 +26,13 @@ from pathlib import Path
 
 MIN_PYTHON = (3, 12)
 OLLAMA_URL = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
-# Cognithor home: prefer COGNITHOR_HOME, fall back to legacy COGNITHOR_HOME
-# (kept for backwards-compat with pre-rebrand installs), then default
-# to ~/.cognithor/. The legacy ~/.jarvis/ path is no longer the default.
+# Cognithor home: prefer COGNITHOR_HOME env var, fall back to legacy
+# JARVIS_HOME (kept for backwards-compat with pre-rebrand installs),
+# then default to ~/.cognithor/. The legacy ~/.jarvis/ path is no longer
+# the default but still honored if the user has it set explicitly.
 COGNITHOR_HOME = Path(
     os.environ.get("COGNITHOR_HOME")
-    or os.environ.get("COGNITHOR_HOME")
+    or os.environ.get("JARVIS_HOME")
     or (Path.home() / ".cognithor")
 )
 


### PR DESCRIPTION
## Summary

Three small tooling-hygiene improvements bundled because each is a one-file diff and they all relate to dev/CI hygiene.

### 1. Pre-commit auto-install in bootstrap_windows.py
Bootstrap now detects dev-mode (`.git/` directory + `.pre-commit-config.yaml` both present) and runs `python -m pre_commit install` automatically. End-user wheel installs skip this silently. Removes the "forgot to set up pre-commit" footgun for new contributors.

### 2. verify_readme_claims.py in CI Scripts job
Wired with `continue-on-error: true` — drift surfaces in build log without blocking unrelated PRs. Currently reports:
- tools=145/145 ✅
- channels=18 vs 21 actual (info)
- providers=19/19 ✅
- tests=14 313

### 3. **Bug fix** — JARVIS_HOME legacy fallback restored
PR #185's `replace_all=true` rename `JARVIS_HOME` → `COGNITHOR_HOME` was overzealous. It nuked the *legacy fallback* `os.environ.get("JARVIS_HOME")` to also be `COGNITHOR_HOME`, leaving a dead duplicate:

```python
COGNITHOR_HOME = Path(
    os.environ.get("COGNITHOR_HOME")
    or os.environ.get("COGNITHOR_HOME")  # was JARVIS_HOME — broken
    or (Path.home() / ".cognithor")
)
```

Effect: pre-rebrand installs that still set `JARVIS_HOME` were silently ignored — bootstrap created a fresh `~/.cognithor/` instead of using their existing data dir. Affected `scripts/bootstrap_windows.py` and `scripts/preflight_check.py`.

## Test plan
- [x] `ruff check + format` clean.
- [x] `python scripts/preflight_check.py` → 29/33 passed unchanged.
- [x] `python -c "import scripts.bootstrap_windows"` → parses cleanly.
- [ ] CI full regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)