### PR TITLE
feat(pse): Phase-2 Sprint-1 — telemetry counters (§11)

### DIFF
--- a/src/cognithor/channels/program_synthesis/phase2/__init__.py
+++ b/src/cognithor/channels/program_synthesis/phase2/__init__.py
@@ -23,6 +23,9 @@ from cognithor.channels.program_synthesis.phase2.config import (
     DEFAULT_PHASE2_CONFIG,
     Phase2Config,
 )
+from cognithor.channels.program_synthesis.phase2.telemetry import (
+    phase2_counters,
+)
 from cognithor.channels.program_synthesis.phase2.verifier import (
     SuspicionScore,
     compute_suspicion,
@@ -39,4 +42,5 @@ __all__ = [
     "classify_primitive_name",
     "compute_suspicion",
     "mix_alpha",
+    "phase2_counters",
 ]

--- a/src/cognithor/channels/program_synthesis/phase2/telemetry.py
+++ b/src/cognithor/channels/program_synthesis/phase2/telemetry.py
@@ -1,0 +1,67 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Phase-2 telemetry counters (spec v1.4 §11).
+
+Spec §11 lists four new Prometheus counters that the Phase-2 surface
+must emit. They mirror the existing Phase-1 ``standard_counters`` shape
+so the channel binds them once and references them by short key.
+
+The four counters:
+
+* ``cognithor_synthesis_refiner_mode_total`` (label: ``mode``)
+  — every refiner-mode selection, partitioned by the chosen mode
+  (``full_llm`` / ``hybrid`` / ``symbolic``).
+* ``cognithor_synthesis_refiner_hybrid_winner_total`` (label: ``winner``)
+  — every hybrid-mode repair, partitioned by who won
+  (``symbolic`` / ``llm``).
+* ``cognithor_synthesis_refiner_mode_hysteresis_held_total``
+  — every time the hysteresis window blocked a mode change.
+* ``cognithor_synthesis_structural_abstraction_token_total``
+  — count of structural-abstraction tokens seen by the verifier
+  per evaluated program.
+
+Returned as a typed dict so the channel can pass the relevant
+counter to the matching collaborator (e.g. give the
+``RefinerModeController`` a callback bound to ``refiner_mode_total``).
+"""
+
+from __future__ import annotations
+
+from cognithor.channels.program_synthesis.observability.metrics import (
+    DEFAULT_REGISTRY,
+    Counter,
+    Registry,
+)
+
+
+def phase2_counters(registry: Registry | None = None) -> dict[str, Counter]:
+    """Bind the spec §11 Phase-2 counters once.
+
+    Returned dict keys (kept short for call sites):
+
+    * ``refiner_mode_total``
+    * ``refiner_hybrid_winner_total``
+    * ``refiner_mode_hysteresis_held_total``
+    * ``structural_abstraction_token_total``
+    """
+    r = registry if registry is not None else DEFAULT_REGISTRY
+    return {
+        "refiner_mode_total": r.counter(
+            "cognithor_synthesis_refiner_mode_total",
+            "Refiner mode-selection events partitioned by the chosen mode.",
+        ),
+        "refiner_hybrid_winner_total": r.counter(
+            "cognithor_synthesis_refiner_hybrid_winner_total",
+            "Hybrid-mode repair winners (symbolic vs llm).",
+        ),
+        "refiner_mode_hysteresis_held_total": r.counter(
+            "cognithor_synthesis_refiner_mode_hysteresis_held_total",
+            "Number of mode-changes blocked by the hysteresis window.",
+        ),
+        "structural_abstraction_token_total": r.counter(
+            "cognithor_synthesis_structural_abstraction_token_total",
+            "Total structural-abstraction tokens seen by the verifier.",
+        ),
+    }
+
+
+__all__ = ["phase2_counters"]

--- a/tests/test_channels/test_program_synthesis/phase2/test_telemetry.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_telemetry.py
@@ -1,0 +1,57 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Phase-2 telemetry counter tests (spec v1.4 §11)."""
+
+from __future__ import annotations
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.observability.metrics import Registry
+from cognithor.channels.program_synthesis.phase2 import phase2_counters
+
+
+class TestPhase2Counters:
+    def test_returns_four_named_counters(self) -> None:
+        c = phase2_counters(registry=Registry())
+        assert set(c) == {
+            "refiner_mode_total",
+            "refiner_hybrid_winner_total",
+            "refiner_mode_hysteresis_held_total",
+            "structural_abstraction_token_total",
+        }
+
+    def test_counter_names_match_spec_prometheus_strings(self) -> None:
+        registry = Registry()
+        phase2_counters(registry=registry)
+        # ``Registry.snapshot().counters`` is name → label-dict, so the
+        # spec-mandated Prometheus names must be top-level keys.
+        emitted = set(registry.snapshot().counters)
+        assert "cognithor_synthesis_refiner_mode_total" in emitted
+        assert "cognithor_synthesis_refiner_hybrid_winner_total" in emitted
+        assert "cognithor_synthesis_refiner_mode_hysteresis_held_total" in emitted
+        assert "cognithor_synthesis_structural_abstraction_token_total" in emitted
+
+    def test_counters_are_independent_per_registry(self) -> None:
+        # Two registries → two distinct sets of counters.
+        c1 = phase2_counters(registry=Registry())
+        c2 = phase2_counters(registry=Registry())
+        c1["refiner_mode_total"].inc(1.0, mode="full_llm")
+        # c2 unchanged.
+        assert c2["refiner_mode_total"] is not c1["refiner_mode_total"]
+
+    def test_inc_increments_and_partitions_by_label(self) -> None:
+        registry = Registry()
+        c = phase2_counters(registry=registry)
+        c["refiner_mode_total"].inc(1.0, mode="full_llm")
+        c["refiner_mode_total"].inc(1.0, mode="hybrid")
+        c["refiner_mode_total"].inc(1.0, mode="hybrid")
+        target = registry.snapshot().counters["cognithor_synthesis_refiner_mode_total"]
+        assert target[(("mode", "full_llm"),)] == 1.0
+        assert target[(("mode", "hybrid"),)] == 2.0
+
+    def test_default_registry_used_when_none_passed(self) -> None:
+        # Spec: should bind on the default registry without an
+        # explicit argument so the channel can call it once at boot.
+        c = phase2_counters()
+        assert "refiner_mode_total" in c
+        assert "structural_abstraction_token_total" in c


### PR DESCRIPTION
## Summary
Fifth Sprint-1 PR. Wires the four spec v1.4 §11 Phase-2 Prometheus counters onto the existing Phase-1 Registry:

- \`cognithor_synthesis_refiner_mode_total\` (label: \`mode\`)
- \`cognithor_synthesis_refiner_hybrid_winner_total\` (label: \`winner\`)
- \`cognithor_synthesis_refiner_mode_hysteresis_held_total\`
- \`cognithor_synthesis_structural_abstraction_token_total\`

\`phase2_counters(registry)\` returns a dict so call sites keep the short keys instead of re-resolving the registry on every emit. Mirrors the Phase-1 \`standard_counters\` shape.

## Test plan
- [x] **5 new tests** in \`phase2/test_telemetry.py\`: name set, spec-verbatim Prometheus strings, registry isolation, label partitioning, default registry fallback.
- [x] PSE suite: **882 passed, 10 skipped** (was 877 + 10).
- [x] \`mypy --strict\` clean (53 source files).
- [x] \`ruff check\`, \`ruff format --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)