### PR TITLE
feat(pse): seed Predicate/Lambda bank for HO-primitive enumeration

### DIFF
--- a/src/cognithor/channels/program_synthesis/search/candidate.py
+++ b/src/cognithor/channels/program_synthesis/search/candidate.py
@@ -42,18 +42,29 @@ class InputRef:
 
 @dataclass(frozen=True)
 class Const:
-    """A literal value (color index, integer parameter, enum tag, ...)."""
+    """A literal value (color index, integer parameter, enum tag, Predicate, Lambda, ...).
 
-    value: int | str
+    Predicate and Lambda values are accepted so the enumerator can seed
+    higher-order primitive arguments as bank leaves. The executor returns
+    these values verbatim — primitives like ``filter_objects`` /
+    ``map_objects`` consume them as their second argument.
+    """
+
+    value: object
     output_type: str
 
     def to_source(self) -> str:
-        # Ints render as their decimal value, strings keep their quotes
-        # so the source round-trips through eval() (used only by the
+        # Ints render as their decimal value. Predicate / Lambda values
+        # carry their own ``to_source`` and we delegate so the program
+        # source stays round-trippable. Strings keep their quotes so the
+        # source round-trips through eval() (used only by the
         # `cognithor pse explain` formatter, never by the search engine).
-        if isinstance(self.value, int) and not isinstance(self.value, bool):
-            return str(self.value)
-        return repr(self.value)
+        v = self.value
+        if isinstance(v, int) and not isinstance(v, bool):
+            return str(v)
+        if hasattr(v, "to_source") and callable(v.to_source):
+            return v.to_source()
+        return repr(v)
 
     def depth(self) -> int:
         return 0

--- a/src/cognithor/channels/program_synthesis/search/enumerative.py
+++ b/src/cognithor/channels/program_synthesis/search/enumerative.py
@@ -153,6 +153,82 @@ def _seed_color_bank(
         bank.setdefault("Color", []).append(Const(value=c, output_type="Color"))
 
 
+def _predicate_seeds() -> list[object]:
+    """Curated, finite list of leaf Predicate values for the bank.
+
+    The closed-set predicate constructor catalog is enumeration-safe by
+    design (spec §6.4) — but the search engine still needs a *bounded*
+    seed list, otherwise size_eq/size_gt/size_lt with arbitrary integers
+    would blow the bank up. The list below is the canonical Phase-1.5
+    seed:
+
+    * ``color_eq(c)`` for every ARC color (10).
+    * ``size_eq/gt/lt(n)`` for n ∈ {1, 2, 3, 4, 5} — covers every demo
+      grid up to 5×5 plus the typical "single-cell vs multi-cell"
+      distinction (15).
+    * ``is_rectangle()``, ``is_square()``, ``touches_border()`` (3).
+
+    Total: 28 Predicate leaves. Combinator constructors (``not``,
+    ``and``, ``or``) are intentionally excluded from Phase 1 — they
+    would be reachable via depth-(d+1) Program nodes with a Predicate
+    output type, which the engine doesn't yet enumerate.
+    """
+    from cognithor.channels.program_synthesis.dsl.predicates import (
+        Predicate,
+    )
+
+    seeds: list[object] = []
+    for color in range(10):
+        seeds.append(Predicate(constructor="color_eq", args=(color,)))
+    for n in (1, 2, 3, 4, 5):
+        seeds.append(Predicate(constructor="size_eq", args=(n,)))
+        seeds.append(Predicate(constructor="size_gt", args=(n,)))
+        seeds.append(Predicate(constructor="size_lt", args=(n,)))
+    seeds.append(Predicate(constructor="is_rectangle"))
+    seeds.append(Predicate(constructor="is_square"))
+    seeds.append(Predicate(constructor="touches_border"))
+    return seeds
+
+
+def _lambda_seeds() -> list[object]:
+    """Curated, finite list of leaf Lambda values for the bank.
+
+    * ``identity_lambda()`` (1).
+    * ``recolor_lambda(c)`` for every ARC color (10).
+    * ``shift_lambda(dy, dx)`` for the four cardinal unit shifts (4).
+
+    Total: 15 Lambda leaves. ``branch_lambda`` is intentionally excluded
+    — it requires a Predicate plus two Lambdas, so it would balloon the
+    seed list combinatorially. Phase-2 search may construct branch
+    Lambdas via the depth-(d+1) recursion the engine grows in spec §15
+    (Phase-2: cost-aware Lambda enumeration).
+    """
+    from cognithor.channels.program_synthesis.dsl.lambdas import Lambda
+
+    seeds: list[object] = [Lambda(constructor="identity_lambda")]
+    for color in range(10):
+        seeds.append(Lambda(constructor="recolor_lambda", args=(color,)))
+    for dy, dx in ((-1, 0), (1, 0), (0, -1), (0, 1)):
+        seeds.append(Lambda(constructor="shift_lambda", args=(dy, dx)))
+    return seeds
+
+
+def _seed_higher_order_bank(bank: dict[str, list[ProgramNode]]) -> None:
+    """Populate the bank with Predicate and Lambda leaves.
+
+    These are the closed-set seed values that make higher-order
+    primitives (``filter_objects``, ``map_objects``, ``branch``)
+    actually reachable in enumeration. Each seed is a depth-0 ``Const``
+    leaf carrying the Predicate/Lambda value verbatim — the executor
+    returns them as-is, so the host primitive receives a real
+    Predicate/Lambda dataclass to evaluate.
+    """
+    for pred in _predicate_seeds():
+        bank.setdefault("Predicate", []).append(Const(value=pred, output_type="Predicate"))
+    for fn in _lambda_seeds():
+        bank.setdefault("Lambda", []).append(Const(value=fn, output_type="Lambda"))
+
+
 def _budget_exhausted(budget: Budget, stats: _SearchStats) -> bool:
     return (
         stats.candidates_examined >= budget.max_candidates
@@ -228,6 +304,7 @@ class EnumerativeSearch:
         bank: dict[str, list[ProgramNode]] = _zero_arity_leaves(self._registry)
         bank.setdefault("Grid", []).append(InputRef())
         _seed_color_bank(bank)
+        _seed_higher_order_bank(bank)
 
         # Trivial-task fast path: input == output.
         if _all_demos_correct(InputRef(), spec, self._executor):

--- a/tests/test_channels/test_program_synthesis/unit/test_search_higher_order.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_search_higher_order.py
@@ -1,0 +1,180 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Higher-order primitive reachability tests.
+
+The base enumerative search only enumerates over base primitives — it
+never builds Predicate/Lambda *values* on its own. Spec §6.4 mandates a
+closed, enumerable set of constructors, but they live in their own
+registries and the bank therefore needs to be seeded with the canonical
+leaf values before HO primitives like ``filter_objects``,
+``map_objects`` can match their argument types.
+
+This module pins three properties of that seed:
+
+1. The seed lists are bounded and contain the canonical Phase-1.5
+   constructors (``color_eq``, ``size_*``, ``identity/recolor/shift_lambda``).
+2. ``Const`` values now carry Predicate / Lambda dataclasses verbatim
+   and ``to_source`` round-trips them through their constructor source.
+3. With those leaves seeded, ``EnumerativeSearch`` produces a depth-2
+   candidate that combines an ObjectSet-producer with a Predicate seed
+   — i.e. ``filter_objects(connected_components_4(input), <Predicate>)``
+   is enumerable and executable.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.dsl.lambdas import Lambda
+from cognithor.channels.program_synthesis.dsl.predicates import Predicate
+from cognithor.channels.program_synthesis.dsl.types_grid import Object, ObjectSet
+from cognithor.channels.program_synthesis.search.candidate import Const, InputRef, Program
+from cognithor.channels.program_synthesis.search.enumerative import (
+    _lambda_seeds,
+    _predicate_seeds,
+    _seed_higher_order_bank,
+)
+from cognithor.channels.program_synthesis.search.executor import InProcessExecutor
+
+# ---------------------------------------------------------------------------
+# 1. Seed lists
+# ---------------------------------------------------------------------------
+
+
+class TestSeedLists:
+    def test_predicate_seeds_count_matches_canonical_set(self) -> None:
+        seeds = _predicate_seeds()
+        # 10 colors + 5*3 size constructors + 3 zero-arg constructors.
+        assert len(seeds) == 10 + 15 + 3
+
+    def test_predicate_seeds_include_color_eq_and_size_predicates(self) -> None:
+        names = {(s.constructor, s.args) for s in _predicate_seeds()}
+        assert ("color_eq", (0,)) in names
+        assert ("color_eq", (9,)) in names
+        assert ("size_gt", (3,)) in names
+        assert ("is_rectangle", ()) in names
+
+    def test_predicate_seeds_are_all_predicate_dataclasses(self) -> None:
+        for s in _predicate_seeds():
+            assert isinstance(s, Predicate)
+
+    def test_lambda_seeds_count_matches_canonical_set(self) -> None:
+        seeds = _lambda_seeds()
+        # 1 identity + 10 recolor + 4 cardinal shifts.
+        assert len(seeds) == 1 + 10 + 4
+
+    def test_lambda_seeds_include_identity_and_recolor(self) -> None:
+        names = {(s.constructor, s.args) for s in _lambda_seeds()}
+        assert ("identity_lambda", ()) in names
+        assert ("recolor_lambda", (0,)) in names
+        assert ("recolor_lambda", (9,)) in names
+        assert ("shift_lambda", (1, 0)) in names
+
+    def test_lambda_seeds_are_all_lambda_dataclasses(self) -> None:
+        for s in _lambda_seeds():
+            assert isinstance(s, Lambda)
+
+
+# ---------------------------------------------------------------------------
+# 2. Const carries Predicate / Lambda values
+# ---------------------------------------------------------------------------
+
+
+class TestConstCarriesHigherOrderValues:
+    def test_const_predicate_to_source_delegates_to_predicate(self) -> None:
+        leaf = Const(value=Predicate(constructor="color_eq", args=(3,)), output_type="Predicate")
+        assert leaf.to_source() == "color_eq(3)"
+        assert leaf.depth() == 0
+
+    def test_const_lambda_to_source_delegates_to_lambda(self) -> None:
+        leaf = Const(
+            value=Lambda(constructor="recolor_lambda", args=(7,)),
+            output_type="Lambda",
+        )
+        assert leaf.to_source() == "recolor_lambda(7)"
+        assert leaf.depth() == 0
+
+    def test_executor_returns_predicate_value_verbatim(self) -> None:
+        pred = Predicate(constructor="color_eq", args=(2,))
+        leaf = Const(value=pred, output_type="Predicate")
+        result = InProcessExecutor().execute(leaf, np.array([[0]], dtype=np.int8))
+        assert result.ok
+        assert result.value is pred
+
+    def test_executor_returns_lambda_value_verbatim(self) -> None:
+        fn = Lambda(constructor="identity_lambda")
+        leaf = Const(value=fn, output_type="Lambda")
+        result = InProcessExecutor().execute(leaf, np.array([[0]], dtype=np.int8))
+        assert result.ok
+        assert result.value is fn
+
+
+# ---------------------------------------------------------------------------
+# 3. Higher-order seeds populate the bank
+# ---------------------------------------------------------------------------
+
+
+class TestSeedHigherOrderBank:
+    def test_bank_has_predicate_and_lambda_buckets(self) -> None:
+        bank: dict[str, list] = {}
+        _seed_higher_order_bank(bank)
+        assert "Predicate" in bank
+        assert "Lambda" in bank
+        assert len(bank["Predicate"]) == 28
+        assert len(bank["Lambda"]) == 15
+
+    def test_bank_predicate_entries_are_const_leaves(self) -> None:
+        bank: dict[str, list] = {}
+        _seed_higher_order_bank(bank)
+        for leaf in bank["Predicate"]:
+            assert isinstance(leaf, Const)
+            assert leaf.output_type == "Predicate"
+            assert isinstance(leaf.value, Predicate)
+
+
+# ---------------------------------------------------------------------------
+# 4. End-to-end: filter_objects is now executable through the engine
+# ---------------------------------------------------------------------------
+
+
+class TestFilterObjectsThroughExecutor:
+    """Manually constructs the depth-2 program the engine can now build.
+
+    The point is to prove the `Const(Predicate, ...)` mechanism plumbs
+    through to the host primitive correctly — once that works, the
+    enumerator's existing arg-matching loop reaches it for free.
+    """
+
+    def test_filter_objects_keeps_only_matching_color(self) -> None:
+        # Two objects, one color-1 and one color-2.
+        program = Program(
+            primitive="filter_objects",
+            children=(
+                Program(
+                    primitive="connected_components_4",
+                    children=(InputRef(),),
+                    output_type="ObjectSet",
+                ),
+                Const(
+                    value=Predicate(constructor="color_eq", args=(1,)),
+                    output_type="Predicate",
+                ),
+            ),
+            output_type="ObjectSet",
+        )
+        grid = np.array(
+            [
+                [1, 0, 2],
+                [1, 0, 2],
+            ],
+            dtype=np.int8,
+        )
+        result = InProcessExecutor().execute(program, grid)
+        assert result.ok, result.error
+        out = result.value
+        assert isinstance(out, ObjectSet)
+        # Only the color-1 connected component survives the filter.
+        assert len(out) == 1
+        only = next(iter(out.objects))
+        assert isinstance(only, Object)
+        assert only.color == 1
+        assert only.size == 2  # the two color-1 cells


### PR DESCRIPTION
## Summary
- Higher-order primitives (`filter_objects`, `map_objects`, `branch`) declare `Predicate` / `Lambda` argument types. The enumerator only built bank entries for base-primitive output types, so those argument slots never resolved and HO solutions were unreachable in Phase 1 search.
- Phase 1.5 spec §6.4 mandates a closed, enumerable Predicate/Lambda constructor set — this PR adds the canonical depth-0 seed:
  - **28 Predicate seeds** — 10 `color_eq` + 5×3 `size_{eq,gt,lt}` + 3 zero-arg (`is_rectangle`, `is_square`, `touches_border`).
  - **15 Lambda seeds** — `identity_lambda` + 10 `recolor_lambda` + 4 cardinal `shift_lambda`.
- `Const.value` widened to carry Predicate / Lambda dataclasses verbatim; `to_source` delegates to the value's own renderer so program sources round-trip.
- Combinator constructors (`not` / `and` / `or` for predicates, `branch_lambda`) are intentionally excluded — they need recursive Predicate/Lambda enumeration, which is a Phase-2 piece.

## Test plan
- [x] +13 unit tests in `test_search_higher_order.py`: seed-list count, dataclass typing, Const round-trip (`color_eq(3)`, `recolor_lambda(7)`), executor plumbing, and a manually-constructed `filter_objects(connected_components_4(input), color_eq(1))` program.
- [x] Full PSE suite: 746 passed, 12 skipped (was 733 + 12 → +13 new).
- [x] `ruff check` clean, `ruff format --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)