### PR TITLE
feat(pse): Phase-2 Sprint-1 — Module A LLM-Prior over vLLM/Qwen 3.6 27B

### DIFF
--- a/src/cognithor/channels/program_synthesis/phase2/__init__.py
+++ b/src/cognithor/channels/program_synthesis/phase2/__init__.py
@@ -23,6 +23,11 @@ from cognithor.channels.program_synthesis.phase2.config import (
     DEFAULT_PHASE2_CONFIG,
     Phase2Config,
 )
+from cognithor.channels.program_synthesis.phase2.llm_prior import (
+    LLMPrior,
+    LLMPriorClient,
+    LLMPriorError,
+)
 from cognithor.channels.program_synthesis.phase2.telemetry import (
     phase2_counters,
 )
@@ -35,6 +40,9 @@ __all__ = [
     "DEFAULT_PHASE2_CONFIG",
     "HIGH_IMPACT_PRIMITIVES",
     "STRUCTURAL_ABSTRACTION_PRIMITIVES",
+    "LLMPrior",
+    "LLMPriorClient",
+    "LLMPriorError",
     "Phase2Config",
     "SuspicionScore",
     "alpha_bounds",

--- a/src/cognithor/channels/program_synthesis/phase2/config.py
+++ b/src/cognithor/channels/program_synthesis/phase2/config.py
@@ -75,6 +75,28 @@ class Phase2Config:
     # at n=12 it's 0.75; at n=∞ it's 1.0.
     sample_size_dampening_n0: int = 4
 
+    # ── Module A — LLM-Prior over vLLM (spec §4.2 / §4.3 / §4.7) ────
+    # Backend: vLLM exposing OpenAI-compat /v1/chat/completions.
+    # Default model is the spec-anchored Qwen3.6-27B-Instruct on the
+    # RTX 5090 (32 GB VRAM); Q5_K_M is the default quantisation,
+    # Q4_K_M is the fallback for tighter VRAM budgets.
+    llm_base_url: str = "http://localhost:8000/v1"
+    llm_model_name: str = "Qwen/Qwen3.6-27B-Instruct"
+    llm_fallback_model_name: str = "Qwen/Qwen3.6-27B-Instruct-AWQ"
+    # Two-Stage prompting (spec §4.7): Stage-1 free-form CoT, Stage-2
+    # constrained JSON. Different temperatures because Stage-1 wants
+    # exploration (default 0.7) and Stage-2 wants determinism (0.1).
+    llm_temperature_stage1: float = 0.7
+    llm_temperature_stage2: float = 0.1
+    # Spec §4.7: retry the JSON stage exactly once on parse failure.
+    llm_json_max_retries: int = 1
+    # Spec §4.5: top-K depth-dependent. K starts at this default for
+    # depth-1 candidates; deeper levels narrow it via the search engine.
+    llm_top_k_default: int = 5
+    # Wall-clock cap per LLM call (seconds). Spec §13.3 budget for
+    # repair stages is sub-second; 8 s is a safe outer bound.
+    llm_call_timeout_seconds: float = 8.0
+
     def __post_init__(self) -> None:
         # Sanity: zones must form a non-empty graybereich.
         if not 0.0 < self.repair_alpha_zone3_upper < self.repair_alpha_zone1_lower < 1.0:
@@ -123,6 +145,32 @@ class Phase2Config:
             raise ValueError(
                 f"Phase2Config: sample_size_dampening_n0 must be >= 1; "
                 f"got {self.sample_size_dampening_n0}."
+            )
+        # LLM prior validation.
+        if not self.llm_model_name:
+            raise ValueError("Phase2Config: llm_model_name must be non-empty.")
+        if not 0.0 <= self.llm_temperature_stage1 <= 2.0:
+            raise ValueError(
+                f"Phase2Config: llm_temperature_stage1 must be in [0, 2]; "
+                f"got {self.llm_temperature_stage1}."
+            )
+        if not 0.0 <= self.llm_temperature_stage2 <= 2.0:
+            raise ValueError(
+                f"Phase2Config: llm_temperature_stage2 must be in [0, 2]; "
+                f"got {self.llm_temperature_stage2}."
+            )
+        if self.llm_json_max_retries < 0:
+            raise ValueError(
+                f"Phase2Config: llm_json_max_retries must be >= 0; got {self.llm_json_max_retries}."
+            )
+        if self.llm_top_k_default < 1:
+            raise ValueError(
+                f"Phase2Config: llm_top_k_default must be >= 1; got {self.llm_top_k_default}."
+            )
+        if self.llm_call_timeout_seconds <= 0.0:
+            raise ValueError(
+                f"Phase2Config: llm_call_timeout_seconds must be > 0; "
+                f"got {self.llm_call_timeout_seconds}."
             )
 
 

--- a/src/cognithor/channels/program_synthesis/phase2/llm_prior.py
+++ b/src/cognithor/channels/program_synthesis/phase2/llm_prior.py
@@ -1,0 +1,327 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Module A — LLM-Prior over vLLM/Qwen 3.6 27B (spec v1.4 §4).
+
+The LLM-Prior takes a Phase-1 :class:`TaskSpec` plus a depth context
+and returns a per-primitive probability distribution that the
+Dual-Prior mixer combines with the Symbolic-Prior. Spec §4 anchors the
+contract; Sprint-1 ships:
+
+* the **client** that talks to a vLLM-served Qwen 3.6 27B via the
+  existing :class:`VLLMBackend` from ``cognithor.core.vllm_backend``;
+* the **Two-Stage prompt schema** (CoT → JSON) per spec §4.7, with the
+  retry-once-on-parse-failure rule;
+* the **LLMPrior** dataclass (immutable), keyed by primitive name and
+  carrying the alpha_entropy hint the mixer reads.
+
+What it deliberately does not do yet:
+
+* Constrained decoding (§4.6) — vLLM doesn't enforce a closed token
+  set automatically. Sprint-1 filters the JSON keys against the live
+  ``REGISTRY``; tightening this with vLLM ``guided_grammar`` lands
+  later.
+* Caching (§4.9) — α-aware mixing cache is a Module-A piece scheduled
+  for the same Sprint-2 PR that lights up the symbolic-heuristic catalog.
+* Top-K depth-dependent narrowing (§4.5) — Sprint-1 returns the full
+  primitive distribution; the search engine slices it.
+
+The client is fully :class:`Phase2Config`-driven. Tests inject a
+fake ``LLMBackend`` so no vLLM has to be running for CI.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from cognithor.channels.program_synthesis.phase2.alpha_mixer import alpha_bounds
+from cognithor.channels.program_synthesis.phase2.config import (
+    DEFAULT_PHASE2_CONFIG,
+    Phase2Config,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from cognithor.core.llm_backend import LLMBackend
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LLMPrior:
+    """One LLM-prior call's output.
+
+    ``primitive_scores`` is keyed by primitive name and carries a
+    softmax-like distribution over the registered primitives. Sums to
+    approximately 1.0 (slack permitted within ``EPS`` for numerical
+    drift). Names not present in the registered set are dropped before
+    returning, so the consumer never has to whitelist again.
+
+    ``alpha_entropy_hint`` is the LLM's self-reported confidence-from-
+    entropy, clamped to the ``alpha_entropy`` band in :class:`Phase2Config`.
+    The mixer multiplies it by ``alpha_performance`` to yield the final
+    Search-α (spec §4.4.4).
+
+    ``stage1_reasoning`` is the free-form CoT block from Stage 1; kept
+    only for telemetry / debug, never read by the search engine.
+
+    ``raw_response`` is the verbatim JSON string the LLM returned in
+    Stage 2, useful for replay-debugging when the parser needs to be
+    audited.
+    """
+
+    primitive_scores: dict[str, float]
+    alpha_entropy_hint: float
+    stage1_reasoning: str = ""
+    raw_response: str = ""
+
+
+class LLMPriorError(Exception):
+    """Raised when the LLM-Prior call cannot produce a usable distribution."""
+
+
+# ---------------------------------------------------------------------------
+# Prompt schema (spec §4.7 Two-Stage)
+# ---------------------------------------------------------------------------
+
+
+_STAGE1_SYSTEM = (
+    "You are a programmatic-synthesis advisor. Given an ARC-AGI grid task "
+    "with paired example inputs and outputs, you reason briefly about what "
+    "transformation is being applied — what changes (size, palette, "
+    "structure, objects), what stays the same, and which DSL primitive "
+    "categories most plausibly produce that change. Be concise: at most "
+    "six sentences. Do not return a program. Do not return JSON. Return "
+    "plain prose only."
+)
+
+
+_STAGE2_SYSTEM = (
+    "You are a programmatic-synthesis advisor. Given the prior reasoning "
+    "and the same task, return a JSON object whose keys are DSL primitive "
+    "names from the provided whitelist and whose values are floats in "
+    "[0, 1] approximating their relative usefulness for synthesizing this "
+    "task. Include an additional key ``alpha_entropy_hint`` ∈ [0, 1] "
+    "indicating how confident you are. Do not include any keys outside "
+    "the whitelist. Do not include text outside the JSON object. Do not "
+    "wrap the JSON in markdown code fences."
+)
+
+
+def _format_examples_block(examples: Iterable[tuple[Any, Any]]) -> str:
+    rendered: list[str] = []
+    for i, (inp, out) in enumerate(examples):
+        # numpy / list-of-lists both support repr — keep it terse.
+        rendered.append(
+            f"Example {i + 1}:\n  input  = {_compact_repr(inp)}\n  output = {_compact_repr(out)}"
+        )
+    return "\n".join(rendered)
+
+
+def _compact_repr(value: Any) -> str:
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        return repr(tolist())
+    return repr(value)
+
+
+def _build_stage1_user(examples: Iterable[tuple[Any, Any]]) -> str:
+    return f"Task examples (input → output pairs):\n{_format_examples_block(examples)}"
+
+
+def _build_stage2_user(
+    examples: Iterable[tuple[Any, Any]],
+    *,
+    primitive_whitelist: list[str],
+    stage1_reasoning: str,
+) -> str:
+    whitelist_block = ", ".join(sorted(primitive_whitelist))
+    return (
+        f"Task examples (input → output pairs):\n"
+        f"{_format_examples_block(examples)}\n\n"
+        f"Prior reasoning:\n{stage1_reasoning}\n\n"
+        f"Allowed primitive keys (use only these): {whitelist_block}\n\n"
+        "Return the JSON object now."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+class LLMPriorClient:
+    """Two-Stage CoT→JSON LLM-prior client over an injected ``LLMBackend``.
+
+    The backend is the abstract :class:`LLMBackend` from
+    ``cognithor.core.llm_backend``; production wires
+    :class:`VLLMBackend`, tests wire a stub. The client is otherwise
+    pure: it formats the prompts, calls the backend twice (Stage-1 CoT,
+    Stage-2 JSON with a single retry), parses and filters the JSON,
+    and returns an :class:`LLMPrior`.
+    """
+
+    def __init__(
+        self,
+        backend: LLMBackend,
+        *,
+        primitive_whitelist: list[str] | None = None,
+        config: Phase2Config = DEFAULT_PHASE2_CONFIG,
+    ) -> None:
+        self._backend = backend
+        # Lazy-resolve the live REGISTRY if no explicit whitelist is
+        # passed, but only at call time — keeps imports clean for tests
+        # that don't need the registry.
+        self._explicit_whitelist = primitive_whitelist
+        self._config = config
+
+    async def get_prior(
+        self,
+        examples: Iterable[tuple[Any, Any]],
+    ) -> LLMPrior:
+        """Run the two-stage prompt and return the parsed prior."""
+        materialised = list(examples)
+        whitelist = self._resolve_whitelist()
+        stage1_reasoning = await self._stage1(materialised)
+        raw_json, parsed = await self._stage2_with_retry(materialised, stage1_reasoning, whitelist)
+        primitive_scores = self._extract_primitive_scores(parsed, whitelist)
+        alpha_hint = self._extract_alpha_hint(parsed)
+        return LLMPrior(
+            primitive_scores=primitive_scores,
+            alpha_entropy_hint=alpha_hint,
+            stage1_reasoning=stage1_reasoning,
+            raw_response=raw_json,
+        )
+
+    # -- Internals ---------------------------------------------------
+
+    def _resolve_whitelist(self) -> list[str]:
+        if self._explicit_whitelist is not None:
+            return list(self._explicit_whitelist)
+        # Lazy import — the prior module loads cleanly even without the
+        # full DSL wired (e.g. for unit tests on the parser).
+        from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+
+        return list(REGISTRY.names())
+
+    async def _stage1(self, examples: list[tuple[Any, Any]]) -> str:
+        response = await self._backend.chat(
+            model=self._config.llm_model_name,
+            messages=[
+                {"role": "system", "content": _STAGE1_SYSTEM},
+                {"role": "user", "content": _build_stage1_user(examples)},
+            ],
+            temperature=self._config.llm_temperature_stage1,
+        )
+        return response.content.strip()
+
+    async def _stage2_with_retry(
+        self,
+        examples: list[tuple[Any, Any]],
+        stage1_reasoning: str,
+        whitelist: list[str],
+    ) -> tuple[str, dict[str, Any]]:
+        attempts = 1 + max(0, self._config.llm_json_max_retries)
+        last_error: Exception | None = None
+        for _ in range(attempts):
+            response = await self._backend.chat(
+                model=self._config.llm_model_name,
+                messages=[
+                    {"role": "system", "content": _STAGE2_SYSTEM},
+                    {
+                        "role": "user",
+                        "content": _build_stage2_user(
+                            examples,
+                            primitive_whitelist=whitelist,
+                            stage1_reasoning=stage1_reasoning,
+                        ),
+                    },
+                ],
+                temperature=self._config.llm_temperature_stage2,
+                format_json=True,
+            )
+            try:
+                parsed = json.loads(response.content)
+            except json.JSONDecodeError as exc:
+                last_error = exc
+                continue
+            if not isinstance(parsed, dict):
+                last_error = LLMPriorError(
+                    f"Stage-2 returned non-object JSON: {response.content[:120]!r}"
+                )
+                continue
+            return response.content, parsed
+        raise LLMPriorError(f"Stage-2 JSON parse failed after {attempts} attempts: {last_error}")
+
+    def _extract_primitive_scores(
+        self,
+        parsed: dict[str, Any],
+        whitelist: list[str],
+    ) -> dict[str, float]:
+        allowed = set(whitelist)
+        scores: dict[str, float] = {}
+        for key, value in parsed.items():
+            if key == "alpha_entropy_hint":
+                continue
+            if key not in allowed:
+                # Quietly drop hallucinated primitives — spec §4.6's
+                # "constrained decoding" intent.
+                continue
+            try:
+                f = float(value)
+            except (TypeError, ValueError):
+                continue
+            if not math.isfinite(f) or f < 0.0:
+                continue
+            scores[key] = f
+        if not scores:
+            raise LLMPriorError("Stage-2 produced no usable primitive scores after filtering.")
+        return _normalise(scores)
+
+    def _extract_alpha_hint(self, parsed: dict[str, Any]) -> float:
+        raw = parsed.get("alpha_entropy_hint")
+        if raw is None:
+            f = 0.5
+        else:
+            try:
+                f = float(raw)
+            except (TypeError, ValueError):
+                f = 0.5  # neutral default — mid of the spec band
+        if not math.isfinite(f):
+            f = 0.5
+        # Clamp to the configured α_entropy band so a misbehaving LLM
+        # cannot push α outside the spec range.
+        lo = self._config.alpha_entropy_lower
+        hi = self._config.alpha_entropy_upper
+        if f < lo:
+            return lo
+        if f > hi:
+            return hi
+        return f
+
+
+def _normalise(scores: dict[str, float]) -> dict[str, float]:
+    total = sum(scores.values())
+    if total <= 0:
+        # All zero — degrade to uniform over the keys we kept.
+        n = len(scores) or 1
+        return {k: 1.0 / n for k in scores}
+    return {k: v / total for k, v in scores.items()}
+
+
+__all__ = [
+    "LLMPrior",
+    "LLMPriorClient",
+    "LLMPriorError",
+]
+
+
+# Suppress unused-import lint — alpha_bounds is used by future Module
+# A wiring (mixer integration). Keeping the import sets a clean import
+# surface for the next sprint without an awkward re-export-only file.
+_ = alpha_bounds

--- a/tests/test_channels/test_program_synthesis/phase2/test_llm_prior.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_llm_prior.py
@@ -1,0 +1,353 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Module A — LLM-Prior over vLLM tests (spec v1.4 §4 Sprint-1).
+
+These exercise the prompt schema + parser + retry logic against a
+stub :class:`LLMBackend`. No vLLM has to be running — the backend is
+fully dependency-injected. The production wiring (
+:class:`VLLMBackend` against a Qwen 3.6 27B served on RTX 5090) is
+covered by ``tests/test_vllm_*`` already, separately.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.phase2 import (
+    LLMPrior,
+    LLMPriorClient,
+    LLMPriorError,
+    Phase2Config,
+)
+from cognithor.core.llm_backend import (
+    ChatResponse,
+    EmbedResponse,
+    LLMBackend,
+    LLMBackendType,
+)
+
+# ---------------------------------------------------------------------------
+# Stub backend
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubBackend(LLMBackend):
+    """Minimal LLMBackend stub that yields a queued list of responses."""
+
+    queued: list[str] = field(default_factory=list)
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def backend_type(self) -> LLMBackendType:
+        return LLMBackendType.VLLM
+
+    async def chat(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        format_json: bool = False,
+        images: list[str] | None = None,
+        video: dict[str, Any] | None = None,
+    ) -> ChatResponse:
+        self.calls.append(
+            {
+                "model": model,
+                "messages": messages,
+                "temperature": temperature,
+                "format_json": format_json,
+            }
+        )
+        if not self.queued:
+            raise AssertionError("stub backend ran out of queued responses")
+        content = self.queued.pop(0)
+        return ChatResponse(content=content, model=model)
+
+    async def chat_stream(self, *_: Any, **__: Any) -> Any:
+        raise NotImplementedError
+
+    async def embed(self, *_: Any, **__: Any) -> EmbedResponse:
+        raise NotImplementedError
+
+    async def is_available(self) -> bool:
+        return True
+
+    async def list_models(self) -> list[str]:
+        return ["Qwen/Qwen3.6-27B-Instruct"]
+
+    async def close(self) -> None:
+        pass
+
+
+def _examples() -> list[tuple[Any, Any]]:
+    return [
+        ([[1, 0], [0, 1]], [[0, 1], [1, 0]]),
+        ([[1]], [[0]]),
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Two-stage call sequence
+# ---------------------------------------------------------------------------
+
+
+class TestTwoStageHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_normalised_distribution(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "The output flips colors via a global recolor.",
+                json.dumps(
+                    {
+                        "rotate90": 0.1,
+                        "recolor": 0.7,
+                        "tile": 0.2,
+                        "alpha_entropy_hint": 0.65,
+                    }
+                ),
+            ]
+        )
+        client = LLMPriorClient(
+            backend,
+            primitive_whitelist=["rotate90", "recolor", "tile", "mirror"],
+        )
+        prior = await client.get_prior(_examples())
+
+        assert isinstance(prior, LLMPrior)
+        # Scores sum to ~1.0 (normalised).
+        assert abs(sum(prior.primitive_scores.values()) - 1.0) < 1e-9
+        # Keys preserved + filtered to whitelist.
+        assert set(prior.primitive_scores) == {"rotate90", "recolor", "tile"}
+        # Stage-1 reasoning preserved verbatim.
+        assert "global recolor" in prior.stage1_reasoning
+
+    @pytest.mark.asyncio
+    async def test_stage1_uses_stage1_temperature(self) -> None:
+        backend = _StubBackend(
+            queued=["reasoning", json.dumps({"recolor": 1.0, "alpha_entropy_hint": 0.5})]
+        )
+        config = Phase2Config(llm_temperature_stage1=0.42, llm_temperature_stage2=0.07)
+        client = LLMPriorClient(backend, primitive_whitelist=["recolor"], config=config)
+        await client.get_prior(_examples())
+        assert backend.calls[0]["temperature"] == 0.42
+        assert backend.calls[1]["temperature"] == 0.07
+
+    @pytest.mark.asyncio
+    async def test_stage2_requests_json_format(self) -> None:
+        backend = _StubBackend(
+            queued=["reasoning", json.dumps({"recolor": 1.0, "alpha_entropy_hint": 0.5})]
+        )
+        client = LLMPriorClient(backend, primitive_whitelist=["recolor"])
+        await client.get_prior(_examples())
+        assert backend.calls[0]["format_json"] is False
+        assert backend.calls[1]["format_json"] is True
+
+    @pytest.mark.asyncio
+    async def test_uses_configured_model_name(self) -> None:
+        backend = _StubBackend(
+            queued=["reasoning", json.dumps({"recolor": 1.0, "alpha_entropy_hint": 0.5})]
+        )
+        config = Phase2Config(llm_model_name="Qwen/Qwen3.6-27B-Instruct-AWQ")
+        client = LLMPriorClient(backend, primitive_whitelist=["recolor"], config=config)
+        await client.get_prior(_examples())
+        assert all(call["model"] == "Qwen/Qwen3.6-27B-Instruct-AWQ" for call in backend.calls)
+
+
+# ---------------------------------------------------------------------------
+# JSON parser robustness
+# ---------------------------------------------------------------------------
+
+
+class TestJsonParser:
+    @pytest.mark.asyncio
+    async def test_filters_hallucinated_primitives(self) -> None:
+        # The LLM returns a name not in the whitelist — quietly dropped.
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps(
+                    {
+                        "recolor": 0.5,
+                        "fictional_primitive_xyz": 0.5,
+                        "alpha_entropy_hint": 0.6,
+                    }
+                ),
+            ]
+        )
+        client = LLMPriorClient(backend, primitive_whitelist=["recolor", "rotate90"])
+        prior = await client.get_prior(_examples())
+        assert "fictional_primitive_xyz" not in prior.primitive_scores
+        assert prior.primitive_scores == {"recolor": 1.0}
+
+    @pytest.mark.asyncio
+    async def test_negative_or_nan_scores_dropped(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps(
+                    {
+                        "recolor": -0.5,
+                        "rotate90": 0.4,
+                        "tile": "not a number",
+                        "alpha_entropy_hint": 0.5,
+                    }
+                ),
+            ]
+        )
+        client = LLMPriorClient(backend, primitive_whitelist=["recolor", "rotate90", "tile"])
+        prior = await client.get_prior(_examples())
+        assert prior.primitive_scores == {"rotate90": 1.0}
+
+    @pytest.mark.asyncio
+    async def test_retry_once_on_parse_failure(self) -> None:
+        # Stage-1 returns reasoning. Stage-2 first attempt is invalid JSON;
+        # retry returns valid JSON. Result should succeed.
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                "{ not json",
+                json.dumps({"recolor": 1.0, "alpha_entropy_hint": 0.5}),
+            ]
+        )
+        client = LLMPriorClient(backend, primitive_whitelist=["recolor"])
+        prior = await client.get_prior(_examples())
+        assert prior.primitive_scores == {"recolor": 1.0}
+
+    @pytest.mark.asyncio
+    async def test_raises_after_retries_exhausted(self) -> None:
+        backend = _StubBackend(queued=["reasoning", "{ broken", "{ still broken"])
+        client = LLMPriorClient(backend, primitive_whitelist=["recolor"])
+        with pytest.raises(LLMPriorError, match="JSON parse failed"):
+            await client.get_prior(_examples())
+
+    @pytest.mark.asyncio
+    async def test_empty_filtered_set_raises(self) -> None:
+        # Every score gets dropped (all not in whitelist).
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps({"unknown1": 0.4, "unknown2": 0.6, "alpha_entropy_hint": 0.5}),
+            ]
+        )
+        client = LLMPriorClient(backend, primitive_whitelist=["recolor"])
+        with pytest.raises(LLMPriorError, match="no usable primitive scores"):
+            await client.get_prior(_examples())
+
+    @pytest.mark.asyncio
+    async def test_non_object_json_treated_as_parse_failure(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps([1, 2, 3]),
+                json.dumps([4, 5]),
+            ]
+        )
+        config = Phase2Config(llm_json_max_retries=1)
+        client = LLMPriorClient(backend, primitive_whitelist=["recolor"], config=config)
+        with pytest.raises(LLMPriorError, match="non-object"):
+            await client.get_prior(_examples())
+
+
+# ---------------------------------------------------------------------------
+# Alpha-entropy hint clamping
+# ---------------------------------------------------------------------------
+
+
+class TestAlphaEntropyHint:
+    @pytest.mark.asyncio
+    async def test_value_within_band_passes_through(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps({"recolor": 1.0, "alpha_entropy_hint": 0.7}),
+            ]
+        )
+        client = LLMPriorClient(backend, primitive_whitelist=["recolor"])
+        prior = await client.get_prior(_examples())
+        assert prior.alpha_entropy_hint == 0.7
+
+    @pytest.mark.asyncio
+    async def test_above_band_clamps_to_upper_bound(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps({"recolor": 1.0, "alpha_entropy_hint": 1.5}),
+            ]
+        )
+        client = LLMPriorClient(backend, primitive_whitelist=["recolor"])
+        prior = await client.get_prior(_examples())
+        # Default upper bound is 0.85.
+        assert prior.alpha_entropy_hint == 0.85
+
+    @pytest.mark.asyncio
+    async def test_below_band_clamps_to_lower_bound(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps({"recolor": 1.0, "alpha_entropy_hint": 0.0}),
+            ]
+        )
+        client = LLMPriorClient(backend, primitive_whitelist=["recolor"])
+        prior = await client.get_prior(_examples())
+        assert prior.alpha_entropy_hint == 0.5
+
+    @pytest.mark.asyncio
+    async def test_missing_hint_falls_back_to_neutral(self) -> None:
+        backend = _StubBackend(queued=["reasoning", json.dumps({"recolor": 1.0})])
+        client = LLMPriorClient(backend, primitive_whitelist=["recolor"])
+        prior = await client.get_prior(_examples())
+        # Neutral 0.5 is inside the band so it doesn't get clamped.
+        assert prior.alpha_entropy_hint == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Phase2Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidation:
+    def test_empty_model_name_rejected(self) -> None:
+        with pytest.raises(ValueError, match="llm_model_name"):
+            Phase2Config(llm_model_name="")
+
+    def test_negative_temperature_rejected(self) -> None:
+        with pytest.raises(ValueError, match="llm_temperature_stage1"):
+            Phase2Config(llm_temperature_stage1=-0.1)
+        with pytest.raises(ValueError, match="llm_temperature_stage2"):
+            Phase2Config(llm_temperature_stage2=-0.1)
+
+    def test_too_high_temperature_rejected(self) -> None:
+        with pytest.raises(ValueError, match="llm_temperature_stage1"):
+            Phase2Config(llm_temperature_stage1=2.1)
+
+    def test_negative_retries_rejected(self) -> None:
+        with pytest.raises(ValueError, match="llm_json_max_retries"):
+            Phase2Config(llm_json_max_retries=-1)
+
+    def test_zero_top_k_rejected(self) -> None:
+        with pytest.raises(ValueError, match="llm_top_k_default"):
+            Phase2Config(llm_top_k_default=0)
+
+    def test_zero_timeout_rejected(self) -> None:
+        with pytest.raises(ValueError, match="llm_call_timeout_seconds"):
+            Phase2Config(llm_call_timeout_seconds=0.0)
+
+    def test_default_model_is_qwen_3_6_27b(self) -> None:
+        # Spec anchors the default model.
+        from cognithor.channels.program_synthesis.phase2 import (
+            DEFAULT_PHASE2_CONFIG,
+        )
+
+        assert DEFAULT_PHASE2_CONFIG.llm_model_name == "Qwen/Qwen3.6-27B-Instruct"
+        assert DEFAULT_PHASE2_CONFIG.llm_fallback_model_name == "Qwen/Qwen3.6-27B-Instruct-AWQ"
+        assert DEFAULT_PHASE2_CONFIG.llm_base_url == "http://localhost:8000/v1"


### PR DESCRIPTION
## Summary
Implements the **Module-A LLM-Prior client surface** (spec v1.4 §4) over the existing production-ready \`VLLMBackend\` (\`cognithor.core.vllm_backend\`).

### What lands
- \`phase2/llm_prior.py\`:
  - \`LLMPriorClient\` with Two-Stage CoT→JSON prompt schema (spec §4.7).
  - \`LLMPrior\` frozen dataclass (\`primitive_scores\`, \`alpha_entropy_hint\`, \`stage1_reasoning\`, \`raw_response\`).
  - \`LLMPriorError\` typed exception.
  - Retry-once-on-parse-failure (spec §4.7).
  - Output filter against the live \`REGISTRY\` whitelist (poor-man Constrained-Decoding for §4.6).
  - Score normalisation (sum-to-1).
  - α_entropy_hint clamped to \`Phase2Config\` band.

- \`Phase2Config\` grew **8 new LLM fields** with construction-time invariants:
  - \`llm_base_url\` = \"http://localhost:8000/v1\"
  - \`llm_model_name\` = **\"Qwen/Qwen3.6-27B-Instruct\"** (spec default)
  - \`llm_fallback_model_name\` = \"Qwen/Qwen3.6-27B-Instruct-AWQ\"
  - \`llm_temperature_stage1\` = 0.7, \`llm_temperature_stage2\` = 0.1
  - \`llm_json_max_retries\` = 1, \`llm_top_k_default\` = 5
  - \`llm_call_timeout_seconds\` = 8.0

### Production wiring
One line once Module B's MCTS controller adopts the prior:
\`\`\`python
client = LLMPriorClient(VLLMBackend(base_url=cfg.llm_base_url), config=cfg)
prior = await client.get_prior(spec.examples)
\`\`\`

## Test plan
- [x] **21 new tests** in \`phase2/test_llm_prior.py\` drive the client with a stub \`LLMBackend\` (no vLLM needed for CI):
  - Two-stage call sequence + temperature + \`format_json\` + model name.
  - JSON parser robustness: hallucinated-key drop, NaN/negative drop, retry behaviour, exhaustion, non-object JSON.
  - α-entropy hint clamping (within band / above / below / missing).
  - Phase2Config validation: empty model name, out-of-range temperatures, negative retries, zero top_k, zero timeout, plus default-model spec anchor.
- [x] PSE suite: **898 passed, 10 skipped** (was 877 + 10 → +21).
- [x] \`mypy --strict\` clean (53 source files).
- [x] \`ruff check\`, \`ruff format --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)