### PR TITLE
feat(pse): Phase-2 Sprint-1 — auto-classify primitives via @primitive decorator

### DIFF
--- a/src/cognithor/channels/program_synthesis/dsl/registry.py
+++ b/src/cognithor/channels/program_synthesis/dsl/registry.py
@@ -135,6 +135,8 @@ def primitive(
     cost: float,
     description: str = "",
     examples: tuple[tuple[str, str], ...] = (),
+    is_high_impact: bool = False,
+    is_structural_abstraction: bool = False,
     registry: PrimitiveRegistry | None = None,
 ) -> Callable[[_F], _F]:
     """Decorator that registers ``fn`` as a primitive in ``registry``.
@@ -144,9 +146,29 @@ def primitive(
         @primitive(name="rotate90", signature=Signature(("Grid",), "Grid"), cost=1.0)
         def rotate90(grid):
             return np.rot90(grid, k=-1).copy()
+
+    Phase-2 (spec v1.4 §7.3.2) classification flags map to
+    :class:`PrimitiveSpec`'s mutually-exclusive attributes; see that
+    class for the multiplier semantics.
     """
 
     target = registry if registry is not None else REGISTRY
+
+    # Phase-2 auto-classification: if the caller didn't pin a flag,
+    # the static whitelists in :mod:`phase2.classification` decide.
+    # Lazy import keeps phase2 ↔ dsl decoupled at module-init time.
+    auto_high = is_high_impact
+    auto_struct = is_structural_abstraction
+    if not auto_high and not auto_struct:
+        from cognithor.channels.program_synthesis.phase2.classification import (
+            classify_primitive_name,
+        )
+
+        cls = classify_primitive_name(name)
+        if cls == "high_impact":
+            auto_high = True
+        elif cls == "structural_abstraction":
+            auto_struct = True
 
     def decorator(fn: _F) -> _F:
         spec = PrimitiveSpec(
@@ -156,6 +178,8 @@ def primitive(
             fn=fn,
             description=description,
             examples=examples,
+            is_high_impact=auto_high,
+            is_structural_abstraction=auto_struct,
         )
         target.register(spec)
         return fn

--- a/tests/test_channels/test_program_synthesis/phase2/test_registry_classification.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_registry_classification.py
@@ -1,0 +1,102 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Drift gate: live REGISTRY agrees with Phase-2 classification whitelists.
+
+Spec v1.4 §7.3.2 says the suspicion-score reads two mutually-exclusive
+flags off ``PrimitiveSpec``. Sprint-1 wires those flags from the
+phase2.classification whitelists into the @primitive decorator, so
+every primitive registered through the decorator picks up its
+classification automatically.
+
+This test pins the agreement: if a future PR registers a primitive
+whose name is in HIGH_IMPACT_PRIMITIVES, its spec must carry
+``is_high_impact=True`` — and the whitelists themselves must remain
+disjoint.
+"""
+
+from __future__ import annotations
+
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+
+# Load integration first to avoid the existing PSE import-cycle.
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.phase2 import (
+    HIGH_IMPACT_PRIMITIVES,
+    STRUCTURAL_ABSTRACTION_PRIMITIVES,
+    classify_primitive_name,
+)
+
+
+class TestRegistryAutoClassification:
+    """Decorator-driven flag-setting matches the static whitelists."""
+
+    def test_every_registered_high_impact_primitive_has_flag_set(self) -> None:
+        for spec in REGISTRY.all_primitives():
+            if spec.name in HIGH_IMPACT_PRIMITIVES:
+                assert spec.is_high_impact, (
+                    f"Primitive {spec.name!r} is in HIGH_IMPACT_PRIMITIVES "
+                    f"but its registered spec has is_high_impact=False."
+                )
+                assert not spec.is_structural_abstraction
+
+    def test_every_registered_structural_abstraction_primitive_has_flag_set(
+        self,
+    ) -> None:
+        for spec in REGISTRY.all_primitives():
+            if spec.name in STRUCTURAL_ABSTRACTION_PRIMITIVES:
+                assert spec.is_structural_abstraction, (
+                    f"Primitive {spec.name!r} is in "
+                    f"STRUCTURAL_ABSTRACTION_PRIMITIVES but its "
+                    f"registered spec has is_structural_abstraction=False."
+                )
+                assert not spec.is_high_impact
+
+    def test_flagged_primitives_are_in_the_corresponding_whitelist(self) -> None:
+        # Reverse direction: if a primitive carries a flag, its name
+        # must appear in the matching whitelist. Catches accidental
+        # hand-added flags in @primitive(...) calls that bypass the
+        # auto-classification path.
+        for spec in REGISTRY.all_primitives():
+            if spec.is_high_impact:
+                assert spec.name in HIGH_IMPACT_PRIMITIVES, (
+                    f"Primitive {spec.name!r} has is_high_impact=True "
+                    f"but is not in HIGH_IMPACT_PRIMITIVES."
+                )
+            if spec.is_structural_abstraction:
+                assert spec.name in STRUCTURAL_ABSTRACTION_PRIMITIVES, (
+                    f"Primitive {spec.name!r} has "
+                    f"is_structural_abstraction=True but is not in "
+                    f"STRUCTURAL_ABSTRACTION_PRIMITIVES."
+                )
+
+    def test_classify_function_agrees_with_registered_specs(self) -> None:
+        # Final sanity: the pure helper and the decorator-driven path
+        # report the same answer for every registered primitive.
+        for spec in REGISTRY.all_primitives():
+            cls = classify_primitive_name(spec.name)
+            if cls == "high_impact":
+                assert spec.is_high_impact
+                assert not spec.is_structural_abstraction
+            elif cls == "structural_abstraction":
+                assert spec.is_structural_abstraction
+                assert not spec.is_high_impact
+            else:
+                assert not spec.is_high_impact
+                assert not spec.is_structural_abstraction
+
+    def test_at_least_one_primitive_per_class(self) -> None:
+        # Spec rationale: if either class is empty in the registry,
+        # the suspicion multipliers can never differentiate, which
+        # defeats F1's purpose.
+        any_high = any(s.is_high_impact for s in REGISTRY.all_primitives())
+        any_struct = any(s.is_structural_abstraction for s in REGISTRY.all_primitives())
+        assert any_high, (
+            "no registered primitive carries is_high_impact=True; "
+            "F1 multipliers cannot discriminate."
+        )
+        assert any_struct, (
+            "no registered primitive carries "
+            "is_structural_abstraction=True; F1 multipliers cannot "
+            "discriminate."
+        )


### PR DESCRIPTION
## Summary
Continuation of **Phase-2 Sprint-1** (spec v1.4). Wires the live DSL registry to the F1 whitelists so every Phase-1 primitive picks up its \`is_high_impact\` / \`is_structural_abstraction\` flag automatically — no per-primitive source edits required.

### How it works
- \`@primitive(...)\` keeps both classification kwargs as opt-out overrides (default \`False/False\`).
- When neither flag is pinned, the decorator looks up the primitive name in \`phase2.classification.classify_primitive_name\` and sets the matching flag. A primitive whose name is not in either whitelist gets the default Regular treatment.
- Lazy import of \`phase2.classification\` keeps the two sub-packages decoupled at module-init time.

### Effect on live REGISTRY
- **9 High-Impact** flagged: \`rotate90\`, \`rotate180\`, \`rotate270\`, \`mirror_horizontal\`, \`mirror_vertical\`, \`transpose\`, \`scale_up_2x\`, \`scale_up_3x\`, \`scale_down_2x\`.
- **8 Structural-Abstraction** flagged: \`connected_components_4\`, \`connected_components_8\`, \`filter_objects\`, \`bounding_box\`, \`largest_object\`, \`smallest_object\`, \`mask_eq\`, \`mask_ne\`.
- 44 remain Regular (1× multiplier, the default).

### New drift gate
\`tests/.../phase2/test_registry_classification.py\` — 5 tests:
- Every whitelisted primitive in the registry has the matching flag.
- Every flagged spec corresponds to a name in the matching whitelist (catches accidental hand-edits that bypass auto-classification).
- \`classify_primitive_name\` helper agrees with every registered spec.
- At least one primitive per class is registered (so multipliers can actually discriminate).

## Test plan
- [x] PSE suite: **846 passed, 10 skipped** (was 841 + 10 → +5 new).
- [x] \`mypy --strict\` clean — 50 source files.
- [x] \`ruff check\` + \`ruff format --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)