### PR TITLE
feat(pse): align_to (H3) + AlignMode enum — Week 6 day 4-5

### DIFF
--- a/src/cognithor/channels/program_synthesis/dsl/primitives.py
+++ b/src/cognithor/channels/program_synthesis/dsl/primitives.py
@@ -1086,3 +1086,100 @@ def filter_objects(objects: ObjectSet, pred: Predicate) -> ObjectSet:
     ctx = PredicateContext(object_set=objects)
     kept = tuple(o for o in objects.objects if evaluate_predicate(pred, o, ctx))
     return ObjectSet(objects=kept)
+
+
+# ---------------------------------------------------------------------------
+# Phase 1.5: H3 align_to + AlignMode enum
+# ---------------------------------------------------------------------------
+
+
+from enum import Enum
+
+
+class AlignMode(str, Enum):
+    """Where to anchor object A relative to object B's bounding box."""
+
+    CENTER = "center"
+    LEFT = "left"
+    RIGHT = "right"
+    TOP = "top"
+    BOTTOM = "bottom"
+    TOP_LEFT = "top_left"
+    TOP_RIGHT = "top_right"
+    BOTTOM_LEFT = "bottom_left"
+    BOTTOM_RIGHT = "bottom_right"
+
+
+def _check_align_mode(m: object, name: str) -> AlignMode:
+    if isinstance(m, AlignMode):
+        return m
+    if isinstance(m, str):
+        try:
+            return AlignMode(m)
+        except ValueError as exc:
+            raise TypeMismatchError(
+                f"{name}: unknown AlignMode {m!r}; allowed: {[mode.value for mode in AlignMode]}"
+            ) from exc
+    raise TypeMismatchError(f"{name}: expected AlignMode or str, got {type(m).__name__}")
+
+
+def _bbox_center(bbox: tuple[int, int, int, int]) -> tuple[int, int]:
+    """Integer center of a half-open bbox (r0, r1, c0, c1).
+
+    Uses floor-division so the result is always a valid cell position.
+    """
+    r0, r1, c0, c1 = bbox
+    return ((r0 + r1 - 1) // 2, (c0 + c1 - 1) // 2)
+
+
+def _align_delta(
+    a_bbox: tuple[int, int, int, int],
+    b_bbox: tuple[int, int, int, int],
+    mode: AlignMode,
+) -> tuple[int, int]:
+    """How much to shift A so its bbox aligns with B's per *mode*."""
+    ar0, ar1, ac0, ac1 = a_bbox
+    br0, br1, bc0, bc1 = b_bbox
+    a_cy, a_cx = _bbox_center(a_bbox)
+    b_cy, b_cx = _bbox_center(b_bbox)
+
+    # Default: centre-aligned on both axes.
+    dy = b_cy - a_cy
+    dx = b_cx - a_cx
+
+    if mode in (AlignMode.LEFT, AlignMode.TOP_LEFT, AlignMode.BOTTOM_LEFT):
+        dx = bc0 - ac0
+    if mode in (AlignMode.RIGHT, AlignMode.TOP_RIGHT, AlignMode.BOTTOM_RIGHT):
+        # bbox is half-open; right edge cell is r1-1.
+        dx = (bc1 - 1) - (ac1 - 1)
+    if mode in (AlignMode.TOP, AlignMode.TOP_LEFT, AlignMode.TOP_RIGHT):
+        dy = br0 - ar0
+    if mode in (AlignMode.BOTTOM, AlignMode.BOTTOM_LEFT, AlignMode.BOTTOM_RIGHT):
+        dy = (br1 - 1) - (ar1 - 1)
+    return (dy, dx)
+
+
+@primitive(
+    name="align_to",
+    signature=Signature(inputs=("Object", "Object", "AlignMode"), output="Object"),
+    cost=3.0,
+    description=(
+        "Translate object A so its bounding box aligns with B's per *mode*. "
+        "CENTER aligns both axes; the four edges align that axis and "
+        "centre the other; corners align both axes simultaneously."
+    ),
+    examples=(("a, b, CENTER", "a translated so its centre matches b's centre"),),
+)
+def align_to(a: Object, b: Object, mode: AlignMode) -> Object:
+    _check_object(a, "align_to.a")
+    _check_object(b, "align_to.b")
+    m = _check_align_mode(mode, "align_to.mode")
+    if not a.cells or not b.cells:
+        return a
+    dy, dx = _align_delta(a.bbox, b.bbox, m)
+    if dy == 0 and dx == 0:
+        return a
+    return Object(
+        color=a.color,
+        cells=tuple((r + dy, c + dx) for r, c in a.cells),
+    )

--- a/tests/test_channels/test_program_synthesis/unit/test_dsl_align_to.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_dsl_align_to.py
@@ -1,0 +1,222 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""align_to (H3) + AlignMode tests (spec §7.5)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cognithor.channels.program_synthesis.core.exceptions import TypeMismatchError
+from cognithor.channels.program_synthesis.dsl.primitives import (
+    AlignMode,
+    align_to,
+)
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+from cognithor.channels.program_synthesis.dsl.types_grid import Object
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _square(top_left: tuple[int, int], side: int = 2, color: int = 1) -> Object:
+    r0, c0 = top_left
+    cells = tuple((r0 + dr, c0 + dc) for dr in range(side) for dc in range(side))
+    return Object(color=color, cells=cells)
+
+
+# ---------------------------------------------------------------------------
+# AlignMode enum
+# ---------------------------------------------------------------------------
+
+
+class TestAlignModeEnum:
+    def test_nine_modes_present(self) -> None:
+        assert len(list(AlignMode)) == 9
+
+    def test_exact_value_strings(self) -> None:
+        assert AlignMode.CENTER.value == "center"
+        assert AlignMode.LEFT.value == "left"
+        assert AlignMode.RIGHT.value == "right"
+        assert AlignMode.TOP.value == "top"
+        assert AlignMode.BOTTOM.value == "bottom"
+        assert AlignMode.TOP_LEFT.value == "top_left"
+        assert AlignMode.TOP_RIGHT.value == "top_right"
+        assert AlignMode.BOTTOM_LEFT.value == "bottom_left"
+        assert AlignMode.BOTTOM_RIGHT.value == "bottom_right"
+
+    def test_string_subclass_lets_value_pass_to_string_apis(self) -> None:
+        assert isinstance(AlignMode.CENTER, str)
+        assert AlignMode.LEFT == "left"
+
+
+# ---------------------------------------------------------------------------
+# align_to — single-axis modes
+# ---------------------------------------------------------------------------
+
+
+class TestAlignTo:
+    # Reference object B is a 4×4 square at (10..13, 10..13).
+    B = _square((10, 10), side=4, color=2)
+
+    def test_center_aligns_both_axes(self) -> None:
+        a = _square((0, 0), side=2, color=1)
+        # B center ((10+13)//2, (10+13)//2) == (11, 11).
+        # A center ((0+1)//2, (0+1)//2) == (0, 0).
+        # Delta = (11, 11).
+        result = align_to(a, self.B, AlignMode.CENTER)
+        assert result.color == a.color
+        # New cells: original (0..1)×(0..1) + (11, 11).
+        assert result.cells == ((11, 11), (11, 12), (12, 11), (12, 12))
+
+    def test_left_aligns_left_edge_centers_y(self) -> None:
+        a = _square((0, 0), side=2, color=1)
+        # Left edge of B is c0=10. dx = 10 - 0 = 10.
+        # dy = 11 - 0 = 11.
+        result = align_to(a, self.B, AlignMode.LEFT)
+        # Cells start at (11, 10).
+        assert (11, 10) in result.cells
+
+    def test_right_aligns_right_edge(self) -> None:
+        a = _square((0, 0), side=2, color=1)
+        # Right edge of B is c1-1 == 13. A's right edge is c1-1 == 1.
+        # dx = 13 - 1 = 12.
+        # dy = centred = 11.
+        result = align_to(a, self.B, AlignMode.RIGHT)
+        # Cells end at column 13.
+        max_c = max(c for _, c in result.cells)
+        assert max_c == 13
+
+    def test_top_aligns_top_edge_centers_x(self) -> None:
+        a = _square((0, 0), side=2, color=1)
+        # Top of B is r0=10. dy = 10 - 0 = 10.
+        # dx centred = 11 - 0 = 11.
+        result = align_to(a, self.B, AlignMode.TOP)
+        # Top row of A's bbox is now 10.
+        min_r = min(r for r, _ in result.cells)
+        assert min_r == 10
+
+    def test_bottom_aligns_bottom_edge(self) -> None:
+        a = _square((0, 0), side=2, color=1)
+        result = align_to(a, self.B, AlignMode.BOTTOM)
+        max_r = max(r for r, _ in result.cells)
+        assert max_r == 13
+
+    def test_top_left_corner(self) -> None:
+        a = _square((0, 0), side=2, color=1)
+        result = align_to(a, self.B, AlignMode.TOP_LEFT)
+        # A's top-left should now match B's top-left == (10, 10).
+        min_r = min(r for r, _ in result.cells)
+        min_c = min(c for _, c in result.cells)
+        assert (min_r, min_c) == (10, 10)
+
+    def test_top_right_corner(self) -> None:
+        a = _square((0, 0), side=2, color=1)
+        result = align_to(a, self.B, AlignMode.TOP_RIGHT)
+        # A's top-right should match B's top-right == (10, 13).
+        min_r = min(r for r, _ in result.cells)
+        max_c = max(c for _, c in result.cells)
+        assert (min_r, max_c) == (10, 13)
+
+    def test_bottom_left_corner(self) -> None:
+        a = _square((0, 0), side=2, color=1)
+        result = align_to(a, self.B, AlignMode.BOTTOM_LEFT)
+        max_r = max(r for r, _ in result.cells)
+        min_c = min(c for _, c in result.cells)
+        assert (max_r, min_c) == (13, 10)
+
+    def test_bottom_right_corner(self) -> None:
+        a = _square((0, 0), side=2, color=1)
+        result = align_to(a, self.B, AlignMode.BOTTOM_RIGHT)
+        max_r = max(r for r, _ in result.cells)
+        max_c = max(c for _, c in result.cells)
+        assert (max_r, max_c) == (13, 13)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases + type validation
+# ---------------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_already_aligned_returns_input(self) -> None:
+        a = _square((10, 10), side=2, color=1)
+        b = _square((10, 10), side=2, color=2)
+        # CENTER between identical bboxes → no movement.
+        result = align_to(a, b, AlignMode.CENTER)
+        # Returns the same Object instance when no shift is needed.
+        assert result is a
+
+    def test_empty_a_returns_a(self) -> None:
+        a = Object(color=1, cells=())
+        b = _square((5, 5), side=2, color=2)
+        assert align_to(a, b, AlignMode.CENTER) is a
+
+    def test_empty_b_returns_a(self) -> None:
+        a = _square((0, 0), side=2, color=1)
+        b = Object(color=2, cells=())
+        assert align_to(a, b, AlignMode.CENTER) is a
+
+    def test_string_mode_accepted_and_normalised(self) -> None:
+        a = _square((0, 0), side=2, color=1)
+        b = _square((10, 10), side=4, color=2)
+        # AlignMode is StrEnum; passing the raw string should resolve.
+        as_string = align_to(a, b, "center")  # type: ignore[arg-type]
+        as_enum = align_to(a, b, AlignMode.CENTER)
+        assert as_string.cells == as_enum.cells
+
+    def test_unknown_string_mode_rejected(self) -> None:
+        a = _square((0, 0), side=2, color=1)
+        b = _square((10, 10), side=4, color=2)
+        with pytest.raises(TypeMismatchError, match="unknown AlignMode"):
+            align_to(a, b, "diagonal")  # type: ignore[arg-type]
+
+    def test_non_object_rejected(self) -> None:
+        b = _square((10, 10), side=4, color=2)
+        with pytest.raises(TypeMismatchError):
+            align_to("nope", b, AlignMode.CENTER)  # type: ignore[arg-type]
+
+    def test_non_align_mode_rejected(self) -> None:
+        a = _square((0, 0), side=2, color=1)
+        b = _square((10, 10), side=4, color=2)
+        with pytest.raises(TypeMismatchError):
+            align_to(a, b, 42)  # type: ignore[arg-type]
+
+    def test_color_preserved(self) -> None:
+        a = _square((0, 0), side=2, color=7)
+        b = _square((10, 10), side=4, color=2)
+        assert align_to(a, b, AlignMode.CENTER).color == 7
+
+
+# ---------------------------------------------------------------------------
+# Algebraic identities
+# ---------------------------------------------------------------------------
+
+
+class TestAlgebraicIdentities:
+    def test_aligning_to_self_after_shift_inverts(self) -> None:
+        # Shift A, then align it back to its origin → original cells.
+        b = _square((0, 0), side=2, color=2)
+        a_shifted = Object(color=1, cells=((100, 100), (100, 101), (101, 100), (101, 101)))
+        # CENTER align of a_shifted to b returns it to (0,0)..(1,1).
+        result = align_to(a_shifted, b, AlignMode.CENTER)
+        assert result.cells == ((0, 0), (0, 1), (1, 0), (1, 1))
+
+    def test_top_left_of_self_equal_to_self(self) -> None:
+        a = _square((5, 5), side=2, color=1)
+        result = align_to(a, a, AlignMode.TOP_LEFT)
+        assert result.cells == a.cells
+
+
+# ---------------------------------------------------------------------------
+# Registry side-effect.
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_align_to_registered(self) -> None:
+        assert "align_to" in REGISTRY.names()
+
+    def test_signature(self) -> None:
+        spec = REGISTRY.get("align_to")
+        assert spec.signature.inputs == ("Object", "Object", "AlignMode")
+        assert spec.signature.output == "Object"

--- a/tests/test_channels/test_program_synthesis/unit/test_dsl_higher_order.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_dsl_higher_order.py
@@ -199,7 +199,10 @@ class TestRegistry:
         assert spec.signature.inputs == ("ObjectSet", "Predicate")
         assert spec.signature.output == "ObjectSet"
 
-    def test_total_catalog_grows_to_58(self) -> None:
-        # 56 base primitives + 2 higher-order so far (H1 + H2). H3-H5
-        # bring it to 61 (or more if helper sub-primitives land).
-        assert len(REGISTRY) == 58
+    def test_catalog_includes_higher_order(self) -> None:
+        # Phase-1.5 primitives extend the 56-primitive base catalog.
+        # The exact total grows as more higher-order primitives land —
+        # this test only locks in the floor + presence of H1 + H2.
+        assert len(REGISTRY) >= 58
+        assert "map_objects" in REGISTRY
+        assert "filter_objects" in REGISTRY


### PR DESCRIPTION
## Summary
Third higher-order primitive from spec §7.5: positions object A relative to object B's bounding box per a **9-mode enum**.

### \`dsl/primitives.py\`
- **\`AlignMode\`** StrEnum — 9 modes:
  - **CENTER** — both axes
  - **LEFT / RIGHT / TOP / BOTTOM** — single axis (other centred)
  - **TOP_LEFT / TOP_RIGHT / BOTTOM_LEFT / BOTTOM_RIGHT** — both corners
  - StrEnum so call sites can pass the enum value or the raw string (the search engine emits \`Const("center")\` nodes).
- **\`_check_align_mode\`** validator accepts \`AlignMode\` or \`str\`; rejects unknown strings + non-string types with \`TypeMismatchError\`.
- **\`_bbox_center\` / \`_align_delta\`** — small pure helpers compute the \`(dy, dx)\` shift. CENTER uses integer floor-division so the result is always a valid cell; edges align that axis + centre the other; corners align both.
- **\`align_to(Object, Object, AlignMode) → Object\`** — cost 3.0. Empty A/B degenerate to "return A unchanged" so the search engine can enumerate candidates without crashing. Already-aligned input returns the same instance.

## Tests
**+24 unit tests:**
- **TestAlignModeEnum** (3) — 9 modes, exact value strings, str-subclass behaviour.
- **TestAlignTo** (9) — one test per mode (CENTER + 4 edges + 4 corners), verifying the resulting bbox edges land where they should.
- **TestEdgeCases** (8) — already-aligned returns same instance, empty A/B return A unchanged, raw string accepted, unknown string rejected, non-Object rejected, non-AlignMode rejected, color preserved.
- **TestAlgebraicIdentities** (2) — aligning a shifted A back via CENTER inverts the shift; aligning A to itself with TOP_LEFT is identity.
- **TestRegistry** (2) — \`align_to\` registered with signature \`(Object, Object, AlignMode) → Object\`.

The catalog-size assertion in \`test_dsl_higher_order.py\` is loosened from \`== 58\` to \`>= 58\` + presence check to accommodate further H4/H5 growth without churn.

**Total PSE tests: 574 → 598** (+ 12 skipped), all pass in ~2.5s. \`ruff format\` and \`ruff check\` clean.

## Test plan
- [x] \`pytest tests/test_channels/test_program_synthesis/ -q\` — 598 passed, 12 skipped.
- [x] \`ruff format --check\` — clean.
- [x] \`ruff check\` — clean.
- [ ] CI: full backend matrix green.

## Roadmap
**Week 6 H1+H2+H3 done.** Remaining higher-order:
- **H4 \`sort_objects\`** + SortKey enum.
- **H5 \`branch\`** — conditional Lambda combinator (the v1.2 spec addition).
- Search-engine adaptation for the predicate / lambda sub-bank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)