### PR TITLE
perf(flutter): migrate workflows-categories tab to lazy slivers

### DIFF
--- a/flutter_app/lib/screens/workflows_screen.dart
+++ b/flutter_app/lib/screens/workflows_screen.dart
@@ -176,14 +176,35 @@ class _WorkflowsScreenState extends State<WorkflowsScreen>
           );
         }
 
+        final categories = provider.categories;
         return RefreshIndicator(
           onRefresh: () => provider.loadCategories(),
-          child: ListView(
-            padding: const EdgeInsets.all(CognithorTheme.spacing),
-            children: [
-              CognithorSection(title: l.categories),
-              const SizedBox(height: CognithorTheme.spacingSm),
-              ...provider.categories.map(_buildCategoryCard),
+          child: CustomScrollView(
+            slivers: [
+              SliverPadding(
+                padding: const EdgeInsets.fromLTRB(
+                  CognithorTheme.spacing,
+                  CognithorTheme.spacing,
+                  CognithorTheme.spacing,
+                  CognithorTheme.spacingSm,
+                ),
+                sliver: SliverToBoxAdapter(
+                  child: CognithorSection(title: l.categories),
+                ),
+              ),
+              SliverPadding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: CognithorTheme.spacing,
+                ),
+                sliver: SliverList.builder(
+                  itemCount: categories.length,
+                  itemBuilder: (context, i) =>
+                      _buildCategoryCard(categories[i]),
+                ),
+              ),
+              const SliverPadding(
+                padding: EdgeInsets.only(bottom: CognithorTheme.spacing),
+              ),
             ],
           ),
         );


### PR DESCRIPTION
## Summary
The Categories tab on the Workflows screen rendered every category card eagerly via \`...provider.categories.map(_buildCategoryCard)\` inside a plain \`ListView\`. Each card is a non-trivial widget tree (\`NeonCard\` with glow, icon, description, action button).

For users with many workflow categories (or when the backend lists templates per category), this caused the entire list to be built up-front and held in the layout pass, even off-screen.

Migrate the tab body to \`CustomScrollView\` with a \`SliverToBoxAdapter\` section header + \`SliverList.builder(itemCount, itemBuilder)\` so cards are only built on demand. \`RefreshIndicator\` works transparently with \`CustomScrollView\`.

## Visual change
None. Same padding (\`CognithorTheme.spacing\` top + horizontal, \`spacingSm\` gap to first card, \`spacing\` trailing).

## Test plan
- [x] \`flutter test\` — all 73 tests pass.
- [x] \`dart format --set-exit-if-changed lib/screens/workflows_screen.dart\` — clean.
- [x] \`dart analyze lib/screens/workflows_screen.dart\` — no issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)