### PR TITLE
feat(pse): Lambda type + map_objects + filter_objects — Week 6 H1+H2

### DIFF
--- a/src/cognithor/channels/program_synthesis/dsl/lambdas.py
+++ b/src/cognithor/channels/program_synthesis/dsl/lambdas.py
@@ -1,0 +1,126 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Lambda type + closed-set constructors (spec §6.4 + §7.5).
+
+Higher-order primitives (``map_objects``, ``branch``) take Lambda
+arguments. Like Predicates, the spec mandates a *closed* enumerable
+set — free Python lambdas would unravel the sandbox guarantee.
+
+Phase 1.5 ships three Lambda constructors over Object → Object:
+
+* ``identity_lambda()`` — passes the object through unchanged.
+* ``recolor_lambda(new_color)`` — repaints every cell with new_color.
+* ``shift_lambda(dy, dx)`` — translates every cell by (dy, dx).
+
+The :func:`evaluate_lambda` function takes a Lambda + an Object and
+returns the transformed Object. It's pure — same inputs, same output.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from cognithor.channels.program_synthesis.dsl.types_grid import Object
+
+
+@dataclass(frozen=True)
+class Lambda:
+    """A geschlossener (closed-set) 1-arg function over Object.
+
+    ``constructor`` is one of the names in :data:`LAMBDA_CONSTRUCTORS`.
+    ``args`` is a tuple of primitive values — never a free Python
+    callable.
+
+    Phase 1.5 only allows Object → Object lambdas; future phases may
+    extend to Object → T or T → T.
+    """
+
+    constructor: str
+    args: tuple[Any, ...] = ()
+    variable_type: str = "Object"
+    output_type: str = "Object"
+
+    def __post_init__(self) -> None:
+        if self.constructor not in LAMBDA_CONSTRUCTORS:
+            raise ValueError(
+                f"Unknown lambda constructor {self.constructor!r}; "
+                f"allowed: {sorted(LAMBDA_CONSTRUCTORS)}"
+            )
+
+    def to_source(self) -> str:
+        if not self.args:
+            return f"{self.constructor}()"
+        rendered = ", ".join(repr(a) for a in self.args)
+        return f"{self.constructor}({rendered})"
+
+
+# Constructor registry — closed set, enumeration-ready.
+LAMBDA_CONSTRUCTORS: dict[str, int] = {
+    "identity_lambda": 0,
+    "recolor_lambda": 1,
+    "shift_lambda": 2,
+}
+
+
+# ---------------------------------------------------------------------------
+# Pure evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_lambda(fn: Lambda, obj: Object) -> Object:
+    """Apply ``fn`` to ``obj`` and return the transformed Object.
+
+    Strict typing: invalid arg shapes raise TypeError. The output is a
+    fresh Object — input is never mutated (Object is frozen anyway,
+    but the contract is explicit).
+    """
+    name = fn.constructor
+
+    if name == "identity_lambda":
+        return obj
+
+    if name == "recolor_lambda":
+        (new_color,) = fn.args
+        if not isinstance(new_color, int) or isinstance(new_color, bool):
+            raise TypeError("recolor_lambda: arg must be int")
+        if not 0 <= new_color <= 9:
+            raise TypeError(f"recolor_lambda: color {new_color} out of ARC range 0..9")
+        return Object(color=new_color, cells=obj.cells)
+
+    if name == "shift_lambda":
+        dy, dx = fn.args
+        if not (isinstance(dy, int) and isinstance(dx, int)) or (
+            isinstance(dy, bool) or isinstance(dx, bool)
+        ):
+            raise TypeError("shift_lambda: dy and dx must both be int")
+        new_cells = tuple((r + dy, c + dx) for r, c in obj.cells)
+        return Object(color=obj.color, cells=new_cells)
+
+    raise ValueError(f"evaluate_lambda: unhandled constructor {name!r}")
+
+
+# ---------------------------------------------------------------------------
+# Convenience builders.
+# ---------------------------------------------------------------------------
+
+
+def identity_lambda() -> Lambda:
+    return Lambda(constructor="identity_lambda")
+
+
+def recolor_lambda(new_color: int) -> Lambda:
+    return Lambda(constructor="recolor_lambda", args=(new_color,))
+
+
+def shift_lambda(dy: int, dx: int) -> Lambda:
+    return Lambda(constructor="shift_lambda", args=(dy, dx))
+
+
+__all__ = [
+    "LAMBDA_CONSTRUCTORS",
+    "Lambda",
+    "evaluate_lambda",
+    "identity_lambda",
+    "recolor_lambda",
+    "shift_lambda",
+]

--- a/src/cognithor/channels/program_synthesis/dsl/primitives.py
+++ b/src/cognithor/channels/program_synthesis/dsl/primitives.py
@@ -1021,3 +1021,68 @@ def _make_color_const(c: int) -> None:
 
 for _c in range(10):
     _make_color_const(_c)
+
+
+# ---------------------------------------------------------------------------
+# Phase 1.5: Higher-order primitives (H1, H2). H3-H5 follow in subsequent PRs.
+# ---------------------------------------------------------------------------
+
+
+from cognithor.channels.program_synthesis.dsl.lambdas import (
+    Lambda,
+    evaluate_lambda,
+)
+from cognithor.channels.program_synthesis.dsl.predicates import (
+    Predicate,
+    PredicateContext,
+    evaluate_predicate,
+)
+
+
+def _check_lambda(fn: object, name: str) -> Lambda:
+    if not isinstance(fn, Lambda):
+        raise TypeMismatchError(f"{name}: expected Lambda, got {type(fn).__name__}")
+    return fn
+
+
+def _check_predicate(p: object, name: str) -> Predicate:
+    if not isinstance(p, Predicate):
+        raise TypeMismatchError(f"{name}: expected Predicate, got {type(p).__name__}")
+    return p
+
+
+@primitive(
+    name="map_objects",
+    signature=Signature(inputs=("ObjectSet", "Lambda"), output="ObjectSet"),
+    cost=3.0,
+    description=(
+        "Apply *fn* to every object in the set; return the resulting "
+        "ObjectSet in the same order. Pure, no in-place mutation."
+    ),
+    examples=(("ObjectSet of 3, recolor_lambda(5)", "ObjectSet of 3, all color=5"),),
+)
+def map_objects(objects: ObjectSet, fn: Lambda) -> ObjectSet:
+    _check_object_set(objects, "map_objects")
+    _check_lambda(fn, "map_objects.fn")
+    transformed = tuple(evaluate_lambda(fn, o) for o in objects.objects)
+    return ObjectSet(objects=transformed)
+
+
+@primitive(
+    name="filter_objects",
+    signature=Signature(inputs=("ObjectSet", "Predicate"), output="ObjectSet"),
+    cost=2.5,
+    description=(
+        "Keep only objects for which *pred* is True. The predicate's "
+        "is_largest_in / is_smallest_in receive the original ObjectSet "
+        "as context so 'largest' refers to the input set, not the "
+        "filtered output."
+    ),
+    examples=(("ObjectSet of 3 (colors 1,2,3), color_eq(2)", "ObjectSet of 1 (color=2)"),),
+)
+def filter_objects(objects: ObjectSet, pred: Predicate) -> ObjectSet:
+    _check_object_set(objects, "filter_objects")
+    _check_predicate(pred, "filter_objects.pred")
+    ctx = PredicateContext(object_set=objects)
+    kept = tuple(o for o in objects.objects if evaluate_predicate(pred, o, ctx))
+    return ObjectSet(objects=kept)

--- a/tests/test_channels/test_program_synthesis/unit/test_dsl_higher_order.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_dsl_higher_order.py
@@ -1,0 +1,205 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Higher-order primitive tests — H1 map_objects + H2 filter_objects (spec §7.5)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.core.exceptions import TypeMismatchError
+from cognithor.channels.program_synthesis.dsl.lambdas import (
+    identity_lambda,
+    recolor_lambda,
+    shift_lambda,
+)
+from cognithor.channels.program_synthesis.dsl.predicates import (
+    color_eq,
+    is_largest_in,
+    pred_not,
+    size_gt,
+)
+from cognithor.channels.program_synthesis.dsl.primitives import (
+    filter_objects,
+    map_objects,
+)
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+from cognithor.channels.program_synthesis.dsl.types_grid import Object, ObjectSet
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+def _three_objects() -> ObjectSet:
+    return ObjectSet(
+        objects=(
+            Object(color=1, cells=((0, 0),)),
+            Object(color=2, cells=((1, 0), (1, 1))),
+            Object(color=3, cells=((2, 0), (2, 1), (2, 2))),
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# map_objects (H1)
+# ---------------------------------------------------------------------------
+
+
+class TestMapObjects:
+    def test_recolor_every_object(self) -> None:
+        s = _three_objects()
+        result = map_objects(s, recolor_lambda(5))
+        assert len(result) == 3
+        for o in result:
+            assert o.color == 5
+
+    def test_identity_is_no_op(self) -> None:
+        s = _three_objects()
+        result = map_objects(s, identity_lambda())
+        assert len(result) == len(s)
+        for a, b in zip(result.objects, s.objects, strict=True):
+            assert a == b
+
+    def test_shift_every_object(self) -> None:
+        s = _three_objects()
+        result = map_objects(s, shift_lambda(10, 0))
+        # Every cell should be shifted down by 10 rows.
+        for original, shifted in zip(s.objects, result.objects, strict=True):
+            for (or_, oc), (sr, sc) in zip(original.cells, shifted.cells, strict=True):
+                assert sr == or_ + 10
+                assert sc == oc
+
+    def test_empty_input_returns_empty(self) -> None:
+        result = map_objects(ObjectSet(), recolor_lambda(5))
+        assert result.is_empty()
+
+    def test_preserves_order(self) -> None:
+        s = _three_objects()
+        result = map_objects(s, recolor_lambda(7))
+        # Order must match input.
+        assert len(result) == 3
+
+    def test_rejects_non_object_set(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            map_objects([1, 2], recolor_lambda(5))  # type: ignore[arg-type]
+
+    def test_rejects_non_lambda(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            map_objects(_three_objects(), "not a lambda")  # type: ignore[arg-type]
+
+    def test_input_set_not_mutated(self) -> None:
+        s = _three_objects()
+        original_colors = [o.color for o in s.objects]
+        map_objects(s, recolor_lambda(9))
+        # Source set untouched.
+        assert [o.color for o in s.objects] == original_colors
+
+
+# ---------------------------------------------------------------------------
+# filter_objects (H2)
+# ---------------------------------------------------------------------------
+
+
+class TestFilterObjects:
+    def test_filter_by_color(self) -> None:
+        s = _three_objects()
+        result = filter_objects(s, color_eq(2))
+        assert len(result) == 1
+        assert result[0].color == 2
+
+    def test_filter_by_size_gt(self) -> None:
+        s = _three_objects()
+        result = filter_objects(s, size_gt(1))
+        # Two objects have size > 1 (size 2 and size 3).
+        assert len(result) == 2
+
+    def test_no_match_returns_empty(self) -> None:
+        s = _three_objects()
+        result = filter_objects(s, color_eq(9))
+        assert result.is_empty()
+
+    def test_all_match_returns_full_set(self) -> None:
+        s = _three_objects()
+        result = filter_objects(s, size_gt(0))
+        assert len(result) == 3
+
+    def test_empty_input_returns_empty(self) -> None:
+        result = filter_objects(ObjectSet(), color_eq(1))
+        assert result.is_empty()
+
+    def test_preserves_order(self) -> None:
+        s = _three_objects()
+        result = filter_objects(s, size_gt(0))
+        # Must keep discovery order.
+        assert tuple(o.color for o in result.objects) == (1, 2, 3)
+
+    def test_negation_combinator(self) -> None:
+        s = _three_objects()
+        # NOT color_eq(2) → keep colors 1 and 3.
+        result = filter_objects(s, pred_not(color_eq(2)))
+        colors = sorted(o.color for o in result.objects)
+        assert colors == [1, 3]
+
+    def test_largest_in_uses_input_set_context(self) -> None:
+        s = _three_objects()
+        # is_largest_in(s) — only the size=3 object survives.
+        result = filter_objects(s, is_largest_in(s))
+        assert len(result) == 1
+        assert result[0].size == 3
+
+    def test_rejects_non_object_set(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            filter_objects("nope", color_eq(1))  # type: ignore[arg-type]
+
+    def test_rejects_non_predicate(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            filter_objects(_three_objects(), "not a predicate")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Compose: filter then map (the canonical Phase-1.5 pattern)
+# ---------------------------------------------------------------------------
+
+
+class TestCompose:
+    def test_filter_then_map_recolor(self) -> None:
+        # Spec §24.4 example: blue objects → red.
+        s = _three_objects()  # colors 1, 2, 3
+        # Keep only color=2, then recolor to 5.
+        filtered = filter_objects(s, color_eq(2))
+        recolored = map_objects(filtered, recolor_lambda(5))
+        assert len(recolored) == 1
+        assert recolored[0].color == 5
+
+    def test_compose_stays_pure(self) -> None:
+        s = _three_objects()
+        original = tuple((o.color, o.cells) for o in s.objects)
+        filter_objects(s, color_eq(2))
+        map_objects(s, recolor_lambda(5))
+        # Source set untouched after both calls.
+        assert tuple((o.color, o.cells) for o in s.objects) == original
+
+
+# ---------------------------------------------------------------------------
+# Registry side-effect
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_higher_order_primitives_registered(self) -> None:
+        names = REGISTRY.names()
+        assert "map_objects" in names
+        assert "filter_objects" in names
+
+    def test_signatures(self) -> None:
+        spec = REGISTRY.get("map_objects")
+        assert spec.signature.inputs == ("ObjectSet", "Lambda")
+        assert spec.signature.output == "ObjectSet"
+        spec = REGISTRY.get("filter_objects")
+        assert spec.signature.inputs == ("ObjectSet", "Predicate")
+        assert spec.signature.output == "ObjectSet"
+
+    def test_total_catalog_grows_to_58(self) -> None:
+        # 56 base primitives + 2 higher-order so far (H1 + H2). H3-H5
+        # bring it to 61 (or more if helper sub-primitives land).
+        assert len(REGISTRY) == 58

--- a/tests/test_channels/test_program_synthesis/unit/test_dsl_primitives_mask_construct_const.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_dsl_primitives_mask_construct_const.py
@@ -387,6 +387,8 @@ class TestRegistry:
         ):
             assert expected in names, f"{expected} not registered"
 
-    def test_full_catalog_size_matches_spec(self) -> None:
-        # 56 base primitives expected after Week 2 (incl. 10 constants).
-        assert len(REGISTRY) == 56
+    def test_base_primitives_present(self) -> None:
+        # The Phase-1 base catalog has 56 primitives. Higher-order
+        # primitives (Phase 1.5) extend the registry further; this
+        # test only locks down the floor.
+        assert len(REGISTRY) >= 56

--- a/tests/test_channels/test_program_synthesis/unit/test_lambdas.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_lambdas.py
@@ -1,0 +1,144 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Lambda type + evaluator tests (spec §6.4 + §7.5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cognithor.channels.program_synthesis.dsl.lambdas import (
+    LAMBDA_CONSTRUCTORS,
+    Lambda,
+    evaluate_lambda,
+    identity_lambda,
+    recolor_lambda,
+    shift_lambda,
+)
+from cognithor.channels.program_synthesis.dsl.types_grid import Object
+
+
+def _obj(color: int = 1) -> Object:
+    return Object(color=color, cells=((0, 0), (0, 1), (1, 0)))
+
+
+# ---------------------------------------------------------------------------
+# Lambda dataclass
+# ---------------------------------------------------------------------------
+
+
+class TestLambda:
+    def test_known_constructor_accepted(self) -> None:
+        fn = Lambda(constructor="recolor_lambda", args=(5,))
+        assert fn.constructor == "recolor_lambda"
+        assert fn.args == (5,)
+        assert fn.variable_type == "Object"
+        assert fn.output_type == "Object"
+
+    def test_unknown_constructor_rejected(self) -> None:
+        with pytest.raises(ValueError, match="Unknown lambda constructor"):
+            Lambda(constructor="not_a_thing")
+
+    def test_to_source_zero_arity(self) -> None:
+        assert Lambda(constructor="identity_lambda").to_source() == "identity_lambda()"
+
+    def test_to_source_with_int_arg(self) -> None:
+        assert recolor_lambda(5).to_source() == "recolor_lambda(5)"
+
+    def test_to_source_with_two_args(self) -> None:
+        assert shift_lambda(1, 2).to_source() == "shift_lambda(1, 2)"
+
+    def test_lambda_is_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        fn = recolor_lambda(5)
+        with pytest.raises(FrozenInstanceError):
+            fn.constructor = "identity_lambda"  # type: ignore[misc]
+
+    def test_three_constructors_registered(self) -> None:
+        assert len(LAMBDA_CONSTRUCTORS) == 3
+        for name in ("identity_lambda", "recolor_lambda", "shift_lambda"):
+            assert name in LAMBDA_CONSTRUCTORS
+
+
+# ---------------------------------------------------------------------------
+# evaluate_lambda
+# ---------------------------------------------------------------------------
+
+
+class TestIdentityLambda:
+    def test_returns_same_object(self) -> None:
+        obj = _obj(color=4)
+        result = evaluate_lambda(identity_lambda(), obj)
+        assert result is obj or result == obj
+
+
+class TestRecolorLambda:
+    def test_recolors_to_new_value(self) -> None:
+        obj = _obj(color=1)
+        result = evaluate_lambda(recolor_lambda(7), obj)
+        assert result.color == 7
+        # Cells are preserved.
+        assert result.cells == obj.cells
+
+    def test_recolor_to_same_color_is_no_op(self) -> None:
+        obj = _obj(color=3)
+        result = evaluate_lambda(recolor_lambda(3), obj)
+        assert result.color == 3
+
+    def test_out_of_range_color_raises(self) -> None:
+        with pytest.raises(TypeError, match="out of ARC range"):
+            evaluate_lambda(recolor_lambda(99), _obj())
+
+    def test_negative_color_raises(self) -> None:
+        with pytest.raises(TypeError, match="out of ARC range"):
+            evaluate_lambda(recolor_lambda(-1), _obj())
+
+    def test_bool_arg_rejected(self) -> None:
+        bad = Lambda(constructor="recolor_lambda", args=(True,))
+        with pytest.raises(TypeError, match="int"):
+            evaluate_lambda(bad, _obj())
+
+
+class TestShiftLambda:
+    def test_shifts_cells_by_delta(self) -> None:
+        obj = Object(color=2, cells=((0, 0), (1, 1)))
+        result = evaluate_lambda(shift_lambda(2, 3), obj)
+        # cells are sorted on construction by Object — so the output is
+        # ((2, 3), (3, 4)).
+        assert result.cells == ((2, 3), (3, 4))
+        assert result.color == 2
+
+    def test_zero_shift_preserves_cells(self) -> None:
+        obj = _obj(color=5)
+        result = evaluate_lambda(shift_lambda(0, 0), obj)
+        assert result.cells == obj.cells
+
+    def test_negative_shift_works(self) -> None:
+        obj = Object(color=1, cells=((5, 5),))
+        result = evaluate_lambda(shift_lambda(-3, -3), obj)
+        assert result.cells == ((2, 2),)
+
+    def test_non_int_dy_raises(self) -> None:
+        bad = Lambda(constructor="shift_lambda", args=(1.5, 0))
+        with pytest.raises(TypeError, match="int"):
+            evaluate_lambda(bad, _obj())
+
+    def test_bool_dx_rejected(self) -> None:
+        bad = Lambda(constructor="shift_lambda", args=(0, True))
+        with pytest.raises(TypeError, match="int"):
+            evaluate_lambda(bad, _obj())
+
+
+class TestEvaluatorContract:
+    def test_input_object_not_mutated(self) -> None:
+        obj = _obj(color=1)
+        original_color = obj.color
+        original_cells = obj.cells
+        evaluate_lambda(recolor_lambda(9), obj)
+        assert obj.color == original_color
+        assert obj.cells == original_cells
+
+    def test_pure_function_deterministic(self) -> None:
+        obj = _obj(color=1)
+        a = evaluate_lambda(recolor_lambda(7), obj)
+        b = evaluate_lambda(recolor_lambda(7), obj)
+        assert a == b


### PR DESCRIPTION
## Summary
Lands the Lambda type system + the first two higher-order primitives from spec §7.5. The Phase 1.5 toolkit now lets the search engine express "transform every object" and "keep only matching objects" — the patterns that unlock the bulk of object-manipulation ARC tasks.

### \`dsl/lambdas.py\`
- **\`Lambda\`** frozen dataclass mirroring Predicate's shape. \`__post_init__\` rejects unknown constructors.
- **\`LAMBDA_CONSTRUCTORS\`** — closed registry of three Object→Object lambdas:
  - \`identity_lambda()\` — pass-through.
  - \`recolor_lambda(new_color)\` — paint every cell with new_color.
  - \`shift_lambda(dy, dx)\` — translate every cell by (dy, dx).
- **\`evaluate_lambda(fn, obj)\`** — pure function with strict \`TypeError\` for bad arg shapes (color out of range, non-int dy/dx, bool-as-int).

### \`dsl/primitives.py\` — H1 + H2 registered
- **\`map_objects(ObjectSet, Lambda) → ObjectSet\`** — apply fn to every object, preserving order. Cost 3.0.
- **\`filter_objects(ObjectSet, Predicate) → ObjectSet\`** — keep only matching objects. Predicate's \`is_largest_in\` / \`is_smallest_in\` receive the *original* ObjectSet via \`PredicateContext\` so "largest" refers to the input set, not the filtered output. Cost 2.5.
- New \`_check_lambda\` + \`_check_predicate\` validators raise \`TypeMismatchError\` so the search engine catches type errors at candidate-construction time.

## Tests
**+43 unit tests:**
- \`test_lambdas.py\` (15) — dataclass (7: known/unknown, to_source variants, frozen, registry), evaluator (8: identity, recolor preserves cells / range checks, shift with neg/zero/pos deltas, non-int rejection, input-not-mutated, deterministic).
- \`test_dsl_higher_order.py\` (28) — map_objects (8), filter_objects (10 incl. NOT combinator + is_largest_in context), filter→map composition (2 incl. purity), registry side-effect (3).

The catalog-size assertion in \`test_dsl_primitives_mask_construct_const.py\` is loosened from \`== 56\` to \`>= 56\` to accommodate Phase-1.5 growth without churn.

**Total PSE tests: 531 → 574** (+ 12 skipped), all pass in ~2.4s. \`ruff format\` and \`ruff check\` clean.

## Test plan
- [x] \`pytest tests/test_channels/test_program_synthesis/ -q\` — 574 passed, 12 skipped.
- [x] \`ruff format --check\` — clean.
- [x] \`ruff check\` — clean.
- [ ] CI: full backend matrix green.

## Roadmap
**Week 6 day 3-4 done.** Remaining Week 6:
- Day 4-5: \`align_to\` (H3) + AlignMode enum.
- Day 5-6: \`sort_objects\` (H4) + \`branch\` (H5).
- Day 6: Search-engine adaptation for the new sub-bank (predicate / lambda enumeration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)