### PR TITLE
test(flutter): unit tests for 4 more ChangeNotifier providers (+22 tests)

### DIFF
--- a/flutter_app/test/providers/hacker_mode_provider_test.dart
+++ b/flutter_app/test/providers/hacker_mode_provider_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:cognithor_ui/providers/hacker_mode_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('HackerModeProvider', () {
+    setUp(() {
+      SharedPreferences.setMockInitialValues({});
+    });
+
+    test('default enabled is false when no preference is stored', () async {
+      final provider = HackerModeProvider();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.enabled, false);
+    });
+
+    test('persisted true preference loads as enabled', () async {
+      SharedPreferences.setMockInitialValues({'hacker_mode_enabled': true});
+      final provider = HackerModeProvider();
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.enabled, true);
+    });
+
+    test('toggle flips state + persists', () async {
+      final provider = HackerModeProvider();
+      await Future<void>.delayed(Duration.zero);
+
+      await provider.toggle();
+      expect(provider.enabled, true);
+
+      final prefs = await SharedPreferences.getInstance();
+      expect(prefs.getBool('hacker_mode_enabled'), true);
+
+      await provider.toggle();
+      expect(provider.enabled, false);
+      expect(prefs.getBool('hacker_mode_enabled'), false);
+    });
+
+    test('toggle notifies listeners', () async {
+      final provider = HackerModeProvider();
+      await Future<void>.delayed(Duration.zero);
+
+      var notifyCount = 0;
+      provider.addListener(() => notifyCount++);
+
+      await provider.toggle();
+      expect(notifyCount, greaterThanOrEqualTo(1));
+    });
+  });
+}

--- a/flutter_app/test/providers/packs_provider_test.dart
+++ b/flutter_app/test/providers/packs_provider_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:cognithor_ui/providers/packs_provider.dart';
+import 'package:cognithor_ui/services/api_client.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+void main() {
+  group('PacksProvider', () {
+    late _MockApiClient api;
+    late PacksProvider provider;
+
+    setUp(() {
+      api = _MockApiClient();
+      provider = PacksProvider()..setApi(api);
+    });
+
+    test('initial state has no packs', () {
+      expect(provider.packs, isEmpty);
+      expect(provider.hasPackLoaded('any.pack'), false);
+    });
+
+    test('refresh populates packs from API response', () async {
+      when(() => api.get('/api/v1/packs/loaded')).thenAnswer(
+        (_) async => {
+          'packs': [
+            {
+              'qualified_id': 'cognithor.deep_research',
+              'version': '1.0.0',
+              'display_name': 'Deep Research',
+              'tools': ['research_one', 'research_two'],
+            },
+            {
+              'qualified_id': 'cognithor.reddit',
+              'version': '0.5.0',
+              'display_name': 'Reddit Lead Source',
+              'tools': [],
+            },
+          ],
+        },
+      );
+
+      await provider.refresh();
+
+      expect(provider.packs.length, 2);
+      expect(provider.packs.first.qualifiedId, 'cognithor.deep_research');
+      expect(provider.packs.first.tools, ['research_one', 'research_two']);
+      expect(provider.hasPackLoaded('cognithor.reddit'), true);
+      expect(provider.hasPackLoaded('cognithor.unknown'), false);
+    });
+
+    test('refresh swallows errors and leaves packs unchanged', () async {
+      when(
+        () => api.get('/api/v1/packs/loaded'),
+      ).thenThrow(Exception('offline'));
+
+      await provider.refresh();
+
+      expect(provider.packs, isEmpty);
+    });
+
+    test('refresh handles missing "packs" key gracefully', () async {
+      when(() => api.get('/api/v1/packs/loaded')).thenAnswer((_) async => {});
+
+      await provider.refresh();
+
+      expect(provider.packs, isEmpty);
+    });
+
+    test('refresh notifies listeners', () async {
+      when(
+        () => api.get('/api/v1/packs/loaded'),
+      ).thenAnswer((_) async => {'packs': []});
+
+      var notifyCount = 0;
+      provider.addListener(() => notifyCount++);
+
+      await provider.refresh();
+
+      expect(notifyCount, greaterThanOrEqualTo(1));
+    });
+
+    test('LoadedPack.fromJson uses defaults for missing fields', () {
+      final pack = LoadedPack.fromJson({});
+
+      expect(pack.qualifiedId, '');
+      expect(pack.version, '');
+      expect(pack.displayName, '');
+      expect(pack.tools, isEmpty);
+    });
+  });
+}

--- a/flutter_app/test/providers/sources_provider_test.dart
+++ b/flutter_app/test/providers/sources_provider_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:cognithor_ui/providers/sources_provider.dart';
+import 'package:cognithor_ui/services/api_client.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+void main() {
+  group('SourcesProvider', () {
+    late _MockApiClient api;
+    late SourcesProvider provider;
+
+    setUp(() {
+      api = _MockApiClient();
+      provider = SourcesProvider()..setApi(api);
+    });
+
+    test('initial state is empty + not loading', () {
+      expect(provider.sources, isEmpty);
+      expect(provider.isEmpty, true);
+      expect(provider.loading, false);
+      expect(provider.error, isNull);
+      expect(provider.hasSource('reddit'), false);
+    });
+
+    test('refresh populates sources from API response', () async {
+      when(() => api.get('/api/v1/leads/sources')).thenAnswer(
+        (_) async => {
+          'sources': [
+            {
+              'source_id': 'reddit',
+              'display_name': 'Reddit',
+              'icon': 'reddit',
+              'color': '#FF4500',
+              'capabilities': ['monitor_keywords', 'reply'],
+            },
+            {
+              'source_id': 'twitter',
+              'display_name': 'Twitter',
+              'icon': 'twitter',
+              'color': '#1DA1F2',
+              'capabilities': ['monitor_keywords'],
+            },
+          ],
+        },
+      );
+
+      await provider.refresh();
+
+      expect(provider.sources.length, 2);
+      expect(provider.isEmpty, false);
+      expect(provider.hasSource('reddit'), true);
+      expect(provider.sources.first.capabilities, contains('reply'));
+      expect(provider.loading, false);
+      expect(provider.error, isNull);
+    });
+
+    test('refresh sets error on failure', () async {
+      when(
+        () => api.get('/api/v1/leads/sources'),
+      ).thenThrow(Exception('unreachable'));
+
+      await provider.refresh();
+
+      expect(provider.sources, isEmpty);
+      expect(provider.error, contains('unreachable'));
+      expect(provider.loading, false);
+    });
+
+    test('refresh handles missing "sources" key gracefully', () async {
+      when(() => api.get('/api/v1/leads/sources')).thenAnswer((_) async => {});
+
+      await provider.refresh();
+
+      expect(provider.sources, isEmpty);
+      expect(provider.error, isNull);
+    });
+
+    test('refresh no-ops when API not set', () async {
+      final unbound = SourcesProvider();
+
+      await unbound.refresh();
+
+      expect(unbound.loading, false);
+      expect(unbound.sources, isEmpty);
+      verifyZeroInteractions(api);
+    });
+
+    test('LeadSourceInfo.fromJson uses defaults for missing fields', () {
+      final src = LeadSourceInfo.fromJson({});
+
+      expect(src.sourceId, '');
+      expect(src.displayName, '');
+      expect(src.icon, '');
+      expect(src.color, '');
+      expect(src.capabilities, isEmpty);
+    });
+  });
+}

--- a/flutter_app/test/providers/workflow_provider_test.dart
+++ b/flutter_app/test/providers/workflow_provider_test.dart
@@ -1,0 +1,86 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:cognithor_ui/providers/workflow_provider.dart';
+import 'package:cognithor_ui/services/api_client.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+void main() {
+  group('WorkflowProvider', () {
+    late _MockApiClient api;
+    late WorkflowProvider provider;
+
+    setUp(() {
+      api = _MockApiClient();
+      provider = WorkflowProvider()..setApi(api);
+    });
+
+    test('initial state is empty', () {
+      expect(provider.categories, isEmpty);
+      expect(provider.isLoading, false);
+      expect(provider.error, isNull);
+    });
+
+    test('loadCategories populates categories from API response', () async {
+      when(() => api.getWorkflowCategories()).thenAnswer(
+        (_) async => {
+          'categories': [
+            {'id': 'a', 'name': 'Alpha'},
+            {'id': 'b', 'name': 'Beta'},
+          ],
+        },
+      );
+
+      await provider.loadCategories();
+
+      expect(provider.categories.length, 2);
+      expect(provider.isLoading, false);
+      expect(provider.error, isNull);
+    });
+
+    test('loadCategories sets error on failure', () async {
+      when(
+        () => api.getWorkflowCategories(),
+      ).thenThrow(Exception('network down'));
+
+      await provider.loadCategories();
+
+      expect(provider.categories, isEmpty);
+      expect(provider.error, contains('network down'));
+      expect(provider.isLoading, false);
+    });
+
+    test('loadCategories no-ops when API not set', () async {
+      final unboundProvider = WorkflowProvider();
+
+      await unboundProvider.loadCategories();
+
+      expect(unboundProvider.isLoading, false);
+      expect(unboundProvider.categories, isEmpty);
+      verifyZeroInteractions(api);
+    });
+
+    test(
+      'startWorkflow forwards templateId and clears error on success',
+      () async {
+        when(() => api.startWorkflow('tpl-1')).thenAnswer((_) async => {});
+
+        await provider.startWorkflow('tpl-1');
+
+        verify(() => api.startWorkflow('tpl-1')).called(1);
+        expect(provider.error, isNull);
+        expect(provider.isLoading, false);
+      },
+    );
+
+    test('startWorkflow sets error on failure', () async {
+      when(() => api.startWorkflow(any())).thenThrow(Exception('boom'));
+
+      await provider.startWorkflow('tpl-2');
+
+      expect(provider.error, contains('boom'));
+      expect(provider.isLoading, false);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Batch D of the 24-provider test backlog (after batch C #196 added 4 prefs/in-memory providers).
- Adds 22 new unit tests covering 4 previously-untested providers:
  - **HackerModeProvider** — SharedPreferences-persisted bool toggle (4 tests)
  - **WorkflowProvider** — categories load + workflow start via mocktail-mocked `ApiClient` (6 tests)
  - **PacksProvider** — `/api/v1/packs/loaded` fetch + `LoadedPack.fromJson` defaults (6 tests)
  - **SourcesProvider** — `/api/v1/leads/sources` fetch + `LeadSourceInfo.fromJson` defaults (6 tests)
- Provider tests in `flutter_app/test/providers/` grow from **43 → 65**.

## Test plan
- [x] `flutter test test/providers/` — all 65 pass locally (run-time ~2s).
- [x] `dart format --set-exit-if-changed test/providers/` — clean.
- [x] `dart analyze test/providers/` — no issues.
- [ ] CI: Flutter (analyze + test) job green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)