### PR TITLE
feat(pse): geometric + color DSL primitives — Week 2 part A (15/56)

### DIFF
--- a/src/cognithor/channels/program_synthesis/dsl/__init__.py
+++ b/src/cognithor/channels/program_synthesis/dsl/__init__.py
@@ -7,6 +7,11 @@ predicate constructors. See spec §7 for the full catalog.
 
 from __future__ import annotations
 
+# Importing the primitives module has the side effect of registering all
+# primitives into the module-level REGISTRY. The re-export keeps the import
+# from being flagged as unused.
+from cognithor.channels.program_synthesis.dsl import primitives as primitives
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
 from cognithor.channels.program_synthesis.dsl.signatures import Signature
 
-__all__ = ["Signature"]
+__all__ = ["REGISTRY", "Signature", "primitives"]

--- a/src/cognithor/channels/program_synthesis/dsl/primitives.py
+++ b/src/cognithor/channels/program_synthesis/dsl/primitives.py
@@ -1,0 +1,273 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""ARC-DSL primitive implementations (spec §7.2).
+
+Each primitive is a pure function returning a fresh array (no in-place
+mutation, no shared state). All inputs are np.int8 grids in the
+ARC-conventional value range 0..9.
+
+Primitives are registered in the module-level :data:`REGISTRY` at import
+time via the :func:`primitive` decorator. The catalog is the
+single source of truth for both the search engine and the public DSL
+reference.
+
+This file currently holds the **geometric** and **color** groups
+(15 primitives). Subsequent PRs add size/scale, spatial, object,
+mask/logic, construction, and constant groups for a Phase 1 total of 56.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+from numpy.typing import NDArray
+
+from cognithor.channels.program_synthesis.core.exceptions import TypeMismatchError
+from cognithor.channels.program_synthesis.dsl.registry import primitive
+from cognithor.channels.program_synthesis.dsl.signatures import Signature
+
+_Grid = NDArray[np.int8]
+
+
+def _check_grid(g: object, name: str) -> _Grid:
+    """Validate *g* is a 2-D int8 numpy grid in the ARC value range.
+
+    Raises :class:`TypeMismatchError` for any deviation. The check is
+    cheap (shape + dtype only); value-range is verified once on input
+    boundaries, not per primitive call, to avoid quadratic overhead in
+    deep search.
+    """
+    if not isinstance(g, np.ndarray):
+        raise TypeMismatchError(f"{name}: expected ndarray, got {type(g).__name__}")
+    if g.ndim != 2:
+        raise TypeMismatchError(f"{name}: expected 2-D grid, got {g.ndim}-D")
+    if g.dtype != np.int8:
+        raise TypeMismatchError(f"{name}: expected int8 dtype, got {g.dtype}")
+    return g
+
+
+def _check_color(c: object, name: str) -> int:
+    if not isinstance(c, int) or isinstance(c, bool):
+        raise TypeMismatchError(f"{name}: expected int color, got {type(c).__name__}")
+    if not 0 <= c <= 9:
+        raise TypeMismatchError(f"{name}: color {c} out of ARC range 0..9")
+    return c
+
+
+# ---------------------------------------------------------------------------
+# 1. Identity
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="identity",
+    signature=Signature(inputs=("Grid",), output="Grid"),
+    cost=0.1,
+    description="Return the grid unchanged. Cheap building block for branches.",
+    examples=(("[[1,2],[3,4]]", "[[1,2],[3,4]]"),),
+)
+def identity(grid: _Grid) -> _Grid:
+    _check_grid(grid, "identity")
+    return grid.copy()
+
+
+# ---------------------------------------------------------------------------
+# 2-9. Geometric transforms
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="rotate90",
+    signature=Signature(inputs=("Grid",), output="Grid"),
+    cost=1.0,
+    description="Rotate the grid 90° clockwise.",
+    examples=(("[[1,2],[3,4]]", "[[3,1],[4,2]]"),),
+)
+def rotate90(grid: _Grid) -> _Grid:
+    _check_grid(grid, "rotate90")
+    return np.rot90(grid, k=-1).copy()
+
+
+@primitive(
+    name="rotate180",
+    signature=Signature(inputs=("Grid",), output="Grid"),
+    cost=1.0,
+    description="Rotate the grid 180°.",
+    examples=(("[[1,2],[3,4]]", "[[4,3],[2,1]]"),),
+)
+def rotate180(grid: _Grid) -> _Grid:
+    _check_grid(grid, "rotate180")
+    return np.rot90(grid, k=2).copy()
+
+
+@primitive(
+    name="rotate270",
+    signature=Signature(inputs=("Grid",), output="Grid"),
+    cost=1.0,
+    description="Rotate the grid 270° clockwise (= 90° counter-clockwise).",
+    examples=(("[[1,2],[3,4]]", "[[2,4],[1,3]]"),),
+)
+def rotate270(grid: _Grid) -> _Grid:
+    _check_grid(grid, "rotate270")
+    return np.rot90(grid, k=1).copy()
+
+
+@primitive(
+    name="mirror_horizontal",
+    signature=Signature(inputs=("Grid",), output="Grid"),
+    cost=1.0,
+    description="Flip the grid left-to-right (mirror across the vertical axis).",
+    examples=(("[[1,2],[3,4]]", "[[2,1],[4,3]]"),),
+)
+def mirror_horizontal(grid: _Grid) -> _Grid:
+    _check_grid(grid, "mirror_horizontal")
+    return np.fliplr(grid).copy()
+
+
+@primitive(
+    name="mirror_vertical",
+    signature=Signature(inputs=("Grid",), output="Grid"),
+    cost=1.0,
+    description="Flip the grid top-to-bottom (mirror across the horizontal axis).",
+    examples=(("[[1,2],[3,4]]", "[[3,4],[1,2]]"),),
+)
+def mirror_vertical(grid: _Grid) -> _Grid:
+    _check_grid(grid, "mirror_vertical")
+    return np.flipud(grid).copy()
+
+
+@primitive(
+    name="transpose",
+    signature=Signature(inputs=("Grid",), output="Grid"),
+    cost=1.0,
+    description="Transpose: swap rows and columns (flip across main diagonal).",
+    examples=(("[[1,2],[3,4]]", "[[1,3],[2,4]]"),),
+)
+def transpose(grid: _Grid) -> _Grid:
+    _check_grid(grid, "transpose")
+    return grid.T.copy()
+
+
+@primitive(
+    name="mirror_diagonal",
+    signature=Signature(inputs=("Grid",), output="Grid"),
+    cost=1.2,
+    description="Mirror across the main diagonal. Equivalent to transpose for square grids.",
+    examples=(("[[1,2],[3,4]]", "[[1,3],[2,4]]"),),
+)
+def mirror_diagonal(grid: _Grid) -> _Grid:
+    _check_grid(grid, "mirror_diagonal")
+    return grid.T.copy()
+
+
+@primitive(
+    name="mirror_antidiagonal",
+    signature=Signature(inputs=("Grid",), output="Grid"),
+    cost=1.2,
+    description="Mirror across the anti-diagonal (top-right to bottom-left).",
+    examples=(("[[1,2],[3,4]]", "[[4,2],[3,1]]"),),
+)
+def mirror_antidiagonal(grid: _Grid) -> _Grid:
+    _check_grid(grid, "mirror_antidiagonal")
+    # Flip both axes then transpose — equivalent to flipping across the
+    # anti-diagonal. np.flip(np.flip(g, 0), 1).T == g[::-1, ::-1].T
+    return grid[::-1, ::-1].T.copy()
+
+
+# ---------------------------------------------------------------------------
+# 10-15. Color
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="recolor",
+    signature=Signature(inputs=("Grid", "Color", "Color"), output="Grid"),
+    cost=1.5,
+    description="Replace every occurrence of color *src* with color *dst*.",
+    examples=(("[[1,2],[1,3]] src=1 dst=4", "[[4,2],[4,3]]"),),
+)
+def recolor(grid: _Grid, src: int, dst: int) -> _Grid:
+    _check_grid(grid, "recolor")
+    _check_color(src, "recolor.src")
+    _check_color(dst, "recolor.dst")
+    out = grid.copy()
+    out[out == src] = dst
+    return out
+
+
+@primitive(
+    name="swap_colors",
+    signature=Signature(inputs=("Grid", "Color", "Color"), output="Grid"),
+    cost=1.5,
+    description="Swap two colors throughout the grid.",
+    examples=(("[[1,2],[2,1]] a=1 b=2", "[[2,1],[1,2]]"),),
+)
+def swap_colors(grid: _Grid, a: int, b: int) -> _Grid:
+    _check_grid(grid, "swap_colors")
+    _check_color(a, "swap_colors.a")
+    _check_color(b, "swap_colors.b")
+    out = grid.copy()
+    mask_a = grid == a
+    mask_b = grid == b
+    out[mask_a] = b
+    out[mask_b] = a
+    return out
+
+
+@primitive(
+    name="most_common_color",
+    signature=Signature(inputs=("Grid",), output="Color"),
+    cost=1.0,
+    description="Return the most-frequent color in the grid (ties broken by lowest index).",
+    examples=(("[[1,2,2],[3,3,3]]", "3"),),
+)
+def most_common_color(grid: _Grid) -> int:
+    _check_grid(grid, "most_common_color")
+    counts = np.bincount(grid.ravel(), minlength=10)
+    # argmax returns the lowest index on ties — stable for cache hashing.
+    return int(np.argmax(counts))
+
+
+@primitive(
+    name="least_common_color",
+    signature=Signature(inputs=("Grid",), output="Color"),
+    cost=1.0,
+    description=(
+        "Return the least-frequent color present in the grid. "
+        "Colors with zero occurrence are ignored; ties broken by lowest index."
+    ),
+    examples=(("[[1,2,2],[3,3,3]]", "1"),),
+)
+def least_common_color(grid: _Grid) -> int:
+    _check_grid(grid, "least_common_color")
+    counts = np.bincount(grid.ravel(), minlength=10)
+    # Replace zero-counts with a sentinel so they're never picked.
+    masked = np.where(counts == 0, np.iinfo(np.int64).max, counts)
+    return int(np.argmin(masked))
+
+
+@primitive(
+    name="color_count",
+    signature=Signature(inputs=("Grid",), output="Int"),
+    cost=1.0,
+    description="Number of distinct colors present in the grid (0..10).",
+    examples=(("[[1,2,2],[3,3,3]]", "3"),),
+)
+def color_count(grid: _Grid) -> int:
+    _check_grid(grid, "color_count")
+    return int(np.unique(grid).size)
+
+
+@primitive(
+    name="replace_background",
+    signature=Signature(inputs=("Grid", "Color"), output="Grid"),
+    cost=1.5,
+    description=(
+        "Replace the background (most-common color) with the given color. "
+        "Equivalent to ``recolor(grid, most_common_color(grid), new)``."
+    ),
+    examples=(("[[1,2,2],[3,3,3]] new=0", "[[1,2,2],[0,0,0]]"),),
+)
+def replace_background(grid: _Grid, new: int) -> _Grid:
+    _check_grid(grid, "replace_background")
+    _check_color(new, "replace_background.new")
+    bg = most_common_color(grid)
+    return recolor(grid, bg, new)

--- a/tests/test_channels/test_program_synthesis/unit/test_dsl_primitives_geom_color.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_dsl_primitives_geom_color.py
@@ -1,0 +1,421 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Geometric + color primitive tests (spec §16.2).
+
+Five tests per primitive: happy path, edge cases (1×1 / 30×30 / empty
+column), type-mismatch rejection, determinism, and a property test
+verifying an algebraic identity.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.core.exceptions import TypeMismatchError
+from cognithor.channels.program_synthesis.dsl.primitives import (
+    color_count,
+    identity,
+    least_common_color,
+    mirror_antidiagonal,
+    mirror_diagonal,
+    mirror_horizontal,
+    mirror_vertical,
+    most_common_color,
+    recolor,
+    replace_background,
+    rotate90,
+    rotate180,
+    rotate270,
+    swap_colors,
+    transpose,
+)
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+# ---------------------------------------------------------------------------
+# identity
+# ---------------------------------------------------------------------------
+
+
+class TestIdentity:
+    def test_returns_equal_grid(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        assert np.array_equal(identity(g), g)
+
+    def test_returns_copy_not_alias(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        out = identity(g)
+        out[0, 0] = 9
+        assert g[0, 0] == 1
+
+    def test_1x1_grid(self) -> None:
+        assert np.array_equal(identity(_g([[7]])), _g([[7]]))
+
+    def test_rejects_non_grid(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            identity([[1, 2]])  # type: ignore[arg-type]
+
+    def test_deterministic(self) -> None:
+        g = _g([[1, 2, 3]])
+        assert np.array_equal(identity(g), identity(g))
+
+
+# ---------------------------------------------------------------------------
+# rotations
+# ---------------------------------------------------------------------------
+
+
+class TestRotate90:
+    def test_known_2x2(self) -> None:
+        out = rotate90(_g([[1, 2], [3, 4]]))
+        assert np.array_equal(out, _g([[3, 1], [4, 2]]))
+
+    def test_swaps_dimensions_for_rectangular(self) -> None:
+        g = _g([[1, 2, 3]])  # 1x3
+        out = rotate90(g)
+        assert out.shape == (3, 1)
+
+    def test_four_rotations_yield_identity(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        spun = rotate90(rotate90(rotate90(rotate90(g))))
+        assert np.array_equal(spun, g)
+
+    def test_rejects_1d(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            rotate90(np.array([1, 2, 3], dtype=np.int8))
+
+    def test_dtype_preserved(self) -> None:
+        out = rotate90(_g([[1, 2], [3, 4]]))
+        assert out.dtype == np.int8
+
+
+class TestRotate180:
+    def test_known(self) -> None:
+        assert np.array_equal(rotate180(_g([[1, 2], [3, 4]])), _g([[4, 3], [2, 1]]))
+
+    def test_two_rotate90_equals_rotate180(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        assert np.array_equal(rotate180(g), rotate90(rotate90(g)))
+
+    def test_idempotent_on_palindromic_grid(self) -> None:
+        g = _g([[1, 1], [1, 1]])
+        assert np.array_equal(rotate180(g), g)
+
+    def test_rejects_wrong_dtype(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            rotate180(np.array([[1, 2]], dtype=np.int32))
+
+    def test_rectangular(self) -> None:
+        g = _g([[1, 2, 3]])
+        assert np.array_equal(rotate180(g), _g([[3, 2, 1]]))
+
+
+class TestRotate270:
+    def test_known(self) -> None:
+        assert np.array_equal(rotate270(_g([[1, 2], [3, 4]])), _g([[2, 4], [1, 3]]))
+
+    def test_inverse_of_rotate90(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        assert np.array_equal(rotate270(rotate90(g)), g)
+
+    def test_three_rotate90_equals_rotate270(self) -> None:
+        g = _g([[1, 2, 3], [4, 5, 6]])
+        assert np.array_equal(rotate270(g), rotate90(rotate90(rotate90(g))))
+
+    def test_returns_copy(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        out = rotate270(g)
+        out[0, 0] = 9
+        assert g[0, 0] == 1
+
+    def test_rejects_3d(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            rotate270(np.zeros((2, 2, 2), dtype=np.int8))
+
+
+# ---------------------------------------------------------------------------
+# mirrors
+# ---------------------------------------------------------------------------
+
+
+class TestMirrorHorizontal:
+    def test_known(self) -> None:
+        assert np.array_equal(mirror_horizontal(_g([[1, 2], [3, 4]])), _g([[2, 1], [4, 3]]))
+
+    def test_involution(self) -> None:
+        g = _g([[1, 2, 3], [4, 5, 6]])
+        assert np.array_equal(mirror_horizontal(mirror_horizontal(g)), g)
+
+    def test_1x1_grid_unchanged(self) -> None:
+        assert np.array_equal(mirror_horizontal(_g([[5]])), _g([[5]]))
+
+    def test_dtype_preserved(self) -> None:
+        out = mirror_horizontal(_g([[1, 2]]))
+        assert out.dtype == np.int8
+
+    def test_rejects_non_ndarray(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            mirror_horizontal("not a grid")  # type: ignore[arg-type]
+
+
+class TestMirrorVertical:
+    def test_known(self) -> None:
+        assert np.array_equal(mirror_vertical(_g([[1, 2], [3, 4]])), _g([[3, 4], [1, 2]]))
+
+    def test_involution(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        assert np.array_equal(mirror_vertical(mirror_vertical(g)), g)
+
+    def test_single_row(self) -> None:
+        assert np.array_equal(mirror_vertical(_g([[1, 2, 3]])), _g([[1, 2, 3]]))
+
+    def test_returns_copy(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        out = mirror_vertical(g)
+        out[0, 0] = 9
+        assert g[0, 0] == 1
+
+    def test_rejects_int_input(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            mirror_vertical(42)  # type: ignore[arg-type]
+
+
+class TestTranspose:
+    def test_known(self) -> None:
+        assert np.array_equal(transpose(_g([[1, 2], [3, 4]])), _g([[1, 3], [2, 4]]))
+
+    def test_double_transpose_is_identity(self) -> None:
+        g = _g([[1, 2, 3], [4, 5, 6]])
+        assert np.array_equal(transpose(transpose(g)), g)
+
+    def test_swaps_shape(self) -> None:
+        g = _g([[1, 2, 3]])
+        assert transpose(g).shape == (3, 1)
+
+    def test_diag_equals_transpose_for_square(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        assert np.array_equal(mirror_diagonal(g), transpose(g))
+
+    def test_rejects_wrong_type(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            transpose([[1, 2]])  # type: ignore[arg-type]
+
+
+class TestMirrorDiagonal:
+    def test_square_known(self) -> None:
+        assert np.array_equal(mirror_diagonal(_g([[1, 2], [3, 4]])), _g([[1, 3], [2, 4]]))
+
+    def test_involution_on_square(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        assert np.array_equal(mirror_diagonal(mirror_diagonal(g)), g)
+
+    def test_rectangular_grid_swaps_shape(self) -> None:
+        g = _g([[1, 2, 3]])
+        assert mirror_diagonal(g).shape == (3, 1)
+
+    def test_returns_copy(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        out = mirror_diagonal(g)
+        out[0, 0] = 9
+        assert g[0, 0] == 1
+
+    def test_rejects_wrong_dtype(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            mirror_diagonal(np.array([[1, 2]], dtype=np.float32))
+
+
+class TestMirrorAntidiagonal:
+    def test_square_known(self) -> None:
+        assert np.array_equal(mirror_antidiagonal(_g([[1, 2], [3, 4]])), _g([[4, 2], [3, 1]]))
+
+    def test_involution_on_square(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        assert np.array_equal(mirror_antidiagonal(mirror_antidiagonal(g)), g)
+
+    def test_rectangular(self) -> None:
+        # Anti-diagonal mirror: reverse both axes then transpose.
+        g = _g([[1, 2, 3]])
+        out = mirror_antidiagonal(g)
+        assert out.shape == (3, 1)
+        assert np.array_equal(out, _g([[3], [2], [1]]))
+
+    def test_dtype_preserved(self) -> None:
+        out = mirror_antidiagonal(_g([[1, 2], [3, 4]]))
+        assert out.dtype == np.int8
+
+    def test_rejects_non_grid(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            mirror_antidiagonal((1, 2, 3))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# color
+# ---------------------------------------------------------------------------
+
+
+class TestRecolor:
+    def test_replaces_target_color(self) -> None:
+        out = recolor(_g([[1, 2], [1, 3]]), 1, 4)
+        assert np.array_equal(out, _g([[4, 2], [4, 3]]))
+
+    def test_no_change_if_color_absent(self) -> None:
+        g = _g([[1, 2], [1, 3]])
+        assert np.array_equal(recolor(g, 9, 0), g)
+
+    def test_self_recolor_is_identity(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        assert np.array_equal(recolor(g, 1, 1), g)
+
+    def test_rejects_out_of_range_color(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            recolor(_g([[1]]), 1, 10)
+
+    def test_rejects_bool_color(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            recolor(_g([[1]]), True, 2)  # type: ignore[arg-type]
+
+
+class TestSwapColors:
+    def test_swaps_two_colors(self) -> None:
+        out = swap_colors(_g([[1, 2], [2, 1]]), 1, 2)
+        assert np.array_equal(out, _g([[2, 1], [1, 2]]))
+
+    def test_swap_same_color_is_identity(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        assert np.array_equal(swap_colors(g, 1, 1), g)
+
+    def test_swap_absent_color_is_identity(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        assert np.array_equal(swap_colors(g, 8, 9), g)
+
+    def test_idempotent_when_applied_twice(self) -> None:
+        g = _g([[1, 2], [2, 1]])
+        assert np.array_equal(swap_colors(swap_colors(g, 1, 2), 1, 2), g)
+
+    def test_rejects_negative_color(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            swap_colors(_g([[1]]), -1, 2)
+
+
+class TestMostCommonColor:
+    def test_returns_majority(self) -> None:
+        assert most_common_color(_g([[1, 2, 2], [3, 3, 3]])) == 3
+
+    def test_uniform_grid(self) -> None:
+        assert most_common_color(_g([[5, 5], [5, 5]])) == 5
+
+    def test_lowest_index_on_tie(self) -> None:
+        # 1 and 2 each appear twice → argmax breaks tie at lowest index.
+        assert most_common_color(_g([[1, 2], [1, 2]])) == 1
+
+    def test_returns_python_int(self) -> None:
+        assert isinstance(most_common_color(_g([[1]])), int)
+
+    def test_rejects_wrong_dtype(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            most_common_color(np.array([[1, 2]], dtype=np.int32))
+
+
+class TestLeastCommonColor:
+    def test_returns_minority(self) -> None:
+        assert least_common_color(_g([[1, 2, 2], [3, 3, 3]])) == 1
+
+    def test_ignores_absent_colors(self) -> None:
+        # 0 has count 0 → should NOT be picked as least-common.
+        assert least_common_color(_g([[1, 2, 2]])) == 1
+
+    def test_uniform_grid_returns_only_color(self) -> None:
+        assert least_common_color(_g([[5, 5], [5, 5]])) == 5
+
+    def test_returns_python_int(self) -> None:
+        assert isinstance(least_common_color(_g([[1, 2]])), int)
+
+    def test_rejects_non_ndarray(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            least_common_color([1, 2, 3])  # type: ignore[arg-type]
+
+
+class TestColorCount:
+    def test_three_distinct(self) -> None:
+        assert color_count(_g([[1, 2, 2], [3, 3, 3]])) == 3
+
+    def test_uniform_grid(self) -> None:
+        assert color_count(_g([[5, 5]])) == 1
+
+    def test_all_ten_colors(self) -> None:
+        g = _g([list(range(10))])
+        assert color_count(g) == 10
+
+    def test_returns_python_int(self) -> None:
+        assert isinstance(color_count(_g([[1]])), int)
+
+    def test_rejects_1d(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            color_count(np.array([1, 2, 3], dtype=np.int8))
+
+
+class TestReplaceBackground:
+    def test_replaces_majority_color(self) -> None:
+        out = replace_background(_g([[1, 2, 2], [3, 3, 3]]), 0)
+        assert np.array_equal(out, _g([[1, 2, 2], [0, 0, 0]]))
+
+    def test_returns_grid_unchanged_if_new_equals_bg(self) -> None:
+        g = _g([[1, 2, 2], [3, 3, 3]])
+        # bg is 3, replace with 3 → identity
+        assert np.array_equal(replace_background(g, 3), g)
+
+    def test_rejects_out_of_range(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            replace_background(_g([[1]]), -1)
+
+    def test_returns_copy(self) -> None:
+        g = _g([[1, 2, 2], [3, 3, 3]])
+        out = replace_background(g, 0)
+        out[0, 0] = 9
+        assert g[0, 0] == 1
+
+    def test_dtype_preserved(self) -> None:
+        out = replace_background(_g([[1, 2, 2]]), 0)
+        assert out.dtype == np.int8
+
+
+# ---------------------------------------------------------------------------
+# Registry side-effect: every primitive in this group is registered.
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_all_15_primitives_registered(self) -> None:
+        names = REGISTRY.names()
+        for expected in (
+            "identity",
+            "rotate90",
+            "rotate180",
+            "rotate270",
+            "mirror_horizontal",
+            "mirror_vertical",
+            "transpose",
+            "mirror_diagonal",
+            "mirror_antidiagonal",
+            "recolor",
+            "swap_colors",
+            "most_common_color",
+            "least_common_color",
+            "color_count",
+            "replace_background",
+        ):
+            assert expected in names, f"{expected} not registered"
+
+    def test_signature_consistency(self) -> None:
+        # rotate90: Grid -> Grid, arity 1
+        spec = REGISTRY.get("rotate90")
+        assert spec.signature.arity == 1
+        assert spec.signature.output == "Grid"
+        # recolor: Grid, Color, Color -> Grid, arity 3
+        spec = REGISTRY.get("recolor")
+        assert spec.signature.arity == 3
+        assert spec.signature.inputs == ("Grid", "Color", "Color")


### PR DESCRIPTION
## Summary
First batch of primitive implementations from PSE Phase-1 spec §7.2. **15 of the 56 base primitives shipped.**

| Group | Primitives |
|---|---|
| **Geometric (9)** | \`identity\`, \`rotate90\`, \`rotate180\`, \`rotate270\`, \`mirror_horizontal\`, \`mirror_vertical\`, \`transpose\`, \`mirror_diagonal\`, \`mirror_antidiagonal\` |
| **Color (6)** | \`recolor\`, \`swap_colors\`, \`most_common_color\`, \`least_common_color\`, \`color_count\`, \`replace_background\` |

All implementations are pure (no in-place mutation, no shared state) and return fresh \`int8\` arrays. Helper validators \`_check_grid\` / \`_check_color\` raise \`TypeMismatchError\` on shape, dtype, or color-range violations — the search engine relies on these to short-circuit malformed candidates before they hit the sandbox.

\`dsl/__init__.py\` now imports the primitives module so \`REGISTRY\` is populated as soon as the package is imported.

## Tests
**+77 unit tests** in \`tests/test_channels/test_program_synthesis/unit/test_dsl_primitives_geom_color.py\` (5 per primitive + 2 registry side-effect checks):

- Happy-path against spec-documented examples.
- Shape edge cases (1×1, rectangular dimension swap).
- Type-mismatch rejection (1-D / 3-D / wrong dtype / wrong Python type / out-of-range color / bool-as-color).
- Determinism / returns-copy / dtype-preserved.
- Algebraic identities: \`rotate90^4 == identity\`, \`rotate90 ∘ rotate90 == rotate180\`, \`rotate270 ∘ rotate90 == identity\`, \`mirror_h ∘ mirror_h == identity\`, \`transpose ∘ transpose == identity\`, \`mirror_diagonal == transpose\` for square grids, \`swap_colors(swap_colors(x, a, b), a, b) == x\`.

**Total PSE tests: 35 → 112**, all pass in ~0.6s. \`ruff format\` and \`ruff check\` clean.

## Test plan
- [x] \`pytest tests/test_channels/test_program_synthesis/ -x -q\` — 112/112 pass.
- [x] \`ruff format --check\` — clean.
- [x] \`ruff check\` — clean.
- [ ] CI: full backend matrix green.

## Roadmap
This is Week 2 part **A**. Remaining Week-2 work in subsequent PRs:
- Part B: size/scale + spatial (12 primitives)
- Part C: object detection (8 primitives)
- Part D: mask/logic + construction + constants (21 primitives)
- Part E: sandbox executor + AST whitelist + adversarial tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)