### PR TITLE
docs(pse): record D3/D9/D12 + fix HO-count drift

### DIFF
--- a/docs/channels/program_synthesis/benchmarks.md
+++ b/docs/channels/program_synthesis/benchmarks.md
@@ -67,7 +67,7 @@ pre-conditions for the success threshold above.
 | Base primitives | **61** (56 base + 5 Phase-1.5 higher-order) |
 | Predicate constructors | **13** (10 leaf + 3 combinators) |
 | Lambda constructors | **4** (`identity`, `recolor`, `shift`, `branch`) |
-| Higher-order primitives | **3** (`filter_objects`, `map_objects`, `branch`) |
+| Higher-order primitives | **5** (`map_objects`, `filter_objects`, `align_to`, `sort_objects`, `branch`) |
 | Default budget | `max_depth=4`, `wall_clock=30 s`, `max_candidates=50 000` |
 | Cost-Tuner final pass | **D18 ✅** — see `dsl/auto_tuner.py` |
 

--- a/docs/channels/program_synthesis/overview.md
+++ b/docs/channels/program_synthesis/overview.md
@@ -89,9 +89,12 @@ cognithor pse run task.json             # E2E synthesis + trace
 | **K4** 100 % adversarial-cases blocked | ✅ active layers; 12 subprocess cases scaffolded |
 | **D17** WSL2-Default under Windows | ✅ Strategy router |
 | **D18** Auto-Tuner Pflichtlauf | ✅ Deterministic, no-ML |
+| **D3** Test coverage ≥ 90 % on new code | ✅ 95 % on `channels/program_synthesis/` |
 | **D8** CLI works | ✅ Subset shipped |
+| **D9** Docs (overview + architecture + dsl_reference + tutorial + benchmarks) | ✅ All five present |
 | **D10** Hashline audit trail | ✅ Chain-hash verifier |
 | **D11** Telemetry counters | ✅ In-process Registry |
+| **D12** Hello-World task documented with full trace | ✅ `tutorial.md` + drift gate |
 
 ## What's NOT in Phase 1 (Phase 2 / 3 / 4)
 

--- a/tests/test_channels/test_program_synthesis/unit/test_benchmarks_doc.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_benchmarks_doc.py
@@ -71,6 +71,5 @@ class TestBenchmarksDoc:
             if any(t in ho_arg_types for t in s.signature.inputs)
         )
         assert f"**{ho_count}**" in body, (
-            f"benchmarks.md higher-order-primitive count is stale; live count "
-            f"is {ho_count}."
+            f"benchmarks.md higher-order-primitive count is stale; live count is {ho_count}."
         )

--- a/tests/test_channels/test_program_synthesis/unit/test_benchmarks_doc.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_benchmarks_doc.py
@@ -62,3 +62,15 @@ class TestBenchmarksDoc:
             f"benchmarks.md lambda-constructor count is stale; live count "
             f"is {len(LAMBDA_CONSTRUCTORS)}."
         )
+        # Higher-order primitive count (spec §7.5 — anything taking a
+        # closed-set parametric arg: Predicate, Lambda, AlignMode, SortKey).
+        ho_arg_types = {"Predicate", "Lambda", "AlignMode", "SortKey"}
+        ho_count = sum(
+            1
+            for s in REGISTRY.all_primitives()
+            if any(t in ho_arg_types for t in s.signature.inputs)
+        )
+        assert f"**{ho_count}**" in body, (
+            f"benchmarks.md higher-order-primitive count is stale; live count "
+            f"is {ho_count}."
+        )


### PR DESCRIPTION
## Summary
- Three new green rows in the overview hard-gate table:
  - **D3** ✅ — `pytest --cov=channels/program_synthesis/` reports **95 %** (well above the spec's 90 % bar).
  - **D9** ✅ — overview + architecture + dsl_reference + tutorial + benchmarks all present after #226 / #227 / #229.
  - **D12** ✅ — `tutorial.md` with the rotate90 task + full trace + four-test drift gate (#227).
- Fixes a silent count drift in `benchmarks.md`: the higher-order count was \"3\" but the spec §7.5 definition (closed-set parametric args — Predicate, Lambda, AlignMode, SortKey) yields **5**. Updated the doc to list `map_objects`, `filter_objects`, `align_to`, `sort_objects`, `branch`.
- Strengthens the benchmarks drift test to also assert the HO count, so this category can no longer drift silently.

## Test plan
- [x] `pytest tests/test_channels/test_program_synthesis/unit/test_benchmarks_doc.py` — 3 passed.
- [x] `ruff check` clean.
- [x] HO count derived from a live registry walk (`Predicate`/`Lambda`/`AlignMode`/`SortKey` in `signature.inputs`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)