### PR TITLE
feat(pse): mask/logic + construction + color-constants — Week 2 part D (21/56) — DSL CATALOG COMPLETE

### DIFF
--- a/src/cognithor/channels/program_synthesis/dsl/primitives.py
+++ b/src/cognithor/channels/program_synthesis/dsl/primitives.py
@@ -10,10 +10,9 @@ time via the :func:`primitive` decorator. The catalog is the
 single source of truth for both the search engine and the public DSL
 reference.
 
-This file currently holds the **geometric**, **color**, **size/scale**,
-**spatial**, and **object-detection** groups (35 primitives). Subsequent
-PRs add mask/logic, construction, and constant groups for a Phase 1
-total of 56.
+This file holds the full Phase-1 base catalog (56 primitives):
+geometric, color, size/scale, spatial, object-detection, mask/logic,
+construction, and color constants.
 """
 
 from __future__ import annotations
@@ -779,3 +778,246 @@ def render_objects(objects: ObjectSet, base: _Grid) -> _Grid:
             if 0 <= r < h and 0 <= c < w:
                 out[r, c] = obj.color
     return out
+
+
+_Mask = NDArray[np.bool_]
+
+
+def _check_mask(m: object, name: str) -> _Mask:
+    if not isinstance(m, np.ndarray):
+        raise TypeMismatchError(f"{name}: expected ndarray, got {type(m).__name__}")
+    if m.ndim != 2:
+        raise TypeMismatchError(f"{name}: expected 2-D mask, got {m.ndim}-D")
+    if m.dtype != np.bool_:
+        raise TypeMismatchError(f"{name}: expected bool dtype, got {m.dtype}")
+    return m
+
+
+# ---------------------------------------------------------------------------
+# 36-42. Mask / Logic
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="mask_eq",
+    signature=Signature(inputs=("Grid", "Color"), output="Mask"),
+    cost=1.5,
+    description="Return a boolean mask: True where the grid equals *color*.",
+    examples=(("[[1,2],[1,3]] color=1", "[[True,False],[True,False]]"),),
+)
+def mask_eq(grid: _Grid, color: int) -> _Mask:
+    _check_grid(grid, "mask_eq")
+    _check_color(color, "mask_eq.color")
+    return (grid == color).copy()
+
+
+@primitive(
+    name="mask_ne",
+    signature=Signature(inputs=("Grid", "Color"), output="Mask"),
+    cost=1.5,
+    description="Return a boolean mask: True where the grid is *not* color.",
+    examples=(("[[1,2],[1,3]] color=1", "[[False,True],[False,True]]"),),
+)
+def mask_ne(grid: _Grid, color: int) -> _Mask:
+    _check_grid(grid, "mask_ne")
+    _check_color(color, "mask_ne.color")
+    return (grid != color).copy()
+
+
+@primitive(
+    name="mask_apply",
+    signature=Signature(inputs=("Grid", "Mask", "Color"), output="Grid"),
+    cost=2.0,
+    description=(
+        "Set every cell of the grid where *mask* is True to *color*. "
+        "Mask shape must match the grid shape exactly."
+    ),
+    examples=(("[[1,2]] mask=[[T,F]] color=9", "[[9,2]]"),),
+)
+def mask_apply(grid: _Grid, mask: _Mask, color: int) -> _Grid:
+    _check_grid(grid, "mask_apply")
+    _check_mask(mask, "mask_apply.mask")
+    _check_color(color, "mask_apply.color")
+    if mask.shape != grid.shape:
+        raise TypeMismatchError(f"mask_apply: mask shape {mask.shape} != grid shape {grid.shape}")
+    out = grid.copy()
+    out[mask] = color
+    return out
+
+
+def _check_same_shape(a: _Mask, b: _Mask, name: str) -> None:
+    if a.shape != b.shape:
+        raise TypeMismatchError(f"{name}: shape mismatch {a.shape} vs {b.shape}")
+
+
+@primitive(
+    name="mask_and",
+    signature=Signature(inputs=("Mask", "Mask"), output="Mask"),
+    cost=1.5,
+    description="Pixel-wise logical AND of two masks of equal shape.",
+    examples=(("[[T,F]] AND [[T,T]]", "[[T,F]]"),),
+)
+def mask_and(a: _Mask, b: _Mask) -> _Mask:
+    _check_mask(a, "mask_and.a")
+    _check_mask(b, "mask_and.b")
+    _check_same_shape(a, b, "mask_and")
+    return np.logical_and(a, b).copy()
+
+
+@primitive(
+    name="mask_or",
+    signature=Signature(inputs=("Mask", "Mask"), output="Mask"),
+    cost=1.5,
+    description="Pixel-wise logical OR of two masks of equal shape.",
+    examples=(("[[T,F]] OR [[F,T]]", "[[T,T]]"),),
+)
+def mask_or(a: _Mask, b: _Mask) -> _Mask:
+    _check_mask(a, "mask_or.a")
+    _check_mask(b, "mask_or.b")
+    _check_same_shape(a, b, "mask_or")
+    return np.logical_or(a, b).copy()
+
+
+@primitive(
+    name="mask_xor",
+    signature=Signature(inputs=("Mask", "Mask"), output="Mask"),
+    cost=1.5,
+    description="Pixel-wise logical XOR of two masks of equal shape.",
+    examples=(("[[T,F]] XOR [[T,T]]", "[[F,T]]"),),
+)
+def mask_xor(a: _Mask, b: _Mask) -> _Mask:
+    _check_mask(a, "mask_xor.a")
+    _check_mask(b, "mask_xor.b")
+    _check_same_shape(a, b, "mask_xor")
+    return np.logical_xor(a, b).copy()
+
+
+@primitive(
+    name="mask_not",
+    signature=Signature(inputs=("Mask",), output="Mask"),
+    cost=1.2,
+    description="Pixel-wise logical NOT (involution: mask_not(mask_not(x)) == x).",
+    examples=(("[[T,F]]", "[[F,T]]"),),
+)
+def mask_not(a: _Mask) -> _Mask:
+    _check_mask(a, "mask_not")
+    return np.logical_not(a).copy()
+
+
+# ---------------------------------------------------------------------------
+# 43-46. Construction / Composition
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="stack_horizontal",
+    signature=Signature(inputs=("Grid", "Grid"), output="Grid"),
+    cost=2.0,
+    description=(
+        "Stack two grids side-by-side (left-to-right). "
+        "Row counts must match; output cols = left.cols + right.cols."
+    ),
+    examples=(("[[1]]||[[2]]", "[[1,2]]"),),
+)
+def stack_horizontal(left: _Grid, right: _Grid) -> _Grid:
+    _check_grid(left, "stack_horizontal.left")
+    _check_grid(right, "stack_horizontal.right")
+    if left.shape[0] != right.shape[0]:
+        raise TypeMismatchError(
+            f"stack_horizontal: row mismatch {left.shape[0]} vs {right.shape[0]}"
+        )
+    return np.concatenate([left, right], axis=1).copy()
+
+
+@primitive(
+    name="stack_vertical",
+    signature=Signature(inputs=("Grid", "Grid"), output="Grid"),
+    cost=2.0,
+    description=(
+        "Stack two grids top-to-bottom. "
+        "Column counts must match; output rows = top.rows + bottom.rows."
+    ),
+    examples=(("[[1,2]]==[[3,4]]", "[[1,2],[3,4]]"),),
+)
+def stack_vertical(top: _Grid, bottom: _Grid) -> _Grid:
+    _check_grid(top, "stack_vertical.top")
+    _check_grid(bottom, "stack_vertical.bottom")
+    if top.shape[1] != bottom.shape[1]:
+        raise TypeMismatchError(f"stack_vertical: col mismatch {top.shape[1]} vs {bottom.shape[1]}")
+    return np.concatenate([top, bottom], axis=0).copy()
+
+
+@primitive(
+    name="overlay",
+    signature=Signature(inputs=("Grid", "Grid", "Color"), output="Grid"),
+    cost=2.5,
+    description=(
+        "Overlay *top* onto *base*: cells of *top* equal to *transparent_color* "
+        "are skipped, all other cells overwrite *base*. Both grids must have "
+        "the same shape."
+    ),
+    examples=(("base=[[1,1]] top=[[0,2]] transparent=0", "[[1,2]]"),),
+)
+def overlay(base: _Grid, top: _Grid, transparent_color: int) -> _Grid:
+    _check_grid(base, "overlay.base")
+    _check_grid(top, "overlay.top")
+    _check_color(transparent_color, "overlay.transparent_color")
+    if base.shape != top.shape:
+        raise TypeMismatchError(f"overlay: shape mismatch {base.shape} vs {top.shape}")
+    out = base.copy()
+    mask = top != transparent_color
+    out[mask] = top[mask]
+    return out
+
+
+@primitive(
+    name="frame",
+    signature=Signature(inputs=("Grid", "Color"), output="Grid"),
+    cost=1.8,
+    description=(
+        "Draw a 1-pixel border of *color* around the grid edge, "
+        "leaving the interior unchanged. Grid must be at least 1×1."
+    ),
+    examples=(("[[1,2],[3,4]] color=0", "[[0,0],[0,0]] (2x2 fully framed → all border)"),),
+)
+def frame(grid: _Grid, color: int) -> _Grid:
+    _check_grid(grid, "frame")
+    _check_color(color, "frame.color")
+    out = grid.copy()
+    out[0, :] = color
+    out[-1, :] = color
+    out[:, 0] = color
+    out[:, -1] = color
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 47-56. Color constants
+# ---------------------------------------------------------------------------
+
+
+def _make_color_const(c: int) -> None:
+    """Register a zero-arity primitive that returns the literal color *c*.
+
+    Each is its own primitive in the catalog so the search engine can
+    enumerate them as leaves; the cost is intentionally low (0.5) so they
+    don't dominate Occam ranking.
+    """
+
+    @primitive(
+        name=f"const_color_{c}",
+        signature=Signature(inputs=(), output="Color"),
+        cost=0.5,
+        description=f"Constant color {c}.",
+        examples=(("(no input)", str(c)),),
+    )
+    def _const() -> int:
+        return c
+
+    # Suppress "function defined but never used" — Python keeps the
+    # registry reference alive via the decorator.
+    _ = _const
+
+
+for _c in range(10):
+    _make_color_const(_c)

--- a/tests/test_channels/test_program_synthesis/unit/test_dsl_primitives_mask_construct_const.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_dsl_primitives_mask_construct_const.py
@@ -1,0 +1,392 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Mask / logic, construction, and color-constant primitive tests (spec §16.2)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.core.exceptions import TypeMismatchError
+from cognithor.channels.program_synthesis.dsl.primitives import (
+    frame,
+    mask_and,
+    mask_apply,
+    mask_eq,
+    mask_ne,
+    mask_not,
+    mask_or,
+    mask_xor,
+    overlay,
+    stack_horizontal,
+    stack_vertical,
+)
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+def _m(rows: list[list[bool]]) -> np.ndarray:
+    return np.array(rows, dtype=np.bool_)
+
+
+# ---------------------------------------------------------------------------
+# mask_eq / mask_ne
+# ---------------------------------------------------------------------------
+
+
+class TestMaskEq:
+    def test_returns_bool_mask(self) -> None:
+        m = mask_eq(_g([[1, 2], [1, 3]]), color=1)
+        assert m.dtype == np.bool_
+        assert np.array_equal(m, _m([[True, False], [True, False]]))
+
+    def test_no_match_all_false(self) -> None:
+        m = mask_eq(_g([[1, 2]]), color=9)
+        assert not m.any()
+
+    def test_all_match(self) -> None:
+        m = mask_eq(_g([[5, 5]]), color=5)
+        assert m.all()
+
+    def test_rejects_non_grid(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            mask_eq([[1, 2]], color=1)  # type: ignore[arg-type]
+
+    def test_complement_of_mask_ne(self) -> None:
+        g = _g([[1, 2, 1]])
+        eq = mask_eq(g, 1)
+        ne = mask_ne(g, 1)
+        assert np.array_equal(eq, np.logical_not(ne))
+
+
+class TestMaskNe:
+    def test_returns_bool_mask(self) -> None:
+        m = mask_ne(_g([[1, 2], [1, 3]]), color=1)
+        assert np.array_equal(m, _m([[False, True], [False, True]]))
+
+    def test_all_distinct_all_true(self) -> None:
+        m = mask_ne(_g([[1, 2]]), color=9)
+        assert m.all()
+
+    def test_dtype_preserved(self) -> None:
+        assert mask_ne(_g([[5]]), color=5).dtype == np.bool_
+
+    def test_rejects_out_of_range_color(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            mask_ne(_g([[1]]), color=10)
+
+    def test_returns_copy(self) -> None:
+        g = _g([[1]])
+        m = mask_ne(g, color=2)
+        m[0, 0] = False
+        # Source untouched.
+        assert g[0, 0] == 1
+
+
+# ---------------------------------------------------------------------------
+# mask_apply
+# ---------------------------------------------------------------------------
+
+
+class TestMaskApply:
+    def test_paints_masked_cells(self) -> None:
+        out = mask_apply(_g([[1, 2]]), _m([[True, False]]), color=9)
+        assert np.array_equal(out, _g([[9, 2]]))
+
+    def test_empty_mask_returns_copy(self) -> None:
+        g = _g([[1, 2]])
+        out = mask_apply(g, _m([[False, False]]), color=9)
+        assert np.array_equal(out, g)
+        out[0, 0] = 7
+        assert g[0, 0] == 1
+
+    def test_full_mask_overwrites_entire_grid(self) -> None:
+        out = mask_apply(_g([[1, 2]]), _m([[True, True]]), color=9)
+        assert np.array_equal(out, _g([[9, 9]]))
+
+    def test_shape_mismatch_raises(self) -> None:
+        with pytest.raises(TypeMismatchError, match="shape"):
+            mask_apply(_g([[1, 2]]), _m([[True, False, True]]), color=0)
+
+    def test_rejects_non_bool_mask(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            mask_apply(_g([[1, 2]]), _g([[1, 0]]), color=0)
+
+
+# ---------------------------------------------------------------------------
+# mask_and / or / xor / not
+# ---------------------------------------------------------------------------
+
+
+class TestMaskAnd:
+    def test_known(self) -> None:
+        out = mask_and(_m([[True, False]]), _m([[True, True]]))
+        assert np.array_equal(out, _m([[True, False]]))
+
+    def test_with_self_is_identity(self) -> None:
+        a = _m([[True, False, True]])
+        assert np.array_equal(mask_and(a, a), a)
+
+    def test_with_all_false_is_all_false(self) -> None:
+        a = _m([[True, False]])
+        b = _m([[False, False]])
+        assert not mask_and(a, b).any()
+
+    def test_shape_mismatch_raises(self) -> None:
+        with pytest.raises(TypeMismatchError, match="shape"):
+            mask_and(_m([[True, False]]), _m([[True, False, True]]))
+
+    def test_dtype_bool(self) -> None:
+        assert mask_and(_m([[True]]), _m([[True]])).dtype == np.bool_
+
+
+class TestMaskOr:
+    def test_known(self) -> None:
+        out = mask_or(_m([[True, False]]), _m([[False, True]]))
+        assert np.array_equal(out, _m([[True, True]]))
+
+    def test_with_self_is_identity(self) -> None:
+        a = _m([[True, False, True]])
+        assert np.array_equal(mask_or(a, a), a)
+
+    def test_or_all_true_is_all_true(self) -> None:
+        a = _m([[True, False]])
+        b = _m([[True, True]])
+        assert mask_or(a, b).all()
+
+    def test_shape_mismatch_raises(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            mask_or(_m([[True]]), _m([[True, True]]))
+
+    def test_distributes_over_and(self) -> None:
+        # De Morgan: NOT (a AND b) == (NOT a) OR (NOT b)
+        a = _m([[True, False, True]])
+        b = _m([[True, True, False]])
+        lhs = mask_not(mask_and(a, b))
+        rhs = mask_or(mask_not(a), mask_not(b))
+        assert np.array_equal(lhs, rhs)
+
+
+class TestMaskXor:
+    def test_known(self) -> None:
+        out = mask_xor(_m([[True, False]]), _m([[True, True]]))
+        assert np.array_equal(out, _m([[False, True]]))
+
+    def test_with_self_is_all_false(self) -> None:
+        a = _m([[True, False, True]])
+        assert not mask_xor(a, a).any()
+
+    def test_xor_with_all_false_is_identity(self) -> None:
+        a = _m([[True, False, True]])
+        b = _m([[False, False, False]])
+        assert np.array_equal(mask_xor(a, b), a)
+
+    def test_commutative(self) -> None:
+        a = _m([[True, False]])
+        b = _m([[False, True]])
+        assert np.array_equal(mask_xor(a, b), mask_xor(b, a))
+
+    def test_shape_mismatch_raises(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            mask_xor(_m([[True]]), _m([[True, True]]))
+
+
+class TestMaskNot:
+    def test_known(self) -> None:
+        assert np.array_equal(mask_not(_m([[True, False]])), _m([[False, True]]))
+
+    def test_involution(self) -> None:
+        a = _m([[True, False, True]])
+        assert np.array_equal(mask_not(mask_not(a)), a)
+
+    def test_dtype_bool(self) -> None:
+        assert mask_not(_m([[True]])).dtype == np.bool_
+
+    def test_rejects_non_mask(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            mask_not(_g([[1, 0]]))
+
+    def test_returns_copy(self) -> None:
+        a = _m([[True]])
+        out = mask_not(a)
+        out[0, 0] = True
+        assert a[0, 0]
+
+
+# ---------------------------------------------------------------------------
+# stack_horizontal / vertical
+# ---------------------------------------------------------------------------
+
+
+class TestStackHorizontal:
+    def test_known(self) -> None:
+        out = stack_horizontal(_g([[1]]), _g([[2]]))
+        assert np.array_equal(out, _g([[1, 2]]))
+
+    def test_grows_columns(self) -> None:
+        out = stack_horizontal(_g([[1, 2], [3, 4]]), _g([[5], [6]]))
+        assert out.shape == (2, 3)
+
+    def test_row_mismatch_raises(self) -> None:
+        with pytest.raises(TypeMismatchError, match="row mismatch"):
+            stack_horizontal(_g([[1]]), _g([[2], [3]]))
+
+    def test_dtype_preserved(self) -> None:
+        assert stack_horizontal(_g([[1]]), _g([[2]])).dtype == np.int8
+
+    def test_rejects_non_grid(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            stack_horizontal(_g([[1]]), [[2]])  # type: ignore[arg-type]
+
+
+class TestStackVertical:
+    def test_known(self) -> None:
+        out = stack_vertical(_g([[1, 2]]), _g([[3, 4]]))
+        assert np.array_equal(out, _g([[1, 2], [3, 4]]))
+
+    def test_grows_rows(self) -> None:
+        out = stack_vertical(_g([[1, 2]]), _g([[3, 4], [5, 6]]))
+        assert out.shape == (3, 2)
+
+    def test_col_mismatch_raises(self) -> None:
+        with pytest.raises(TypeMismatchError, match="col mismatch"):
+            stack_vertical(_g([[1, 2]]), _g([[3]]))
+
+    def test_compose_h_v_equals_block(self) -> None:
+        a = _g([[1]])
+        b = _g([[2]])
+        c = _g([[3]])
+        d = _g([[4]])
+        block = stack_vertical(stack_horizontal(a, b), stack_horizontal(c, d))
+        assert np.array_equal(block, _g([[1, 2], [3, 4]]))
+
+    def test_rejects_non_grid(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            stack_vertical([[1]], _g([[2]]))  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# overlay
+# ---------------------------------------------------------------------------
+
+
+class TestOverlay:
+    def test_replaces_non_transparent_cells(self) -> None:
+        out = overlay(_g([[1, 1]]), _g([[0, 2]]), transparent_color=0)
+        assert np.array_equal(out, _g([[1, 2]]))
+
+    def test_full_transparent_returns_base(self) -> None:
+        base = _g([[1, 2]])
+        out = overlay(base, _g([[0, 0]]), transparent_color=0)
+        assert np.array_equal(out, base)
+
+    def test_no_transparent_overwrites_all(self) -> None:
+        out = overlay(_g([[1, 1]]), _g([[2, 3]]), transparent_color=0)
+        assert np.array_equal(out, _g([[2, 3]]))
+
+    def test_shape_mismatch_raises(self) -> None:
+        with pytest.raises(TypeMismatchError, match="shape mismatch"):
+            overlay(_g([[1]]), _g([[1, 1]]), transparent_color=0)
+
+    def test_returns_copy(self) -> None:
+        base = _g([[1]])
+        out = overlay(base, _g([[2]]), transparent_color=0)
+        out[0, 0] = 9
+        assert base[0, 0] == 1
+
+
+# ---------------------------------------------------------------------------
+# frame
+# ---------------------------------------------------------------------------
+
+
+class TestFrame:
+    def test_2x2_fully_framed(self) -> None:
+        # Every cell of a 2×2 is on the border.
+        out = frame(_g([[1, 2], [3, 4]]), color=0)
+        assert np.array_equal(out, _g([[0, 0], [0, 0]]))
+
+    def test_3x3_keeps_centre(self) -> None:
+        g = _g([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        out = frame(g, color=0)
+        # Border = 0, centre = 5
+        assert out[1, 1] == 5
+        assert out[0, 0] == 0
+        assert out[-1, -1] == 0
+
+    def test_1x1_becomes_color(self) -> None:
+        out = frame(_g([[7]]), color=3)
+        assert out[0, 0] == 3
+
+    def test_returns_copy(self) -> None:
+        g = _g([[1, 2], [3, 4]])
+        out = frame(g, color=0)
+        out[0, 0] = 9
+        assert g[0, 0] == 1
+
+    def test_rejects_out_of_range_color(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            frame(_g([[1]]), color=-1)
+
+
+# ---------------------------------------------------------------------------
+# Color constants
+# ---------------------------------------------------------------------------
+
+
+class TestColorConstants:
+    def test_all_10_constants_registered(self) -> None:
+        for c in range(10):
+            spec = REGISTRY.get(f"const_color_{c}")
+            assert spec.signature.arity == 0
+            assert spec.signature.output == "Color"
+
+    def test_const_returns_correct_int(self) -> None:
+        for c in range(10):
+            spec = REGISTRY.get(f"const_color_{c}")
+            assert spec.fn() == c
+
+    def test_const_cost_is_cheap(self) -> None:
+        for c in range(10):
+            spec = REGISTRY.get(f"const_color_{c}")
+            assert spec.cost == 0.5
+
+    def test_const_zero_separate_from_const_nine(self) -> None:
+        zero = REGISTRY.get("const_color_0").fn()
+        nine = REGISTRY.get("const_color_9").fn()
+        assert zero == 0
+        assert nine == 9
+
+    def test_const_returns_python_int(self) -> None:
+        assert isinstance(REGISTRY.get("const_color_5").fn(), int)
+
+
+# ---------------------------------------------------------------------------
+# Registry side-effect.
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_all_21_primitives_registered(self) -> None:
+        names = REGISTRY.names()
+        for expected in (
+            "mask_eq",
+            "mask_ne",
+            "mask_apply",
+            "mask_and",
+            "mask_or",
+            "mask_xor",
+            "mask_not",
+            "stack_horizontal",
+            "stack_vertical",
+            "overlay",
+            "frame",
+            *(f"const_color_{c}" for c in range(10)),
+        ):
+            assert expected in names, f"{expected} not registered"
+
+    def test_full_catalog_size_matches_spec(self) -> None:
+        # 56 base primitives expected after Week 2 (incl. 10 constants).
+        assert len(REGISTRY) == 56


### PR DESCRIPTION
## Summary
**Final Week 2 batch — Phase 1 base catalog now complete at 56 primitives.** Rebased on main after #206 (Week 2C) merged.

| Group | Primitives |
|---|---|
| **Mask / Logic (7)** | \`mask_eq\`, \`mask_ne\`, \`mask_apply\`, \`mask_and\`, \`mask_or\`, \`mask_xor\`, \`mask_not\` |
| **Construction (4)** | \`stack_horizontal\`, \`stack_vertical\`, \`overlay\`, \`frame\` |
| **Color constants (10)** | \`const_color_0\` … \`const_color_9\` |

## Implementation notes
- \`Mask\` is a \`NDArray[bool_]\`. New \`_check_mask\` validator enforces shape + dtype, parallel to \`_check_grid\` for grids.
- \`mask_apply\` and \`overlay\` raise \`TypeMismatchError\` on shape mismatch — the search engine's type stage will reject those candidates without entering the sandbox.
- \`frame\` paints the outer ring; for a 2×2 grid every cell is on the border, so it returns all-color.
- The const-factory uses a tiny loop \`for c in range(10): _make_color_const(c)\` so the registry sees ten distinct zero-arity Color leaves with cost 0.5 each, without writing ten near-identical functions.

## Tests
**+62 unit tests** (5 per primitive + constants block + registry catalog-size check).

New algebraic / structural identities verified:
- **De Morgan:** \`mask_not(mask_and(a,b)) == mask_or(mask_not(a), mask_not(b))\`
- \`mask_xor(a, a) == all_false\`
- \`mask_xor\` commutative, \`mask_not\` involution
- Stack composition: \`stack_v(stack_h(a,b), stack_h(c,d)) == [[a,b],[c,d]]\`
- **Catalog-size invariant:** \`len(REGISTRY) == 56\` — locks the Phase-1 base count.

**Total PSE tests: 229 → 291**, all pass in ~0.7s. \`ruff format\` and \`ruff check\` clean.

## Test plan
- [x] \`pytest tests/test_channels/test_program_synthesis/ -x -q\` — 291/291 pass.
- [x] \`ruff format --check\` — clean.
- [x] \`ruff check\` — clean.
- [ ] CI: full backend matrix green.

## Roadmap status
**Week 2 base-DSL slice: 56 / 56 ✓.** Remaining for Week 2:
- Part E: sandbox executor + AST whitelist + adversarial tests (separate PR — different surface area, deserves its own review).

Phase 1.5 higher-order primitives (\`map_objects\`, \`filter_objects\`, \`align_to\`, \`sort_objects\`, \`branch\` + 12 predicate constructors) come in Week 6 per the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)