### PR TITLE
docs(pse): auto-generated DSL reference + overview + architecture (D9)

### DIFF
--- a/docs/channels/program_synthesis/architecture.md
+++ b/docs/channels/program_synthesis/architecture.md
@@ -1,0 +1,103 @@
+# Cognithor PSE — Architecture
+
+## Data flow (happy path)
+
+```
+SynthesisRequest (spec, budget, sgn_hints?)
+          │
+          ▼
+┌──────────────────────────────────────┐
+│ ProgramSynthesisChannel.synthesize() │
+└──────┬───────────────────────────────┘
+       │
+       ▼  apply SGN hints if any
+TaskSpec (annotated)
+       │
+       ▼  hash spec + budget + dsl_version
+Cache lookup ──── hit? ───── return cached result
+       │ miss
+       ▼
+NumPy fast-path ──── solved? ── stamp + cache + return
+       │ no
+       ▼
+EnumerativeSearch.search()
+       │
+       │ depth=0..max_depth:
+       │   for each primitive p of arity > 0:
+       │     for each typed-arg-tuple in bank^arity:
+       │       candidate = Program(p, args)
+       │       if pruner.admit(candidate, output_type): bank.append
+       │       if candidate satisfies all demos: return SUCCESS
+       │
+       ▼
+Verifier (5-stage)         ← syntax → type → demo → property → held-out
+       │
+       ▼
+SynthesisResult (status, program, score, confidence, trace, ...)
+       │
+       ▼
+Cache write (if status cacheable)
+       │
+       ▼  always emits
+Telemetry counters + AuditTrail entry (chain-hash)
+       │
+       ▼
+return SynthesisResult
+```
+
+## Layers
+
+| Layer | What it does | Phase-1 entry |
+|---|---|---|
+| **`core/`** | Frozen data types (`TaskSpec`, `Budget`, `SynthesisResult`), exception hierarchy, version constants. | — |
+| **`dsl/`** | Primitive registry + 56 base primitives + 5 higher-order primitives + closed Predicate / Lambda systems + deterministic Cost-Auto-Tuner. | `REGISTRY`, `auto_tune` |
+| **`search/`** | Bottom-up `EnumerativeSearch`, `ObservationalEquivalencePruner`, `Executor` protocol + `InProcessExecutor`. | `EnumerativeSearch().search(spec, budget)` |
+| **`verify/`** | 5-stage `Verifier` pipeline (syntax → type → demo → property → held-out). | `Verifier().verify(program, spec)` |
+| **`sandbox/`** | Strategy router: Linux native / WSL2 worker / Windows research-mode. Capability allow-list per strategy. | `select_sandbox_strategy()` |
+| **`integration/`** | `ProgramSynthesisChannel` (orchestrator), `PSECache` (Tactical Memory shape), `NumpySolverBridge` (fast-path), `StateGraphBridge` (cost multipliers), capability constants. | `ProgramSynthesisChannel().synthesize(...)` |
+| **`observability/`** | Counters + Histograms + AuditTrail (Hashline-shape SHA-256 chain). | `Registry`, `AuditTrail` |
+| **`trace/`** | K9 trace builder, K10 replay verifier. | `build_trace`, `replay_program` |
+| **`cli/`** | `cognithor pse <subcommand>` argparse front-end. | `python -m cognithor.channels.program_synthesis.cli` |
+
+## Key invariants
+
+* **Pure DSL primitives.** No in-place mutation, no shared state. Each
+  call returns a fresh array / Object. Tested per primitive.
+* **Closed predicate / lambda set.** No free Python lambdas. The
+  search engine constructs predicates and lambdas only from the
+  registered constructors (10 + 3 + 3 + 1 = 17 buildable nodes).
+* **Sub-tiefe ≤ 1 for `branch`.** Phase 1 forbids `branch(branch(...))`
+  to keep the search tractable; enforced both at construction time
+  (the `branch` primitive) and at evaluation time (the `branch_lambda`
+  evaluator).
+* **Deterministic everything.** Same inputs → same outputs. Cache keys
+  are byte-stable across processes (canonical JSON + SHA-256). Sort /
+  filter / fingerprint all break ties by discovery order.
+* **Sandbox is policy boundary.** The Strategy is the same `Executor`
+  the search engine uses, so production-grade isolation slots in
+  without changing call sites. The actual subprocess + AST whitelist
+  + setrlimit machinery is a planned follow-up that swaps `execute()`
+  on the strategy class.
+
+## Capability gates
+
+| Capability | Holder | Notes |
+|---|---|---|
+| `pse:synthesize` | Planner | Allowed on every strategy. |
+| `pse:synthesize:production` | Planner | Linux/WSL2 only — research mode strips this. |
+| `pse:execute` | Executor | Run the synthesized program. |
+| `pse:cache:read` / `pse:cache:write` | Channel | Tactical-memory cache. |
+| `pse:dsl:extend` | Admin | Register a new primitive at runtime. |
+| `pse:dsl:tune` | Admin | Run the deterministic Cost-Auto-Tuner. |
+
+## What's been validated end-to-end
+
+* `output = rotate90(input)` — synthesized at depth 1 in < 100 ms.
+* `output = rotate180(input)` — depth-2 search picks `rotate180`
+  directly (cheaper) over `rotate90 ∘ rotate90` via cost prior.
+* Identity tasks (`output = input`) — short-circuit returns `InputRef`
+  before the search starts.
+* CLI `pse run` solves a 2-demo rotate90 task and emits the trace
+  block (K9 verified).
+* Cache round-trip: second call to the same `(spec, budget)` returns
+  in microseconds with `cache_hit=True`.

--- a/docs/channels/program_synthesis/dsl_reference.md
+++ b/docs/channels/program_synthesis/dsl_reference.md
@@ -1,0 +1,126 @@
+# Cognithor PSE — ARC-DSL Reference
+
+_Auto-generated. PSE version `1.2.0-draft`, DSL version `1.2.0`._
+
+**61 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
+
+Run `cognithor pse dsl describe <name>` for any primitive to see its full record (signature + cost + description + examples).
+
+## Catalog
+
+### Output type: `Grid`
+
+| Name | Signature | Cost | Description |
+|---|---|---|---|
+| `bounding_box` | `(Object) → Grid` | 1.50 | Render the object as a tight grid of size = bbox dimensions. Pixels inside the object get its color, pixels outside get 0. |
+| `crop_bbox` | `(Grid) → Grid` | 1.50 | Crop to the bounding box of all non-background pixels (background = most-common color). Returns a 1×1 grid containing the background color if the grid is uniformly background. |
+| `frame` | `(Grid, Color) → Grid` | 1.80 | Draw a 1-pixel border of *color* around the grid edge, leaving the interior unchanged. Grid must be at least 1×1. |
+| `gravity_down` | `(Grid) → Grid` | 2.00 | Pull all non-background pixels in each column toward the bottom edge. |
+| `gravity_left` | `(Grid) → Grid` | 2.00 | Pull all non-background pixels in each row toward the left edge. |
+| `gravity_right` | `(Grid) → Grid` | 2.00 | Pull all non-background pixels in each row toward the right edge. |
+| `gravity_up` | `(Grid) → Grid` | 2.00 | Pull all non-background pixels in each column toward the top edge. |
+| `identity` | `(Grid) → Grid` | 0.10 | Return the grid unchanged. Cheap building block for branches. |
+| `mask_apply` | `(Grid, Mask, Color) → Grid` | 2.00 | Set every cell of the grid where *mask* is True to *color*. Mask shape must match the grid shape exactly. |
+| `mirror_antidiagonal` | `(Grid) → Grid` | 1.20 | Mirror across the anti-diagonal (top-right to bottom-left). |
+| `mirror_diagonal` | `(Grid) → Grid` | 1.20 | Mirror across the main diagonal. Equivalent to transpose for square grids. |
+| `mirror_horizontal` | `(Grid) → Grid` | 1.00 | Flip the grid left-to-right (mirror across the vertical axis). |
+| `mirror_vertical` | `(Grid) → Grid` | 1.00 | Flip the grid top-to-bottom (mirror across the horizontal axis). |
+| `overlay` | `(Grid, Grid, Color) → Grid` | 2.50 | Overlay *top* onto *base*: cells of *top* equal to *transparent_color* are skipped, all other cells overwrite *base*. Both grids must have the same shape. |
+| `pad_with` | `(Grid, Color, Int) → Grid` | 1.80 | Pad the grid on all four sides with *width* pixels of *color*. Width must be ≥ 0. |
+| `recolor` | `(Grid, Color, Color) → Grid` | 1.50 | Replace every occurrence of color *src* with color *dst*. |
+| `render_objects` | `(ObjectSet, Grid) → Grid` | 2.00 | Paint every object in the set onto a copy of *base*. Cells outside the grid are silently dropped (clip-to-edge). Later objects overwrite earlier ones at overlapping cells. |
+| `replace_background` | `(Grid, Color) → Grid` | 1.50 | Replace the background (most-common color) with the given color. Equivalent to ``recolor(grid, most_common_color(grid), new)``. |
+| `rotate180` | `(Grid) → Grid` | 1.00 | Rotate the grid 180°. |
+| `rotate270` | `(Grid) → Grid` | 1.00 | Rotate the grid 270° clockwise (= 90° counter-clockwise). |
+| `rotate90` | `(Grid) → Grid` | 1.00 | Rotate the grid 90° clockwise. |
+| `scale_down_2x` | `(Grid) → Grid` | 2.00 | Scale the grid down by 2× by sampling the top-left pixel of each 2×2 block. Odd dimensions are truncated. Only valid for grids with shape ≥ 2×2. |
+| `scale_up_2x` | `(Grid) → Grid` | 2.00 | Scale the grid up by 2× (each pixel becomes a 2×2 block). |
+| `scale_up_3x` | `(Grid) → Grid` | 2.00 | Scale the grid up by 3× (each pixel becomes a 3×3 block). |
+| `shift` | `(Grid, Int, Int) → Grid` | 2.00 | Shift the grid by (dy, dx). Pixels that fall off the edge are dropped, exposed cells are filled with the background (most-common color). Range is unrestricted; large shifts collapse the output to all-background. |
+| `stack_horizontal` | `(Grid, Grid) → Grid` | 2.00 | Stack two grids side-by-side (left-to-right). Row counts must match; output cols = left.cols + right.cols. |
+| `stack_vertical` | `(Grid, Grid) → Grid` | 2.00 | Stack two grids top-to-bottom. Column counts must match; output rows = top.rows + bottom.rows. |
+| `swap_colors` | `(Grid, Color, Color) → Grid` | 1.50 | Swap two colors throughout the grid. |
+| `tile_2x` | `(Grid) → Grid` | 2.00 | Tile the grid in a 2×2 pattern (output dimensions = input × 2). |
+| `transpose` | `(Grid) → Grid` | 1.00 | Transpose: swap rows and columns (flip across main diagonal). |
+| `wrap_shift` | `(Grid, Int, Int) → Grid` | 2.20 | Shift the grid by (dy, dx) with toroidal wrap-around (numpy.roll). |
+
+### Output type: `Color`
+
+| Name | Signature | Cost | Description |
+|---|---|---|---|
+| `const_color_0` | `() → Color` | 0.50 | Constant color 0. |
+| `const_color_1` | `() → Color` | 0.50 | Constant color 1. |
+| `const_color_2` | `() → Color` | 0.50 | Constant color 2. |
+| `const_color_3` | `() → Color` | 0.50 | Constant color 3. |
+| `const_color_4` | `() → Color` | 0.50 | Constant color 4. |
+| `const_color_5` | `() → Color` | 0.50 | Constant color 5. |
+| `const_color_6` | `() → Color` | 0.50 | Constant color 6. |
+| `const_color_7` | `() → Color` | 0.50 | Constant color 7. |
+| `const_color_8` | `() → Color` | 0.50 | Constant color 8. |
+| `const_color_9` | `() → Color` | 0.50 | Constant color 9. |
+| `least_common_color` | `(Grid) → Color` | 1.00 | Return the least-frequent color present in the grid. Colors with zero occurrence are ignored; ties broken by lowest index. |
+| `most_common_color` | `(Grid) → Color` | 1.00 | Return the most-frequent color in the grid (ties broken by lowest index). |
+
+### Output type: `Mask`
+
+| Name | Signature | Cost | Description |
+|---|---|---|---|
+| `mask_and` | `(Mask, Mask) → Mask` | 1.50 | Pixel-wise logical AND of two masks of equal shape. |
+| `mask_eq` | `(Grid, Color) → Mask` | 1.50 | Return a boolean mask: True where the grid equals *color*. |
+| `mask_ne` | `(Grid, Color) → Mask` | 1.50 | Return a boolean mask: True where the grid is *not* color. |
+| `mask_not` | `(Mask) → Mask` | 1.20 | Pixel-wise logical NOT (involution: mask_not(mask_not(x)) == x). |
+| `mask_or` | `(Mask, Mask) → Mask` | 1.50 | Pixel-wise logical OR of two masks of equal shape. |
+| `mask_xor` | `(Mask, Mask) → Mask` | 1.50 | Pixel-wise logical XOR of two masks of equal shape. |
+
+### Output type: `Object`
+
+| Name | Signature | Cost | Description |
+|---|---|---|---|
+| `align_to` | `(Object, Object, AlignMode) → Object` | 3.00 | Translate object A so its bounding box aligns with B's per *mode*. CENTER aligns both axes; the four edges align that axis and centre the other; corners align both axes simultaneously. |
+| `largest_object` | `(ObjectSet) → Object` | 1.50 | Object with the largest pixel count in the set. Ties broken by discovery order (first occurrence wins). |
+| `smallest_object` | `(ObjectSet) → Object` | 1.50 | Object with the smallest pixel count in the set. Ties broken by discovery order (first occurrence wins). |
+
+### Output type: `ObjectSet`
+
+| Name | Signature | Cost | Description |
+|---|---|---|---|
+| `connected_components_4` | `(Grid) → ObjectSet` | 2.50 | 4-connectivity flood-fill of all non-background pixels. Background = most-common color (excluded from output). |
+| `connected_components_8` | `(Grid) → ObjectSet` | 2.50 | 8-connectivity flood-fill of all non-background pixels. Diagonal neighbours count; otherwise identical to ``connected_components_4``. |
+| `filter_objects` | `(ObjectSet, Predicate) → ObjectSet` | 2.50 | Keep only objects for which *pred* is True. The predicate's is_largest_in / is_smallest_in receive the original ObjectSet as context so 'largest' refers to the input set, not the filtered output. |
+| `map_objects` | `(ObjectSet, Lambda) → ObjectSet` | 3.00 | Apply *fn* to every object in the set; return the resulting ObjectSet in the same order. Pure, no in-place mutation. |
+| `objects_of_color` | `(Grid, Color) → ObjectSet` | 2.00 | Return the 4-connected components whose color matches the argument. Treats the requested color as foreground regardless of background. |
+| `sort_objects` | `(ObjectSet, SortKey) → ObjectSet` | 2.50 | Stable-sort the set by *key*. Ties break by discovery order so the result is reproducible across runs (cache-stable). |
+
+### Output type: `Lambda`
+
+| Name | Signature | Cost | Description |
+|---|---|---|---|
+| `branch` | `(Predicate, Lambda, Lambda) → Lambda` | 3.50 | Build a conditional Lambda: ``λobj. then_fn(obj) if pred(obj) else else_fn(obj)``. Sub-tiefe ≤ 1 — nested ``branch`` forbidden in Phase 1 (spec §7.5). |
+
+### Output type: `Int`
+
+| Name | Signature | Cost | Description |
+|---|---|---|---|
+| `color_count` | `(Grid) → Int` | 1.00 | Number of distinct colors present in the grid (0..10). |
+| `object_count` | `(ObjectSet) → Int` | 1.00 | Number of objects in the set (≥ 0). |
+
+## Predicate constructors (closed set)
+
+Higher-order primitives like `filter_objects` accept a `Predicate` argument. The constructor names below are the only predicates the search engine may construct (free Python lambdas are forbidden — sandbox guarantee, see spec §6.4).
+
+| Constructor | Arity | Notes |
+|---|---|---|
+| `and` | 2 | combinator |
+| `color_eq` | 1 |  |
+| `color_in` | 1 |  |
+| `is_largest_in` | 1 | needs ObjectSet context |
+| `is_rectangle` | 0 |  |
+| `is_smallest_in` | 1 | needs ObjectSet context |
+| `is_square` | 0 |  |
+| `not` | 1 | combinator |
+| `or` | 2 | combinator |
+| `size_eq` | 1 |  |
+| `size_gt` | 1 |  |
+| `size_lt` | 1 |  |
+| `touches_border` | 0 | needs grid_shape context |
+

--- a/docs/channels/program_synthesis/overview.md
+++ b/docs/channels/program_synthesis/overview.md
@@ -1,0 +1,103 @@
+# Cognithor PSE — Channel Overview
+
+The **Program Synthesis Engine (PSE)** is a Cognithor channel that
+synthesizes deterministic, replay-able **programs** instead of
+free-form LLM answers. Given a task with input/output demo pairs (an
+ARC-AGI-3 task, in Phase 1), the channel searches a typed DSL for a
+program that maps every demo input to its expected output, then ships
+the program plus a step-by-step trace as the response.
+
+## Why programs
+
+Three concrete properties LLM-only ARC solvers can't match:
+
+1. **Deterministic.** The same program against the same input always
+   yields the same output (K10 hard gate; verified by replay tests).
+2. **Replay-able.** A solved program re-executes in P95 ≤ 100 ms on
+   any solver host (K10 hard gate). The cache stores the program
+   source rather than the cached output, so re-execution always works.
+3. **Explainable.** Every solved task ships a human-readable
+   pseudo-code trace with intermediate values (K9 hard gate). The
+   trace is the spec's answer to "why did the model do that?".
+
+## Where it lives
+
+```
+src/cognithor/channels/program_synthesis/
+├── core/         types, exceptions, version constants
+├── dsl/          primitives + Predicate + Lambda + auto-tuner
+├── search/       enumerative bottom-up + observational equivalence
+├── verify/       five-stage pipeline (syntax → type → demo → property → held-out)
+├── sandbox/      strategy router (Linux / WSL2 / Windows-research)
+├── integration/  PGE adapter, cache, capability tokens, SGN bridge,
+│                 numpy fast-path
+├── observability/ counters + histograms + Hashline-style audit trail
+├── trace/        K9/K10 trace builder + replay verifier
+└── cli/          `cognithor pse <subcommand>`
+```
+
+## Phase-1 catalog (current)
+
+* **56 base primitives** — geometric, color, size/scale, spatial,
+  object detection, mask/logic, construction, color constants.
+* **5 higher-order primitives** — `map_objects`, `filter_objects`,
+  `align_to`, `sort_objects`, `branch`.
+* **13 predicate constructors** — `color_eq`, `color_in`, `size_eq`,
+  `size_gt`, `size_lt`, `is_rectangle`, `is_square`, `is_largest_in`,
+  `is_smallest_in`, `touches_border`, plus combinators
+  `not` / `and` / `or`.
+* **4 lambda constructors** — `identity_lambda`, `recolor_lambda`,
+  `shift_lambda`, `branch_lambda`.
+
+Auto-generated complete catalog: [`dsl_reference.md`](./dsl_reference.md).
+
+## Public API
+
+```python
+from cognithor.channels.program_synthesis import (
+    ProgramSynthesisChannel, SynthesisRequest,
+    Budget, TaskSpec, SynthesisResult,
+)
+
+channel = ProgramSynthesisChannel()
+result = channel.synthesize(SynthesisRequest(spec, Budget(max_depth=4)))
+```
+
+The channel is dependency-injection-friendly — every collaborator
+(`PSECache`, `NumpySolverBridge`, `StateGraphBridge`, the sandbox
+strategy, the search engine, a `Registry`, an `AuditTrail`) can be
+swapped for tests.
+
+## CLI
+
+```sh
+cognithor pse dsl list                  # all primitives
+cognithor pse dsl describe rotate90     # one primitive
+cognithor pse dsl reference --output X  # auto-gen this catalog
+cognithor pse sandbox doctor            # platform-detected strategy
+cognithor pse run task.json             # E2E synthesis + trace
+```
+
+## Spec hard-gates
+
+| Gate | Status |
+|---|---|
+| **K9** Trace-Vollständigkeit (every solved task has a trace) | ✅ Phase 1 |
+| **K10** Replay-Reproduzierbarkeit (P95 ≤ 100 ms, byte-identical) | ✅ Phase 1 |
+| **K4** 100 % adversarial-cases blocked | ✅ active layers; 12 subprocess cases scaffolded |
+| **D17** WSL2-Default under Windows | ✅ Strategy router |
+| **D18** Auto-Tuner Pflichtlauf | ✅ Deterministic, no-ML |
+| **D8** CLI works | ✅ Subset shipped |
+| **D10** Hashline audit trail | ✅ Chain-hash verifier |
+| **D11** Telemetry counters | ✅ In-process Registry |
+
+## What's NOT in Phase 1 (Phase 2 / 3 / 4)
+
+* No LLM prior — search is rein symbolisch.
+* No MCTS — bottom-up enumeration only.
+* No Library Learning / DreamCoder.
+* No CEGIS.
+* No additional DSLs (only ARC-DSL).
+
+See `docs/superpowers/specs/2026-04-29-pse-phase1-spec-v1.2.md` for
+the full spec, including the seven Phase-2 open questions.

--- a/src/cognithor/channels/program_synthesis/cli/dsl_reference.py
+++ b/src/cognithor/channels/program_synthesis/cli/dsl_reference.py
@@ -1,0 +1,180 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""DSL reference Markdown generator.
+
+Reads :data:`REGISTRY` and produces a single Markdown document with
+one row per primitive, grouped by output type. The output is
+deterministic so it can be checked in and verified by drift checks
+(``verify_readme_claims.py`` style).
+
+Wired into the CLI as ``pse dsl reference --output <path>``; if no
+output is given, prints to stdout.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from typing import IO
+
+from cognithor.channels.program_synthesis.core.version import (
+    DSL_VERSION,
+    PSE_VERSION,
+)
+from cognithor.channels.program_synthesis.dsl.predicates import (
+    PREDICATE_CONSTRUCTORS,
+)
+from cognithor.channels.program_synthesis.dsl.registry import (
+    REGISTRY,
+    PrimitiveSpec,
+)
+
+# Order primitives appear in the generated reference. Anything not in
+# this list lands in the "Other" group at the bottom.
+GROUP_ORDER: tuple[str, ...] = (
+    "Grid",
+    "Color",
+    "Mask",
+    "Object",
+    "ObjectSet",
+    "Lambda",
+    "Bool",
+    "Int",
+    "AlignMode",
+    "SortKey",
+)
+
+
+def _group_for(spec: PrimitiveSpec) -> str:
+    """Map output_type → display group."""
+    return spec.signature.output
+
+
+def _format_signature(spec: PrimitiveSpec) -> str:
+    if not spec.signature.inputs:
+        return f"() → {spec.signature.output}"
+    return f"({', '.join(spec.signature.inputs)}) → {spec.signature.output}"
+
+
+def _format_primitive_row(spec: PrimitiveSpec) -> str:
+    """One Markdown table row."""
+    desc = (spec.description or "").replace("|", "\\|").replace("\n", " ")
+    return f"| `{spec.name}` | `{_format_signature(spec)}` | {spec.cost:.2f} | {desc} |"
+
+
+def _format_examples(spec: PrimitiveSpec) -> str:
+    if not spec.examples:
+        return ""
+    lines = []
+    for inp, out in spec.examples:
+        lines.append(f"  - `{inp}` → `{out}`")
+    return "\n".join(lines)
+
+
+def render_dsl_reference() -> str:
+    """Build the full Markdown document.
+
+    The output is deterministic across runs — primitives are sorted
+    by (group_index, name); examples render verbatim.
+    """
+    grouped: dict[str, list[PrimitiveSpec]] = defaultdict(list)
+    for spec in REGISTRY.all_primitives():
+        grouped[_group_for(spec)].append(spec)
+    for specs in grouped.values():
+        specs.sort(key=lambda s: s.name)
+
+    out: list[str] = []
+    out.append("# Cognithor PSE — ARC-DSL Reference")
+    out.append("")
+    out.append(f"_Auto-generated. PSE version `{PSE_VERSION}`, DSL version `{DSL_VERSION}`._")
+    out.append("")
+    total = len(REGISTRY)
+    out.append(
+        f"**{total} primitives** registered, plus {len(PREDICATE_CONSTRUCTORS)} "
+        "predicate constructors and the closed Lambda / AlignMode / "
+        "SortKey enums."
+    )
+    out.append("")
+    out.append(
+        "Run `cognithor pse dsl describe <name>` for any primitive to see "
+        "its full record (signature + cost + description + examples)."
+    )
+    out.append("")
+    out.append("## Catalog")
+    out.append("")
+
+    rendered_groups: list[str] = []
+    for group in GROUP_ORDER:
+        specs = grouped.pop(group, [])
+        if not specs:
+            continue
+        rendered_groups.append(group)
+        out.append(f"### Output type: `{group}`")
+        out.append("")
+        out.append("| Name | Signature | Cost | Description |")
+        out.append("|---|---|---|---|")
+        for spec in specs:
+            out.append(_format_primitive_row(spec))
+        out.append("")
+
+    # Anything left over goes under "Other".
+    other = sorted(grouped.items())
+    if other:
+        out.append("### Output type: other")
+        out.append("")
+        out.append("| Name | Signature | Cost | Description |")
+        out.append("|---|---|---|---|")
+        for _, specs in other:
+            for spec in sorted(specs, key=lambda s: s.name):
+                out.append(_format_primitive_row(spec))
+        out.append("")
+
+    # Predicate constructor list — closed set, useful reference.
+    out.append("## Predicate constructors (closed set)")
+    out.append("")
+    out.append(
+        "Higher-order primitives like `filter_objects` accept a "
+        "`Predicate` argument. The constructor names below are the only "
+        "predicates the search engine may construct (free Python "
+        "lambdas are forbidden — sandbox guarantee, see spec §6.4)."
+    )
+    out.append("")
+    out.append("| Constructor | Arity | Notes |")
+    out.append("|---|---|---|")
+    for name, arity in sorted(PREDICATE_CONSTRUCTORS.items()):
+        notes = ""
+        if name in {"not", "and", "or"}:
+            notes = "combinator"
+        elif name in {"is_largest_in", "is_smallest_in"}:
+            notes = "needs ObjectSet context"
+        elif name == "touches_border":
+            notes = "needs grid_shape context"
+        out.append(f"| `{name}` | {arity} | {notes} |")
+    out.append("")
+
+    return "\n".join(out) + "\n"
+
+
+def write_dsl_reference(path: str) -> int:
+    """Write the rendered document to *path*. Returns byte count."""
+    body = render_dsl_reference()
+    with open(path, "w", encoding="utf-8", newline="\n") as f:
+        f.write(body)
+    return len(body.encode("utf-8"))
+
+
+def cmd_dsl_reference(stream: IO[str], output: str | None) -> int:
+    """``pse dsl reference [--output PATH]`` — emit the reference."""
+    body = render_dsl_reference()
+    if output:
+        with open(output, "w", encoding="utf-8", newline="\n") as f:
+            f.write(body)
+        print(f"wrote {len(body)} chars to {output}", file=stream)
+    else:
+        print(body, file=stream)
+    return 0
+
+
+__all__ = [
+    "cmd_dsl_reference",
+    "render_dsl_reference",
+    "write_dsl_reference",
+]

--- a/src/cognithor/channels/program_synthesis/cli/pse_cli.py
+++ b/src/cognithor/channels/program_synthesis/cli/pse_cli.py
@@ -27,6 +27,9 @@ from typing import IO
 
 import numpy as np
 
+from cognithor.channels.program_synthesis.cli.dsl_reference import (
+    cmd_dsl_reference,
+)
 from cognithor.channels.program_synthesis.core.types import (
     Budget,
     SynthesisStatus,
@@ -242,6 +245,15 @@ def _build_parser() -> argparse.ArgumentParser:
     dsl_sub.add_parser("list", help="list every registered primitive")
     dsl_describe = dsl_sub.add_parser("describe", help="show signature + cost + description")
     dsl_describe.add_argument("name", help="primitive name (e.g. rotate90)")
+    dsl_ref = dsl_sub.add_parser(
+        "reference",
+        help="emit the auto-generated DSL reference Markdown",
+    )
+    dsl_ref.add_argument(
+        "--output",
+        default=None,
+        help="path to write reference to (default: stdout)",
+    )
 
     # sandbox
     sandbox = sub.add_parser("sandbox", help="sandbox utilities")
@@ -273,6 +285,8 @@ def main(argv: list[str] | None = None, stream: IO[str] | None = None) -> int:
             return cmd_dsl_list(out)
         if args.dsl_command == "describe":
             return cmd_dsl_describe(args.name, out)
+        if args.dsl_command == "reference":
+            return cmd_dsl_reference(out, args.output)
     if args.command == "sandbox" and args.sandbox_command == "doctor":
         return cmd_sandbox_doctor(out)
     if args.command == "run":

--- a/tests/test_channels/test_program_synthesis/unit/test_dsl_reference.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_dsl_reference.py
@@ -1,0 +1,162 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Auto-generated DSL reference tests (D9 piece)."""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+from cognithor.channels.program_synthesis.cli import main
+from cognithor.channels.program_synthesis.cli.dsl_reference import (
+    render_dsl_reference,
+    write_dsl_reference,
+)
+from cognithor.channels.program_synthesis.core.version import (
+    DSL_VERSION,
+    PSE_VERSION,
+)
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+
+# ---------------------------------------------------------------------------
+# render_dsl_reference
+# ---------------------------------------------------------------------------
+
+
+class TestRenderDslReference:
+    def test_includes_pse_and_dsl_versions(self) -> None:
+        body = render_dsl_reference()
+        assert PSE_VERSION in body
+        assert DSL_VERSION in body
+
+    def test_lists_canonical_primitives(self) -> None:
+        body = render_dsl_reference()
+        # Spot-check every group has at least one expected primitive.
+        for primitive_name in (
+            "rotate90",
+            "recolor",
+            "scale_up_2x",
+            "gravity_down",
+            "connected_components_4",
+            "mask_eq",
+            "stack_horizontal",
+            "const_color_0",
+            "map_objects",
+            "filter_objects",
+            "align_to",
+            "sort_objects",
+            "branch",
+        ):
+            assert f"`{primitive_name}`" in body, f"missing {primitive_name}"
+
+    def test_predicate_constructors_listed(self) -> None:
+        body = render_dsl_reference()
+        for name in (
+            "color_eq",
+            "color_in",
+            "size_gt",
+            "is_rectangle",
+            "is_largest_in",
+            "touches_border",
+            "and",
+            "or",
+            "not",
+        ):
+            assert f"`{name}`" in body
+
+    def test_groups_by_output_type(self) -> None:
+        body = render_dsl_reference()
+        assert "Output type: `Grid`" in body
+        assert "Output type: `Color`" in body
+        assert "Output type: `ObjectSet`" in body
+
+    def test_total_count_present(self) -> None:
+        body = render_dsl_reference()
+        assert f"**{len(REGISTRY)} primitives**" in body
+
+    def test_deterministic_across_calls(self) -> None:
+        # Same registry → same bytes.
+        a = render_dsl_reference()
+        b = render_dsl_reference()
+        assert a == b
+
+    def test_table_columns_present(self) -> None:
+        body = render_dsl_reference()
+        assert "| Name | Signature | Cost | Description |" in body
+
+
+# ---------------------------------------------------------------------------
+# write_dsl_reference (file path)
+# ---------------------------------------------------------------------------
+
+
+class TestWriteDslReference:
+    def test_round_trip_via_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "ref.md"
+        n = write_dsl_reference(str(target))
+        body = target.read_text(encoding="utf-8")
+        assert n == len(body.encode("utf-8"))
+        assert body.startswith("# Cognithor PSE — ARC-DSL Reference")
+
+    def test_lf_line_endings_only(self, tmp_path: Path) -> None:
+        target = tmp_path / "ref.md"
+        write_dsl_reference(str(target))
+        raw = target.read_bytes()
+        # Spec convention for the project: LF-only line endings, even
+        # on Windows. open(..., newline="\n") enforces this.
+        assert b"\r\n" not in raw
+
+
+# ---------------------------------------------------------------------------
+# CLI subcommand wiring
+# ---------------------------------------------------------------------------
+
+
+class TestCliSubcommand:
+    def test_pse_dsl_reference_to_stdout(self) -> None:
+        buf = io.StringIO()
+        rc = main(["dsl", "reference"], stream=buf)
+        assert rc == 0
+        out = buf.getvalue()
+        assert "# Cognithor PSE — ARC-DSL Reference" in out
+        assert "rotate90" in out
+
+    def test_pse_dsl_reference_to_file(self, tmp_path: Path) -> None:
+        target = tmp_path / "from_cli.md"
+        buf = io.StringIO()
+        rc = main(["dsl", "reference", "--output", str(target)], stream=buf)
+        assert rc == 0
+        # Echo confirms the write.
+        assert "wrote" in buf.getvalue()
+        assert str(target) in buf.getvalue()
+        # File contents match the in-memory render.
+        assert target.read_text(encoding="utf-8") == render_dsl_reference()
+
+
+# ---------------------------------------------------------------------------
+# Drift check — committed reference must match what the renderer
+# currently produces. This locks the docs against silent staleness.
+# ---------------------------------------------------------------------------
+
+
+class TestCommittedReferenceUpToDate:
+    def test_dsl_reference_md_matches_renderer(self) -> None:
+        committed_path = (
+            Path(__file__).resolve().parents[4]
+            / "docs"
+            / "channels"
+            / "program_synthesis"
+            / "dsl_reference.md"
+        )
+        if not committed_path.is_file():
+            # If the doc isn't committed yet (first-run scaffold),
+            # skip rather than fail. Once committed in CI the test is
+            # a hard drift gate.
+            import pytest
+
+            pytest.skip(f"dsl_reference.md not committed at {committed_path}")
+        committed = committed_path.read_text(encoding="utf-8")
+        assert committed == render_dsl_reference(), (
+            "docs/channels/program_synthesis/dsl_reference.md is stale — "
+            "regenerate via `cognithor pse dsl reference --output "
+            "docs/channels/program_synthesis/dsl_reference.md`"
+        )


### PR DESCRIPTION
## Summary
Lands the user-facing docs spec §22 D9 mandates. The DSL reference is **auto-generated from the live REGISTRY** so it can never drift — a CI-side drift test fails the moment the committed copy falls out of sync with the renderer.

### \`cli/dsl_reference.py\`
- **\`render_dsl_reference()\`** — deterministic Markdown emitter.
- **\`write_dsl_reference(path)\`** — LF-only UTF-8 writer.
- **\`cmd_dsl_reference(stream, output?)\`** — CLI subcommand handler.

### \`cli/pse_cli.py\` — new subcommand
- \`pse dsl reference [--output PATH]\` (prints to stdout if no \`--output\`).

### \`docs/channels/program_synthesis/\`
- **\`dsl_reference.md\`** — generated, ~9.8 KB. One doc per primitive grouped by output type, plus the closed predicate constructor table.
- **\`overview.md\`** — channel intro, why-programs, layer-diagram, public API, CLI cheatsheet, hard-gate status table, Phase-2/3/4 non-goals.
- **\`architecture.md\`** — happy-path data flow ASCII, layer responsibilities, key invariants, capability gates, end-to-end validations.

## Tests
**+12 unit tests:**
- TestRenderDslReference (7) — versions present, canonical primitives listed, predicate constructors listed, output-type groups, total count, deterministic across calls, table columns.
- TestWriteDslReference (2) — file round-trip byte count match, LF-only line endings on Windows.
- TestCliSubcommand (2) — \`pse dsl reference\` to stdout / \`--output\` writes file matching the in-memory render.
- **TestCommittedReferenceUpToDate (1)** — DRIFT GATE: the committed \`dsl_reference.md\` must equal the current renderer output; fails with a regen instruction if the catalog grew without a doc bump.

**Total PSE tests: 721 → 733** (+ 12 skipped), all pass in ~3.5s. \`ruff format\` and \`ruff check\` clean.

## Test plan
- [x] \`pytest tests/test_channels/test_program_synthesis/ -q\` — 733 passed, 12 skipped.
- [x] \`ruff format --check\` — clean.
- [x] \`ruff check\` — clean.
- [ ] CI: full backend matrix green.

## Roadmap
**Closes spec D9** (overview / dsl_reference / architecture). Benchmarks doc + tutorial (D9 remainder + D12 Hello-World) follow when the benchmark machinery lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)