### PR TITLE
feat(pse): Phase-2 Sprint-1 — compute_suspicion helper (§7.3.2)

### DIFF
--- a/src/cognithor/channels/program_synthesis/phase2/__init__.py
+++ b/src/cognithor/channels/program_synthesis/phase2/__init__.py
@@ -18,11 +18,17 @@ from cognithor.channels.program_synthesis.phase2.config import (
     DEFAULT_PHASE2_CONFIG,
     Phase2Config,
 )
+from cognithor.channels.program_synthesis.phase2.verifier import (
+    SuspicionScore,
+    compute_suspicion,
+)
 
 __all__ = [
     "DEFAULT_PHASE2_CONFIG",
     "HIGH_IMPACT_PRIMITIVES",
     "STRUCTURAL_ABSTRACTION_PRIMITIVES",
     "Phase2Config",
+    "SuspicionScore",
     "classify_primitive_name",
+    "compute_suspicion",
 ]

--- a/src/cognithor/channels/program_synthesis/phase2/verifier.py
+++ b/src/cognithor/channels/program_synthesis/phase2/verifier.py
@@ -1,0 +1,109 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Phase-2 Verifier extension — Triviality + Suspicion (spec v1.4 §7.3).
+
+Spec v1.4 §7.3 splits the verifier extension into two pieces:
+
+* **§7.3.1 Regelbasierte Triviality** — a list of structural rules
+  that detect "this program is too simple to plausibly produce that
+  partial score" (e.g. ``InputRef`` alone with score 0.85). Carried
+  over from v1.3 unchanged.
+* **§7.3.2 Suspicion-Score** — multiplies a syntactic-complexity
+  measure (which now distinguishes High-Impact / Structural-
+  Abstraction / Regular tokens, the F1 split) with the partial score
+  to produce a "should-we-trust-it" number.
+
+This Sprint-1 module ships the **Suspicion-Score** surface only. The
+exact number-formula for §7.3.3 ("Effekt auf Score") lives in a
+later sprint that wires this into the live verifier. Here we pin:
+
+* the public dataclass shape (so callers can subscribe early);
+* the qualitative F1 invariant (1-token ``objects()`` is *more*
+  suspect than 1-token ``tile()``, which is more suspect than
+  ``recolor(...)``);
+* the config-overridability rule (Sprint-1 contract).
+
+The numeric formula intentionally stays simple — ``partial_score *
+(1 - syntactic_complexity)``. This satisfies the F1 ordering and is
+safe to replace when later sprints land the spec's exact §7.3.3
+formula.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from cognithor.channels.program_synthesis.phase2.config import (
+    DEFAULT_PHASE2_CONFIG,
+    Phase2Config,
+)
+from cognithor.channels.program_synthesis.phase2.suspicion import (
+    compute_syntactic_complexity,
+)
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.search.candidate import (
+        ProgramNode,
+    )
+
+
+@dataclass(frozen=True)
+class SuspicionScore:
+    """The result of one suspicion evaluation.
+
+    ``value`` is in ``[0, 1]``. Higher means *more* suspect — i.e.
+    the partial score looks too good for how simple the program is.
+    Consumers compare against a configurable threshold (typically 0.5)
+    to decide whether to apply a Triviality penalty.
+
+    ``syntactic_complexity`` and ``partial_score`` are echoed back so
+    telemetry can store the inputs alongside the verdict without
+    re-computing.
+    """
+
+    value: float
+    syntactic_complexity: float
+    partial_score: float
+
+
+def compute_suspicion(
+    program: ProgramNode,
+    partial_score: float,
+    *,
+    config: Phase2Config = DEFAULT_PHASE2_CONFIG,
+) -> SuspicionScore:
+    """Score how suspect *program* is given its *partial_score*.
+
+    Sprint-1 formula::
+
+        syntactic_complexity = compute_syntactic_complexity(program, config)
+        suspicion = partial_score * (1 - syntactic_complexity)
+
+    F1 invariant follows from this formula:
+
+    * ``objects(g)`` alone has a lower complexity (1.5× multiplier)
+      than ``tile(g)`` alone (3× multiplier), so the same partial
+      score yields a *higher* suspicion for ``objects``. That
+      reproduces the spec §7.3.2 ordering "1-token ``objects()`` ohne
+      nachgelagerte Verarbeitung ist tatsächlich verdächtig".
+    * Pure ``InputRef`` (no primitives at all) has zero complexity →
+      suspicion equals the full ``partial_score``.
+
+    The exact §7.3.3 score-effect formula is reserved for a later
+    sprint; this helper exists so verifier callers can adopt the
+    public shape now without pinning to a number that will change.
+    """
+    if not 0.0 <= partial_score <= 1.0:
+        raise ValueError(
+            f"compute_suspicion: partial_score must be in [0, 1]; got {partial_score!r}"
+        )
+    sc = compute_syntactic_complexity(program, config=config)
+    value = partial_score * (1.0 - sc)
+    return SuspicionScore(
+        value=value,
+        syntactic_complexity=sc,
+        partial_score=partial_score,
+    )
+
+
+__all__ = ["SuspicionScore", "compute_suspicion"]

--- a/tests/test_channels/test_program_synthesis/phase2/test_suspicion_verifier.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_suspicion_verifier.py
@@ -1,0 +1,133 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""F1 — compute_suspicion ordering invariants (spec v1.4 §7.3.2).
+
+Spec rationale: ``objects()`` alone is more suspect than ``tile()``
+alone, which is more suspect than ``recolor()`` alone — when all three
+get the same partial score. This file pins that ordering so any future
+formula change still has to satisfy F1.
+
+We deliberately do not pin numeric suspicion values to specific
+constants — the exact §7.3.3 score-effect formula is reserved for a
+later sprint. Sprint-1 ships the qualitative contract.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+# Load integration first to avoid the existing PSE import-cycle.
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.phase2 import (
+    DEFAULT_PHASE2_CONFIG,
+    Phase2Config,
+    SuspicionScore,
+    compute_suspicion,
+)
+from cognithor.channels.program_synthesis.search.candidate import InputRef, Program
+
+
+def _g(name: str) -> Program:
+    return Program(primitive=name, children=(InputRef(),), output_type="Grid")
+
+
+class TestSuspicionScoreShape:
+    def test_returns_dataclass_with_three_fields(self) -> None:
+        s = compute_suspicion(_g("tile"), partial_score=0.85)
+        assert isinstance(s, SuspicionScore)
+        assert isinstance(s.value, float)
+        assert isinstance(s.syntactic_complexity, float)
+        assert s.partial_score == 0.85
+
+    def test_value_in_unit_interval(self) -> None:
+        for partial in (0.0, 0.25, 0.5, 0.85, 1.0):
+            for prog in (_g("tile"), _g("objects"), _g("recolor")):
+                s = compute_suspicion(prog, partial_score=partial)
+                assert 0.0 <= s.value <= 1.0
+
+    def test_partial_score_must_be_in_unit_interval(self) -> None:
+        with pytest.raises(ValueError, match="partial_score must be in"):
+            compute_suspicion(_g("tile"), partial_score=-0.1)
+        with pytest.raises(ValueError, match="partial_score must be in"):
+            compute_suspicion(_g("tile"), partial_score=1.5)
+
+
+class TestF1OrderingInvariant:
+    """Spec §7.3.2 verbatim ordering invariant."""
+
+    def test_objects_more_suspect_than_tile_at_same_partial_score(self) -> None:
+        p = 0.85
+        s_tile = compute_suspicion(_g("tile"), partial_score=p)
+        s_objects = compute_suspicion(_g("objects"), partial_score=p)
+        # objects has lower syntactic_complexity → higher suspicion.
+        assert s_objects.syntactic_complexity < s_tile.syntactic_complexity
+        assert s_objects.value > s_tile.value
+
+    def test_recolor_more_suspect_than_objects_at_same_partial_score(self) -> None:
+        # Regular primitives have the lowest multiplier, so a 1-token
+        # recolor() with high score is the most suspect of all.
+        p = 0.85
+        s_recolor = compute_suspicion(_g("recolor"), partial_score=p)
+        s_objects = compute_suspicion(_g("objects"), partial_score=p)
+        assert s_recolor.value > s_objects.value
+
+    def test_full_chain_ordering(self) -> None:
+        p = 0.85
+        s_tile = compute_suspicion(_g("tile"), partial_score=p).value
+        s_objects = compute_suspicion(_g("objects"), partial_score=p).value
+        s_recolor = compute_suspicion(_g("recolor"), partial_score=p).value
+        # Spec §7.3.2 verbatim: tile < objects < recolor (in suspicion).
+        assert s_tile < s_objects < s_recolor
+
+
+class TestEdgeCases:
+    def test_pure_input_ref_max_suspicion_equals_partial_score(self) -> None:
+        # No primitives → zero complexity → full partial_score is
+        # suspicious. A program that's just InputRef cannot honestly
+        # produce a partial_score = 0.85.
+        s = compute_suspicion(InputRef(), partial_score=0.85)
+        assert s.syntactic_complexity == 0.0
+        assert s.value == 0.85
+
+    def test_zero_partial_score_yields_zero_suspicion(self) -> None:
+        s = compute_suspicion(_g("tile"), partial_score=0.0)
+        assert s.value == 0.0
+
+    def test_perfect_partial_score_still_below_one_for_complex_program(self) -> None:
+        # A long high-impact chain has near-1 complexity → suspicion
+        # near 0 even with a perfect partial_score.
+        prog: Program = _g("tile")
+        for _ in range(20):
+            prog = Program("tile", (prog,), "Grid")
+        s = compute_suspicion(prog, partial_score=1.0)
+        assert s.syntactic_complexity == 1.0
+        assert s.value == 0.0
+
+
+class TestConfigOverride:
+    def test_collapsing_multipliers_collapses_ordering(self) -> None:
+        # If all classes get a 1.0 multiplier, the F1 distinction
+        # disappears: objects(), tile(), and recolor() all weigh the
+        # same. The Sprint-1 A/B knob in Phase2Config must pass
+        # through to compute_suspicion.
+        flat = Phase2Config(
+            high_impact_multiplier=1.0,
+            structural_abstraction_multiplier=1.0,
+            regular_primitive_multiplier=1.0,
+        )
+        p = 0.85
+        s_tile = compute_suspicion(_g("tile"), partial_score=p, config=flat)
+        s_objects = compute_suspicion(_g("objects"), partial_score=p, config=flat)
+        s_recolor = compute_suspicion(_g("recolor"), partial_score=p, config=flat)
+        # All three identical under the flat config.
+        assert s_tile.value == s_objects.value == s_recolor.value
+
+    def test_default_config_used_when_none_passed(self) -> None:
+        s_default = compute_suspicion(_g("tile"), partial_score=0.85)
+        s_explicit = compute_suspicion(
+            _g("tile"),
+            partial_score=0.85,
+            config=DEFAULT_PHASE2_CONFIG,
+        )
+        assert s_default.value == s_explicit.value


### PR DESCRIPTION
## Summary
Third Sprint-1 PR for Phase-2. Wires \`compute_syntactic_complexity\` (already in main) into a \`SuspicionScore\` dataclass that verifier callers can adopt now. Sprint-1 ships the **qualitative F1 ordering invariant**; the exact §7.3.3 numeric formula stays reserved for a later sprint.

### Sprint-1 formula
\`\`\`
syntactic_complexity = compute_syntactic_complexity(program, config)
suspicion = partial_score * (1 - syntactic_complexity)
\`\`\`
This satisfies the spec §7.3.2 verbatim claim:

    tile(g) < objects(g) < recolor(g)   (in suspicion, at same partial_score)

because the multipliers (3× / 1.5× / 1×) drive \`syntactic_complexity\` down for simpler classes, which drives suspicion up.

### New
- \`phase2/verifier.py\` — \`SuspicionScore\` dataclass + \`compute_suspicion(program, partial_score, *, config)\` function.
- \`phase2/__init__.py\` — re-exports both.
- 11 new tests in \`phase2/test_suspicion_verifier.py\` pinning:
  - dataclass shape + value-range invariants
  - F1 ordering at the same partial_score
  - Edge cases: pure InputRef = full partial_score, zero score = zero suspicion, deeply-nested high-impact chain = zero suspicion
  - Config override: collapsing multipliers collapses ordering (Sprint-1 A/B knob actually wires through)

## Test plan
- [x] PSE suite: **857 passed, 10 skipped** (was 846 + 10 → +11 new).
- [x] \`mypy --strict\` clean (51 source files, +1 phase2/verifier.py).
- [x] \`ruff check\`, \`ruff format --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)