### PR TITLE
feat(pse): telemetry counters + audit trail — Week 7 day 4-5 (D10 + D11 close)

### DIFF
--- a/src/cognithor/channels/program_synthesis/observability/__init__.py
+++ b/src/cognithor/channels/program_synthesis/observability/__init__.py
@@ -1,2 +1,46 @@
 # Licensed under the Apache License, Version 2.0 (see LICENSE).
-"""PSE observability — scaffold (Week 1). Implementation lands in later weeks."""
+"""PSE observability: telemetry counters, histograms, audit trail.
+
+Phase-1 ships in-process emitters that the channel hot-path can call
+synchronously. External wiring (Prometheus scrape endpoint,
+Hashline-Guard writer) reads the snapshots / chain-hash these modules
+expose.
+"""
+
+from __future__ import annotations
+
+from cognithor.channels.program_synthesis.observability.audit import (
+    AuditEntry,
+    AuditTrail,
+    audit_entry_for,
+)
+from cognithor.channels.program_synthesis.observability.metrics import (
+    CANDIDATES_EXPLORED_BUCKETS,
+    DEFAULT_REGISTRY,
+    DURATION_SECONDS_BUCKETS,
+    PROGRAM_DEPTH_BUCKETS,
+    PROGRAM_SIZE_BUCKETS,
+    Counter,
+    Histogram,
+    HistogramSnapshot,
+    Registry,
+    standard_counters,
+    standard_histograms,
+)
+
+__all__ = [
+    "CANDIDATES_EXPLORED_BUCKETS",
+    "DEFAULT_REGISTRY",
+    "DURATION_SECONDS_BUCKETS",
+    "PROGRAM_DEPTH_BUCKETS",
+    "PROGRAM_SIZE_BUCKETS",
+    "AuditEntry",
+    "AuditTrail",
+    "Counter",
+    "Histogram",
+    "HistogramSnapshot",
+    "Registry",
+    "audit_entry_for",
+    "standard_counters",
+    "standard_histograms",
+]

--- a/src/cognithor/channels/program_synthesis/observability/audit.py
+++ b/src/cognithor/channels/program_synthesis/observability/audit.py
@@ -1,0 +1,169 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""PSE audit trail — Hashline-style append-only entries (spec §13.2).
+
+Every synthesis request lands as one entry::
+
+    {
+      "ts": "2026-04-30T01:13:42.123Z",
+      "actor": "planner@cognithor",
+      "capability": "pse:synthesize",
+      "spec_hash": "sha256:abc...",
+      "budget": {"max_depth": 4, "wall_clock_seconds": 30.0},
+      "result_status": "success",
+      "program_hash": "sha256:def...",
+      "duration_ms": 4321,
+      "candidates_explored": 8742
+    }
+
+The Hashline guarantee (manipulationssicher via SHA-256 chain) is the
+job of the host Hashline subsystem; this module produces the entries
+in the canonical shape and writes them to a sink (memory, file, or the
+external Hashline writer).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _utc_now_iso() -> str:
+    """Spec-canonical timestamp: UTC ISO with millisecond precision + ``Z``."""
+    return datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%S.") + (
+        f"{datetime.now(UTC).microsecond // 1000:03d}Z"
+    )
+
+
+@dataclass(frozen=True)
+class AuditEntry:
+    """One audit record. Frozen so a writer can't mutate after emit."""
+
+    ts: str
+    actor: str
+    capability: str
+    spec_hash: str
+    budget: dict[str, Any]
+    result_status: str
+    program_hash: str | None
+    duration_ms: int
+    candidates_explored: int
+    extra: tuple[tuple[str, Any], ...] = ()
+
+    def to_json(self) -> str:
+        """Canonical JSON serialization for the Hashline body.
+
+        Keys sorted, separators tight, NaN/Inf rejected — gives a
+        deterministic byte-string the chain hash can be computed over.
+        """
+        payload = {
+            "ts": self.ts,
+            "actor": self.actor,
+            "capability": self.capability,
+            "spec_hash": self.spec_hash,
+            "budget": self.budget,
+            "result_status": self.result_status,
+            "program_hash": self.program_hash,
+            "duration_ms": self.duration_ms,
+            "candidates_explored": self.candidates_explored,
+        }
+        if self.extra:
+            payload["extra"] = dict(self.extra)
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"), allow_nan=False)
+
+
+class AuditTrail:
+    """Append-only sink for :class:`AuditEntry`.
+
+    Phase-1 implementation keeps entries in memory (tests + dev mode);
+    production wires a callback to the Hashline writer via
+    ``on_emit``. Each call hashes the JSON body and chains it with
+    the previous entry's hash, mimicking the Hashline-Guard invariant
+    (spec §13.2 calls out the manipulationssichere Hashkette).
+    """
+
+    GENESIS_HASH = "sha256:" + ("0" * 64)
+
+    def __init__(self, on_emit: Callable[[AuditEntry, str], None] | None = None) -> None:
+        self._entries: list[AuditEntry] = []
+        self._chain_hash: str = self.GENESIS_HASH
+        self._on_emit = on_emit
+
+    def emit(self, entry: AuditEntry) -> str:
+        """Record *entry*; return the new chain-hash after this entry."""
+        body = entry.to_json()
+        chained = (self._chain_hash + body).encode("utf-8")
+        new_hash = "sha256:" + hashlib.sha256(chained).hexdigest()
+        self._chain_hash = new_hash
+        self._entries.append(entry)
+        if self._on_emit is not None:
+            self._on_emit(entry, new_hash)
+        return new_hash
+
+    def latest_hash(self) -> str:
+        return self._chain_hash
+
+    def entries(self) -> tuple[AuditEntry, ...]:
+        return tuple(self._entries)
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+    def reset(self) -> None:
+        """Clear entries + reset chain to genesis. Tests only."""
+        self._entries.clear()
+        self._chain_hash = self.GENESIS_HASH
+
+    def verify(self) -> bool:
+        """Re-walk the chain; True iff every entry's hash matches.
+
+        Catches tampering: if an entry's body or order were modified
+        between emit and verify, the chain hashes diverge.
+        """
+        running = self.GENESIS_HASH
+        for entry in self._entries:
+            chained = (running + entry.to_json()).encode("utf-8")
+            running = "sha256:" + hashlib.sha256(chained).hexdigest()
+        return running == self._chain_hash
+
+
+def audit_entry_for(
+    *,
+    actor: str,
+    capability: str,
+    spec_hash: str,
+    budget: dict[str, Any],
+    result_status: str,
+    program_hash: str | None,
+    duration_ms: int,
+    candidates_explored: int,
+    extra: dict[str, Any] | None = None,
+) -> AuditEntry:
+    """Convenience constructor that fills the timestamp + sorted-extras."""
+    return AuditEntry(
+        ts=_utc_now_iso(),
+        actor=actor,
+        capability=capability,
+        spec_hash=spec_hash,
+        budget=dict(budget),
+        result_status=result_status,
+        program_hash=program_hash,
+        duration_ms=duration_ms,
+        candidates_explored=candidates_explored,
+        extra=tuple(sorted(extra.items())) if extra else (),
+    )
+
+
+__all__ = [
+    "AuditEntry",
+    "AuditTrail",
+    "audit_entry_for",
+]
+
+
+_ = field  # keep dataclass.field import valid for future fields

--- a/src/cognithor/channels/program_synthesis/observability/metrics.py
+++ b/src/cognithor/channels/program_synthesis/observability/metrics.py
@@ -1,0 +1,297 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Telemetry counters + histograms (spec §17.1, §17.2).
+
+Phase-1 ships a Prometheus-shaped, in-process metrics registry. Real
+Prometheus / OpenTelemetry export is a thin wrapper over this — it
+reads ``Registry.snapshot()`` and forwards the values. The channel
+emits its metrics through ``DEFAULT_REGISTRY`` so callers can either
+poll programmatically (cheap, deterministic) or hook a metrics-export
+backend later.
+
+Spec inventory of metric names::
+
+    Counters
+        pse_synthesis_requests_total{status, domain}
+        pse_sandbox_violations_total{kind}
+        pse_cache_hits_total
+        pse_cache_misses_total
+        pse_dsl_primitive_uses_total{primitive}
+
+    Histograms (bucketed)
+        pse_synthesis_duration_seconds  buckets=(0.1, 0.5, 1, 5, 10, 30, 60)
+        pse_candidates_explored         buckets=(100, 1k, 10k, 100k, 1M)
+        pse_program_depth               buckets=(1..6)
+        pse_program_size                buckets=(1, 5, 10, 20, 50)
+
+Counters are append-only; histograms are bucket counters + sum.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+
+# ---------------------------------------------------------------------------
+# Counter
+# ---------------------------------------------------------------------------
+
+
+def _label_key(labels: dict[str, str] | None) -> tuple[tuple[str, str], ...]:
+    """Canonical hashable form of a label-set."""
+    if not labels:
+        return ()
+    return tuple(sorted(labels.items()))
+
+
+class Counter:
+    """Append-only counter with optional label dimensions.
+
+    Thread-safe: the channel's enumerator is single-threaded but
+    metric reads come from observers that may live on other threads
+    (Prometheus scrape, dashboard polling).
+    """
+
+    def __init__(self, name: str, description: str = "") -> None:
+        self.name = name
+        self.description = description
+        self._values: dict[tuple[tuple[str, str], ...], float] = {}
+        self._lock = threading.Lock()
+
+    def inc(self, value: float = 1.0, **labels: str) -> None:
+        if value < 0:
+            raise ValueError(f"Counter.inc must be non-negative; got {value}")
+        key = _label_key(labels)
+        with self._lock:
+            self._values[key] = self._values.get(key, 0.0) + value
+
+    def value(self, **labels: str) -> float:
+        key = _label_key(labels)
+        with self._lock:
+            return self._values.get(key, 0.0)
+
+    def snapshot(self) -> dict[tuple[tuple[str, str], ...], float]:
+        with self._lock:
+            return dict(self._values)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._values.clear()
+
+
+# ---------------------------------------------------------------------------
+# Histogram
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HistogramSnapshot:
+    """Immutable view of a Histogram's state."""
+
+    buckets: tuple[float, ...]
+    counts: tuple[int, ...]  # cumulative ≤-bucket counts
+    sum_value: float
+    count: int
+
+
+class Histogram:
+    """Prometheus-style cumulative-bucket histogram.
+
+    ``buckets`` are the upper bounds (exclusive on the upper end of
+    each bucket; the final +Inf bucket is implicit and equals
+    ``count``).
+    """
+
+    def __init__(
+        self,
+        name: str,
+        buckets: tuple[float, ...],
+        description: str = "",
+    ) -> None:
+        if not buckets or list(buckets) != sorted(buckets):
+            raise ValueError("buckets must be a non-empty ascending sequence")
+        self.name = name
+        self.description = description
+        self._buckets = tuple(buckets)
+        self._counts: list[int] = [0] * len(self._buckets)
+        self._sum: float = 0.0
+        self._count: int = 0
+        self._lock = threading.Lock()
+
+    def observe(self, value: float) -> None:
+        with self._lock:
+            self._sum += value
+            self._count += 1
+            for i, upper in enumerate(self._buckets):
+                if value <= upper:
+                    self._counts[i] += 1
+
+    def snapshot(self) -> HistogramSnapshot:
+        with self._lock:
+            return HistogramSnapshot(
+                buckets=self._buckets,
+                counts=tuple(self._counts),
+                sum_value=self._sum,
+                count=self._count,
+            )
+
+    def reset(self) -> None:
+        with self._lock:
+            self._counts = [0] * len(self._buckets)
+            self._sum = 0.0
+            self._count = 0
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _RegistrySnapshot:
+    counters: dict[str, dict[tuple[tuple[str, str], ...], float]] = field(default_factory=dict)
+    histograms: dict[str, HistogramSnapshot] = field(default_factory=dict)
+
+
+class Registry:
+    """Holds named Counter / Histogram instances.
+
+    Each metric is registered exactly once; subsequent ``counter`` /
+    ``histogram`` calls with the same name return the existing instance
+    (idempotent — the channel can wire its emit-points without
+    coordinating who registers first).
+    """
+
+    def __init__(self) -> None:
+        self._counters: dict[str, Counter] = {}
+        self._histograms: dict[str, Histogram] = {}
+        self._lock = threading.Lock()
+
+    def counter(self, name: str, description: str = "") -> Counter:
+        with self._lock:
+            existing = self._counters.get(name)
+            if existing is not None:
+                return existing
+            c = Counter(name, description)
+            self._counters[name] = c
+            return c
+
+    def histogram(
+        self,
+        name: str,
+        buckets: tuple[float, ...],
+        description: str = "",
+    ) -> Histogram:
+        with self._lock:
+            existing = self._histograms.get(name)
+            if existing is not None:
+                if existing._buckets != tuple(buckets):
+                    raise ValueError(
+                        f"Histogram {name!r} already registered with different buckets"
+                    )
+                return existing
+            h = Histogram(name, buckets, description)
+            self._histograms[name] = h
+            return h
+
+    def names(self) -> tuple[str, ...]:
+        with self._lock:
+            return tuple(sorted({*self._counters, *self._histograms}))
+
+    def snapshot(self) -> _RegistrySnapshot:
+        with self._lock:
+            return _RegistrySnapshot(
+                counters={n: c.snapshot() for n, c in self._counters.items()},
+                histograms={n: h.snapshot() for n, h in self._histograms.items()},
+            )
+
+    def reset(self) -> None:
+        with self._lock:
+            for c in self._counters.values():
+                c.reset()
+            for h in self._histograms.values():
+                h.reset()
+
+
+# Default bucket sequences for the spec-listed histograms.
+DURATION_SECONDS_BUCKETS: tuple[float, ...] = (0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0)
+CANDIDATES_EXPLORED_BUCKETS: tuple[float, ...] = (100, 1_000, 10_000, 100_000, 1_000_000)
+PROGRAM_DEPTH_BUCKETS: tuple[float, ...] = (1, 2, 3, 4, 5, 6)
+PROGRAM_SIZE_BUCKETS: tuple[float, ...] = (1, 5, 10, 20, 50)
+
+
+# Default registry. Tests construct their own ``Registry()`` instances
+# rather than mutating this one.
+DEFAULT_REGISTRY = Registry()
+
+
+# ---------------------------------------------------------------------------
+# Pre-registered standard metrics — call from the channel's hot paths.
+# ---------------------------------------------------------------------------
+
+
+def standard_counters(registry: Registry | None = None) -> dict[str, Counter]:
+    """Bind the spec-mandated counters once.
+
+    Returns a dict so the channel can reference them by short key
+    rather than re-resolving the registry on every emit.
+    """
+    r = registry if registry is not None else DEFAULT_REGISTRY
+    return {
+        "synthesis_requests_total": r.counter(
+            "pse_synthesis_requests_total",
+            "Total synthesis requests by status + domain.",
+        ),
+        "sandbox_violations_total": r.counter(
+            "pse_sandbox_violations_total",
+            "Sandbox-policy violations by kind.",
+        ),
+        "cache_hits_total": r.counter("pse_cache_hits_total", "Tactical-memory cache hits."),
+        "cache_misses_total": r.counter("pse_cache_misses_total", "Tactical-memory cache misses."),
+        "dsl_primitive_uses_total": r.counter(
+            "pse_dsl_primitive_uses_total",
+            "Per-primitive use count across all solved programs.",
+        ),
+    }
+
+
+def standard_histograms(registry: Registry | None = None) -> dict[str, Histogram]:
+    r = registry if registry is not None else DEFAULT_REGISTRY
+    return {
+        "synthesis_duration_seconds": r.histogram(
+            "pse_synthesis_duration_seconds",
+            DURATION_SECONDS_BUCKETS,
+            "Wall-clock seconds per synthesis request.",
+        ),
+        "candidates_explored": r.histogram(
+            "pse_candidates_explored",
+            CANDIDATES_EXPLORED_BUCKETS,
+            "Number of enumerated candidates per request.",
+        ),
+        "program_depth": r.histogram(
+            "pse_program_depth", PROGRAM_DEPTH_BUCKETS, "Depth of solved programs."
+        ),
+        "program_size": r.histogram(
+            "pse_program_size", PROGRAM_SIZE_BUCKETS, "Node count of solved programs."
+        ),
+    }
+
+
+__all__ = [
+    "CANDIDATES_EXPLORED_BUCKETS",
+    "DEFAULT_REGISTRY",
+    "DURATION_SECONDS_BUCKETS",
+    "PROGRAM_DEPTH_BUCKETS",
+    "PROGRAM_SIZE_BUCKETS",
+    "Counter",
+    "Histogram",
+    "HistogramSnapshot",
+    "Registry",
+    "standard_counters",
+    "standard_histograms",
+]
+
+
+# Suppress unused-import lint for the Iterable forward-reference (kept
+# for future signature additions).
+_ = Iterable

--- a/tests/test_channels/test_program_synthesis/unit/test_observability.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_observability.py
@@ -1,0 +1,327 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Telemetry + audit-trail tests (spec §13.2 + §17)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cognithor.channels.program_synthesis.observability import (
+    CANDIDATES_EXPLORED_BUCKETS,
+    DURATION_SECONDS_BUCKETS,
+    PROGRAM_DEPTH_BUCKETS,
+    PROGRAM_SIZE_BUCKETS,
+    AuditEntry,
+    AuditTrail,
+    Counter,
+    Histogram,
+    Registry,
+    audit_entry_for,
+    standard_counters,
+    standard_histograms,
+)
+
+# ---------------------------------------------------------------------------
+# Counter
+# ---------------------------------------------------------------------------
+
+
+class TestCounter:
+    def test_starts_at_zero(self) -> None:
+        c = Counter("test")
+        assert c.value() == 0.0
+
+    def test_inc_default_one(self) -> None:
+        c = Counter("test")
+        c.inc()
+        c.inc()
+        assert c.value() == 2.0
+
+    def test_inc_custom_amount(self) -> None:
+        c = Counter("test")
+        c.inc(0.5)
+        c.inc(0.5)
+        assert c.value() == 1.0
+
+    def test_negative_inc_rejected(self) -> None:
+        c = Counter("test")
+        with pytest.raises(ValueError, match="non-negative"):
+            c.inc(-1.0)
+
+    def test_labels_isolate_counts(self) -> None:
+        c = Counter("test")
+        c.inc(status="success")
+        c.inc(status="success")
+        c.inc(status="error")
+        assert c.value(status="success") == 2.0
+        assert c.value(status="error") == 1.0
+
+    def test_snapshot_contains_all_label_combos(self) -> None:
+        c = Counter("test")
+        c.inc(status="success", domain="arc_agi_3")
+        c.inc(status="error", domain="arc_agi_3")
+        snap = c.snapshot()
+        assert len(snap) == 2
+
+    def test_reset_clears(self) -> None:
+        c = Counter("test")
+        c.inc()
+        c.reset()
+        assert c.value() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Histogram
+# ---------------------------------------------------------------------------
+
+
+class TestHistogram:
+    def test_observe_increments_correct_buckets(self) -> None:
+        h = Histogram("test", buckets=(1.0, 5.0, 10.0))
+        h.observe(0.5)  # ≤ 1.0 → buckets [1.0, 5.0, 10.0] all incremented
+        h.observe(2.0)  # ≤ 5.0, not 1.0
+        h.observe(20.0)  # > 10.0 → no bucket incremented (caught in +Inf)
+        snap = h.snapshot()
+        assert snap.counts == (1, 2, 2)
+        assert snap.sum_value == 22.5
+        assert snap.count == 3
+
+    def test_buckets_must_be_ascending(self) -> None:
+        with pytest.raises(ValueError, match="ascending"):
+            Histogram("test", buckets=(5.0, 1.0))
+
+    def test_empty_buckets_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            Histogram("test", buckets=())
+
+    def test_snapshot_immutable(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        h = Histogram("test", buckets=(1.0,))
+        h.observe(0.5)
+        snap = h.snapshot()
+        with pytest.raises(FrozenInstanceError):
+            snap.count = 99  # type: ignore[misc]
+
+    def test_reset_clears_state(self) -> None:
+        h = Histogram("test", buckets=(1.0,))
+        h.observe(0.5)
+        h.reset()
+        snap = h.snapshot()
+        assert snap.count == 0
+        assert snap.sum_value == 0.0
+        assert snap.counts == (0,)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_counter_idempotent(self) -> None:
+        r = Registry()
+        a = r.counter("foo")
+        b = r.counter("foo")
+        # Same instance — multiple registrations don't shadow.
+        assert a is b
+
+    def test_histogram_idempotent(self) -> None:
+        r = Registry()
+        a = r.histogram("foo", buckets=(1.0,))
+        b = r.histogram("foo", buckets=(1.0,))
+        assert a is b
+
+    def test_histogram_bucket_mismatch_rejected(self) -> None:
+        r = Registry()
+        r.histogram("foo", buckets=(1.0,))
+        with pytest.raises(ValueError, match="different buckets"):
+            r.histogram("foo", buckets=(2.0,))
+
+    def test_names_returns_sorted(self) -> None:
+        r = Registry()
+        r.counter("zebra")
+        r.histogram("alpha", buckets=(1.0,))
+        r.counter("middle")
+        assert r.names() == ("alpha", "middle", "zebra")
+
+    def test_snapshot_includes_both_kinds(self) -> None:
+        r = Registry()
+        r.counter("c").inc()
+        r.histogram("h", buckets=(1.0,)).observe(0.5)
+        snap = r.snapshot()
+        assert "c" in snap.counters
+        assert "h" in snap.histograms
+
+    def test_reset_clears_all(self) -> None:
+        r = Registry()
+        c = r.counter("c")
+        h = r.histogram("h", buckets=(1.0,))
+        c.inc()
+        h.observe(0.5)
+        r.reset()
+        assert c.value() == 0.0
+        assert h.snapshot().count == 0
+
+
+class TestStandardMetrics:
+    def test_standard_counters_match_spec(self) -> None:
+        r = Registry()
+        cs = standard_counters(r)
+        assert "synthesis_requests_total" in cs
+        assert "sandbox_violations_total" in cs
+        assert "cache_hits_total" in cs
+        assert "cache_misses_total" in cs
+        assert "dsl_primitive_uses_total" in cs
+
+    def test_standard_histograms_match_spec(self) -> None:
+        r = Registry()
+        hs = standard_histograms(r)
+        assert "synthesis_duration_seconds" in hs
+        assert "candidates_explored" in hs
+        assert "program_depth" in hs
+        assert "program_size" in hs
+
+    def test_bucket_constants_match_spec(self) -> None:
+        # Spec §17.2 bucket definitions.
+        assert DURATION_SECONDS_BUCKETS == (0.1, 0.5, 1.0, 5.0, 10.0, 30.0, 60.0)
+        assert CANDIDATES_EXPLORED_BUCKETS == (100, 1_000, 10_000, 100_000, 1_000_000)
+        assert PROGRAM_DEPTH_BUCKETS == (1, 2, 3, 4, 5, 6)
+        assert PROGRAM_SIZE_BUCKETS == (1, 5, 10, 20, 50)
+
+
+# ---------------------------------------------------------------------------
+# Audit Trail
+# ---------------------------------------------------------------------------
+
+
+class TestAuditEntry:
+    def test_to_json_canonical_keys_sorted(self) -> None:
+        entry = audit_entry_for(
+            actor="planner@cognithor",
+            capability="pse:synthesize",
+            spec_hash="sha256:abc",
+            budget={"max_depth": 4},
+            result_status="success",
+            program_hash="sha256:def",
+            duration_ms=1234,
+            candidates_explored=5678,
+        )
+        body = entry.to_json()
+        # Keys appear in sorted order.
+        decoded = json.loads(body)
+        assert list(decoded.keys()) == sorted(decoded.keys())
+
+    def test_to_json_no_nan(self) -> None:
+        # Spec mandates allow_nan=False — any non-finite slips fail loudly.
+        entry = AuditEntry(
+            ts="2026-04-30T00:00:00.000Z",
+            actor="x",
+            capability="pse:synthesize",
+            spec_hash="sha256:0",
+            budget={"v": float("nan")},
+            result_status="success",
+            program_hash=None,
+            duration_ms=0,
+            candidates_explored=0,
+        )
+        with pytest.raises(ValueError):
+            entry.to_json()
+
+    def test_extra_round_trip(self) -> None:
+        entry = audit_entry_for(
+            actor="x",
+            capability="pse:synthesize",
+            spec_hash="sha256:0",
+            budget={},
+            result_status="success",
+            program_hash=None,
+            duration_ms=0,
+            candidates_explored=0,
+            extra={"source": "fast_path", "version": "1.2.0"},
+        )
+        body = json.loads(entry.to_json())
+        assert body["extra"]["source"] == "fast_path"
+        assert body["extra"]["version"] == "1.2.0"
+
+    def test_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        entry = audit_entry_for(
+            actor="x",
+            capability="pse:synthesize",
+            spec_hash="sha256:0",
+            budget={},
+            result_status="success",
+            program_hash=None,
+            duration_ms=0,
+            candidates_explored=0,
+        )
+        with pytest.raises(FrozenInstanceError):
+            entry.actor = "tampered"  # type: ignore[misc]
+
+
+class TestAuditTrail:
+    def _entry(self, *, status: str = "success") -> AuditEntry:
+        return audit_entry_for(
+            actor="planner@cognithor",
+            capability="pse:synthesize",
+            spec_hash="sha256:abc",
+            budget={"max_depth": 4},
+            result_status=status,
+            program_hash="sha256:def",
+            duration_ms=1234,
+            candidates_explored=5678,
+        )
+
+    def test_initial_genesis_hash(self) -> None:
+        trail = AuditTrail()
+        assert trail.latest_hash() == AuditTrail.GENESIS_HASH
+        assert len(trail) == 0
+
+    def test_emit_advances_hash(self) -> None:
+        trail = AuditTrail()
+        h1 = trail.emit(self._entry())
+        assert h1 != AuditTrail.GENESIS_HASH
+        h2 = trail.emit(self._entry(status="partial"))
+        assert h2 != h1
+
+    def test_chain_verify_passes_clean(self) -> None:
+        trail = AuditTrail()
+        for status in ("success", "partial", "no_solution"):
+            trail.emit(self._entry(status=status))
+        assert trail.verify()
+
+    def test_chain_verify_fails_on_tamper(self) -> None:
+        trail = AuditTrail()
+        trail.emit(self._entry())
+        trail.emit(self._entry(status="error"))
+        # Tamper: replace an entry with a different one in-place via
+        # the internal list. (Real attackers would re-write the
+        # JSON-line file; here we simulate that.)
+        trail._entries[0] = self._entry(status="success_TAMPERED")  # type: ignore[index]
+        assert not trail.verify()
+
+    def test_on_emit_callback_invoked(self) -> None:
+        seen: list[tuple[AuditEntry, str]] = []
+        trail = AuditTrail(on_emit=lambda e, h: seen.append((e, h)))
+        trail.emit(self._entry())
+        trail.emit(self._entry(status="error"))
+        assert len(seen) == 2
+        # Hash returned to caller matches what the callback received.
+        assert seen[1][1] == trail.latest_hash()
+
+    def test_reset_returns_to_genesis(self) -> None:
+        trail = AuditTrail()
+        trail.emit(self._entry())
+        trail.reset()
+        assert trail.latest_hash() == AuditTrail.GENESIS_HASH
+        assert len(trail) == 0
+
+    def test_entries_returns_tuple_view(self) -> None:
+        trail = AuditTrail()
+        trail.emit(self._entry())
+        entries = trail.entries()
+        assert isinstance(entries, tuple)
+        assert len(entries) == 1


### PR DESCRIPTION
## Summary
Lands the observability backbone the channel emits through. Phase-1 is in-process — Prometheus / OpenTelemetry export and the Hashline-Guard writer slot in as thin adapters over the snapshot / chain-hash these modules expose.

### \`observability/metrics.py\`
- **\`Counter\`** — append-only with optional label dimensions; thread-safe (Prometheus scrape may run on another thread).
- **\`Histogram\`** — Prometheus-style cumulative buckets + sum + count.
- **\`Registry\`** — idempotent name → Counter/Histogram; bucket-mismatch on re-registration rejected.
- **\`standard_counters()\` / \`standard_histograms()\`** bind the spec-§17 metrics in one call:
  - \`pse_synthesis_requests_total{status, domain}\`
  - \`pse_sandbox_violations_total{kind}\`
  - \`pse_cache_hits_total\` / \`pse_cache_misses_total\`
  - \`pse_dsl_primitive_uses_total{primitive}\`
  - Histograms: \`pse_synthesis_duration_seconds\`, \`pse_candidates_explored\`, \`pse_program_depth\`, \`pse_program_size\`
- All bucket sequences match spec §17.2 verbatim (locked by test).

### \`observability/audit.py\`
- **\`AuditEntry\`** frozen dataclass — exact spec §13.2 shape.
- \`AuditEntry.to_json()\` — sorted keys, tight separators, \`allow_nan=False\` → deterministic byte-string the chain hash can be computed over.
- **\`AuditTrail\`** — append-only sink with SHA-256 chain hash:
  - \`GENESIS_HASH = "sha256:000…000"\`
  - \`emit()\` hashes \`(prev_hash + body)\` and chains; returns the new hash.
  - **\`verify()\`** re-walks the chain and returns False on tamper.
  - \`on_emit\` callback hook for live wiring to the host Hashline writer.
- \`audit_entry_for(...)\` convenience constructor — fills timestamp + sorts the extras.

## Tests
**+32 unit tests:**
- TestCounter (7) — zero start, default + custom inc, negative rejection, label isolation, multi-label snapshot, reset.
- TestHistogram (5) — bucket increments, ascending validation, empty rejection, frozen snapshot, reset.
- TestRegistry (6) — counter/histogram idempotent, bucket-mismatch rejected, names sorted, snapshot includes both, reset clears all.
- TestStandardMetrics (3) — spec counter + histogram names + bucket constants locked.
- TestAuditEntry (4) — to_json sorted-key canonicalisation, NaN rejected, extra round-trip, frozen.
- **TestAuditTrail (7)** — initial genesis, emit advances hash, verify clean, **verify catches tamper**, on_emit callback fires, reset, entries() tuple view.

**Total PSE tests: 674 → 706** (+ 12 skipped), all pass in ~3.5s. \`ruff format\` and \`ruff check\` clean.

## Test plan
- [x] \`pytest tests/test_channels/test_program_synthesis/ -q\` — 706 passed, 12 skipped.
- [x] \`ruff format --check\` — clean.
- [x] \`ruff check\` — clean.
- [ ] CI: full backend matrix green.

## Roadmap
**Closes spec D10 (audit-trail) + D11 (telemetry counters).** The channel-side wiring (calling \`counter.inc\` / \`trail.emit\` from the hot path) is a small follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)