### PR TITLE
feat(pse): trace + replay system — Week 5 day 4-5 — K9/K10 HARD GATES

### DIFF
--- a/src/cognithor/channels/program_synthesis/trace/__init__.py
+++ b/src/cognithor/channels/program_synthesis/trace/__init__.py
@@ -1,0 +1,37 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Trace system for the PSE channel — K9 and K10 hard gates (spec §3 + §22).
+
+This module turns a synthesised :class:`Program` into a deterministic,
+human-readable, replay-able pseudo-code trace. The trace is the
+differentiator vs. LLM-only ARC solvers — every solved task ships with
+a step-by-step explanation that an end user can read.
+
+K9 — Trace-Vollständigkeit: every solved program must have a complete,
+human-readable trace.
+
+K10 — Programm-Replay-Reproduzierbarkeit: re-executing the program on
+the same input produces identical output, and the replay completes in
+P95 ≤ 100 ms.
+"""
+
+from __future__ import annotations
+
+from cognithor.channels.program_synthesis.trace.builder import (
+    TraceLine,
+    TraceResult,
+    build_trace,
+    format_trace,
+)
+from cognithor.channels.program_synthesis.trace.replay import (
+    ReplayResult,
+    replay_program,
+)
+
+__all__ = [
+    "ReplayResult",
+    "TraceLine",
+    "TraceResult",
+    "build_trace",
+    "format_trace",
+    "replay_program",
+]

--- a/src/cognithor/channels/program_synthesis/trace/builder.py
+++ b/src/cognithor/channels/program_synthesis/trace/builder.py
@@ -1,0 +1,254 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Trace-builder — turns a Program into a step-by-step pseudo-code trace.
+
+For every primitive call (ProgramNode in the tree) we record:
+
+* an auto-generated variable name
+* the source-line equivalent (``var = primitive(args...)``)
+* a short summary of the produced value (shape for grids, size + colors
+  for ObjectSets, integer/string verbatim, error tag on crash)
+* the wall-clock duration of the call
+
+The trace is intentionally deterministic — the same Program against the
+same input grid always yields the same trace bytes, which is the
+foundation for K9 (every solved program has a trace) and K10 (replay
+matches exactly).
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.dsl.types_grid import Object, ObjectSet
+from cognithor.channels.program_synthesis.search.candidate import (
+    Const,
+    InputRef,
+    Program,
+    ProgramNode,
+)
+from cognithor.channels.program_synthesis.search.executor import (
+    Executor,
+    InProcessExecutor,
+)
+
+
+@dataclass(frozen=True)
+class TraceLine:
+    """One step in the trace.
+
+    ``index`` is 1-based for human display. ``var`` is the name bound
+    to this step's result (e.g. ``step3``); inner Const / InputRef
+    nodes don't get their own line — they're inlined into the parent's
+    source.
+    """
+
+    index: int
+    var: str
+    source: str
+    summary: str
+    duration_ms: float
+    ok: bool
+
+
+@dataclass(frozen=True)
+class TraceResult:
+    """Aggregate of every :class:`TraceLine` plus the program's final value."""
+
+    program_source: str
+    program_hash: str | None
+    final_value_summary: str
+    final_value_ok: bool
+    lines: tuple[TraceLine, ...]
+
+    @property
+    def total_duration_ms(self) -> float:
+        return sum(line.duration_ms for line in self.lines)
+
+    @property
+    def all_ok(self) -> bool:
+        return self.final_value_ok and all(line.ok for line in self.lines)
+
+
+# ---------------------------------------------------------------------------
+# Value-summary helpers — short human strings for each ARC value type.
+# ---------------------------------------------------------------------------
+
+
+def _summarise(value: Any) -> str:
+    if isinstance(value, np.ndarray) and value.dtype == np.bool_:
+        return f"Mask {value.shape} ({int(value.sum())} true)"
+    if isinstance(value, np.ndarray):
+        return f"Grid {value.shape}"
+    if isinstance(value, ObjectSet):
+        if len(value) == 0:
+            return "ObjectSet (empty)"
+        colors = sorted({o.color for o in value})
+        return f"ObjectSet of {len(value)} objects, colors={colors}"
+    if isinstance(value, Object):
+        return f"Object color={value.color} cells={value.size} bbox={value.bbox}"
+    if isinstance(value, bool):
+        return f"Bool {value}"
+    if isinstance(value, int):
+        return f"Int {value}"
+    if isinstance(value, str):
+        return f"Str {value!r}"
+    return f"{type(value).__name__} {value!r}"
+
+
+# ---------------------------------------------------------------------------
+# Tree-walking trace builder.
+# ---------------------------------------------------------------------------
+
+
+def _is_terminal(node: ProgramNode) -> bool:
+    """A node we don't render as its own trace line.
+
+    ``InputRef`` is the literal input — no need to repeat it.
+    ``Const`` values are inlined as arguments in the parent's source.
+    Zero-arity Program nodes (e.g. ``const_color_5()``) DO get their
+    own line so the trace shows where each constant came from.
+    """
+    return isinstance(node, InputRef | Const)
+
+
+def _next_var_name(counter: list[int]) -> str:
+    counter[0] += 1
+    return f"step{counter[0]}"
+
+
+def _node_source_with_vars(node: ProgramNode, var_for: dict[int, str]) -> str:
+    """Render *node* with its child Program references replaced by step-vars.
+
+    Inner Const / InputRef nodes are still rendered inline. Inner
+    Program nodes are replaced by their bound step-var so the trace
+    reads as a sequence of assignments rather than nested calls.
+    """
+    if isinstance(node, InputRef):
+        return "input"
+    if isinstance(node, Const):
+        if isinstance(node.value, int) and not isinstance(node.value, bool):
+            return str(node.value)
+        return repr(node.value)
+    # Program
+    args: list[str] = []
+    for child in node.children:
+        if isinstance(child, Program) and id(child) in var_for:
+            args.append(var_for[id(child)])
+        else:
+            args.append(_node_source_with_vars(child, var_for))
+    return f"{node.primitive}({', '.join(args)})"
+
+
+def build_trace(
+    program: ProgramNode,
+    input_grid: Any,
+    executor: Executor | None = None,
+) -> TraceResult:
+    """Walk *program* bottom-up; record every primitive call.
+
+    Children are evaluated before their parents, so the trace reads
+    naturally as ``step1 = ...; step2 = ...; result = stepN``.
+    """
+    ex = executor if executor is not None else InProcessExecutor()
+    counter: list[int] = [0]
+    var_for: dict[int, str] = {}
+    lines: list[TraceLine] = []
+
+    def visit(node: ProgramNode) -> tuple[Any, bool]:
+        # Recurse into children first so inner steps are emitted before
+        # outer steps — bottom-up DFS.
+        if isinstance(node, Program):
+            for child in node.children:
+                if isinstance(child, Program):
+                    visit(child)
+
+        if _is_terminal(node):
+            # Terminal nodes don't get their own line; the executor
+            # handles them as part of the outer call.
+            return _eval_terminal(node, input_grid), True
+
+        # Time and execute this Program node via the executor.
+        t0 = time.monotonic()
+        result = ex.execute(node, input_grid)
+        elapsed_ms = (time.monotonic() - t0) * 1000.0
+
+        var = _next_var_name(counter)
+        var_for[id(node)] = var
+        source = _node_source_with_vars(node, var_for)
+        if result.ok:
+            summary = _summarise(result.value)
+        else:
+            summary = f"<error: {result.error}>"
+        lines.append(
+            TraceLine(
+                index=counter[0],
+                var=var,
+                source=source,
+                summary=summary,
+                duration_ms=elapsed_ms,
+                ok=result.ok,
+            )
+        )
+        return result.value, result.ok
+
+    final_value, final_ok = visit(program)
+    if final_ok:
+        final_summary = _summarise(final_value)
+    else:
+        final_summary = "<error during execution>"
+
+    program_hash: str | None = None
+    if isinstance(program, Program):
+        program_hash = program.stable_hash()
+    program_source = program.to_source() if hasattr(program, "to_source") else repr(program)
+
+    return TraceResult(
+        program_source=program_source,
+        program_hash=program_hash,
+        final_value_summary=final_summary,
+        final_value_ok=final_ok,
+        lines=tuple(lines),
+    )
+
+
+def _eval_terminal(node: ProgramNode, input_grid: Any) -> Any:
+    if isinstance(node, InputRef):
+        return input_grid
+    if isinstance(node, Const):
+        return node.value
+    raise TypeError(f"_eval_terminal: not a terminal node: {type(node).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# Pretty-printer (the K9 deliverable: human-readable pseudo-code).
+# ---------------------------------------------------------------------------
+
+
+def format_trace(trace: TraceResult, *, header: dict[str, str] | None = None) -> str:
+    """Render *trace* as a multi-line string matching the spec §24.5 example.
+
+    ``header`` is an optional dict of name → value pairs for the ``#``-
+    prefixed metadata block at the top (spec hash, search time, etc.).
+    Callers that have additional context add entries here.
+    """
+    out_lines: list[str] = ["# PSE Solution Trace"]
+    if trace.program_hash:
+        out_lines.append(f"# Program hash: {trace.program_hash}")
+    if header:
+        for k, v in header.items():
+            out_lines.append(f"# {k}: {v}")
+    out_lines.append("")
+    if not trace.lines:
+        out_lines.append(f"result = {trace.program_source}")
+        out_lines.append(f"        # → {trace.final_value_summary}")
+    else:
+        for line in trace.lines:
+            out_lines.append(f"Step {line.index}: {line.var} = {line.source}")
+            out_lines.append(f"        # → {line.summary}")
+        out_lines.append("")
+        out_lines.append(f"# Final: {trace.final_value_summary}")
+    return "\n".join(out_lines)

--- a/src/cognithor/channels/program_synthesis/trace/replay.py
+++ b/src/cognithor/channels/program_synthesis/trace/replay.py
@@ -1,0 +1,111 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Program replay — K10 hard gate (spec §3 + §22).
+
+Re-executes a program on its original input grid and verifies the
+output is byte-identical to the originally produced output. The replay
+must complete in P95 ≤ 100 ms.
+
+Used by:
+* The CLI ``cognithor pse replay <result.json>`` command (Week 7).
+* The eval-suite K10 audit that runs over every solved task and asserts
+  100 % reproducibility.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.dsl.types_grid import Object, ObjectSet
+from cognithor.channels.program_synthesis.search.executor import (
+    InProcessExecutor,
+)
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.search.candidate import ProgramNode
+    from cognithor.channels.program_synthesis.search.executor import Executor
+
+
+@dataclass(frozen=True)
+class ReplayResult:
+    """Outcome of one replay invocation.
+
+    ``identical`` is the K10 verdict: True iff the new value equals the
+    expected value byte-for-byte. ``duration_ms`` is the wall-clock
+    measurement that feeds into the P95 ≤ 100 ms gate.
+    """
+
+    identical: bool
+    duration_ms: float
+    detail: str
+    actual_summary: str
+    expected_summary: str
+
+
+def _value_equal(a: Any, b: Any) -> bool:
+    """Strict equality for ARC value types.
+
+    NumPy arrays compared elementwise; ObjectSet compared by ordered
+    tuple; Object compared structurally. Anything else falls back to
+    ``==``.
+    """
+    if isinstance(a, np.ndarray) and isinstance(b, np.ndarray):
+        return a.shape == b.shape and a.dtype == b.dtype and np.array_equal(a, b)
+    if isinstance(a, ObjectSet) and isinstance(b, ObjectSet):
+        return a.objects == b.objects
+    if isinstance(a, Object) and isinstance(b, Object):
+        return a == b
+    return a == b
+
+
+def _summary(value: Any) -> str:
+    if isinstance(value, np.ndarray):
+        return f"ndarray {value.shape} dtype={value.dtype}"
+    if isinstance(value, ObjectSet):
+        return f"ObjectSet len={len(value)}"
+    if isinstance(value, Object):
+        return f"Object color={value.color} size={value.size}"
+    return f"{type(value).__name__} {value!r}"
+
+
+def replay_program(
+    program: ProgramNode,
+    input_grid: Any,
+    expected_value: Any,
+    *,
+    executor: Executor | None = None,
+) -> ReplayResult:
+    """Re-execute *program* and compare to *expected_value*.
+
+    The K10 contract is:
+
+    * ``identical=True`` for every solved program in the eval suite.
+    * ``duration_ms`` ≤ 100 ms at P95 across the eval suite.
+
+    This function reports per-call data; the eval-suite aggregator
+    enforces the percentile gate.
+    """
+    ex = executor if executor is not None else InProcessExecutor()
+    t0 = time.monotonic()
+    result = ex.execute(program, input_grid)
+    elapsed_ms = (time.monotonic() - t0) * 1000.0
+
+    if not result.ok:
+        return ReplayResult(
+            identical=False,
+            duration_ms=elapsed_ms,
+            detail=f"replay failed: {result.error}",
+            actual_summary=f"<error: {result.error}>",
+            expected_summary=_summary(expected_value),
+        )
+    same = _value_equal(result.value, expected_value)
+    return ReplayResult(
+        identical=same,
+        duration_ms=elapsed_ms,
+        detail="byte-identical" if same else "value mismatch",
+        actual_summary=_summary(result.value),
+        expected_summary=_summary(expected_value),
+    )

--- a/tests/test_channels/test_program_synthesis/unit/test_trace.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_trace.py
@@ -1,0 +1,207 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Trace + replay tests — K9 / K10 hard gates (spec §3 + §22)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.search.candidate import (
+    Const,
+    InputRef,
+    Program,
+)
+from cognithor.channels.program_synthesis.trace import (
+    build_trace,
+    format_trace,
+    replay_program,
+)
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+# ---------------------------------------------------------------------------
+# build_trace — K9 hard gate (every solved program has a trace)
+# ---------------------------------------------------------------------------
+
+
+class TestBuildTrace:
+    def test_trace_has_one_line_per_program_node(self) -> None:
+        # rotate90(input) — single Program node → single trace line.
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        trace = build_trace(prog, _g([[1, 2], [3, 4]]))
+        assert len(trace.lines) == 1
+        assert trace.lines[0].source == "rotate90(input)"
+
+    def test_trace_lines_are_in_bottom_up_order(self) -> None:
+        # mirror_horizontal(rotate90(input)) — inner step1 (rotate90)
+        # must appear BEFORE step2 (mirror_horizontal).
+        inner = Program("rotate90", (InputRef(),), "Grid")
+        outer = Program("mirror_horizontal", (inner,), "Grid")
+        trace = build_trace(outer, _g([[1, 2], [3, 4]]))
+        assert len(trace.lines) == 2
+        assert trace.lines[0].source == "rotate90(input)"
+        assert trace.lines[1].source == "mirror_horizontal(step1)"
+
+    def test_trace_summarises_grid_value(self) -> None:
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        trace = build_trace(prog, _g([[1, 2, 3]]))
+        # rotate90 of 1×3 → 3×1.
+        assert "(3, 1)" in trace.lines[0].summary
+
+    def test_trace_records_per_step_duration(self) -> None:
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        trace = build_trace(prog, _g([[1, 2], [3, 4]]))
+        assert trace.lines[0].duration_ms >= 0.0
+        assert trace.total_duration_ms >= trace.lines[0].duration_ms
+
+    def test_trace_carries_program_hash(self) -> None:
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        trace = build_trace(prog, _g([[1, 2]]))
+        assert trace.program_hash is not None
+        assert trace.program_hash.startswith("sha256:")
+
+    def test_trace_const_args_inlined_not_separate_step(self) -> None:
+        # recolor(input, 1, 2) — Consts inline; only one Program node →
+        # one trace line.
+        prog = Program(
+            "recolor",
+            (
+                InputRef(),
+                Const(value=1, output_type="Color"),
+                Const(value=2, output_type="Color"),
+            ),
+            "Grid",
+        )
+        trace = build_trace(prog, _g([[1, 2]]))
+        assert len(trace.lines) == 1
+        assert "1" in trace.lines[0].source
+        assert "2" in trace.lines[0].source
+
+    def test_trace_marks_failed_step_with_error_tag(self) -> None:
+        # rotate90 expects an int8 grid; passing a string crashes.
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        trace = build_trace(prog, "not a grid")
+        assert not trace.all_ok
+        assert "<error" in trace.lines[0].summary
+
+    def test_trace_is_deterministic(self) -> None:
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        a = build_trace(prog, _g([[1, 2], [3, 4]]))
+        b = build_trace(prog, _g([[1, 2], [3, 4]]))
+        # Source + summary + line count must match exactly; durations
+        # are timing-dependent so we don't compare those.
+        assert a.program_hash == b.program_hash
+        assert a.final_value_summary == b.final_value_summary
+        assert [(l.var, l.source, l.summary) for l in a.lines] == [
+            (l.var, l.source, l.summary) for l in b.lines
+        ]
+
+
+# ---------------------------------------------------------------------------
+# format_trace — human-readable pseudo-code
+# ---------------------------------------------------------------------------
+
+
+class TestFormatTrace:
+    def test_includes_pse_header(self) -> None:
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        trace = build_trace(prog, _g([[1, 2]]))
+        out = format_trace(trace)
+        assert "# PSE Solution Trace" in out
+        assert "Program hash" in out
+
+    def test_renders_step_assignments(self) -> None:
+        inner = Program("rotate90", (InputRef(),), "Grid")
+        outer = Program("mirror_horizontal", (inner,), "Grid")
+        trace = build_trace(outer, _g([[1, 2], [3, 4]]))
+        out = format_trace(trace)
+        assert "Step 1: step1 = rotate90(input)" in out
+        assert "Step 2: step2 = mirror_horizontal(step1)" in out
+
+    def test_includes_optional_header_kv(self) -> None:
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        trace = build_trace(prog, _g([[1, 2]]))
+        out = format_trace(
+            trace,
+            header={"Search time": "0.4s, 12 candidates", "Spec hash": "sha256:abcd"},
+        )
+        assert "Search time" in out
+        assert "0.4s" in out
+        assert "Spec hash" in out
+
+    def test_renders_final_summary(self) -> None:
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        trace = build_trace(prog, _g([[1, 2, 3]]))
+        out = format_trace(trace)
+        assert "# Final" in out
+
+    def test_zero_step_program_renders_inline(self) -> None:
+        # InputRef alone has no Program nodes.
+        trace = build_trace(InputRef(), _g([[1, 2]]))
+        out = format_trace(trace)
+        assert "result = input" in out
+
+
+# ---------------------------------------------------------------------------
+# replay_program — K10 hard gate (byte-identical re-execution + ≤ 100 ms)
+# ---------------------------------------------------------------------------
+
+
+class TestReplay:
+    def test_identical_replay(self) -> None:
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        inp = _g([[1, 2], [3, 4]])
+        expected = _g([[3, 1], [4, 2]])
+        result = replay_program(prog, inp, expected)
+        assert result.identical
+        assert result.duration_ms >= 0.0
+        assert result.detail == "byte-identical"
+
+    def test_mismatch_replay(self) -> None:
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        result = replay_program(
+            prog,
+            _g([[1, 2], [3, 4]]),
+            _g([[9, 9], [9, 9]]),  # wrong expected
+        )
+        assert not result.identical
+        assert "mismatch" in result.detail
+
+    def test_duration_under_100ms_for_simple_program(self) -> None:
+        # K10 hard gate: replay duration P95 ≤ 100 ms. This single-call
+        # check uses the strict 100ms cap as a smoke test (a real
+        # benchmark over many programs would compute P95).
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        result = replay_program(prog, _g([[1, 2], [3, 4]]), _g([[3, 1], [4, 2]]))
+        assert result.identical
+        assert result.duration_ms < 100.0
+
+    def test_replay_failure_reported(self) -> None:
+        # Program crashes (string input → TypeMismatchError).
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        result = replay_program(prog, "not a grid", _g([[1, 2]]))
+        assert not result.identical
+        assert "failed" in result.detail
+        assert "<error" in result.actual_summary
+
+    def test_dtype_mismatch_counts_as_not_identical(self) -> None:
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        # Same shape + values but different dtype → must NOT be identical.
+        actual_input = _g([[1, 2], [3, 4]])
+        expected_wrong_dtype = np.array([[3, 1], [4, 2]], dtype=np.int32)
+        result = replay_program(prog, actual_input, expected_wrong_dtype)
+        # actual is int8, expected is int32 → not identical by K10's strict rule.
+        assert not result.identical
+
+
+class TestReplayDeterminism:
+    def test_two_replays_produce_identical_verdicts(self) -> None:
+        prog = Program("rotate90", (InputRef(),), "Grid")
+        inp = _g([[1, 2], [3, 4]])
+        expected = _g([[3, 1], [4, 2]])
+        a = replay_program(prog, inp, expected)
+        b = replay_program(prog, inp, expected)
+        assert a.identical == b.identical
+        assert a.actual_summary == b.actual_summary


### PR DESCRIPTION
## Summary
Lands the **trace differentiator** that the spec calls "Erstklass-Output". Every solved program now ships with a deterministic, human-readable pseudo-code trace and a byte-identical replay path. These are the **K9** (Trace-Vollständigkeit) and **K10** (Replay-Reproduzierbarkeit) hard gates from spec §3 — releases are blocked if either fails.

### \`trace/builder.py\`
- \`TraceLine\` — frozen per-primitive-call record (index, var, source, summary, duration_ms, ok).
- \`TraceResult\` — aggregate with program_source + program_hash + final_value_summary + final_value_ok + lines tuple, plus total-duration + all-ok properties.
- \`build_trace(program, input_grid, executor)\` — bottom-up DFS:
  - \`InputRef\` + \`Const\` inlined into parent's source line (don't consume their own step).
  - Inner Program nodes get auto-named \`step1..stepN\`; outer node's source references step-vars rather than nested calls → reads as a sequence of assignments.
  - Each step records wall-clock duration via \`time.monotonic()\`.
  - Failed steps surface as \`<error: TypeMismatchError>\` so the trace stays complete even when execution blows up.
- \`format_trace(trace, header?)\` — the **K9 deliverable**: pretty-prints the multi-line pseudo-code matching spec §24.5's example.

### \`trace/replay.py\`
- \`ReplayResult\` — frozen (identical, duration_ms, detail, actual/expected summaries).
- \`replay_program(program, input_grid, expected_value, executor?)\` — the **K10 contract**:
  - Strict equality: ndarray byte-equal + shape + dtype; ObjectSet by ordered tuple; Object structurally; everything else via \`==\`.
  - Reports \`duration_ms\` for the eval-suite **P95 ≤ 100 ms** gate.
  - On execution failure → \`identical=False\` with the error tag.

## Tests
**+19 unit tests** (8 build_trace + 5 format_trace + 6 replay):
- **TestBuildTrace** — one-line-per-Program-node, bottom-up order, grid shape summary, per-step durations, program_hash carried, Const args inlined, error tag on crash, deterministic.
- **TestFormatTrace** — PSE header, Step assignments, optional header k/v, final-summary block, zero-step inline render.
- **TestReplay** — identical replay, mismatch reported, duration < 100 ms smoke (K10), execution failure reported, dtype mismatch counts as not-identical (strict K10), determinism.

**Total PSE tests: 458 → 477**, all pass in ~2.3s. \`ruff format\` and \`ruff check\` clean.

## Test plan
- [x] \`pytest tests/test_channels/test_program_synthesis/ -x -q\` — 477/477 pass.
- [x] \`ruff format --check\` — clean.
- [x] \`ruff check\` — clean.
- [ ] CI: full backend matrix green.

## Roadmap
**Week 5 day 4-5 complete.** Only Week-5 piece remaining is **day 3 — adversarial sandbox tests (K4 hard gate)**, which is a security surface that deserves its own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)