### PR TITLE
feat(pse): object-detection DSL primitives + Object/ObjectSet types — Week 2 part C (8/56)

### DIFF
--- a/src/cognithor/channels/program_synthesis/dsl/__init__.py
+++ b/src/cognithor/channels/program_synthesis/dsl/__init__.py
@@ -13,5 +13,6 @@ from __future__ import annotations
 from cognithor.channels.program_synthesis.dsl import primitives as primitives
 from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
 from cognithor.channels.program_synthesis.dsl.signatures import Signature
+from cognithor.channels.program_synthesis.dsl.types_grid import Mask, Object, ObjectSet
 
-__all__ = ["REGISTRY", "Signature", "primitives"]
+__all__ = ["REGISTRY", "Mask", "Object", "ObjectSet", "Signature", "primitives"]

--- a/src/cognithor/channels/program_synthesis/dsl/primitives.py
+++ b/src/cognithor/channels/program_synthesis/dsl/primitives.py
@@ -10,9 +10,10 @@ time via the :func:`primitive` decorator. The catalog is the
 single source of truth for both the search engine and the public DSL
 reference.
 
-This file currently holds the **geometric** and **color** groups
-(15 primitives). Subsequent PRs add size/scale, spatial, object,
-mask/logic, construction, and constant groups for a Phase 1 total of 56.
+This file currently holds the **geometric**, **color**, **size/scale**,
+**spatial**, and **object-detection** groups (35 primitives). Subsequent
+PRs add mask/logic, construction, and constant groups for a Phase 1
+total of 56.
 """
 
 from __future__ import annotations
@@ -23,6 +24,7 @@ from numpy.typing import NDArray
 from cognithor.channels.program_synthesis.core.exceptions import TypeMismatchError
 from cognithor.channels.program_synthesis.dsl.registry import primitive
 from cognithor.channels.program_synthesis.dsl.signatures import Signature
+from cognithor.channels.program_synthesis.dsl.types_grid import Object, ObjectSet
 
 _Grid = NDArray[np.int8]
 
@@ -507,3 +509,273 @@ def wrap_shift(grid: _Grid, dy: int, dx: int) -> _Grid:
     _check_int(dy, "wrap_shift.dy")
     _check_int(dx, "wrap_shift.dx")
     return np.roll(grid, shift=(dy, dx), axis=(0, 1)).copy()
+
+
+def _check_object(o: object, name: str) -> Object:
+    if not isinstance(o, Object):
+        raise TypeMismatchError(f"{name}: expected Object, got {type(o).__name__}")
+    return o
+
+
+def _check_object_set(s: object, name: str) -> ObjectSet:
+    if not isinstance(s, ObjectSet):
+        raise TypeMismatchError(f"{name}: expected ObjectSet, got {type(s).__name__}")
+    return s
+
+
+# ---------------------------------------------------------------------------
+# 28-29. Connected components
+# ---------------------------------------------------------------------------
+
+
+def _connected_components(grid: _Grid, connectivity: int) -> ObjectSet:
+    """Compute connected components via flood-fill (raster-scan order).
+
+    ``connectivity`` is 4 (orthogonal) or 8 (orthogonal + diagonal).
+    Background pixels (most-common color) are *excluded* — they form no
+    objects. Each non-background color produces its own component(s).
+
+    No scipy dependency: a stack-based flood-fill keeps the implementation
+    sandbox-friendly and avoids pulling in a heavy import for a single
+    primitive group.
+    """
+    bg = int(np.bincount(grid.ravel(), minlength=10).argmax())
+    h, w = grid.shape
+    visited = np.zeros_like(grid, dtype=bool)
+    components: list[Object] = []
+
+    if connectivity == 4:
+        offsets = ((-1, 0), (1, 0), (0, -1), (0, 1))
+    else:  # 8
+        offsets = (
+            (-1, -1),
+            (-1, 0),
+            (-1, 1),
+            (0, -1),
+            (0, 1),
+            (1, -1),
+            (1, 0),
+            (1, 1),
+        )
+
+    for r in range(h):
+        for c in range(w):
+            if visited[r, c] or int(grid[r, c]) == bg:
+                continue
+            color = int(grid[r, c])
+            stack: list[tuple[int, int]] = [(r, c)]
+            cells: list[tuple[int, int]] = []
+            while stack:
+                rr, cc = stack.pop()
+                if (
+                    rr < 0
+                    or rr >= h
+                    or cc < 0
+                    or cc >= w
+                    or visited[rr, cc]
+                    or int(grid[rr, cc]) != color
+                ):
+                    continue
+                visited[rr, cc] = True
+                cells.append((rr, cc))
+                for dr, dc in offsets:
+                    stack.append((rr + dr, cc + dc))
+            components.append(Object(color=color, cells=tuple(cells)))
+
+    return ObjectSet(objects=tuple(components))
+
+
+@primitive(
+    name="connected_components_4",
+    signature=Signature(inputs=("Grid",), output="ObjectSet"),
+    cost=2.5,
+    description=(
+        "4-connectivity flood-fill of all non-background pixels. "
+        "Background = most-common color (excluded from output)."
+    ),
+    examples=(("[[0,1,0],[0,1,0]]", "ObjectSet([Object(color=1, size=2)])"),),
+)
+def connected_components_4(grid: _Grid) -> ObjectSet:
+    _check_grid(grid, "connected_components_4")
+    return _connected_components(grid, connectivity=4)
+
+
+@primitive(
+    name="connected_components_8",
+    signature=Signature(inputs=("Grid",), output="ObjectSet"),
+    cost=2.5,
+    description=(
+        "8-connectivity flood-fill of all non-background pixels. "
+        "Diagonal neighbours count; otherwise identical to "
+        "``connected_components_4``."
+    ),
+    examples=(("[[1,0],[0,1]]", "ObjectSet([Object(color=1, size=2)])"),),
+)
+def connected_components_8(grid: _Grid) -> ObjectSet:
+    _check_grid(grid, "connected_components_8")
+    return _connected_components(grid, connectivity=8)
+
+
+# ---------------------------------------------------------------------------
+# 30. objects_of_color
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="objects_of_color",
+    signature=Signature(inputs=("Grid", "Color"), output="ObjectSet"),
+    cost=2.0,
+    description=(
+        "Return the 4-connected components whose color matches the argument. "
+        "Treats the requested color as foreground regardless of background."
+    ),
+    examples=(("[[1,0,2],[1,0,0]] color=1", "ObjectSet of one 2-cell object"),),
+)
+def objects_of_color(grid: _Grid, color: int) -> ObjectSet:
+    _check_grid(grid, "objects_of_color")
+    _check_color(color, "objects_of_color.color")
+    h, w = grid.shape
+    visited = np.zeros_like(grid, dtype=bool)
+    components: list[Object] = []
+    offsets = ((-1, 0), (1, 0), (0, -1), (0, 1))
+    for r in range(h):
+        for c in range(w):
+            if visited[r, c] or int(grid[r, c]) != color:
+                continue
+            stack = [(r, c)]
+            cells: list[tuple[int, int]] = []
+            while stack:
+                rr, cc = stack.pop()
+                if (
+                    rr < 0
+                    or rr >= h
+                    or cc < 0
+                    or cc >= w
+                    or visited[rr, cc]
+                    or int(grid[rr, cc]) != color
+                ):
+                    continue
+                visited[rr, cc] = True
+                cells.append((rr, cc))
+                for dr, dc in offsets:
+                    stack.append((rr + dr, cc + dc))
+            components.append(Object(color=color, cells=tuple(cells)))
+    return ObjectSet(objects=tuple(components))
+
+
+# ---------------------------------------------------------------------------
+# 31-32. largest / smallest
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="largest_object",
+    signature=Signature(inputs=("ObjectSet",), output="Object"),
+    cost=1.5,
+    description=(
+        "Object with the largest pixel count in the set. "
+        "Ties broken by discovery order (first occurrence wins)."
+    ),
+    examples=(("ObjectSet of [{size=2}, {size=5}]", "Object size=5"),),
+)
+def largest_object(objects: ObjectSet) -> Object:
+    _check_object_set(objects, "largest_object")
+    if objects.is_empty():
+        raise TypeMismatchError("largest_object: empty ObjectSet")
+    best = objects.objects[0]
+    for o in objects.objects[1:]:
+        if o.size > best.size:
+            best = o
+    return best
+
+
+@primitive(
+    name="smallest_object",
+    signature=Signature(inputs=("ObjectSet",), output="Object"),
+    cost=1.5,
+    description=(
+        "Object with the smallest pixel count in the set. "
+        "Ties broken by discovery order (first occurrence wins)."
+    ),
+    examples=(("ObjectSet of [{size=2}, {size=5}]", "Object size=2"),),
+)
+def smallest_object(objects: ObjectSet) -> Object:
+    _check_object_set(objects, "smallest_object")
+    if objects.is_empty():
+        raise TypeMismatchError("smallest_object: empty ObjectSet")
+    best = objects.objects[0]
+    for o in objects.objects[1:]:
+        if o.size < best.size:
+            best = o
+    return best
+
+
+# ---------------------------------------------------------------------------
+# 33. bounding_box
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="bounding_box",
+    signature=Signature(inputs=("Object",), output="Grid"),
+    cost=1.5,
+    description=(
+        "Render the object as a tight grid of size = bbox dimensions. "
+        "Pixels inside the object get its color, pixels outside get 0."
+    ),
+    examples=(("Object(color=5, cells=[(0,0),(0,1),(1,1)])", "[[5,5],[0,5]]"),),
+)
+def bounding_box(obj: Object) -> _Grid:
+    _check_object(obj, "bounding_box")
+    if not obj.cells:
+        return np.array([[0]], dtype=np.int8)
+    r0, r1, c0, c1 = obj.bbox
+    out = np.zeros((r1 - r0, c1 - c0), dtype=np.int8)
+    for r, c in obj.cells:
+        out[r - r0, c - c0] = obj.color
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 34. object_count
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="object_count",
+    signature=Signature(inputs=("ObjectSet",), output="Int"),
+    cost=1.0,
+    description="Number of objects in the set (≥ 0).",
+    examples=(("ObjectSet of 3", "3"),),
+)
+def object_count(objects: ObjectSet) -> int:
+    _check_object_set(objects, "object_count")
+    return len(objects)
+
+
+# ---------------------------------------------------------------------------
+# 35. render_objects
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="render_objects",
+    signature=Signature(inputs=("ObjectSet", "Grid"), output="Grid"),
+    cost=2.0,
+    description=(
+        "Paint every object in the set onto a copy of *base*. "
+        "Cells outside the grid are silently dropped (clip-to-edge). "
+        "Later objects overwrite earlier ones at overlapping cells."
+    ),
+    examples=(("ObjectSet of one (color=2)] onto [[0,0],[0,0]]", "[[2,0],[0,0]]"),),
+)
+def render_objects(objects: ObjectSet, base: _Grid) -> _Grid:
+    _check_object_set(objects, "render_objects")
+    _check_grid(base, "render_objects.base")
+    out = base.copy()
+    h, w = out.shape
+    for obj in objects.objects:
+        for r, c in obj.cells:
+            if 0 <= r < h and 0 <= c < w:
+                out[r, c] = obj.color
+    return out

--- a/src/cognithor/channels/program_synthesis/dsl/types_grid.py
+++ b/src/cognithor/channels/program_synthesis/dsl/types_grid.py
@@ -1,0 +1,90 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Domain types for the ARC-DSL: Object, ObjectSet, Mask.
+
+These structures wrap the raw numpy data that the search engine operates
+on. They are all immutable so they can be safely stored in observational-
+equivalence fingerprints and hashed for cache keys.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+from numpy.typing import NDArray
+
+# A boolean per-pixel mask. Always 2-D, shape matches the source grid.
+type Mask = NDArray[np.bool_]
+
+
+@dataclass(frozen=True)
+class Object:
+    """A single connected component on a grid.
+
+    ``color`` is the fill value (0..9). ``cells`` is the canonical set of
+    (row, col) coordinates the object occupies, sorted lexicographically
+    so equality is structural and hashing is deterministic.
+    """
+
+    color: int
+    cells: tuple[tuple[int, int], ...]
+
+    def __post_init__(self) -> None:
+        if not 0 <= self.color <= 9:
+            raise ValueError(f"Object.color {self.color} out of ARC range 0..9")
+        # Canonicalise: sort the cells tuple. We do this here rather than
+        # at every call site so equality on `Object` is well-defined.
+        if list(self.cells) != sorted(self.cells):
+            object.__setattr__(self, "cells", tuple(sorted(self.cells)))
+
+    @property
+    def size(self) -> int:
+        """Number of pixels in this object."""
+        return len(self.cells)
+
+    @property
+    def bbox(self) -> tuple[int, int, int, int]:
+        """Bounding box as ``(r0, r1, c0, c1)`` — half-open on r1/c1."""
+        if not self.cells:
+            return (0, 0, 0, 0)
+        rs = [r for r, _ in self.cells]
+        cs = [c for _, c in self.cells]
+        return (min(rs), max(rs) + 1, min(cs), max(cs) + 1)
+
+    def is_rectangle(self) -> bool:
+        """True iff every cell inside the bbox is part of the object."""
+        if not self.cells:
+            return False
+        r0, r1, c0, c1 = self.bbox
+        expected = (r1 - r0) * (c1 - c0)
+        return self.size == expected
+
+    def is_square(self) -> bool:
+        if not self.is_rectangle():
+            return False
+        r0, r1, c0, c1 = self.bbox
+        return (r1 - r0) == (c1 - c0)
+
+
+@dataclass(frozen=True)
+class ObjectSet:
+    """An ordered, immutable collection of :class:`Object` instances.
+
+    Order matches discovery order from the source primitive (e.g. raster
+    scan for connected_components). The order is part of the structural
+    identity — search-engine-side observational equivalence relies on it.
+    """
+
+    objects: tuple[Object, ...] = ()
+
+    def __len__(self) -> int:
+        return len(self.objects)
+
+    def __iter__(self):
+        return iter(self.objects)
+
+    def __getitem__(self, index: int) -> Object:
+        return self.objects[index]
+
+    def is_empty(self) -> bool:
+        return len(self.objects) == 0

--- a/tests/test_channels/test_program_synthesis/unit/test_dsl_primitives_object.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_dsl_primitives_object.py
@@ -1,0 +1,303 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Object-detection primitive tests (spec §16.2)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.core.exceptions import TypeMismatchError
+from cognithor.channels.program_synthesis.dsl.primitives import (
+    bounding_box,
+    connected_components_4,
+    connected_components_8,
+    largest_object,
+    object_count,
+    objects_of_color,
+    render_objects,
+    smallest_object,
+)
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+from cognithor.channels.program_synthesis.dsl.types_grid import Object, ObjectSet
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+# ---------------------------------------------------------------------------
+# connected_components_4
+# ---------------------------------------------------------------------------
+
+
+class TestConnectedComponents4:
+    def test_finds_two_separate_components(self) -> None:
+        # bg = 0 (4 zeros, 4 ones — tie broken by lowest index → 0).
+        # Two color-1 components, each 2 cells, separated by zeros.
+        result = connected_components_4(_g([[1, 0, 0, 1], [1, 0, 0, 1]]))
+        assert len(result) == 2
+        for o in result:
+            assert o.color == 1
+            assert o.size == 2
+
+    def test_empty_when_uniform(self) -> None:
+        # Uniform grid → bg matches everywhere → no objects.
+        result = connected_components_4(_g([[3, 3], [3, 3]]))
+        assert result.is_empty()
+
+    def test_diagonal_pixels_not_connected(self) -> None:
+        # Two pixels diagonal of each other → 4-connectivity = 2 separate objects.
+        result = connected_components_4(_g([[1, 0], [0, 1]]))
+        assert len(result) == 2
+
+    def test_dtype_independent_of_input_shape(self) -> None:
+        result = connected_components_4(_g([[5]]))
+        assert isinstance(result, ObjectSet)
+
+    def test_rejects_non_grid(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            connected_components_4([[1, 0]])  # type: ignore[arg-type]
+
+
+class TestConnectedComponents8:
+    def test_diagonal_pixels_form_one_object(self) -> None:
+        # 8-connectivity: diagonal neighbours connect → 1 object.
+        result = connected_components_8(_g([[1, 0], [0, 1]]))
+        assert len(result) == 1
+        assert result[0].size == 2
+
+    def test_matches_4_when_no_diagonals(self) -> None:
+        # bg = 0 (4 zeros vs 4 ones, lowest-index tie wins).
+        # Same shape used in TestConnectedComponents4.
+        g = _g([[1, 0, 0, 1], [1, 0, 0, 1]])
+        cc4 = connected_components_4(g)
+        cc8 = connected_components_8(g)
+        assert len(cc4) == len(cc8)
+
+    def test_returns_object_set(self) -> None:
+        assert isinstance(connected_components_8(_g([[1]])), ObjectSet)
+
+    def test_empty_when_uniform(self) -> None:
+        assert connected_components_8(_g([[5, 5]])).is_empty()
+
+    def test_rejects_wrong_dtype(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            connected_components_8(np.array([[1, 0]], dtype=np.int32))
+
+
+# ---------------------------------------------------------------------------
+# objects_of_color
+# ---------------------------------------------------------------------------
+
+
+class TestObjectsOfColor:
+    def test_filters_by_color(self) -> None:
+        # color=1 has one 2-cell object; color=2 has one 1-cell object.
+        result = objects_of_color(_g([[1, 0, 2], [1, 0, 0]]), color=1)
+        assert len(result) == 1
+        assert result[0].color == 1
+        assert result[0].size == 2
+
+    def test_color_absent_returns_empty(self) -> None:
+        assert objects_of_color(_g([[1, 1]]), color=9).is_empty()
+
+    def test_treats_color_as_foreground_regardless_of_bg(self) -> None:
+        # Even if color matches the background, return the components.
+        result = objects_of_color(_g([[0, 0], [0, 0]]), color=0)
+        assert len(result) == 1  # one big 4-cell component
+        assert result[0].size == 4
+
+    def test_rejects_out_of_range_color(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            objects_of_color(_g([[1]]), color=10)
+
+    def test_rejects_non_grid(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            objects_of_color([[1]], color=1)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# largest_object / smallest_object
+# ---------------------------------------------------------------------------
+
+
+class TestLargestObject:
+    def test_picks_largest_by_size(self) -> None:
+        small = Object(color=1, cells=((0, 0),))
+        big = Object(color=2, cells=((0, 0), (0, 1), (1, 0)))
+        assert largest_object(ObjectSet((small, big))) is big
+
+    def test_ties_break_by_discovery_order(self) -> None:
+        a = Object(color=1, cells=((0, 0), (0, 1)))
+        b = Object(color=2, cells=((1, 0), (1, 1)))
+        # Both size=2; first wins.
+        assert largest_object(ObjectSet((a, b))) is a
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(TypeMismatchError, match="empty"):
+            largest_object(ObjectSet())
+
+    def test_single_object_returns_it(self) -> None:
+        only = Object(color=1, cells=((0, 0),))
+        assert largest_object(ObjectSet((only,))) is only
+
+    def test_rejects_non_object_set(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            largest_object([1, 2])  # type: ignore[arg-type]
+
+
+class TestSmallestObject:
+    def test_picks_smallest_by_size(self) -> None:
+        small = Object(color=1, cells=((0, 0),))
+        big = Object(color=2, cells=((0, 0), (0, 1), (1, 0)))
+        assert smallest_object(ObjectSet((big, small))) is small
+
+    def test_ties_break_by_discovery_order(self) -> None:
+        a = Object(color=1, cells=((0, 0),))
+        b = Object(color=2, cells=((1, 0),))
+        assert smallest_object(ObjectSet((a, b))) is a
+
+    def test_empty_raises(self) -> None:
+        with pytest.raises(TypeMismatchError, match="empty"):
+            smallest_object(ObjectSet())
+
+    def test_single_object_returns_it(self) -> None:
+        only = Object(color=4, cells=((2, 2),))
+        assert smallest_object(ObjectSet((only,))) is only
+
+    def test_rejects_non_object_set(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            smallest_object("nope")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# bounding_box
+# ---------------------------------------------------------------------------
+
+
+class TestBoundingBox:
+    def test_renders_object_in_tight_grid(self) -> None:
+        o = Object(color=5, cells=((0, 0), (0, 1), (1, 1)))
+        out = bounding_box(o)
+        assert np.array_equal(out, _g([[5, 5], [0, 5]]))
+
+    def test_single_cell(self) -> None:
+        o = Object(color=7, cells=((3, 4),))
+        out = bounding_box(o)
+        assert out.shape == (1, 1)
+        assert out[0, 0] == 7
+
+    def test_empty_object_returns_1x1_zero(self) -> None:
+        out = bounding_box(Object(color=2, cells=()))
+        assert out.shape == (1, 1)
+        assert out[0, 0] == 0
+
+    def test_dtype_is_int8(self) -> None:
+        o = Object(color=3, cells=((0, 0),))
+        assert bounding_box(o).dtype == np.int8
+
+    def test_rejects_non_object(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            bounding_box("nope")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# object_count
+# ---------------------------------------------------------------------------
+
+
+class TestObjectCount:
+    def test_zero_for_empty(self) -> None:
+        assert object_count(ObjectSet()) == 0
+
+    def test_three(self) -> None:
+        s = ObjectSet(
+            (
+                Object(color=1, cells=((0, 0),)),
+                Object(color=2, cells=((0, 1),)),
+                Object(color=3, cells=((1, 0),)),
+            )
+        )
+        assert object_count(s) == 3
+
+    def test_returns_python_int(self) -> None:
+        assert isinstance(object_count(ObjectSet()), int)
+
+    def test_matches_components_size(self) -> None:
+        # bg = 0 (lowest-index tie wins on equal counts).
+        g = _g([[1, 0, 0, 1], [1, 0, 0, 1]])
+        assert object_count(connected_components_4(g)) == 2
+
+    def test_rejects_non_object_set(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            object_count([1, 2, 3])  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# render_objects
+# ---------------------------------------------------------------------------
+
+
+class TestRenderObjects:
+    def test_paints_object_onto_base(self) -> None:
+        objs = ObjectSet((Object(color=2, cells=((0, 0),)),))
+        out = render_objects(objs, _g([[0, 0], [0, 0]]))
+        assert np.array_equal(out, _g([[2, 0], [0, 0]]))
+
+    def test_empty_set_returns_base_copy(self) -> None:
+        base = _g([[1, 2], [3, 4]])
+        out = render_objects(ObjectSet(), base)
+        assert np.array_equal(out, base)
+        out[0, 0] = 9
+        assert base[0, 0] == 1
+
+    def test_later_objects_overwrite_earlier(self) -> None:
+        objs = ObjectSet(
+            (
+                Object(color=1, cells=((0, 0),)),
+                Object(color=5, cells=((0, 0),)),
+            )
+        )
+        out = render_objects(objs, _g([[0]]))
+        assert out[0, 0] == 5
+
+    def test_out_of_bounds_cells_are_clipped(self) -> None:
+        objs = ObjectSet((Object(color=9, cells=((5, 5), (0, 0))),))
+        out = render_objects(objs, _g([[0, 0], [0, 0]]))
+        # Only (0,0) lands inside the 2×2 base; (5,5) is dropped.
+        assert out[0, 0] == 9
+        assert int(out.sum()) == 9  # only one cell painted
+
+    def test_rejects_non_grid_base(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            render_objects(ObjectSet(), [[0]])  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Registry side-effect.
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_all_8_primitives_registered(self) -> None:
+        names = REGISTRY.names()
+        for expected in (
+            "connected_components_4",
+            "connected_components_8",
+            "objects_of_color",
+            "largest_object",
+            "smallest_object",
+            "bounding_box",
+            "object_count",
+            "render_objects",
+        ):
+            assert expected in names, f"{expected} not registered"
+
+    def test_signatures(self) -> None:
+        spec = REGISTRY.get("largest_object")
+        assert spec.signature.inputs == ("ObjectSet",)
+        assert spec.signature.output == "Object"
+
+        spec = REGISTRY.get("render_objects")
+        assert spec.signature.inputs == ("ObjectSet", "Grid")
+        assert spec.signature.output == "Grid"

--- a/tests/test_channels/test_program_synthesis/unit/test_dsl_types_grid.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_dsl_types_grid.py
@@ -1,0 +1,84 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Object / ObjectSet tests (spec §6 + §7.5 prerequisite types)."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from cognithor.channels.program_synthesis.dsl.types_grid import (
+    Object,
+    ObjectSet,
+)
+
+
+class TestObject:
+    def test_size_matches_cells(self) -> None:
+        o = Object(color=2, cells=((0, 0), (0, 1), (1, 1)))
+        assert o.size == 3
+
+    def test_bbox(self) -> None:
+        o = Object(color=2, cells=((0, 0), (0, 1), (1, 1)))
+        # half-open: r1 = max_r + 1, c1 = max_c + 1
+        assert o.bbox == (0, 2, 0, 2)
+
+    def test_empty_bbox(self) -> None:
+        o = Object(color=0, cells=())
+        assert o.bbox == (0, 0, 0, 0)
+
+    def test_cells_canonicalised_on_construction(self) -> None:
+        # Cells given in arbitrary order should be sorted at construction.
+        o = Object(color=1, cells=((1, 1), (0, 0), (0, 1)))
+        assert o.cells == ((0, 0), (0, 1), (1, 1))
+
+    def test_is_rectangle_true_for_rect(self) -> None:
+        # Full 2×2 block.
+        o = Object(color=3, cells=((0, 0), (0, 1), (1, 0), (1, 1)))
+        assert o.is_rectangle()
+
+    def test_is_rectangle_false_for_l_shape(self) -> None:
+        o = Object(color=3, cells=((0, 0), (1, 0), (1, 1)))
+        assert not o.is_rectangle()
+
+    def test_is_square_requires_rectangle_and_equal_sides(self) -> None:
+        sq = Object(color=4, cells=((0, 0), (0, 1), (1, 0), (1, 1)))
+        assert sq.is_square()
+        rect = Object(color=4, cells=((0, 0), (0, 1)))
+        assert rect.is_rectangle() and not rect.is_square()
+
+    def test_color_validation(self) -> None:
+        with pytest.raises(ValueError, match="out of ARC range"):
+            Object(color=10, cells=())
+
+    def test_frozen(self) -> None:
+        o = Object(color=1, cells=((0, 0),))
+        with pytest.raises(FrozenInstanceError):
+            o.color = 2  # type: ignore[misc]
+
+    def test_equality_is_structural(self) -> None:
+        a = Object(color=1, cells=((0, 1), (0, 0)))
+        b = Object(color=1, cells=((0, 0), (0, 1)))
+        # Both canonicalised the same way.
+        assert a == b
+        assert hash(a) == hash(b)
+
+
+class TestObjectSet:
+    def test_empty(self) -> None:
+        s = ObjectSet()
+        assert s.is_empty()
+        assert len(s) == 0
+
+    def test_iter_and_index(self) -> None:
+        a = Object(color=1, cells=((0, 0),))
+        b = Object(color=2, cells=((1, 1),))
+        s = ObjectSet(objects=(a, b))
+        assert list(s) == [a, b]
+        assert s[0] is a
+        assert s[1] is b
+
+    def test_frozen(self) -> None:
+        s = ObjectSet(objects=())
+        with pytest.raises(FrozenInstanceError):
+            s.objects = ()  # type: ignore[misc]


### PR DESCRIPTION
## Summary
Third batch of primitive implementations from PSE Phase-1 spec §7.2 plus the prerequisite \`Object\`/\`ObjectSet\` types from §6. Every ARC task that operates on multi-pixel components flows through these.

### New domain types (\`dsl/types_grid.py\`)
- **\`Object\`** — frozen dataclass with \`color\` + canonical-sorted \`cells\` tuple, plus \`size\` / \`bbox\` / \`is_rectangle\` / \`is_square\` helpers. Equality is structural.
- **\`ObjectSet\`** — frozen, ordered collection of Objects with \`__len__\` / \`__iter__\` / \`__getitem__\`. Order matters for observational equivalence in the search engine.
- **\`Mask\`** — type alias for \`NDArray[bool_]\` (used by the upcoming mask/logic primitives in part D).

### Primitives (8)
| Name | Signature |
|---|---|
| \`connected_components_4\` | \`Grid -> ObjectSet\` |
| \`connected_components_8\` | \`Grid -> ObjectSet\` |
| \`objects_of_color\` | \`Grid, Color -> ObjectSet\` |
| \`largest_object\` | \`ObjectSet -> Object\` |
| \`smallest_object\` | \`ObjectSet -> Object\` |
| \`bounding_box\` | \`Object -> Grid\` |
| \`object_count\` | \`ObjectSet -> Int\` |
| \`render_objects\` | \`ObjectSet, Grid -> Grid\` |

### Implementation notes
- Flood-fill uses a private stack-based helper instead of \`scipy.ndimage.label\` — keeps the AST-whitelist simpler in the upcoming sandbox PR.
- \`connected_components_*\` excludes the background (most-common color); \`objects_of_color\` treats the requested color as foreground regardless of background.
- \`largest_object\`/\`smallest_object\` break ties by discovery order so the result is deterministic for caching.
- \`bounding_box\` on an empty Object returns a 1×1 zero grid (search-friendly).
- \`render_objects\` has later-overwrites-earlier semantics and silently clips out-of-bounds cells.

## Tests
**+55 tests**: 40 primitive tests (5 each) + 12 type tests + 3 registry side-effect checks.

Algebraic / structural identities verified:
- Diagonal pixels: \`cc8\` connects them, \`cc4\` doesn't.
- \`objects_of_color\` counts a uniformly-colored grid as 1 component (foreground treatment).
- \`render_objects(empty_set, base)\` returns a copy of \`base\` (immutably).
- \`render_objects\` respects later-overwrites-earlier semantics.
- \`object_count(connected_components_4(g))\` matches the visual count.

**Total PSE tests: 174 → 229**, all pass in ~0.6s. \`ruff format\` and \`ruff check\` clean.

## Test plan
- [x] \`pytest tests/test_channels/test_program_synthesis/ -x -q\` — 229/229 pass.
- [x] \`ruff format --check\` — clean.
- [x] \`ruff check\` — clean.
- [ ] CI: full backend matrix green.

## Roadmap
**Week 2 progress: 35 / 56 base primitives complete.** Remaining:
- Part D: mask/logic (7) + construction (4) + constants (10) — 21 primitives
- Part E: sandbox executor + AST whitelist + adversarial tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)