### PR TITLE
feat(pse): Phase-2 Sprint-1 — α-mixer + sample-size-dampening (§4.4 / §4.4.4)

### DIFF
--- a/src/cognithor/channels/program_synthesis/phase2/__init__.py
+++ b/src/cognithor/channels/program_synthesis/phase2/__init__.py
@@ -9,6 +9,11 @@ one of them lives in :class:`Phase2Config` and is overridable.
 
 from __future__ import annotations
 
+from cognithor.channels.program_synthesis.phase2.alpha_mixer import (
+    alpha_bounds,
+    apply_sample_size_dampening,
+    mix_alpha,
+)
 from cognithor.channels.program_synthesis.phase2.classification import (
     HIGH_IMPACT_PRIMITIVES,
     STRUCTURAL_ABSTRACTION_PRIMITIVES,
@@ -29,6 +34,9 @@ __all__ = [
     "STRUCTURAL_ABSTRACTION_PRIMITIVES",
     "Phase2Config",
     "SuspicionScore",
+    "alpha_bounds",
+    "apply_sample_size_dampening",
     "classify_primitive_name",
     "compute_suspicion",
+    "mix_alpha",
 ]

--- a/src/cognithor/channels/program_synthesis/phase2/alpha_mixer.py
+++ b/src/cognithor/channels/program_synthesis/phase2/alpha_mixer.py
@@ -1,0 +1,112 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Phase-2 α-mixer + sample-size-dampening (spec v1.4 §4.4 / §4.4.4).
+
+The Dual-Prior in Module A combines an LLM-derived prior π_llm with a
+symbolic-heuristic prior π_symbolic via a multiplicative-adaptive α::
+
+    α_entropy ∈ [0.5, 0.85]
+    α_performance ∈ [0.5, 1.0]
+    α = α_entropy · α_performance ∈ [0.25, 0.85]
+
+The product is clamped to the Search-α-bounds derived from
+:class:`Phase2Config`. The default config gives the spec's [0.25, 0.85]
+range.
+
+The Symbolic-Prior side carries a ``Sample-Size-Dämpfung`` so a heuristic
+that has only seen a handful of demos can't over-confidently dominate
+the α-mix. Spec §4.4 (referenced as "unverändert ggü. v1.3") expects
+``effective_confidence = base · (n / (n + n0))`` shape; the constant n0
+is in :class:`Phase2Config` as ``sample_size_dampening_n0`` and defaults
+to 4.
+
+Both helpers are pure, side-effect free, fully Phase2Config-overridable
+— Sprint-1 contract.
+"""
+
+from __future__ import annotations
+
+from cognithor.channels.program_synthesis.phase2.config import (
+    DEFAULT_PHASE2_CONFIG,
+    Phase2Config,
+)
+
+
+def mix_alpha(
+    alpha_entropy: float,
+    alpha_performance: float,
+    *,
+    config: Phase2Config = DEFAULT_PHASE2_CONFIG,
+) -> float:
+    """Spec v1.4 §4.4.4 — multiplicative-adaptive α mixing.
+
+    Both inputs are clamped to their config-defined intervals before
+    multiplication, so a caller passing values outside the spec range
+    (e.g. an over-confident performance tracker reporting 1.2) gets a
+    safe in-bounds α back rather than an exception.
+    """
+    e = _clamp(alpha_entropy, config.alpha_entropy_lower, config.alpha_entropy_upper)
+    p = _clamp(
+        alpha_performance,
+        config.alpha_performance_lower,
+        config.alpha_performance_upper,
+    )
+    return e * p
+
+
+def alpha_bounds(*, config: Phase2Config = DEFAULT_PHASE2_CONFIG) -> tuple[float, float]:
+    """The min/max α a multiplicative-adaptive mix can return.
+
+    Returns ``(lower * lower, upper * upper)`` of the two factor
+    intervals. With spec defaults: ``(0.25, 0.85)``.
+    """
+    lo = config.alpha_entropy_lower * config.alpha_performance_lower
+    hi = config.alpha_entropy_upper * config.alpha_performance_upper
+    return lo, hi
+
+
+def apply_sample_size_dampening(
+    base_confidence: float,
+    n_samples: int,
+    *,
+    config: Phase2Config = DEFAULT_PHASE2_CONFIG,
+) -> float:
+    """Spec §4.4 — dampen *base_confidence* by sample size.
+
+    ``effective = base · (n / (n + n0))``
+
+    At ``n = 0`` the result is ``0.0`` (no observations → no signal).
+    At ``n = n0`` the dampening factor is exactly 0.5.
+    At ``n → ∞`` the factor approaches 1.0.
+
+    ``base_confidence`` must be in ``[0, 1]``; ``n_samples`` must be
+    ``≥ 0``. Both are validated explicitly because the symbolic-prior
+    aggregator is the canonical caller and must surface a typed
+    ValueError on bad input rather than producing a quiet NaN.
+    """
+    if not 0.0 <= base_confidence <= 1.0:
+        raise ValueError(
+            f"apply_sample_size_dampening: base_confidence must be "
+            f"in [0, 1]; got {base_confidence!r}"
+        )
+    if n_samples < 0:
+        raise ValueError(f"apply_sample_size_dampening: n_samples must be >= 0; got {n_samples!r}")
+    if n_samples == 0:
+        return 0.0
+    n0 = config.sample_size_dampening_n0
+    factor = n_samples / (n_samples + n0)
+    return base_confidence * factor
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    if value < lo:
+        return lo
+    if value > hi:
+        return hi
+    return value
+
+
+__all__ = [
+    "alpha_bounds",
+    "apply_sample_size_dampening",
+    "mix_alpha",
+]

--- a/src/cognithor/channels/program_synthesis/phase2/config.py
+++ b/src/cognithor/channels/program_synthesis/phase2/config.py
@@ -57,6 +57,24 @@ class Phase2Config:
     enable_argument_quality_factor: bool = False
     enable_few_demos_dampening: bool = False
 
+    # ── Search-α bounds (spec §4.4.4) ──────────────────────────────
+    # Multiplicative-adaptive α = α_entropy · α_performance.
+    # α_entropy ∈ [alpha_entropy_lower, alpha_entropy_upper]
+    # α_performance ∈ [alpha_performance_lower, alpha_performance_upper]
+    # → α ∈ [alpha_entropy_lower · alpha_performance_lower,
+    #        alpha_entropy_upper · alpha_performance_upper]
+    #   = [0.25, 0.85] with the spec defaults.
+    alpha_entropy_lower: float = 0.5
+    alpha_entropy_upper: float = 0.85
+    alpha_performance_lower: float = 0.5
+    alpha_performance_upper: float = 1.0
+
+    # ── Sample-size dampening (Symbolic-Prior, spec §4.4) ──────────
+    # effective_confidence = base_confidence · (n / (n + dampening_n0))
+    # The default n0=4 means at n=4 demos the dampening factor is 0.5;
+    # at n=12 it's 0.75; at n=∞ it's 1.0.
+    sample_size_dampening_n0: int = 4
+
     def __post_init__(self) -> None:
         # Sanity: zones must form a non-empty graybereich.
         if not 0.0 < self.repair_alpha_zone3_upper < self.repair_alpha_zone1_lower < 1.0:
@@ -85,6 +103,26 @@ class Phase2Config:
                 f"regular ({self.regular_primitive_multiplier}) "
                 f"≤ structural ({self.structural_abstraction_multiplier}) "
                 f"≤ high_impact ({self.high_impact_multiplier})."
+            )
+        # α-bounds (spec §4.4.4): each factor must be a valid
+        # closed-interval inside [0, 1] with lower ≤ upper.
+        for name, lo, hi in (
+            ("alpha_entropy", self.alpha_entropy_lower, self.alpha_entropy_upper),
+            (
+                "alpha_performance",
+                self.alpha_performance_lower,
+                self.alpha_performance_upper,
+            ),
+        ):
+            if not 0.0 <= lo <= hi <= 1.0:
+                raise ValueError(
+                    f"Phase2Config: {name} interval [{lo}, {hi}] must "
+                    f"satisfy 0 ≤ lower ≤ upper ≤ 1."
+                )
+        if self.sample_size_dampening_n0 < 1:
+            raise ValueError(
+                f"Phase2Config: sample_size_dampening_n0 must be >= 1; "
+                f"got {self.sample_size_dampening_n0}."
             )
 
 

--- a/tests/test_channels/test_program_synthesis/phase2/test_alpha_mixer.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_alpha_mixer.py
@@ -1,0 +1,132 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""α-mixer + sample-size-dampening tests (spec v1.4 §4.4 + §4.4.4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.phase2 import (
+    DEFAULT_PHASE2_CONFIG,
+    Phase2Config,
+    alpha_bounds,
+    apply_sample_size_dampening,
+    mix_alpha,
+)
+
+
+class TestAlphaBounds:
+    def test_default_bounds_match_spec_quarter_to_eighty_five(self) -> None:
+        # Spec §4.4.4 verbatim: α ∈ [0.25, 0.85] under the default
+        # entropy [0.5, 0.85] × performance [0.5, 1.0] product.
+        lo, hi = alpha_bounds()
+        assert lo == 0.25
+        assert hi == 0.85
+
+    def test_bounds_track_config_override(self) -> None:
+        config = Phase2Config(
+            alpha_entropy_lower=0.4,
+            alpha_entropy_upper=0.7,
+            alpha_performance_lower=0.5,
+            alpha_performance_upper=0.9,
+        )
+        lo, hi = alpha_bounds(config=config)
+        assert lo == 0.4 * 0.5
+        assert hi == 0.7 * 0.9
+
+
+class TestMixAlphaInRange:
+    def test_default_floor(self) -> None:
+        # Both factors at their minimums → spec floor.
+        assert mix_alpha(0.5, 0.5) == 0.25
+
+    def test_default_ceiling(self) -> None:
+        # Both at their maximums → spec ceiling.
+        assert mix_alpha(0.85, 1.0) == 0.85
+
+    def test_mid_value(self) -> None:
+        # 0.7 · 0.8 = 0.56
+        assert abs(mix_alpha(0.7, 0.8) - 0.56) < 1e-9
+
+
+class TestMixAlphaClamping:
+    """Inputs outside the spec bands clamp to the band edges."""
+
+    def test_below_entropy_floor_clamps_up(self) -> None:
+        # α_entropy = 0.2 < 0.5 lower bound → clamps to 0.5.
+        # Then 0.5 · 0.7 = 0.35.
+        assert mix_alpha(0.2, 0.7) == 0.5 * 0.7
+
+    def test_above_entropy_ceiling_clamps_down(self) -> None:
+        # α_entropy = 0.95 > 0.85 → clamps to 0.85.
+        assert mix_alpha(0.95, 0.7) == 0.85 * 0.7
+
+    def test_above_performance_ceiling_clamps_down(self) -> None:
+        # α_performance = 1.2 > 1.0 → clamps to 1.0.
+        assert mix_alpha(0.7, 1.2) == 0.7 * 1.0
+
+    def test_negative_factor_clamps_to_lower(self) -> None:
+        assert mix_alpha(-0.5, 0.7) == 0.5 * 0.7
+
+
+class TestSampleSizeDampening:
+    """Spec §4.4 — n / (n + n0) dampening."""
+
+    def test_zero_samples_returns_zero(self) -> None:
+        assert apply_sample_size_dampening(0.9, 0) == 0.0
+
+    def test_n_equals_n0_dampens_to_half(self) -> None:
+        # Default n0 = 4. At n = 4: factor = 4 / 8 = 0.5.
+        assert apply_sample_size_dampening(0.9, 4) == 0.45
+
+    def test_n_well_above_n0_approaches_unity(self) -> None:
+        # n=400 → 400/404 ≈ 0.99 → result ≈ 0.891.
+        result = apply_sample_size_dampening(0.9, 400)
+        assert 0.89 < result < 0.9
+
+    def test_large_n0_dampens_more(self) -> None:
+        # Bigger n0 means stronger dampening at low n.
+        config = Phase2Config(sample_size_dampening_n0=100)
+        # At n=4 with n0=100: factor = 4/104 ≈ 0.038 → result ≈ 0.034.
+        result = apply_sample_size_dampening(0.9, 4, config=config)
+        assert 0.03 < result < 0.04
+
+    def test_base_confidence_outside_unit_raises(self) -> None:
+        with pytest.raises(ValueError, match="base_confidence must be"):
+            apply_sample_size_dampening(1.5, 4)
+        with pytest.raises(ValueError, match="base_confidence must be"):
+            apply_sample_size_dampening(-0.1, 4)
+
+    def test_negative_n_samples_raises(self) -> None:
+        with pytest.raises(ValueError, match="n_samples must be"):
+            apply_sample_size_dampening(0.5, -1)
+
+
+class TestConfigInvariants:
+    """Spec §4.4.4 — α-bands themselves must validate at construction."""
+
+    def test_bad_alpha_entropy_band_raises(self) -> None:
+        with pytest.raises(ValueError, match="alpha_entropy"):
+            Phase2Config(alpha_entropy_lower=0.7, alpha_entropy_upper=0.5)
+
+    def test_alpha_band_outside_unit_raises(self) -> None:
+        with pytest.raises(ValueError, match="alpha_performance"):
+            Phase2Config(alpha_performance_lower=-0.1)
+        with pytest.raises(ValueError, match="alpha_performance"):
+            Phase2Config(alpha_performance_upper=1.5)
+
+    def test_dampening_n0_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="dampening_n0"):
+            Phase2Config(sample_size_dampening_n0=0)
+
+
+class TestDefaultConfigUsedWhenNonePassed:
+    def test_mix_alpha_defaults_match_explicit_default(self) -> None:
+        assert mix_alpha(0.7, 0.8) == mix_alpha(0.7, 0.8, config=DEFAULT_PHASE2_CONFIG)
+
+    def test_dampening_defaults_match_explicit_default(self) -> None:
+        assert apply_sample_size_dampening(0.9, 4) == apply_sample_size_dampening(
+            0.9, 4, config=DEFAULT_PHASE2_CONFIG
+        )


### PR DESCRIPTION
## Summary
Fourth Sprint-1 PR for Phase-2. Anchors the spec v1.4 §4.4.4 multiplicative-adaptive α formula and §4.4 sample-size-dampening as pure-math primitives — both Phase2Config-overridable, so the Module-A heuristic catalog (deferred to a later sprint while v1.3 detail is consulted) can plug in without changing this code.

### α-mixer (§4.4.4)
\`\`\`
α_entropy ∈ [0.5, 0.85]
α_performance ∈ [0.5, 1.0]
α = α_entropy · α_performance ∈ [0.25, 0.85]
\`\`\`

- \`mix_alpha(α_e, α_p, *, config)\` — **clamps** out-of-band inputs (a misbehaving performance tracker reporting 1.2 returns 1.0 instead of crashing).
- \`alpha_bounds(*, config)\` — returns the product floor/ceiling. Default = \`(0.25, 0.85)\` exactly.

### Sample-size-dampening (§4.4)
- \`apply_sample_size_dampening(base, n, *, config)\` — \`base · n / (n + n0)\`. At \`n=0\`: 0.0. At \`n=n0\`: 0.5. At \`n→∞\`: → 1.0.
- Bad inputs raise typed \`ValueError\`.

### Phase2Config grew four fields + invariants
- \`alpha_entropy_{lower,upper}\` (defaults 0.5 / 0.85)
- \`alpha_performance_{lower,upper}\` (defaults 0.5 / 1.0)
- \`sample_size_dampening_n0\` (default 4)
- \`__post_init__\` validates band ordering and \`n0 >= 1\`.

## Test plan
- [x] **20 new tests** in \`phase2/test_alpha_mixer.py\` — spec defaults, clamp behaviour, dampening curve at \`n=0/n0/n>>n0\`, typed errors, config invariants.
- [x] PSE suite: **877 passed, 10 skipped** (was 857 + 10 → +20).
- [x] \`mypy --strict\` clean (52 source files).
- [x] \`ruff check\`, \`ruff format --check\` clean.

## Sprint-1 status snapshot (4 PRs in this sprint, all merged or in flight)
- ✅ #235 — F1 classification + F2 RefinerModeController + Phase2Config foundation.
- ✅ #236 — Auto-classify Phase-1 primitives via the @primitive decorator.
- ✅ #237 — \`compute_suspicion\` helper with F1 ordering invariant.
- 🆕 **#238 (this) — α-mixer + sample-size-dampening.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)