### PR TITLE
feat(pse): in-process executor + observational-equivalence pruner — Week 3 day 3-7

### DIFF
--- a/src/cognithor/channels/program_synthesis/search/__init__.py
+++ b/src/cognithor/channels/program_synthesis/search/__init__.py
@@ -14,5 +14,22 @@ from cognithor.channels.program_synthesis.search.candidate import (
     Program,
     ProgramNode,
 )
+from cognithor.channels.program_synthesis.search.equivalence import (
+    ObservationalEquivalencePruner,
+)
+from cognithor.channels.program_synthesis.search.executor import (
+    ExecutionResult,
+    Executor,
+    InProcessExecutor,
+)
 
-__all__ = ["Const", "InputRef", "Program", "ProgramNode"]
+__all__ = [
+    "Const",
+    "ExecutionResult",
+    "Executor",
+    "InProcessExecutor",
+    "InputRef",
+    "ObservationalEquivalencePruner",
+    "Program",
+    "ProgramNode",
+]

--- a/src/cognithor/channels/program_synthesis/search/equivalence.py
+++ b/src/cognithor/channels/program_synthesis/search/equivalence.py
@@ -1,0 +1,171 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Observational-equivalence pruner (spec §9).
+
+Two programs are *observationally equivalent* with respect to a TaskSpec
+if they produce identical outputs on every demo input. The enumerator
+keeps only one representative per equivalence class — the cheapest by
+DSL-cost — and discards the rest.
+
+Phase 1 implementation is a deterministic SHA-256 over the
+concatenated, canonical-byte representation of each output. Sentinel
+hashes encode error states so a candidate that crashes on the same
+input the same way as another candidate is also pruned.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.dsl.types_grid import Object, ObjectSet
+from cognithor.channels.program_synthesis.search.executor import (
+    ExecutionResult,
+    InProcessExecutor,
+)
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.search.candidate import ProgramNode
+    from cognithor.channels.program_synthesis.search.executor import Executor
+
+
+def _value_bytes(value: Any) -> bytes:
+    """Canonical byte representation of one execution result.
+
+    Order is part of the byte stream (e.g. ``ObjectSet`` order matters
+    for fingerprinting — two identical sets in different orders are
+    *not* equivalent because downstream primitives such as
+    ``largest_object`` are order-sensitive on ties).
+    """
+    if isinstance(value, np.ndarray):
+        # Type tag protects against shape collisions across dtypes.
+        return f"ndarray:{value.dtype.str}:{value.shape}:".encode() + value.tobytes()
+    if isinstance(value, np.bool_):
+        return b"npbool:" + (b"1" if value else b"0")
+    if isinstance(value, ObjectSet):
+        parts = [b"objectset:" + str(len(value)).encode("ascii")]
+        for o in value:
+            parts.append(_value_bytes(o))
+        return b"|".join(parts)
+    if isinstance(value, Object):
+        return f"object:{value.color}:{value.cells}".encode()
+    if isinstance(value, bool):
+        return b"bool:1" if value else b"bool:0"
+    if isinstance(value, int):
+        return f"int:{value}".encode("ascii")
+    if isinstance(value, str):
+        return f"str:{value}".encode()
+    # Fall-through for any future type — repr() keeps the fingerprint
+    # well-defined even if it's not byte-perfect across processes.
+    return f"repr:{type(value).__name__}:{value!r}".encode()
+
+
+def _result_bytes(r: ExecutionResult) -> bytes:
+    if r.ok:
+        return b"ok:" + _value_bytes(r.value)
+    # Error fingerprints share the same bucket so candidates that fail
+    # identically are pruned as duplicates.
+    return f"err:{r.error or 'unknown'}".encode("ascii")
+
+
+class ObservationalEquivalencePruner:
+    """Bucket programs by their (input-tuple → output-tuple) fingerprint.
+
+    The pruner is keyed by *output type* — programs with different
+    output types are never compared (they live in disjoint sub-banks
+    of the enumerator).
+    """
+
+    # Sentinel returned when more than half the inputs crash. Spec §9.1
+    # treats such candidates as untrustworthy regardless of partial
+    # matches — they're dropped before they pollute the bank.
+    UNRELIABLE_SENTINEL: str | None = None
+
+    def __init__(
+        self,
+        executor: Executor | None = None,
+        unreliable_threshold: float = 0.5,
+    ) -> None:
+        if not 0.0 < unreliable_threshold <= 1.0:
+            raise ValueError(
+                f"unreliable_threshold must be in (0, 1]; got {unreliable_threshold!r}"
+            )
+        self._executor = executor if executor is not None else InProcessExecutor()
+        self._threshold = unreliable_threshold
+        # type_tag -> set of fingerprints already seen
+        self._seen: dict[str, set[str]] = {}
+
+    # -- Public API --------------------------------------------------
+
+    def fingerprint(self, program: ProgramNode, demo_inputs: tuple[Any, ...]) -> str | None:
+        """Return a SHA-256 hex digest, or ``None`` if the program is unreliable.
+
+        ``None`` means "drop this candidate entirely" — caller should
+        not register it.
+        """
+        if not demo_inputs:
+            # Empty demo set degenerates to a constant program; we still
+            # need a fingerprint, but it's unique by source rather than
+            # by behaviour. Use the tree's stable hash as the fallback.
+            from cognithor.channels.program_synthesis.search.candidate import (
+                Program as _Program,
+            )
+
+            if isinstance(program, _Program):
+                return program.stable_hash().split(":", 1)[1]
+            return hashlib.sha256(repr(program).encode()).hexdigest()
+
+        results: list[ExecutionResult] = []
+        crash_count = 0
+        for inp in demo_inputs:
+            r = self._executor.execute(program, inp)
+            if not r.ok:
+                crash_count += 1
+            results.append(r)
+
+        if crash_count / len(demo_inputs) > self._threshold:
+            return None
+
+        digest = hashlib.sha256()
+        for r in results:
+            digest.update(_result_bytes(r))
+            digest.update(b"||")
+        return digest.hexdigest()
+
+    def is_duplicate(self, fingerprint: str, type_tag: str) -> bool:
+        """True iff a program with this fingerprint already exists for *type_tag*."""
+        return fingerprint in self._seen.get(type_tag, set())
+
+    def register(self, fingerprint: str, type_tag: str) -> None:
+        """Mark *fingerprint* under *type_tag* as seen.
+
+        Idempotent — calling twice with the same args is a no-op.
+        """
+        self._seen.setdefault(type_tag, set()).add(fingerprint)
+
+    def reset(self) -> None:
+        """Clear the seen map. Used between independent search runs."""
+        self._seen.clear()
+
+    # -- Convenience -------------------------------------------------
+
+    def admit(
+        self,
+        program: ProgramNode,
+        type_tag: str,
+        demo_inputs: tuple[Any, ...],
+    ) -> bool:
+        """Return True iff the program is new and reliable; register it.
+
+        Combines fingerprint → is_duplicate → register into one call.
+        Returns False for unreliable programs (over-threshold crashes)
+        and for already-seen fingerprints.
+        """
+        fp = self.fingerprint(program, demo_inputs)
+        if fp is None:
+            return False
+        if self.is_duplicate(fp, type_tag):
+            return False
+        self.register(fp, type_tag)
+        return True

--- a/src/cognithor/channels/program_synthesis/search/executor.py
+++ b/src/cognithor/channels/program_synthesis/search/executor.py
@@ -1,0 +1,78 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Executor protocol + an in-process implementation (spec §11).
+
+The full sandboxed executor with subprocess + AST whitelist + WSL2
+worker (spec §11.6) lands in Week 4-5. For the search engine plumbing —
+observational-equivalence pruning, demo verification — we need the
+*interface* now plus a direct in-process variant suitable for unit
+tests and the trivial-task end-to-end.
+
+Both implementations satisfy :class:`Executor`; the pruner and the
+enumerator stay agnostic to which one is wired in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+from cognithor.channels.program_synthesis.dsl.registry import (
+    REGISTRY,
+    PrimitiveRegistry,
+)
+from cognithor.channels.program_synthesis.search.candidate import (
+    Const,
+    InputRef,
+    ProgramNode,
+)
+
+
+@dataclass(frozen=True)
+class ExecutionResult:
+    """Outcome of running one program on one input.
+
+    ``ok`` is True iff the program ran to completion and produced an
+    output. ``error`` is a *type tag* not a full message, so two
+    candidates that fail the same way share a fingerprint.
+    """
+
+    ok: bool
+    value: Any = None
+    error: str | None = None
+
+
+class Executor(Protocol):
+    """Minimal contract: execute a program on one input, return a result."""
+
+    def execute(self, program: ProgramNode, input_grid: Any) -> ExecutionResult: ...
+
+
+class InProcessExecutor:
+    """Direct call into the registered Python function via REGISTRY.
+
+    Phase 1 fallback used by tests and the trivial-task path. The real
+    sandboxed worker (Week 4-5) implements the same interface in a
+    subprocess with resource limits.
+    """
+
+    def __init__(self, registry: PrimitiveRegistry | None = None) -> None:
+        self._registry = registry if registry is not None else REGISTRY
+
+    def execute(self, program: ProgramNode, input_grid: Any) -> ExecutionResult:
+        try:
+            value = self._eval(program, input_grid)
+        except Exception as exc:
+            return ExecutionResult(ok=False, error=type(exc).__name__)
+        return ExecutionResult(ok=True, value=value)
+
+    # -- internals ---------------------------------------------------
+
+    def _eval(self, node: ProgramNode, input_grid: Any) -> Any:
+        if isinstance(node, InputRef):
+            return input_grid
+        if isinstance(node, Const):
+            return node.value
+        # Program
+        spec = self._registry.get(node.primitive)
+        args = tuple(self._eval(child, input_grid) for child in node.children)
+        return spec.fn(*args)

--- a/tests/test_channels/test_program_synthesis/unit/test_equivalence.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_equivalence.py
@@ -1,0 +1,167 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""ObservationalEquivalencePruner tests (spec §9)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.search.candidate import (
+    Const,
+    InputRef,
+    Program,
+)
+from cognithor.channels.program_synthesis.search.equivalence import (
+    ObservationalEquivalencePruner,
+)
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+# ---------------------------------------------------------------------------
+# Fingerprinting
+# ---------------------------------------------------------------------------
+
+
+class TestFingerprint:
+    def test_deterministic(self) -> None:
+        pruner = ObservationalEquivalencePruner()
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        inputs = (_g([[1, 2], [3, 4]]),)
+        a = pruner.fingerprint(prog, inputs)
+        b = pruner.fingerprint(prog, inputs)
+        assert a == b is not None
+
+    def test_different_programs_different_outputs_different_fps(self) -> None:
+        pruner = ObservationalEquivalencePruner()
+        rot90 = Program("rotate90", (InputRef(),), "Grid")
+        rot180 = Program("rotate180", (InputRef(),), "Grid")
+        inputs = (_g([[1, 2], [3, 4]]),)
+        # rot90 → [[3,1],[4,2]]; rot180 → [[4,3],[2,1]] — different
+        # outputs must hash differently.
+        assert pruner.fingerprint(rot90, inputs) != pruner.fingerprint(rot180, inputs)
+
+    def test_same_outputs_same_fp_even_for_different_sources(self) -> None:
+        # rotate180 and rotate90∘rotate90 are equivalent on every grid.
+        pruner = ObservationalEquivalencePruner()
+        rot180 = Program("rotate180", (InputRef(),), "Grid")
+        rot_twice = Program("rotate90", (Program("rotate90", (InputRef(),), "Grid"),), "Grid")
+        inputs = (_g([[1, 2], [3, 4]]), _g([[5, 6, 7], [8, 9, 0]]))
+        assert pruner.fingerprint(rot180, inputs) == pruner.fingerprint(rot_twice, inputs)
+
+    def test_fingerprint_changes_when_inputs_change(self) -> None:
+        pruner = ObservationalEquivalencePruner()
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        a = pruner.fingerprint(prog, (_g([[1, 2]]),))
+        b = pruner.fingerprint(prog, (_g([[1, 3]]),))
+        assert a != b
+
+    def test_unreliable_program_returns_none(self) -> None:
+        pruner = ObservationalEquivalencePruner(unreliable_threshold=0.5)
+        # rotate90 expects a grid; pass strings → all crash.
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        # 3 inputs all crash (> 50% threshold) → None.
+        fp = pruner.fingerprint(prog, ("nope", "nada", "nogo"))
+        assert fp is None
+
+    def test_below_threshold_not_unreliable(self) -> None:
+        pruner = ObservationalEquivalencePruner(unreliable_threshold=0.5)
+        # 1 of 3 crashes: still below 50% threshold → fingerprint produced.
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        fp = pruner.fingerprint(
+            prog,
+            (_g([[1, 2]]), _g([[3, 4]]), "broken"),
+        )
+        assert fp is not None
+
+    def test_const_color_int_fingerprint(self) -> None:
+        pruner = ObservationalEquivalencePruner()
+        prog = Program(
+            "recolor",
+            (
+                InputRef(),
+                Const(value=1, output_type="Color"),
+                Const(value=2, output_type="Color"),
+            ),
+            "Grid",
+        )
+        inputs = (_g([[1, 2]]),)
+        # Same program/inputs → same fp; sanity check int-encoding works.
+        a = pruner.fingerprint(prog, inputs)
+        b = pruner.fingerprint(prog, inputs)
+        assert a == b is not None
+
+    def test_threshold_validation(self) -> None:
+        with pytest.raises(ValueError, match="threshold"):
+            ObservationalEquivalencePruner(unreliable_threshold=0.0)
+        with pytest.raises(ValueError, match="threshold"):
+            ObservationalEquivalencePruner(unreliable_threshold=1.5)
+
+
+# ---------------------------------------------------------------------------
+# Bookkeeping (is_duplicate / register / reset / admit)
+# ---------------------------------------------------------------------------
+
+
+class TestBookkeeping:
+    def test_register_then_is_duplicate(self) -> None:
+        pruner = ObservationalEquivalencePruner()
+        pruner.register("abc", "Grid")
+        assert pruner.is_duplicate("abc", "Grid")
+        assert not pruner.is_duplicate("def", "Grid")
+
+    def test_register_isolates_per_type_tag(self) -> None:
+        pruner = ObservationalEquivalencePruner()
+        pruner.register("abc", "Grid")
+        # Same fingerprint under a different type tag is *not* a duplicate.
+        assert not pruner.is_duplicate("abc", "Color")
+
+    def test_register_idempotent(self) -> None:
+        pruner = ObservationalEquivalencePruner()
+        pruner.register("abc", "Grid")
+        pruner.register("abc", "Grid")
+        assert pruner.is_duplicate("abc", "Grid")
+
+    def test_reset_clears_seen(self) -> None:
+        pruner = ObservationalEquivalencePruner()
+        pruner.register("abc", "Grid")
+        pruner.reset()
+        assert not pruner.is_duplicate("abc", "Grid")
+
+
+class TestAdmit:
+    def test_first_admit_returns_true(self) -> None:
+        pruner = ObservationalEquivalencePruner()
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        admitted = pruner.admit(prog, "Grid", (_g([[1, 2], [3, 4]]),))
+        assert admitted is True
+
+    def test_second_admit_with_equivalent_program_returns_false(self) -> None:
+        pruner = ObservationalEquivalencePruner()
+        # rotate180 admitted first, then rotate90∘rotate90 should be
+        # rejected as observationally equivalent.
+        rot180 = Program("rotate180", (InputRef(),), "Grid")
+        rot_twice = Program("rotate90", (Program("rotate90", (InputRef(),), "Grid"),), "Grid")
+        inputs = (_g([[1, 2], [3, 4]]),)
+        assert pruner.admit(rot180, "Grid", inputs) is True
+        assert pruner.admit(rot_twice, "Grid", inputs) is False
+
+    def test_unreliable_programs_not_admitted(self) -> None:
+        pruner = ObservationalEquivalencePruner(unreliable_threshold=0.5)
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        # All inputs crash → None fingerprint → not admitted, not registered.
+        assert pruner.admit(prog, "Grid", ("a", "b", "c")) is False
+        # And a subsequent valid call should still admit a fresh program.
+        good = Program("rotate90", (InputRef(),), "Grid")
+        assert pruner.admit(good, "Grid", (_g([[1]]),)) is True
+
+    def test_admit_isolates_per_type_tag(self) -> None:
+        pruner = ObservationalEquivalencePruner()
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        inputs = (_g([[1, 2]]),)
+        # Same program under two different type tags should both succeed
+        # (the pruner's bookkeeping is per-type).
+        assert pruner.admit(prog, "Grid", inputs) is True
+        assert pruner.admit(prog, "OtherType", inputs) is True

--- a/tests/test_channels/test_program_synthesis/unit/test_executor.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_executor.py
@@ -1,0 +1,127 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""InProcessExecutor tests (spec §11 — Phase-1 in-process variant)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.dsl.registry import (
+    PrimitiveRegistry,
+    PrimitiveSpec,
+)
+from cognithor.channels.program_synthesis.dsl.signatures import Signature
+from cognithor.channels.program_synthesis.search.candidate import (
+    Const,
+    InputRef,
+    Program,
+)
+from cognithor.channels.program_synthesis.search.executor import (
+    ExecutionResult,
+    InProcessExecutor,
+)
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+def _registry_with(name: str, fn) -> PrimitiveRegistry:
+    reg = PrimitiveRegistry()
+    reg.register(
+        PrimitiveSpec(
+            name=name,
+            signature=Signature(inputs=("Grid",), output="Grid"),
+            cost=1.0,
+            fn=fn,
+        )
+    )
+    return reg
+
+
+class TestInProcessExecutor:
+    def test_input_ref_returns_input_grid(self) -> None:
+        ex = InProcessExecutor()
+        g = _g([[1, 2], [3, 4]])
+        result = ex.execute(InputRef(), g)
+        assert result.ok is True
+        assert np.array_equal(result.value, g)
+
+    def test_const_returns_value(self) -> None:
+        ex = InProcessExecutor()
+        result = ex.execute(Const(value=5, output_type="Color"), _g([[0]]))
+        assert result.ok is True
+        assert result.value == 5
+
+    def test_unary_program(self) -> None:
+        # Use the real REGISTRY's rotate90.
+        ex = InProcessExecutor()
+        prog = Program(
+            primitive="rotate90",
+            children=(InputRef(),),
+            output_type="Grid",
+        )
+        result = ex.execute(prog, _g([[1, 2], [3, 4]]))
+        assert result.ok is True
+        assert np.array_equal(result.value, _g([[3, 1], [4, 2]]))
+
+    def test_ternary_program(self) -> None:
+        ex = InProcessExecutor()
+        prog = Program(
+            primitive="recolor",
+            children=(
+                InputRef(),
+                Const(value=1, output_type="Color"),
+                Const(value=9, output_type="Color"),
+            ),
+            output_type="Grid",
+        )
+        result = ex.execute(prog, _g([[1, 2], [1, 3]]))
+        assert result.ok is True
+        assert np.array_equal(result.value, _g([[9, 2], [9, 3]]))
+
+    def test_nested_program(self) -> None:
+        # mirror_horizontal(rotate90(input))
+        ex = InProcessExecutor()
+        inner = Program("rotate90", (InputRef(),), "Grid")
+        outer = Program("mirror_horizontal", (inner,), "Grid")
+        result = ex.execute(outer, _g([[1, 2], [3, 4]]))
+        assert result.ok is True
+        # rotate90: [[3,1],[4,2]] -> mirror_h: [[1,3],[2,4]]
+        assert np.array_equal(result.value, _g([[1, 3], [2, 4]]))
+
+    def test_failed_primitive_returns_error_tag(self) -> None:
+        # rotate90 expects an int8 grid; pass a string and confirm the
+        # exception surfaces as an ExecutionResult with ok=False.
+        ex = InProcessExecutor()
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        result = ex.execute(prog, "not a grid")
+        assert result.ok is False
+        # The TypeMismatchError class name should be in the error tag.
+        assert result.error == "TypeMismatchError"
+
+    def test_unknown_primitive_returns_error(self) -> None:
+        # Use a fresh registry that doesn't know "rotate90".
+        ex = InProcessExecutor(registry=PrimitiveRegistry())
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        result = ex.execute(prog, _g([[1]]))
+        assert result.ok is False
+        assert result.error == "UnknownPrimitiveError"
+
+    def test_custom_registry_isolates_from_global(self) -> None:
+        # Register a "double" that returns the input multiplied by 2.
+        reg = _registry_with("double", lambda g: (g * 2).astype(np.int8))
+        ex = InProcessExecutor(registry=reg)
+        prog = Program("double", (InputRef(),), "Grid")
+        result = ex.execute(prog, _g([[1, 2]]))
+        assert result.ok is True
+        assert np.array_equal(result.value, _g([[2, 4]]))
+
+    def test_execution_result_is_frozen_dataclass(self) -> None:
+        r = ExecutionResult(ok=True, value=42)
+        # Frozen — assignment must fail.
+        from dataclasses import FrozenInstanceError
+
+        import pytest as _pytest
+
+        with _pytest.raises(FrozenInstanceError):
+            r.value = 99  # type: ignore[misc]


### PR DESCRIPTION
## Summary
Lands the second half of Week 3 — the search engine now has its core infrastructure in place. The enumerator itself is the next PR.

### \`search/executor.py\`
- **\`Executor\`** protocol (Phase-1 interface; Week 4-5's \`SandboxExecutor\` satisfies the same shape — pruner and enumerator stay agnostic to which one is wired in).
- **\`ExecutionResult\`** — frozen dataclass with \`ok\`, \`value\`, \`error\` (a type tag, not a full message — two crashes of the same kind share one fingerprint bucket).
- **\`InProcessExecutor\`** — direct \`REGISTRY.fn()\` call, used by tests and the trivial-task path. Tree walk via \`_eval\` covers \`Program\` / \`InputRef\` / \`Const\` recursively.

### \`search/equivalence.py\` — ObservationalEquivalencePruner (spec §9)
- **\`fingerprint(program, demo_inputs)\`** → SHA-256 hex digest, or \`None\` if more than \`unreliable_threshold\` (default 0.5) of inputs crash. Sentinel encoding for error states means crash-equivalent candidates share a fingerprint and get pruned together.
- **\`_value_bytes\`** canonicalises Grid/ndarray, Mask/np.bool_, Object, ObjectSet (preserving order — downstream primitives such as \`largest_object\` are order-sensitive on ties), int, str, bool. Future types fall through to a repr-based encoding so the fingerprint stays well-defined.
- **\`is_duplicate\`** / \`register\` / \`reset\` / **\`admit\`** — bookkeeping keyed per output type tag (Grid programs are never compared to Color programs).

## Tests
**+25 unit tests**:
- \`test_executor.py\` (9): InputRef / Const / unary / ternary / nested evaluation, error-tag round-trip, unknown-primitive handling, custom-registry isolation, frozen-result invariant.
- \`test_equivalence.py\` (16): determinism, sensitivity to program / inputs, **equivalence collapse** (\`rotate180\` vs \`rotate90∘rotate90\` → same fingerprint), unreliable-threshold gate (above + below), threshold validation, per-type-tag isolation, idempotent register, reset, \`admit()\` combined flow.

**Total PSE tests: 314 → 339**, all pass in ~0.7s. \`ruff format\` and \`ruff check\` clean.

## Test plan
- [x] \`pytest tests/test_channels/test_program_synthesis/ -x -q\` — 339/339 pass.
- [x] \`ruff format --check\` — clean.
- [x] \`ruff check\` — clean.
- [ ] CI: full backend matrix green.

## Roadmap
Week 3 days 3-7 of the spec. Remaining work for Week 3:
- Day 8: \`enumerative.py\` — bottom-up search loop using the bank/pruner/executor — ships in the next PR with the first non-trivial end-to-end task (\`output = rotate90(input)\`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)