### PR TITLE
test(flutter): unit tests for 4 more ChangeNotifier providers (+45 tests)

### DIFF
--- a/flutter_app/test/providers/cron_provider_test.dart
+++ b/flutter_app/test/providers/cron_provider_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:cognithor_ui/providers/cron_provider.dart';
+import 'package:cognithor_ui/services/api_client.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+void main() {
+  group('CronJob.scheduleLabel', () {
+    test('weekday schedule formatted', () {
+      final job = CronJob(name: 'n', schedule: '30 9 * * 1-5', prompt: '');
+      expect(job.scheduleLabel, 'Weekdays 9:30');
+    });
+
+    test('friday schedule formatted', () {
+      final job = CronJob(name: 'n', schedule: '0 17 * * 5', prompt: '');
+      expect(job.scheduleLabel, 'Fridays 17:00');
+    });
+
+    test('monthly first-of-month schedule formatted', () {
+      final job = CronJob(name: 'n', schedule: '0 8 1 * *', prompt: '');
+      expect(job.scheduleLabel, 'Monthly (1st) 8:00');
+    });
+
+    test('daily schedule formatted', () {
+      final job = CronJob(name: 'n', schedule: '15 6 * * *', prompt: '');
+      expect(job.scheduleLabel, 'Daily 6:15');
+    });
+
+    test('non-matching dow returned verbatim', () {
+      // dow '2' (Tuesday only) has no special-case branch.
+      final job = CronJob(name: 'n', schedule: '0 9 * * 2', prompt: '');
+      expect(job.scheduleLabel, '0 9 * * 2');
+    });
+
+    test('malformed (too few parts) returned verbatim', () {
+      final job = CronJob(name: 'n', schedule: '0 0', prompt: '');
+      expect(job.scheduleLabel, '0 0');
+    });
+  });
+
+  group('CronJob.fromJson', () {
+    test('uses defaults for missing fields', () {
+      final job = CronJob.fromJson({});
+      expect(job.name, '');
+      expect(job.channel, 'telegram');
+      expect(job.model, 'qwen3:8b');
+      expect(job.enabled, false);
+      expect(job.nextRun, isNull);
+    });
+
+    test('reads provided fields', () {
+      final job = CronJob.fromJson({
+        'name': 'morning-news',
+        'schedule': '0 7 * * *',
+        'prompt': 'summarize news',
+        'channel': 'discord',
+        'model': 'qwen3:14b',
+        'enabled': true,
+        'agent': 'newsbot',
+        'next_run': '2026-04-30T07:00:00Z',
+      });
+      expect(job.name, 'morning-news');
+      expect(job.channel, 'discord');
+      expect(job.enabled, true);
+      expect(job.agent, 'newsbot');
+      expect(job.nextRun, '2026-04-30T07:00:00Z');
+    });
+  });
+
+  group('CronProvider', () {
+    late _MockApiClient api;
+    late CronProvider provider;
+
+    setUp(() {
+      api = _MockApiClient();
+      provider = CronProvider();
+    });
+
+    tearDown(() => provider.dispose());
+
+    test('initial state is empty + not loading', () {
+      expect(provider.jobs, isEmpty);
+      expect(provider.loading, false);
+      expect(provider.error, isNull);
+    });
+
+    test('setApiClient triggers initial fetch', () async {
+      when(() => api.get('/cron-jobs/enriched')).thenAnswer(
+        (_) async => {
+          'jobs': [
+            {'name': 'a', 'schedule': '0 8 * * *', 'prompt': 'p'},
+          ],
+        },
+      );
+
+      provider.setApiClient(api);
+      // Allow the awaited fetch in the timer-callback path to settle.
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.jobs.length, 1);
+      expect(provider.jobs.first.name, 'a');
+    });
+
+    test('fetchJobs sets error on failure', () async {
+      when(
+        () => api.get('/cron-jobs/enriched'),
+      ).thenThrow(Exception('cron-down'));
+      provider.setApiClient(api);
+
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.error, contains('cron-down'));
+      expect(provider.loading, false);
+    });
+  });
+}

--- a/flutter_app/test/providers/memory_provider_test.dart
+++ b/flutter_app/test/providers/memory_provider_test.dart
@@ -1,0 +1,122 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:cognithor_ui/providers/memory_provider.dart';
+import 'package:cognithor_ui/services/api_client.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+void main() {
+  group('MemoryProvider', () {
+    late _MockApiClient api;
+    late MemoryProvider provider;
+
+    setUp(() {
+      api = _MockApiClient();
+      provider = MemoryProvider()..setApi(api);
+    });
+
+    test('initial state is empty', () {
+      expect(provider.graphStats, isNull);
+      expect(provider.entities, isEmpty);
+      expect(provider.hygieneStats, isNull);
+      expect(provider.quarantined, isEmpty);
+      expect(provider.explainabilityStats, isNull);
+      expect(provider.trails, isEmpty);
+      expect(provider.lowTrustTrails, isEmpty);
+      expect(provider.isLoading, false);
+      expect(provider.error, isNull);
+    });
+
+    test('loadGraphStats stores result', () async {
+      when(
+        () => api.getMemoryGraphStats(),
+      ).thenAnswer((_) async => {'nodes': 42, 'edges': 99});
+
+      await provider.loadGraphStats();
+
+      expect(provider.graphStats, {'nodes': 42, 'edges': 99});
+      expect(provider.error, isNull);
+      expect(provider.isLoading, false);
+    });
+
+    test('loadEntities populates entities list', () async {
+      when(() => api.getMemoryGraphEntities()).thenAnswer(
+        (_) async => {
+          'entities': [
+            {'id': 'e1'},
+            {'id': 'e2'},
+          ],
+        },
+      );
+
+      await provider.loadEntities();
+
+      expect(provider.entities.length, 2);
+      expect(provider.error, isNull);
+    });
+
+    test('loadHygieneStats sets error on failure', () async {
+      when(() => api.getHygieneStats()).thenThrow(Exception('boom'));
+
+      await provider.loadHygieneStats();
+
+      expect(provider.hygieneStats, isNull);
+      expect(provider.error, contains('boom'));
+      expect(provider.isLoading, false);
+    });
+
+    test('loadQuarantine populates quarantined list', () async {
+      when(() => api.getQuarantine()).thenAnswer(
+        (_) async => {
+          'items': [
+            {'id': 'q1'},
+          ],
+        },
+      );
+
+      await provider.loadQuarantine();
+
+      expect(provider.quarantined.length, 1);
+    });
+
+    test('loadTrails populates trails list', () async {
+      when(() => api.getExplainabilityTrails()).thenAnswer(
+        (_) async => {
+          'trails': [
+            {'id': 't1'},
+            {'id': 't2'},
+            {'id': 't3'},
+          ],
+        },
+      );
+
+      await provider.loadTrails();
+
+      expect(provider.trails.length, 3);
+    });
+
+    test('loadLowTrustTrails populates lowTrustTrails list', () async {
+      when(() => api.getLowTrustTrails()).thenAnswer(
+        (_) async => {
+          'trails': [
+            {'id': 'lt1'},
+          ],
+        },
+      );
+
+      await provider.loadLowTrustTrails();
+
+      expect(provider.lowTrustTrails.length, 1);
+    });
+
+    test('loaders no-op when API not set', () async {
+      final unbound = MemoryProvider();
+      await unbound.loadGraphStats();
+      await unbound.loadEntities();
+      await unbound.loadHygieneStats();
+      expect(unbound.isLoading, false);
+      verifyZeroInteractions(api);
+    });
+  });
+}

--- a/flutter_app/test/providers/research_provider_test.dart
+++ b/flutter_app/test/providers/research_provider_test.dart
@@ -1,0 +1,222 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:cognithor_ui/providers/research_provider.dart';
+import 'package:cognithor_ui/services/api_client.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+void main() {
+  group('ResearchSummary.fromJson', () {
+    test('uses defaults for missing fields', () {
+      final s = ResearchSummary.fromJson({});
+      expect(s.id, '');
+      expect(s.query, '');
+      expect(s.hops, 0);
+      expect(s.confidenceAvg, 0.0);
+      expect(s.createdAt, 0.0);
+    });
+
+    test('reads provided fields with type coercion', () {
+      final s = ResearchSummary.fromJson({
+        'id': 'r1',
+        'query': 'climate',
+        'hops': 3,
+        'confidence_avg': 0.85,
+        'created_at': 1714400000,
+      });
+      expect(s.id, 'r1');
+      expect(s.hops, 3);
+      expect(s.confidenceAvg, 0.85);
+      expect(s.createdAt, 1714400000.0);
+    });
+  });
+
+  group('ResearchSummary.timeAgo', () {
+    test('"just now" for current timestamp', () {
+      final now = DateTime.now().millisecondsSinceEpoch / 1000.0;
+      final s = ResearchSummary(
+        id: 'x',
+        query: '',
+        hops: 0,
+        confidenceAvg: 0,
+        createdAt: now,
+      );
+      expect(s.timeAgo, 'just now');
+    });
+
+    test('"Xm ago" for ~5 minutes old', () {
+      final ts = (DateTime.now().millisecondsSinceEpoch / 1000.0) - 300;
+      final s = ResearchSummary(
+        id: 'x',
+        query: '',
+        hops: 0,
+        confidenceAvg: 0,
+        createdAt: ts,
+      );
+      expect(s.timeAgo, contains('m ago'));
+    });
+
+    test('"Xh ago" for ~3 hours old', () {
+      final ts = (DateTime.now().millisecondsSinceEpoch / 1000.0) - 3 * 3600;
+      final s = ResearchSummary(
+        id: 'x',
+        query: '',
+        hops: 0,
+        confidenceAvg: 0,
+        createdAt: ts,
+      );
+      expect(s.timeAgo, contains('h ago'));
+    });
+
+    test('"Xd ago" for ~2 days old', () {
+      final ts = (DateTime.now().millisecondsSinceEpoch / 1000.0) - 2 * 86400;
+      final s = ResearchSummary(
+        id: 'x',
+        query: '',
+        hops: 0,
+        confidenceAvg: 0,
+        createdAt: ts,
+      );
+      expect(s.timeAgo, contains('d ago'));
+    });
+  });
+
+  group('ResearchResult.fromJson', () {
+    test('uses defaults for missing fields', () {
+      final r = ResearchResult.fromJson({});
+      expect(r.id, '');
+      expect(r.reportMd, '');
+      expect(r.sources, isEmpty);
+    });
+
+    test('reads sources as list of maps', () {
+      final r = ResearchResult.fromJson({
+        'id': 'r1',
+        'report_md': '# Report',
+        'sources': [
+          {'url': 'a'},
+          {'url': 'b'},
+        ],
+      });
+      expect(r.reportMd, '# Report');
+      expect(r.sources.length, 2);
+      expect(r.sources.first['url'], 'a');
+    });
+  });
+
+  group('ResearchProvider', () {
+    late _MockApiClient api;
+    late ResearchProvider provider;
+
+    setUp(() {
+      api = _MockApiClient();
+      provider = ResearchProvider()..setApi(api);
+    });
+
+    test('initial state is empty', () {
+      expect(provider.activeResult, isNull);
+      expect(provider.history, isEmpty);
+      expect(provider.loading, false);
+      expect(provider.error, isNull);
+    });
+
+    test('loadHistory populates history list', () async {
+      when(() => api.get('/api/v1/research/history')).thenAnswer(
+        (_) async => {
+          'results': [
+            {'id': 'r1', 'query': 'q1'},
+            {'id': 'r2', 'query': 'q2'},
+          ],
+        },
+      );
+
+      await provider.loadHistory();
+
+      expect(provider.history.length, 2);
+      expect(provider.history.first.id, 'r1');
+    });
+
+    test('loadHistory swallows errors silently', () async {
+      when(
+        () => api.get('/api/v1/research/history'),
+      ).thenThrow(Exception('offline'));
+
+      await provider.loadHistory();
+
+      expect(provider.history, isEmpty);
+      // Errors here are intentionally swallowed (UI uses freshness, not banner).
+      expect(provider.error, isNull);
+    });
+
+    test('loadResult sets activeResult', () async {
+      when(
+        () => api.get('/api/v1/research/r1'),
+      ).thenAnswer((_) async => {'id': 'r1', 'query': 'q', 'report_md': '# R'});
+
+      await provider.loadResult('r1');
+
+      expect(provider.activeResult?.id, 'r1');
+      expect(provider.activeResult?.reportMd, '# R');
+      expect(provider.loading, false);
+    });
+
+    test('loadResult sets error on failure', () async {
+      when(
+        () => api.get('/api/v1/research/missing'),
+      ).thenThrow(Exception('404'));
+
+      await provider.loadResult('missing');
+
+      expect(provider.error, contains('404'));
+      expect(provider.loading, false);
+    });
+
+    test(
+      'deleteResearch removes from history + clears active if matching',
+      () async {
+        // Seed history.
+        when(() => api.get('/api/v1/research/history')).thenAnswer(
+          (_) async => {
+            'results': [
+              {'id': 'r1', 'query': 'a'},
+              {'id': 'r2', 'query': 'b'},
+            ],
+          },
+        );
+        await provider.loadHistory();
+
+        when(
+          () => api.delete('/api/v1/research/r1'),
+        ).thenAnswer((_) async => {});
+        await provider.deleteResearch('r1');
+
+        expect(provider.history.map((r) => r.id), ['r2']);
+      },
+    );
+
+    test('exportResearch returns path on success', () async {
+      when(
+        () => api.post('/api/v1/research/r1/export', {'format': 'pdf'}),
+      ).thenAnswer((_) async => {'path': '/tmp/r1.pdf'});
+
+      final path = await provider.exportResearch('r1', 'pdf');
+
+      expect(path, '/tmp/r1.pdf');
+    });
+
+    test('exportResearch returns null on failure', () async {
+      when(() => api.post(any(), any())).thenThrow(Exception('boom'));
+
+      final path = await provider.exportResearch('r1', 'pdf');
+
+      expect(path, isNull);
+    });
+
+    test('loadHistory no-ops when API not set', () async {
+      final unbound = ResearchProvider();
+      await unbound.loadHistory();
+      verifyZeroInteractions(api);
+    });
+  });
+}

--- a/flutter_app/test/providers/tree_provider_test.dart
+++ b/flutter_app/test/providers/tree_provider_test.dart
@@ -1,0 +1,239 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:cognithor_ui/models/chat_node.dart';
+import 'package:cognithor_ui/providers/tree_provider.dart';
+import 'package:cognithor_ui/services/api_client.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+ChatNode _node({required String id, String? parent, int branch = 0}) =>
+    ChatNode(
+      id: id,
+      conversationId: 'c1',
+      parentId: parent,
+      role: 'user',
+      text: id,
+      branchIndex: branch,
+    );
+
+void main() {
+  group('TreeProvider', () {
+    late TreeProvider provider;
+    late _MockApiClient api;
+
+    setUp(() {
+      api = _MockApiClient();
+      provider = TreeProvider()..setApi(api);
+    });
+
+    test('initial state has no tree, no branches', () {
+      expect(provider.hasTree, false);
+      expect(provider.hasBranches, false);
+      expect(provider.nodes, isEmpty);
+      expect(provider.activePath, isEmpty);
+    });
+
+    test('addNode appends to activePath + tracks fork when sibling exists', () {
+      provider.addNode(_node(id: 'root'));
+      provider.addNode(_node(id: 'a', parent: 'root', branch: 0));
+      provider.addNode(_node(id: 'b', parent: 'root', branch: 1));
+
+      expect(provider.hasTree, true);
+      expect(provider.activePath, ['root', 'a', 'b']);
+      // 'root' now has 2 children → fork point.
+      expect(provider.isForkPoint('root'), true);
+      expect(provider.getChildCount('root'), 2);
+    });
+
+    test('isForkPoint returns false for single-child node', () {
+      provider.addNode(_node(id: 'root'));
+      provider.addNode(_node(id: 'a', parent: 'root'));
+      expect(provider.isForkPoint('root'), false);
+    });
+
+    test('clear resets all state + notifies listeners', () {
+      provider.addNode(_node(id: 'root'));
+      provider.addNode(_node(id: 'a', parent: 'root'));
+      provider.addNode(_node(id: 'b', parent: 'root', branch: 1));
+
+      var notifyCount = 0;
+      provider.addListener(() => notifyCount++);
+
+      provider.clear();
+
+      expect(provider.nodes, isEmpty);
+      expect(provider.activePath, isEmpty);
+      expect(provider.hasBranches, false);
+      expect(provider.conversationId, isNull);
+      expect(notifyCount, greaterThanOrEqualTo(1));
+    });
+
+    test('loadTree builds nodes + activePath from API response', () async {
+      when(() => api.get('chat/tree/c1')).thenAnswer(
+        (_) async => {
+          'nodes': [
+            {
+              'id': 'root',
+              'conversation_id': 'c1',
+              'parent_id': null,
+              'role': 'user',
+              'text': 'hi',
+              'branch_index': 0,
+            },
+            {
+              'id': 'a',
+              'conversation_id': 'c1',
+              'parent_id': 'root',
+              'role': 'assistant',
+              'text': 'hello',
+              'branch_index': 0,
+            },
+          ],
+          'fork_points': <String, dynamic>{},
+          'active_leaf_id': 'a',
+        },
+      );
+
+      await provider.loadTree('c1');
+
+      expect(provider.nodes.length, 2);
+      expect(provider.activePath, ['root', 'a']);
+      expect(provider.conversationId, 'c1');
+    });
+
+    test('loadTree records fork_points', () async {
+      when(() => api.get('chat/tree/c1')).thenAnswer(
+        (_) async => {
+          'nodes': [
+            {
+              'id': 'root',
+              'conversation_id': 'c1',
+              'role': 'user',
+              'text': 'q',
+            },
+            {
+              'id': 'a',
+              'conversation_id': 'c1',
+              'parent_id': 'root',
+              'role': 'assistant',
+              'text': 'r1',
+              'branch_index': 0,
+            },
+            {
+              'id': 'b',
+              'conversation_id': 'c1',
+              'parent_id': 'root',
+              'role': 'assistant',
+              'text': 'r2',
+              'branch_index': 1,
+            },
+          ],
+          'fork_points': {'root': 2},
+          'active_leaf_id': 'a',
+        },
+      );
+
+      await provider.loadTree('c1');
+
+      expect(provider.hasBranches, true);
+      expect(provider.getChildCount('root'), 2);
+      expect(provider.getActiveChildIndex('root'), 0);
+    });
+
+    test('switchBranch sends ws message + updates activePath', () async {
+      // Seed a tree with two branches off `root`.
+      when(() => api.get('chat/tree/c1')).thenAnswer(
+        (_) async => {
+          'nodes': [
+            {
+              'id': 'root',
+              'conversation_id': 'c1',
+              'role': 'user',
+              'text': 'q',
+            },
+            {
+              'id': 'a',
+              'conversation_id': 'c1',
+              'parent_id': 'root',
+              'role': 'assistant',
+              'text': 'r1',
+              'branch_index': 0,
+            },
+            {
+              'id': 'b',
+              'conversation_id': 'c1',
+              'parent_id': 'root',
+              'role': 'assistant',
+              'text': 'r2',
+              'branch_index': 1,
+            },
+          ],
+          'fork_points': {'root': 2},
+          'active_leaf_id': 'a',
+        },
+      );
+      await provider.loadTree('c1');
+
+      Map<String, dynamic>? sent;
+      provider.setWsSend((msg) => sent = msg);
+
+      await provider.switchBranch('root', 1);
+
+      expect(provider.activePath, ['root', 'b']);
+      expect(provider.getActiveChildIndex('root'), 1);
+      expect(sent, isNotNull);
+      expect(sent!['type'], 'branch_switch');
+      expect(sent!['leaf_id'], 'b');
+    });
+
+    test('switchBranch is a no-op when index is out of range', () async {
+      when(() => api.get('chat/tree/c1')).thenAnswer(
+        (_) async => {
+          'nodes': [
+            {
+              'id': 'root',
+              'conversation_id': 'c1',
+              'role': 'user',
+              'text': 'q',
+            },
+            {
+              'id': 'a',
+              'conversation_id': 'c1',
+              'parent_id': 'root',
+              'role': 'assistant',
+              'text': 'r',
+              'branch_index': 0,
+            },
+          ],
+          'fork_points': {'root': 1},
+          'active_leaf_id': 'a',
+        },
+      );
+      await provider.loadTree('c1');
+
+      Map<String, dynamic>? sent;
+      provider.setWsSend((msg) => sent = msg);
+
+      await provider.switchBranch('root', 99);
+
+      expect(sent, isNull);
+    });
+
+    test('refreshFromSession with sessionId uses query parameter', () async {
+      when(
+        () => api.get('chat/tree/latest?session_id=s1'),
+      ).thenAnswer((_) async => {'conversation_id': 'cX'});
+      when(() => api.get('chat/tree/cX')).thenAnswer(
+        (_) async => <String, dynamic>{
+          'nodes': <Map<String, dynamic>>[],
+          'fork_points': <String, dynamic>{},
+        },
+      );
+
+      await provider.refreshFromSession(api, sessionId: 's1');
+
+      expect(provider.conversationId, 'cX');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
Batch E of the 24-provider test backlog (after batch D #197 added 4 small providers).

Adds **45 new unit tests** covering 4 mid-sized providers that have shipped without coverage:

| Provider | LOC | Tests | What's covered |
|---|---|---|---|
| **CronProvider** | 135 | 11 | `scheduleLabel` parser (weekday/friday/monthly/daily/malformed/verbatim), `CronJob.fromJson` defaults, `fetchJobs` success + error paths |
| **MemoryProvider** | 140 | 8 | `loadGraphStats`, `loadEntities`, `loadHygieneStats` (error path), `loadQuarantine`, `loadTrails`, `loadLowTrustTrails`, no-op-when-unbound |
| **ResearchProvider** | 170 | 15 | `ResearchSummary`/`ResearchResult` `fromJson` defaults, `timeAgo` bucketing (just-now/m/h/d), `loadHistory`, `loadResult`, `deleteResearch`, `exportResearch` |
| **TreeProvider** | 190 | 11 | `addNode` + automatic fork detection, `clear`, `loadTree`, `fork_points`, `switchBranch` (WS relay verification + out-of-range no-op), `refreshFromSession` |

Provider-test count grows from **65 → 110** in \`flutter_app/test/providers/\`.

## Notes
- The \`CronJob.scheduleLabel\` "non-matching dow" case uses \`0 9 * * 2\` (Tuesday-only) instead of \`*/5 * * * *\`, since the latter falsely matches the \"Daily\" branch (\`parts[2]='*' && parts[4]='*'\` is treated as daily regardless of minute pattern). Behavior preserved as-is — pre-existing.
- \`TreeProvider\` tests use explicit \`<String, dynamic>{}\` for empty \`fork_points\` payloads so the provider's \`as Map<String, dynamic>?\` cast succeeds (Dart literal \`{}\` infers \`Map<dynamic, dynamic>\`).

## Test plan
- [x] \`flutter test test/providers/\` — all 110 pass locally (run-time ~2s).
- [x] \`dart format --set-exit-if-changed test/providers/\` — clean.
- [x] \`dart analyze test/providers/\` — no issues.
- [ ] CI: Flutter (analyze + test) job green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)