### PR TITLE
feat(pse): branch (H5) — conditional-Lambda combinator — Week 6 day 6 (v1.2 spec)

### DIFF
--- a/src/cognithor/channels/program_synthesis/dsl/lambdas.py
+++ b/src/cognithor/channels/program_synthesis/dsl/lambdas.py
@@ -5,11 +5,15 @@ Higher-order primitives (``map_objects``, ``branch``) take Lambda
 arguments. Like Predicates, the spec mandates a *closed* enumerable
 set — free Python lambdas would unravel the sandbox guarantee.
 
-Phase 1.5 ships three Lambda constructors over Object → Object:
+Phase 1.5 ships four Lambda constructors over Object → Object:
 
 * ``identity_lambda()`` — passes the object through unchanged.
 * ``recolor_lambda(new_color)`` — repaints every cell with new_color.
 * ``shift_lambda(dy, dx)`` — translates every cell by (dy, dx).
+* ``branch_lambda(predicate, then_fn, else_fn)`` — conditional
+  combinator from spec v1.2: returns then_fn(obj) when the predicate
+  holds, else else_fn(obj). Sub-tiefe limited to 1 (no nested branches)
+  per spec §7.5.
 
 The :func:`evaluate_lambda` function takes a Lambda + an Object and
 returns the transformed Object. It's pure — same inputs, same output.
@@ -18,9 +22,12 @@ returns the transformed Object. It's pure — same inputs, same output.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from cognithor.channels.program_synthesis.dsl.types_grid import Object
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.dsl.predicates import Predicate
 
 
 @dataclass(frozen=True)
@@ -59,6 +66,7 @@ LAMBDA_CONSTRUCTORS: dict[str, int] = {
     "identity_lambda": 0,
     "recolor_lambda": 1,
     "shift_lambda": 2,
+    "branch_lambda": 3,  # (Predicate, Lambda, Lambda) — spec §7.5 H5
 }
 
 
@@ -96,6 +104,30 @@ def evaluate_lambda(fn: Lambda, obj: Object) -> Object:
         new_cells = tuple((r + dy, c + dx) for r, c in obj.cells)
         return Object(color=obj.color, cells=new_cells)
 
+    if name == "branch_lambda":
+        # Lazy import to break the predicates ↔ lambdas circular dependency.
+        from cognithor.channels.program_synthesis.dsl.predicates import (
+            Predicate as _Predicate,
+        )
+        from cognithor.channels.program_synthesis.dsl.predicates import (
+            evaluate_predicate as _evaluate_predicate,
+        )
+
+        pred, then_fn, else_fn = fn.args
+        if not isinstance(pred, _Predicate):
+            raise TypeError("branch_lambda: first arg must be Predicate")
+        if not isinstance(then_fn, Lambda) or not isinstance(else_fn, Lambda):
+            raise TypeError("branch_lambda: branches must both be Lambda")
+        # Sub-tiefe ≤ 1 enforcement — spec §7.5 forbids
+        # branch(branch(...)) in Phase 1.
+        if then_fn.constructor == "branch_lambda" or else_fn.constructor == "branch_lambda":
+            raise ValueError(
+                "branch_lambda: nested branches forbidden in Phase 1 (sub-tiefe limit 1)"
+            )
+        if _evaluate_predicate(pred, obj):
+            return evaluate_lambda(then_fn, obj)
+        return evaluate_lambda(else_fn, obj)
+
     raise ValueError(f"evaluate_lambda: unhandled constructor {name!r}")
 
 
@@ -116,9 +148,20 @@ def shift_lambda(dy: int, dx: int) -> Lambda:
     return Lambda(constructor="shift_lambda", args=(dy, dx))
 
 
+def branch_lambda(predicate: Predicate, then_fn: Lambda, else_fn: Lambda) -> Lambda:
+    """Build a conditional Lambda (spec §7.5 H5).
+
+    Sub-tiefe ≤ 1: nested ``branch_lambda`` is rejected at evaluation
+    time. Constructed eagerly so the search engine can fingerprint the
+    Lambda value before it ever runs.
+    """
+    return Lambda(constructor="branch_lambda", args=(predicate, then_fn, else_fn))
+
+
 __all__ = [
     "LAMBDA_CONSTRUCTORS",
     "Lambda",
+    "branch_lambda",
     "evaluate_lambda",
     "identity_lambda",
     "recolor_lambda",

--- a/src/cognithor/channels/program_synthesis/dsl/primitives.py
+++ b/src/cognithor/channels/program_synthesis/dsl/primitives.py
@@ -1281,3 +1281,38 @@ def sort_objects(objects: ObjectSet, key: SortKey) -> ObjectSet:
     indexed = list(enumerate(objects.objects))
     indexed.sort(key=_sort_keyfn(k))
     return ObjectSet(objects=tuple(o for _, o in indexed))
+
+
+# ---------------------------------------------------------------------------
+# Phase 1.5: H5 branch — conditional-Lambda combinator (spec v1.2 §7.5)
+# ---------------------------------------------------------------------------
+
+
+from cognithor.channels.program_synthesis.dsl.lambdas import (
+    branch_lambda as _branch_lambda,
+)
+
+
+@primitive(
+    name="branch",
+    signature=Signature(inputs=("Predicate", "Lambda", "Lambda"), output="Lambda"),
+    cost=3.5,
+    description=(
+        "Build a conditional Lambda: ``λobj. then_fn(obj) if pred(obj) "
+        "else else_fn(obj)``. Sub-tiefe ≤ 1 — nested ``branch`` "
+        "forbidden in Phase 1 (spec §7.5)."
+    ),
+    examples=(
+        (
+            "branch(size_gt(5), recolor_lambda(2), identity_lambda())",
+            "Lambda that recolours large objects red, leaves others alone.",
+        ),
+    ),
+)
+def branch(predicate: Predicate, then_fn: Lambda, else_fn: Lambda) -> Lambda:
+    _check_predicate(predicate, "branch.predicate")
+    _check_lambda(then_fn, "branch.then_fn")
+    _check_lambda(else_fn, "branch.else_fn")
+    if then_fn.constructor == "branch_lambda" or else_fn.constructor == "branch_lambda":
+        raise TypeMismatchError("branch: nested branches forbidden in Phase 1 (sub-tiefe limit 1)")
+    return _branch_lambda(predicate, then_fn, else_fn)

--- a/tests/test_channels/test_program_synthesis/unit/test_dsl_branch.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_dsl_branch.py
@@ -1,0 +1,195 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""branch (H5) tests (spec §7.5 v1.2 — conditional-Lambda combinator)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cognithor.channels.program_synthesis.core.exceptions import TypeMismatchError
+from cognithor.channels.program_synthesis.dsl.lambdas import (
+    branch_lambda,
+    evaluate_lambda,
+    identity_lambda,
+    recolor_lambda,
+)
+from cognithor.channels.program_synthesis.dsl.predicates import (
+    color_eq,
+    pred_not,
+    size_gt,
+    size_lt,
+)
+from cognithor.channels.program_synthesis.dsl.primitives import (
+    branch,
+    map_objects,
+)
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+from cognithor.channels.program_synthesis.dsl.types_grid import Object, ObjectSet
+
+
+def _obj(*, color: int, cells: tuple[tuple[int, int], ...]) -> Object:
+    return Object(color=color, cells=cells)
+
+
+# ---------------------------------------------------------------------------
+# branch — basic happy paths
+# ---------------------------------------------------------------------------
+
+
+class TestBranchBasics:
+    def test_predicate_true_runs_then_branch(self) -> None:
+        # size_gt(2) on a 3-cell object → true → then_fn (recolor 9).
+        big = _obj(color=1, cells=((0, 0), (0, 1), (0, 2)))
+        fn = branch(size_gt(2), recolor_lambda(9), identity_lambda())
+        result = evaluate_lambda(fn, big)
+        assert result.color == 9
+
+    def test_predicate_false_runs_else_branch(self) -> None:
+        # size_gt(2) on a 1-cell object → false → else_fn (identity).
+        small = _obj(color=1, cells=((0, 0),))
+        fn = branch(size_gt(2), recolor_lambda(9), identity_lambda())
+        result = evaluate_lambda(fn, small)
+        assert result.color == 1
+
+    def test_returns_lambda_not_object(self) -> None:
+        # branch is a primitive that produces a Lambda, not an Object.
+        from cognithor.channels.program_synthesis.dsl.lambdas import Lambda
+
+        fn = branch(color_eq(1), identity_lambda(), recolor_lambda(2))
+        assert isinstance(fn, Lambda)
+        assert fn.constructor == "branch_lambda"
+
+    def test_branch_inside_map_objects(self) -> None:
+        # Spec §7.5 example: large objects → red, small → unchanged.
+        s = ObjectSet(
+            objects=(
+                _obj(color=1, cells=((0, 0),)),  # size 1
+                _obj(color=1, cells=((1, 0), (1, 1))),  # size 2
+                _obj(color=1, cells=((2, 0), (2, 1), (2, 2))),  # size 3
+            )
+        )
+        fn = branch(size_gt(1), recolor_lambda(2), identity_lambda())
+        result = map_objects(s, fn)
+        # Sizes 2 and 3 → recoloured to 2; size 1 stays 1.
+        colors = tuple(o.color for o in result.objects)
+        assert colors == (1, 2, 2)
+
+
+# ---------------------------------------------------------------------------
+# Type validation
+# ---------------------------------------------------------------------------
+
+
+class TestBranchValidation:
+    def test_non_predicate_arg_rejected(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            branch("not a predicate", identity_lambda(), identity_lambda())  # type: ignore[arg-type]
+
+    def test_non_lambda_then_branch_rejected(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            branch(color_eq(1), "not a lambda", identity_lambda())  # type: ignore[arg-type]
+
+    def test_non_lambda_else_branch_rejected(self) -> None:
+        with pytest.raises(TypeMismatchError):
+            branch(color_eq(1), identity_lambda(), 42)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Sub-tiefe ≤ 1 — nested branches forbidden
+# ---------------------------------------------------------------------------
+
+
+class TestSubDepth:
+    def test_nested_branch_in_then_rejected(self) -> None:
+        inner = branch(color_eq(1), identity_lambda(), recolor_lambda(2))
+        with pytest.raises(TypeMismatchError, match="nested"):
+            branch(size_gt(0), inner, identity_lambda())
+
+    def test_nested_branch_in_else_rejected(self) -> None:
+        inner = branch(color_eq(1), identity_lambda(), recolor_lambda(2))
+        with pytest.raises(TypeMismatchError, match="nested"):
+            branch(size_gt(0), identity_lambda(), inner)
+
+
+# ---------------------------------------------------------------------------
+# Algebraic identities (spec §7.5 calls these out explicitly)
+# ---------------------------------------------------------------------------
+
+
+class TestBranchAlgebra:
+    def test_branch_with_always_true_predicate_equals_then_fn(self) -> None:
+        # Always-true predicate (e.g. size_gt(-1)) → behaves like then_fn.
+        always_true = size_gt(-1)
+        fn = branch(always_true, recolor_lambda(7), identity_lambda())
+        obj = _obj(color=1, cells=((0, 0),))
+        result = evaluate_lambda(fn, obj)
+        assert result.color == 7
+
+    def test_branch_with_always_false_predicate_equals_else_fn(self) -> None:
+        always_false = size_lt(0)  # no object can have negative size
+        fn = branch(always_false, recolor_lambda(7), identity_lambda())
+        obj = _obj(color=1, cells=((0, 0),))
+        result = evaluate_lambda(fn, obj)
+        # else_fn is identity → unchanged.
+        assert result.color == 1
+
+    def test_branch_with_negated_predicate_swaps_branches(self) -> None:
+        # branch(not(p), f, g) ≡ branch(p, g, f).
+        obj = _obj(color=1, cells=((0, 0),))
+        positive = branch(color_eq(1), recolor_lambda(2), recolor_lambda(3))
+        negated = branch(pred_not(color_eq(1)), recolor_lambda(3), recolor_lambda(2))
+        a = evaluate_lambda(positive, obj)
+        b = evaluate_lambda(negated, obj)
+        assert a.color == b.color
+
+
+# ---------------------------------------------------------------------------
+# Direct branch_lambda builder also enforces sub-tiefe at eval time
+# ---------------------------------------------------------------------------
+
+
+class TestBranchLambdaBuilder:
+    def test_builder_constructs_lambda(self) -> None:
+        from cognithor.channels.program_synthesis.dsl.lambdas import Lambda
+
+        fn = branch_lambda(color_eq(1), identity_lambda(), identity_lambda())
+        assert isinstance(fn, Lambda)
+        assert fn.constructor == "branch_lambda"
+
+    def test_evaluator_rejects_nested_at_eval(self) -> None:
+        # The builder doesn't pre-check (the @primitive does, but the
+        # raw builder allows it for the search engine to construct
+        # invalid candidates and have them rejected at evaluation).
+        inner = branch_lambda(color_eq(1), identity_lambda(), identity_lambda())
+        nested = branch_lambda(color_eq(1), inner, identity_lambda())
+        obj = _obj(color=1, cells=((0, 0),))
+        with pytest.raises(ValueError, match="nested branches"):
+            evaluate_lambda(nested, obj)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_branch_primitive_registered(self) -> None:
+        assert "branch" in REGISTRY.names()
+
+    def test_branch_signature(self) -> None:
+        spec = REGISTRY.get("branch")
+        assert spec.signature.inputs == ("Predicate", "Lambda", "Lambda")
+        assert spec.signature.output == "Lambda"
+
+    def test_branch_cost_matches_spec(self) -> None:
+        spec = REGISTRY.get("branch")
+        # spec §7.5 mandates cost 3.5 — H5 is the most expensive
+        # higher-order primitive.
+        assert spec.cost == 3.5
+
+    def test_lambda_constructors_now_four(self) -> None:
+        from cognithor.channels.program_synthesis.dsl.lambdas import (
+            LAMBDA_CONSTRUCTORS,
+        )
+
+        assert len(LAMBDA_CONSTRUCTORS) == 4
+        assert "branch_lambda" in LAMBDA_CONSTRUCTORS

--- a/tests/test_channels/test_program_synthesis/unit/test_lambdas.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_lambdas.py
@@ -53,8 +53,9 @@ class TestLambda:
         with pytest.raises(FrozenInstanceError):
             fn.constructor = "identity_lambda"  # type: ignore[misc]
 
-    def test_three_constructors_registered(self) -> None:
-        assert len(LAMBDA_CONSTRUCTORS) == 3
+    def test_base_constructors_registered(self) -> None:
+        # Floor + presence check — Phase 1.5 grows the set as H1+H5 land.
+        assert len(LAMBDA_CONSTRUCTORS) >= 3
         for name in ("identity_lambda", "recolor_lambda", "shift_lambda"):
             assert name in LAMBDA_CONSTRUCTORS
 


### PR DESCRIPTION
## Summary
**Fifth and final higher-order primitive from spec §7.5** (added in v1.2 patch). H5 is the conditional combinator: given a Predicate p and two Lambdas f and g, returns a Lambda that picks between them per object.

**Phase 1.5 toolkit complete:**

| | Primitive | Signature |
|---|---|---|
| H1 | \`map_objects\` | apply Lambda to every object | (#218) |
| H2 | \`filter_objects\` | keep only objects matching Predicate | (#218) |
| H3 | \`align_to\` | position object A to object B's bbox | (#219) |
| H4 | \`sort_objects\` | stable-sort by SortKey | (#220) |
| **H5** | **\`branch\`** | **conditional Lambda combinator** | **this PR** |

### \`dsl/lambdas.py\`
- New constructor \`"branch_lambda"\` added to \`LAMBDA_CONSTRUCTORS\` (4 total).
- \`evaluate_lambda\` gets a "branch_lambda" case: lazy-imports Predicate to break the predicates↔lambdas circular dependency, type-checks the args, enforces the **sub-tiefe ≤ 1 invariant** (no nested branch_lambdas), then dispatches to \`then_fn\` or \`else_fn\` based on the predicate's verdict.
- \`branch_lambda(predicate, then_fn, else_fn)\` builder constructs the conditional Lambda eagerly so the search engine can fingerprint it.

### \`dsl/primitives.py\`
- **\`@primitive("branch")\`** registered with signature \`(Predicate, Lambda, Lambda) → Lambda\` and **cost 3.5** (highest of any higher-order, per spec).
- The primitive enforces sub-tiefe at construction time so search-engine bugs surface as \`TypeMismatchError\` instead of late \`ValueError\`.

## Tests
**+18 unit tests:**
- TestBranchBasics (4) — true → then_fn, false → else_fn, returns Lambda not Object, end-to-end via \`map_objects\` (the spec §7.5 example: "large objects red, small unchanged").
- TestBranchValidation (3) — non-Predicate first arg, non-Lambda branches rejected.
- TestSubDepth (2) — nested branch in \`then\` or \`else\` rejected.
- **TestBranchAlgebra** (3) — always-true predicate ≡ then_fn, always-false ≡ else_fn, **\`branch(not(p), f, g) ≡ branch(p, g, f)\`** per spec §7.5 algebra.
- TestBranchLambdaBuilder (2) — raw builder accepts nested; sub-tiefe enforcement at evaluator-call time.
- TestRegistry (4) — registered, signature matches spec, cost == 3.5, \`LAMBDA_CONSTRUCTORS\` now 4.

The brittle \`len == 3\` assertion in \`test_lambdas.py\` loosened to \`>= 3 + presence check\` to match the same convention elsewhere.

**Total PSE tests: 621 → 639** (+ 12 skipped), all pass in ~2.5s. \`ruff format\` and \`ruff check\` clean.

## Test plan
- [x] \`pytest tests/test_channels/test_program_synthesis/ -q\` — 639 passed, 12 skipped.
- [x] \`ruff format --check\` — clean.
- [x] \`ruff check\` — clean.
- [ ] CI: full backend matrix green.

## Roadmap
**Phase 1.5 higher-order set complete (5/5).** Remaining Phase-1 work:
- **Search-engine adaptation** for the predicate / lambda sub-bank (Week 6 day 6).
- **Week 7**: Cost-Auto-Tuner + benchmark-vs-baseline + telemetry + CLI + docs + Hashline-audit + Release-Cut v0.80.0.
- **Sandbox subprocess** + the 12 skipped K4 cases (parallel work; flips the K4 hard-gate to fully green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)