### PR TITLE
docs(pse): benchmarks.md scaffold + drift gate (D9)

### DIFF
--- a/docs/channels/program_synthesis/benchmarks.md
+++ b/docs/channels/program_synthesis/benchmarks.md
@@ -1,0 +1,121 @@
+# Cognithor PSE — Benchmarks
+
+This page is the spec **D5** / **K1** scaffold. It documents *how*
+Phase-1 PSE is benchmarked against the legacy NumPy-solver baseline
+and is the file the eval-suite writes its numbers into.
+
+The actual ARC-AGI-3 numbers (Solved@30s, Solved@5s, Median-Time, FP-Rate)
+are produced by the eval-suite harness in
+`tests/test_channels/test_program_synthesis/eval/test_arc_agi3_subset.py`
+(spec §17.2) and committed into the *Latest run* table below. The
+harness is marked `slow` and runs nightly, not on every CI push.
+
+## Methodology (spec §18)
+
+### Data
+
+| Subset | Tasks | Use |
+|---|---|---|
+| `train` | 100 | Diversity-balanced — Geom 30 %, Color 30 %, Object 25 %, Mixed 15 %. Used during development. |
+| `held_out` | 30 | Never seen during development. Final validation only. |
+
+Task selection is recorded in `cognithor_bench/arc_agi3/manifest.json`
+once the harness lands.
+
+### Baseline
+
+The current NumPy-solver (v0.78 "660× Speedup"-Solver) on identical
+hardware, frozen as `baseline_v0.78.json` before any PSE search runs
+on the train subset.
+
+### Metrics
+
+| Metric | Definition |
+|---|---|
+| **Solved@30s** | tasks solved within `wall_clock = 30 s` per task |
+| **Solved@5s** | tasks solved within `wall_clock = 5 s` per task |
+| **Median-Time-Solved** | median wall-clock over all *solved* tasks |
+| **FP-Rate** | programs that pass *every* demo pair but fail the held-out check |
+
+### Success threshold (K1)
+
+```
+Solved@30s_PSE  ≥  Solved@30s_baseline + 5
+Solved@5s_PSE   ≥  Solved@5s_baseline           # no regression on easy tasks
+```
+
+### Reproducibility
+
+* Fixed random seed (tie-break only — Phase-1 search is fully
+  deterministic).
+* DSL version recorded in every output row (currently `1.2.0`,
+  pinned in `core/version.py`).
+* Hardware fingerprint (CPU brand, core count, OS, Python) captured
+  alongside the numbers.
+* `make benchmark` is the single reproducible entry point — it boots
+  the eval harness, runs both baseline and PSE, and updates the
+  *Latest run* table below.
+
+## Static catalog metrics
+
+These numbers are derived from the live registry, not measured at
+runtime — they document Phase-1's search-space surface and serve as
+pre-conditions for the success threshold above.
+
+| Metric | Value |
+|---|---|
+| Base primitives | **61** (56 base + 5 Phase-1.5 higher-order) |
+| Predicate constructors | **13** (10 leaf + 3 combinators) |
+| Lambda constructors | **4** (`identity`, `recolor`, `shift`, `branch`) |
+| Higher-order primitives | **3** (`filter_objects`, `map_objects`, `branch`) |
+| Default budget | `max_depth=4`, `wall_clock=30 s`, `max_candidates=50 000` |
+| Cost-Tuner final pass | **D18 ✅** — see `dsl/auto_tuner.py` |
+
+The auto-generated complete catalog with per-primitive cost is in
+[`dsl_reference.md`](./dsl_reference.md).
+
+## Latest run
+
+> **Status: not yet measured.** The eval harness lands as part of D5.
+> Until it does, this section is a placeholder so D9 ("benchmarks.md
+> vorhanden") is satisfied while D5 fills in the numbers.
+
+| Metric | Baseline (v0.78 NumPy solver) | PSE Phase 1 | Δ |
+|---|---|---|---|
+| Solved@30s (train, n=100) | _pending_ | _pending_ | — |
+| Solved@5s (train, n=100) | _pending_ | _pending_ | — |
+| Median-Time-Solved | _pending_ | _pending_ | — |
+| Solved@30s (held-out, n=30) | _pending_ | _pending_ | — |
+| FP-Rate (held-out) | n/a | _pending_ | — |
+| K1 success threshold met? | — | _pending_ | — |
+
+Hardware fingerprint, DSL version, and per-task breakdown will be
+written under `cognithor_bench/arc_agi3/runs/<timestamp>/` and
+summarised here when the harness lands.
+
+## Microbenchmarks
+
+In addition to the ARC-AGI-3 benchmark above, the test suite carries
+microbenchmarks for the inner loops:
+
+* `tests/test_channels/test_program_synthesis/perf/test_search_microbench.py`
+  — depth-1 / depth-2 enumeration over a synthetic 10×10 grid.
+* `tests/test_channels/test_program_synthesis/perf/test_replay_p95.py`
+  — K10 replay budget gate: P95 ≤ 100 ms across the synthesised
+  programs in the unit-test corpus.
+
+These run on every CI push and protect against perf regressions
+between releases. Microbench numbers are intentionally *not*
+benchmarked against an external baseline — their job is "no
+regression", not "beat NumPy".
+
+## See also
+
+* [`overview.md`](./overview.md) — channel intro + spec hard-gate
+  status.
+* [`architecture.md`](./architecture.md) — data-flow diagram.
+* [`tutorial.md`](./tutorial.md) — Hello-World walk-through.
+* [`dsl_reference.md`](./dsl_reference.md) — auto-generated primitive
+  catalog.
+* `docs/superpowers/specs/2026-04-29-pse-phase1-spec-v1.2.md` §18 —
+  full benchmark plan.

--- a/docs/channels/program_synthesis/overview.md
+++ b/docs/channels/program_synthesis/overview.md
@@ -50,6 +50,8 @@ src/cognithor/channels/program_synthesis/
   `shift_lambda`, `branch_lambda`.
 
 Auto-generated complete catalog: [`dsl_reference.md`](./dsl_reference.md).
+Benchmark methodology + latest run: [`benchmarks.md`](./benchmarks.md).
+Hello-World walkthrough: [`tutorial.md`](./tutorial.md).
 
 ## Public API
 

--- a/tests/test_channels/test_program_synthesis/unit/test_benchmarks_doc.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_benchmarks_doc.py
@@ -1,0 +1,64 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Drift-gate for ``docs/channels/program_synthesis/benchmarks.md``.
+
+Phase-1 spec §22 D9 requires a ``benchmarks.md`` to be *present* in the
+docs tree (peer-reviewed, even if the numbers themselves are filled in
+by the spec D5 eval harness later). This test pins three properties:
+
+1. The file exists.
+2. It documents the spec §18 metrics and the K1 success threshold.
+3. The static catalog-metrics line up with the live registry — if a
+   primitive lands or a constructor is added/removed, the numbers in
+   the doc must be updated alongside the code.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cognithor.channels.program_synthesis.dsl.lambdas import LAMBDA_CONSTRUCTORS
+from cognithor.channels.program_synthesis.dsl.predicates import (
+    PREDICATE_CONSTRUCTORS,
+)
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+
+BENCH_DOC = (
+    Path(__file__).resolve().parents[4]
+    / "docs"
+    / "channels"
+    / "program_synthesis"
+    / "benchmarks.md"
+)
+
+
+class TestBenchmarksDoc:
+    def test_doc_exists(self) -> None:
+        assert BENCH_DOC.is_file(), (
+            "docs/channels/program_synthesis/benchmarks.md is missing — "
+            "spec D9 requires it as part of Phase-1 docs."
+        )
+
+    def test_doc_quotes_k1_success_threshold(self) -> None:
+        body = BENCH_DOC.read_text(encoding="utf-8")
+        assert "Solved@30s" in body
+        assert "Solved@5s" in body
+        assert "FP-Rate" in body
+        assert "Median-Time-Solved" in body
+        assert "baseline_v0.78" in body or "v0.78" in body
+
+    def test_doc_quotes_static_catalog_metrics(self) -> None:
+        body = BENCH_DOC.read_text(encoding="utf-8")
+        # Live counts have to appear in the doc — if a primitive lands
+        # this test fails so the doc is updated alongside the catalog.
+        assert f"**{len(REGISTRY)}**" in body, (
+            f"benchmarks.md base-primitive count is stale; live registry has "
+            f"{len(REGISTRY)} primitives but the doc does not quote it."
+        )
+        assert f"**{len(PREDICATE_CONSTRUCTORS)}**" in body, (
+            f"benchmarks.md predicate-constructor count is stale; live count "
+            f"is {len(PREDICATE_CONSTRUCTORS)}."
+        )
+        assert f"**{len(LAMBDA_CONSTRUCTORS)}**" in body, (
+            f"benchmarks.md lambda-constructor count is stale; live count "
+            f"is {len(LAMBDA_CONSTRUCTORS)}."
+        )


### PR DESCRIPTION
## Summary
- Adds `docs/channels/program_synthesis/benchmarks.md` — the spec §18 benchmark plan, methodology, K1 success threshold, and a placeholder *Latest run* table the D5 eval harness will fill in.
- Drift-pins the static catalog-metrics section so the doc fails CI if the live registry, predicate constructors, or lambda constructors drift away from the documented counts.
- Cross-links benchmarks.md and tutorial.md from overview.md so the four Phase-1 docs (overview / architecture / dsl_reference / tutorial / benchmarks) form a navigable set.
- Closes the *file-existence* part of **D9** (numbers themselves come with D5).

## Test plan
- [x] `pytest tests/test_channels/test_program_synthesis/unit/test_benchmarks_doc.py` — 3 passed.
- [x] `ruff check`, `ruff format --check` clean.
- [x] Verified the catalog counts (61 / 13 / 4 / 3) against the live registry before writing them into the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)