### PR TITLE
feat(pse): search candidate-tree types — Week 3 day 1-2 (Program/InputRef/Const)

### DIFF
--- a/src/cognithor/channels/program_synthesis/search/__init__.py
+++ b/src/cognithor/channels/program_synthesis/search/__init__.py
@@ -1,2 +1,18 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-"""PSE search — scaffold (Week 1). Implementation lands in later weeks."""
+"""Enumerative search engine for the PSE channel (spec §8).
+
+Phase 1 ships a bottom-up enumerator with observational-equivalence
+pruning. Week 3 of the roadmap lands the candidate types, the budget
+allocator, and the engine itself.
+"""
+
+from __future__ import annotations
+
+from cognithor.channels.program_synthesis.search.candidate import (
+    Const,
+    InputRef,
+    Program,
+    ProgramNode,
+)
+
+__all__ = ["Const", "InputRef", "Program", "ProgramNode"]

--- a/src/cognithor/channels/program_synthesis/search/candidate.py
+++ b/src/cognithor/channels/program_synthesis/search/candidate.py
@@ -1,0 +1,104 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Program-tree representation used by the enumerative search (spec §6.2).
+
+A program is a typed tree of DSL primitive applications, leafed by either
+``InputRef`` (the task's input grid) or ``Const`` (a literal value such
+as a color index).
+
+Every node is frozen / immutable. Equality is structural so the
+observational-equivalence pruner can use programs directly as keys.
+``stable_hash`` returns a SHA-256 over the canonical source form so the
+hash is portable across Python versions and processes (the sandbox
+worker re-hashes for cache validation).
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class InputRef:
+    """A reference to the task's input grid.
+
+    Always the leaf of a Grid-typed sub-tree. ``output_type`` is fixed at
+    ``"Grid"`` because the input is always the raw grid handed to the
+    program; future generalisations (multi-input tasks) would extend
+    this rather than mutate it.
+    """
+
+    output_type: str = "Grid"
+
+    def to_source(self) -> str:
+        return "input"
+
+    def depth(self) -> int:
+        return 0
+
+    def size(self) -> int:
+        return 1
+
+
+@dataclass(frozen=True)
+class Const:
+    """A literal value (color index, integer parameter, enum tag, ...)."""
+
+    value: int | str
+    output_type: str
+
+    def to_source(self) -> str:
+        # Ints render as their decimal value, strings keep their quotes
+        # so the source round-trips through eval() (used only by the
+        # `cognithor pse explain` formatter, never by the search engine).
+        if isinstance(self.value, int) and not isinstance(self.value, bool):
+            return str(self.value)
+        return repr(self.value)
+
+    def depth(self) -> int:
+        return 0
+
+    def size(self) -> int:
+        return 1
+
+
+@dataclass(frozen=True)
+class Program:
+    """A non-leaf node: a primitive applied to an ordered tuple of children.
+
+    ``children`` are themselves :class:`ProgramNode` (one of Program,
+    InputRef, or Const). The structural ordering is part of the
+    program's identity — search-side equivalence relies on it.
+    """
+
+    primitive: str
+    children: tuple[ProgramNode, ...]
+    output_type: str
+
+    def to_source(self) -> str:
+        if not self.children:
+            return f"{self.primitive}()"
+        args = ", ".join(c.to_source() for c in self.children)
+        return f"{self.primitive}({args})"
+
+    def depth(self) -> int:
+        if not self.children:
+            return 1
+        return 1 + max(c.depth() for c in self.children)
+
+    def size(self) -> int:
+        return 1 + sum(c.size() for c in self.children)
+
+    def stable_hash(self) -> str:
+        """SHA-256 over the canonical source form.
+
+        Stable across processes and Python versions. Cache keys for
+        synthesized programs use this as their suffix.
+        """
+        return "sha256:" + hashlib.sha256(self.to_source().encode("utf-8")).hexdigest()
+
+
+# Union of all node kinds. For runtime isinstance checks consumers
+# should use the explicit tuple ``(Program, InputRef, Const)``; this
+# alias is annotation-only.
+type ProgramNode = Program | InputRef | Const

--- a/tests/test_channels/test_program_synthesis/unit/test_candidate.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_candidate.py
@@ -1,0 +1,187 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Search candidate-tree tests (spec §6.2)."""
+
+from __future__ import annotations
+
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from cognithor.channels.program_synthesis.search.candidate import (
+    Const,
+    InputRef,
+    Program,
+)
+
+
+class TestInputRef:
+    def test_default_output_type_grid(self) -> None:
+        ref = InputRef()
+        assert ref.output_type == "Grid"
+
+    def test_to_source(self) -> None:
+        assert InputRef().to_source() == "input"
+
+    def test_depth_size(self) -> None:
+        ref = InputRef()
+        assert ref.depth() == 0
+        assert ref.size() == 1
+
+    def test_frozen(self) -> None:
+        ref = InputRef()
+        with pytest.raises(FrozenInstanceError):
+            ref.output_type = "Color"  # type: ignore[misc]
+
+    def test_equality(self) -> None:
+        assert InputRef() == InputRef()
+        assert InputRef() != InputRef(output_type="Color")
+
+
+class TestConst:
+    def test_int_to_source(self) -> None:
+        assert Const(value=5, output_type="Color").to_source() == "5"
+
+    def test_str_to_source(self) -> None:
+        # Strings keep their quotes so source round-trips through eval().
+        assert Const(value="center", output_type="AlignMode").to_source() == "'center'"
+
+    def test_depth_size(self) -> None:
+        c = Const(value=0, output_type="Color")
+        assert c.depth() == 0
+        assert c.size() == 1
+
+    def test_frozen(self) -> None:
+        c = Const(value=1, output_type="Int")
+        with pytest.raises(FrozenInstanceError):
+            c.value = 2  # type: ignore[misc]
+
+    def test_equality_is_structural(self) -> None:
+        a = Const(value=3, output_type="Color")
+        b = Const(value=3, output_type="Color")
+        assert a == b
+        assert hash(a) == hash(b)
+
+
+class TestProgram:
+    def test_to_source_unary(self) -> None:
+        p = Program(
+            primitive="rotate90",
+            children=(InputRef(),),
+            output_type="Grid",
+        )
+        assert p.to_source() == "rotate90(input)"
+
+    def test_to_source_ternary_with_consts(self) -> None:
+        p = Program(
+            primitive="recolor",
+            children=(
+                InputRef(),
+                Const(value=1, output_type="Color"),
+                Const(value=2, output_type="Color"),
+            ),
+            output_type="Grid",
+        )
+        assert p.to_source() == "recolor(input, 1, 2)"
+
+    def test_to_source_nested(self) -> None:
+        # mirror_horizontal(rotate90(input))
+        inner = Program(
+            primitive="rotate90",
+            children=(InputRef(),),
+            output_type="Grid",
+        )
+        outer = Program(
+            primitive="mirror_horizontal",
+            children=(inner,),
+            output_type="Grid",
+        )
+        assert outer.to_source() == "mirror_horizontal(rotate90(input))"
+
+    def test_depth_for_leaf_primitive(self) -> None:
+        # rotate90(input) has depth 1: one application above a depth-0 leaf.
+        p = Program(
+            primitive="rotate90",
+            children=(InputRef(),),
+            output_type="Grid",
+        )
+        assert p.depth() == 1
+
+    def test_depth_for_nested(self) -> None:
+        inner = Program("rotate90", (InputRef(),), "Grid")
+        middle = Program("mirror_horizontal", (inner,), "Grid")
+        outer = Program("transpose", (middle,), "Grid")
+        assert outer.depth() == 3
+
+    def test_size_counts_all_nodes(self) -> None:
+        # recolor(input, 1, 2): 1 program node + 1 InputRef + 2 Consts = 4
+        p = Program(
+            primitive="recolor",
+            children=(
+                InputRef(),
+                Const(value=1, output_type="Color"),
+                Const(value=2, output_type="Color"),
+            ),
+            output_type="Grid",
+        )
+        assert p.size() == 4
+
+    def test_zero_arity_primitive(self) -> None:
+        p = Program(
+            primitive="const_color_5",
+            children=(),
+            output_type="Color",
+        )
+        assert p.to_source() == "const_color_5()"
+        assert p.depth() == 1
+        assert p.size() == 1
+
+    def test_stable_hash_deterministic(self) -> None:
+        a = Program("rotate90", (InputRef(),), "Grid")
+        b = Program("rotate90", (InputRef(),), "Grid")
+        assert a.stable_hash() == b.stable_hash()
+        assert a.stable_hash().startswith("sha256:")
+        assert len(a.stable_hash().split(":")[1]) == 64
+
+    def test_stable_hash_changes_on_primitive(self) -> None:
+        a = Program("rotate90", (InputRef(),), "Grid")
+        b = Program("rotate180", (InputRef(),), "Grid")
+        assert a.stable_hash() != b.stable_hash()
+
+    def test_stable_hash_changes_on_const_value(self) -> None:
+        a = Program(
+            "recolor",
+            (InputRef(), Const(1, "Color"), Const(2, "Color")),
+            "Grid",
+        )
+        b = Program(
+            "recolor",
+            (InputRef(), Const(1, "Color"), Const(3, "Color")),
+            "Grid",
+        )
+        assert a.stable_hash() != b.stable_hash()
+
+    def test_frozen(self) -> None:
+        p = Program("rotate90", (InputRef(),), "Grid")
+        with pytest.raises(FrozenInstanceError):
+            p.primitive = "rotate180"  # type: ignore[misc]
+
+    def test_structural_equality(self) -> None:
+        a = Program("rotate90", (InputRef(),), "Grid")
+        b = Program("rotate90", (InputRef(),), "Grid")
+        assert a == b
+        assert hash(a) == hash(b)
+
+    def test_inequality_on_child_order(self) -> None:
+        # swap_colors(input, 1, 2) != swap_colors(input, 2, 1)
+        a = Program(
+            "swap_colors",
+            (InputRef(), Const(1, "Color"), Const(2, "Color")),
+            "Grid",
+        )
+        b = Program(
+            "swap_colors",
+            (InputRef(), Const(2, "Color"), Const(1, "Color")),
+            "Grid",
+        )
+        assert a != b
+        assert a.stable_hash() != b.stable_hash()


### PR DESCRIPTION
## Summary
Lands the program-tree representation the enumerative search engine will operate on (spec §6.2). Three frozen dataclasses + a union alias.

| Type | Role |
|---|---|
| **\`InputRef\`** | Leaf referring to the task's input grid (\`output_type\` defaults to \`"Grid"\`). |
| **\`Const\`** | Literal value (color index, integer parameter, enum tag). \`to_source()\` renders ints decimal and strings repr'd so the source round-trips through \`eval()\` in the \`cognithor pse explain\` formatter. |
| **\`Program\`** | Non-leaf: primitive name + ordered tuple of children + \`output_type\`. \`depth\` / \`size\` / \`to_source\` / \`stable_hash\` on the tree node. |
| **\`ProgramNode\`** | Annotation-only union of the three above; consumers should use the explicit tuple for runtime \`isinstance\` checks. |

## Implementation notes
- \`stable_hash()\` is SHA-256 over the canonical source form so it's portable across Python versions and processes — the sandbox worker re-hashes for cache validation and must agree.
- Equality is structural for all three; the observational-equivalence pruner (Week 3 day 6-7) will use programs directly as dict keys.
- \`type ProgramNode = Program | InputRef | Const\` (PEP 695 \`type\` keyword) — the alias is annotation-only.

## Tests
**+23 unit tests** in \`tests/test_channels/test_program_synthesis/unit/test_candidate.py\`:
- Source rendering: unary, ternary with consts, nested, zero-arity.
- Depth / size for leaves and nested trees (3-deep example).
- Frozen invariants on all three types.
- Structural equality + hash determinism.
- Hash sensitivity: primitive change, const-value change, child-order change (the latter is critical for the equivalence pruner).

**Total PSE tests: 291 → 314**, all pass in ~0.7s. \`ruff format\` and \`ruff check\` clean.

## Test plan
- [x] \`pytest tests/test_channels/test_program_synthesis/ -x -q\` — 314/314 pass.
- [x] \`ruff format --check\` — clean.
- [x] \`ruff check\` — clean.
- [ ] CI: full backend matrix green.

## Roadmap
Week 3 day 1-2 of the spec (\`search/candidate.py\` + \`search/budget.py\` — this PR ships candidate.py, budget allocator follows). Subsequent Week 3 PRs:
- \`budget.py\` — Budget allocator (consumes the existing \`core.types.Budget\` dataclass).
- \`enumerative.py\` — Bottom-up enumeration with the typed bank (Week 3 day 3-5).
- \`equivalence.py\` — Observational-equivalence fingerprinting + pruner (Week 3 day 6-7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)