### PR TITLE
feat(pse): Phase-2 Sprint-1 — Dual-Prior mixer + Symbolic-Prior interface

### DIFF
--- a/src/cognithor/channels/program_synthesis/phase2/__init__.py
+++ b/src/cognithor/channels/program_synthesis/phase2/__init__.py
@@ -23,10 +23,19 @@ from cognithor.channels.program_synthesis.phase2.config import (
     DEFAULT_PHASE2_CONFIG,
     Phase2Config,
 )
+from cognithor.channels.program_synthesis.phase2.dual_prior import (
+    DualPriorMixer,
+    DualPriorResult,
+)
 from cognithor.channels.program_synthesis.phase2.llm_prior import (
     LLMPrior,
     LLMPriorClient,
     LLMPriorError,
+)
+from cognithor.channels.program_synthesis.phase2.symbolic_prior import (
+    SymbolicPrior,
+    SymbolicPriorResult,
+    UniformSymbolicPrior,
 )
 from cognithor.channels.program_synthesis.phase2.telemetry import (
     phase2_counters,
@@ -40,11 +49,16 @@ __all__ = [
     "DEFAULT_PHASE2_CONFIG",
     "HIGH_IMPACT_PRIMITIVES",
     "STRUCTURAL_ABSTRACTION_PRIMITIVES",
+    "DualPriorMixer",
+    "DualPriorResult",
     "LLMPrior",
     "LLMPriorClient",
     "LLMPriorError",
     "Phase2Config",
     "SuspicionScore",
+    "SymbolicPrior",
+    "SymbolicPriorResult",
+    "UniformSymbolicPrior",
     "alpha_bounds",
     "apply_sample_size_dampening",
     "classify_primitive_name",

--- a/src/cognithor/channels/program_synthesis/phase2/dual_prior.py
+++ b/src/cognithor/channels/program_synthesis/phase2/dual_prior.py
@@ -1,0 +1,142 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Module A — Dual-Prior mixer (spec v1.4 §4 + §4.4.4).
+
+Combines an :class:`LLMPriorClient` output with a :class:`SymbolicPrior`
+output via the multiplicative-adaptive α from :mod:`phase2.alpha_mixer`:
+
+    α = α_entropy · α_performance ∈ [0.25, 0.85]
+    π_combined = α · π_llm + (1 − α) · π_symbolic
+
+α_entropy comes from the LLM (its self-reported entropy hint).
+α_performance comes from the Symbolic-Prior's effective_confidence
+(sample-size-dampened, [0, 1]). Both are clamped to their config
+bands inside :func:`mix_alpha`, so a misbehaving side cannot push α
+outside the spec range.
+
+The mixer is fully :class:`Phase2Config`-driven; the heuristic catalog
+behind the SymbolicPrior is a separate concern (lands in a Sprint-2
+PR once spec v1.3 detail is consulted). For now the
+:class:`UniformSymbolicPrior` Stub is the typical injection.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from cognithor.channels.program_synthesis.phase2.alpha_mixer import mix_alpha
+from cognithor.channels.program_synthesis.phase2.config import (
+    DEFAULT_PHASE2_CONFIG,
+    Phase2Config,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from cognithor.channels.program_synthesis.phase2.llm_prior import (
+        LLMPrior,
+        LLMPriorClient,
+    )
+    from cognithor.channels.program_synthesis.phase2.symbolic_prior import (
+        SymbolicPrior,
+        SymbolicPriorResult,
+    )
+
+
+@dataclass(frozen=True)
+class DualPriorResult:
+    """One dual-prior call's combined output.
+
+    ``primitive_scores`` is the mixed distribution; sums to ~1.0.
+    ``alpha`` is the resolved α, in the configured Search-α band.
+    ``llm_prior`` and ``symbolic_prior`` echo the inputs so callers
+    can audit per-side contributions (the spec-mandated telemetry
+    field ``alpha_entropy_hint`` lives on ``llm_prior``).
+    """
+
+    primitive_scores: dict[str, float]
+    alpha: float
+    llm_prior: LLMPrior
+    symbolic_prior: SymbolicPriorResult
+
+
+class DualPriorMixer:
+    """Combines LLM-Prior and Symbolic-Prior into one distribution.
+
+    The mixer is async because the LLM side is. Concrete LLM clients
+    pass a :class:`LLMPriorClient` whose ``get_prior`` returns an
+    :class:`LLMPrior`; concrete symbolic priors implement
+    :class:`SymbolicPrior`.
+    """
+
+    def __init__(
+        self,
+        llm_client: LLMPriorClient,
+        symbolic_prior: SymbolicPrior,
+        *,
+        config: Phase2Config = DEFAULT_PHASE2_CONFIG,
+    ) -> None:
+        self._llm = llm_client
+        self._symbolic = symbolic_prior
+        self._config = config
+
+    async def get_prior(
+        self,
+        examples: Iterable[tuple[Any, Any]],
+    ) -> DualPriorResult:
+        """Run both priors and combine with the configured α."""
+        materialised = list(examples)
+        # Symbolic side first — it's pure and cheap. The LLM call
+        # follows, dominating wall-clock; running them sequentially
+        # keeps the implementation simple and avoids the async-
+        # parallel Pitfalls (event-loop politeness, error attribution).
+        symbolic_result = self._symbolic.get_prior(materialised)
+        llm_result = await self._llm.get_prior(materialised)
+        alpha = mix_alpha(
+            alpha_entropy=llm_result.alpha_entropy_hint,
+            alpha_performance=symbolic_result.effective_confidence,
+            config=self._config,
+        )
+        combined = _convex_mix(
+            llm_result.primitive_scores,
+            symbolic_result.primitive_scores,
+            alpha=alpha,
+        )
+        return DualPriorResult(
+            primitive_scores=combined,
+            alpha=alpha,
+            llm_prior=llm_result,
+            symbolic_prior=symbolic_result,
+        )
+
+
+def _convex_mix(
+    llm_scores: dict[str, float],
+    symbolic_scores: dict[str, float],
+    *,
+    alpha: float,
+) -> dict[str, float]:
+    """Compute ``α · π_llm + (1 − α) · π_symbolic`` over the union of keys.
+
+    Missing keys on one side are treated as zero — the contract is
+    that the result has only keys that were in *some* input. The
+    output is renormalised to sum to 1.0; if every entry collapses to
+    zero (degenerate input), returns an empty dict — the caller is
+    expected to treat that as "no prior signal" (typically falling
+    back to a uniform).
+    """
+    keys = set(llm_scores) | set(symbolic_scores)
+    raw = {
+        k: alpha * llm_scores.get(k, 0.0) + (1.0 - alpha) * symbolic_scores.get(k, 0.0)
+        for k in keys
+    }
+    total = sum(raw.values())
+    if total <= 0:
+        return {}
+    return {k: v / total for k, v in raw.items()}
+
+
+__all__ = [
+    "DualPriorMixer",
+    "DualPriorResult",
+]

--- a/src/cognithor/channels/program_synthesis/phase2/symbolic_prior.py
+++ b/src/cognithor/channels/program_synthesis/phase2/symbolic_prior.py
@@ -1,0 +1,141 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Module A — Symbolic-Prior interface (spec v1.4 §4.4).
+
+The Symbolic-Prior contributes a heuristic-derived per-primitive
+distribution that the Dual-Prior mixer combines with the LLM side.
+Spec §4.4 references "~20 Heuristik-Regeln mit Confidence-Multiplikator"
+plus :class:`apply_sample_size_dampening` from
+:mod:`phase2.alpha_mixer` already; the rules themselves carry over
+from spec v1.3 and land in a follow-up sprint.
+
+Sprint-1 ships:
+
+* the abstract :class:`SymbolicPrior` ABC the mixer reads,
+* a :class:`UniformSymbolicPrior` stub that hands back a flat
+  distribution over the registered DSL primitives — useful for tests
+  and as the Phase-2 default until the heuristic catalog lands.
+
+Both pieces are :class:`Phase2Config`-driven where a constant matters.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from cognithor.channels.program_synthesis.phase2.config import (
+    DEFAULT_PHASE2_CONFIG,
+    Phase2Config,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+@dataclass(frozen=True)
+class SymbolicPriorResult:
+    """One symbolic-prior call's output.
+
+    ``primitive_scores`` is keyed by primitive name and sums to ~1.0.
+    ``effective_confidence`` is the Sample-Size-Dampened confidence
+    the mixer can read into ``α_performance``; it lives in ``[0, 1]``
+    and reflects how well-supported the heuristic verdict is by the
+    number of demos.
+    """
+
+    primitive_scores: dict[str, float]
+    effective_confidence: float
+
+
+class SymbolicPrior(ABC):
+    """Abstract interface every symbolic-prior implementation honours.
+
+    The Dual-Prior mixer asks for a prior given a sequence of
+    ``(input, output)`` example pairs. Concrete implementations may
+    cache, sample-size-dampen, or short-circuit — the contract is a
+    valid :class:`SymbolicPriorResult` whose primitive_scores keys
+    are subset of the live DSL whitelist.
+    """
+
+    @abstractmethod
+    def get_prior(
+        self,
+        examples: Iterable[tuple[Any, Any]],
+    ) -> SymbolicPriorResult:
+        """Return the per-primitive prior + a confidence in [0, 1]."""
+
+
+class UniformSymbolicPrior(SymbolicPrior):
+    """Sprint-1 stub — uniform over the live DSL whitelist.
+
+    Useful for two scenarios:
+
+    * unit tests of the mixer that don't want a real heuristic catalog
+      driving the assertions;
+    * early Phase-2 runs where the heuristic catalog hasn't landed yet
+      — the mixer treats this stub as "no symbolic signal" and the LLM
+      side dominates (subject to the α-band clamping in
+      :class:`Phase2Config`).
+
+    Confidence reports the canonical sample-size-dampened value via
+    :func:`apply_sample_size_dampening` against a base of 1.0, so the
+    α-mixer sees a curve from 0.0 (no demos) to 1.0 (n→∞).
+    """
+
+    def __init__(
+        self,
+        *,
+        primitive_whitelist: list[str] | None = None,
+        config: Phase2Config = DEFAULT_PHASE2_CONFIG,
+    ) -> None:
+        self._explicit_whitelist = primitive_whitelist
+        self._config = config
+
+    def get_prior(
+        self,
+        examples: Iterable[tuple[Any, Any]],
+    ) -> SymbolicPriorResult:
+        from cognithor.channels.program_synthesis.phase2.alpha_mixer import (
+            apply_sample_size_dampening,
+        )
+
+        materialised = list(examples)
+        whitelist = self._resolve_whitelist()
+        if not whitelist:
+            raise ValueError(
+                "UniformSymbolicPrior: empty primitive whitelist; "
+                "the live REGISTRY has no primitives or the explicit "
+                "whitelist is empty."
+            )
+        scores = _uniform_distribution(whitelist)
+        confidence = apply_sample_size_dampening(
+            base_confidence=1.0,
+            n_samples=len(materialised),
+            config=self._config,
+        )
+        return SymbolicPriorResult(
+            primitive_scores=scores,
+            effective_confidence=confidence,
+        )
+
+    def _resolve_whitelist(self) -> list[str]:
+        if self._explicit_whitelist is not None:
+            return list(self._explicit_whitelist)
+        # Lazy import — keeps the module loadable without booting the
+        # full DSL.
+        from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+
+        return list(REGISTRY.names())
+
+
+def _uniform_distribution(names: list[str]) -> dict[str, float]:
+    n = len(names)
+    return {name: 1.0 / n for name in names}
+
+
+__all__ = [
+    "SymbolicPrior",
+    "SymbolicPriorResult",
+    "UniformSymbolicPrior",
+]

--- a/tests/test_channels/test_program_synthesis/phase2/test_dual_prior.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_dual_prior.py
@@ -1,0 +1,236 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Module A — Dual-Prior mixer tests (spec v1.4 §4 + §4.4.4)."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.phase2 import (
+    DualPriorMixer,
+    DualPriorResult,
+    LLMPriorClient,
+    Phase2Config,
+    SymbolicPrior,
+    SymbolicPriorResult,
+    UniformSymbolicPrior,
+)
+from cognithor.core.llm_backend import (
+    ChatResponse,
+    EmbedResponse,
+    LLMBackend,
+    LLMBackendType,
+)
+
+# ---------------------------------------------------------------------------
+# Stub backend (mirrors the LLMPrior tests' shape)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubBackend(LLMBackend):
+    queued: list[str] = field(default_factory=list)
+
+    @property
+    def backend_type(self) -> LLMBackendType:
+        return LLMBackendType.VLLM
+
+    async def chat(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        format_json: bool = False,
+        images: list[str] | None = None,
+        video: dict[str, Any] | None = None,
+    ) -> ChatResponse:
+        if not self.queued:
+            raise AssertionError("stub backend ran out of queued responses")
+        return ChatResponse(content=self.queued.pop(0), model=model)
+
+    async def chat_stream(self, *_: Any, **__: Any) -> Any:
+        raise NotImplementedError
+
+    async def embed(self, *_: Any, **__: Any) -> EmbedResponse:
+        raise NotImplementedError
+
+    async def is_available(self) -> bool:
+        return True
+
+    async def list_models(self) -> list[str]:
+        return ["Qwen/Qwen3.6-27B-Instruct"]
+
+    async def close(self) -> None:
+        pass
+
+
+def _examples() -> list[tuple[Any, Any]]:
+    return [
+        ([[1, 0]], [[0, 1]]),
+        ([[2]], [[3]]),
+        ([[5, 5]], [[6, 6]]),
+        ([[7]], [[8]]),
+    ]
+
+
+def _llm_response(scores: dict[str, float], hint: float) -> str:
+    return json.dumps({**scores, "alpha_entropy_hint": hint})
+
+
+# ---------------------------------------------------------------------------
+# UniformSymbolicPrior
+# ---------------------------------------------------------------------------
+
+
+class TestUniformSymbolicPrior:
+    def test_returns_flat_distribution_over_whitelist(self) -> None:
+        prior = UniformSymbolicPrior(primitive_whitelist=["a", "b", "c", "d"])
+        result = prior.get_prior(_examples())
+        assert set(result.primitive_scores) == {"a", "b", "c", "d"}
+        assert all(abs(v - 0.25) < 1e-9 for v in result.primitive_scores.values())
+
+    def test_effective_confidence_dampened_by_sample_size(self) -> None:
+        prior = UniformSymbolicPrior(primitive_whitelist=["a"])
+        # Default n0 = 4, n_samples = 4 → dampened to 0.5.
+        result = prior.get_prior(_examples())
+        assert result.effective_confidence == 0.5
+
+    def test_zero_examples_yields_zero_confidence(self) -> None:
+        prior = UniformSymbolicPrior(primitive_whitelist=["a"])
+        result = prior.get_prior([])
+        assert result.effective_confidence == 0.0
+        # Distribution still flat over the whitelist.
+        assert result.primitive_scores == {"a": 1.0}
+
+    def test_empty_whitelist_raises(self) -> None:
+        prior = UniformSymbolicPrior(primitive_whitelist=[])
+        with pytest.raises(ValueError, match="empty primitive whitelist"):
+            prior.get_prior(_examples())
+
+
+# ---------------------------------------------------------------------------
+# DualPriorMixer
+# ---------------------------------------------------------------------------
+
+
+class _FakeSymbolic(SymbolicPrior):
+    """Returns a fixed result regardless of input — for deterministic mixer tests."""
+
+    def __init__(self, scores: dict[str, float], confidence: float) -> None:
+        self._scores = scores
+        self._confidence = confidence
+
+    def get_prior(self, examples: Any) -> SymbolicPriorResult:
+        return SymbolicPriorResult(
+            primitive_scores=dict(self._scores),
+            effective_confidence=self._confidence,
+        )
+
+
+class TestDualPriorMixer:
+    @pytest.mark.asyncio
+    async def test_combines_with_alpha_in_band(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                _llm_response({"a": 0.8, "b": 0.2}, hint=0.7),
+            ]
+        )
+        llm = LLMPriorClient(backend, primitive_whitelist=["a", "b"])
+        sym = _FakeSymbolic(scores={"a": 0.4, "b": 0.6}, confidence=0.8)
+        mixer = DualPriorMixer(llm, sym)
+        result = await mixer.get_prior(_examples())
+
+        assert isinstance(result, DualPriorResult)
+        # α = clamp(0.7) * clamp(0.8) = 0.56
+        assert abs(result.alpha - 0.56) < 1e-9
+        # Combined sums to 1.0.
+        assert abs(sum(result.primitive_scores.values()) - 1.0) < 1e-9
+        # Per-side data echoed for telemetry.
+        assert result.llm_prior.alpha_entropy_hint == 0.7
+        assert result.symbolic_prior.effective_confidence == 0.8
+
+    @pytest.mark.asyncio
+    async def test_alpha_clamped_at_band_floor(self) -> None:
+        # α_entropy = 0.5 (floor), α_performance = 0.5 → α = 0.25.
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                _llm_response({"a": 1.0}, hint=0.0),  # below band → clamps to 0.5
+            ]
+        )
+        llm = LLMPriorClient(backend, primitive_whitelist=["a"])
+        sym = _FakeSymbolic(scores={"a": 1.0}, confidence=0.0)  # clamps to 0.5
+        mixer = DualPriorMixer(llm, sym)
+        result = await mixer.get_prior(_examples())
+        assert result.alpha == 0.25
+
+    @pytest.mark.asyncio
+    async def test_disjoint_keys_unioned_in_output(self) -> None:
+        # LLM has only {a, b}; symbolic only {b, c}. Output should
+        # contain {a, b, c} (b weighted on both sides).
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                _llm_response({"a": 0.5, "b": 0.5}, hint=0.7),
+            ]
+        )
+        llm = LLMPriorClient(backend, primitive_whitelist=["a", "b", "c"])
+        sym = _FakeSymbolic(scores={"b": 0.5, "c": 0.5}, confidence=0.8)
+        mixer = DualPriorMixer(llm, sym)
+        result = await mixer.get_prior(_examples())
+        assert set(result.primitive_scores) == {"a", "b", "c"}
+        # b is weighted from both sides → must outrank a and c.
+        assert result.primitive_scores["b"] > result.primitive_scores["a"]
+        assert result.primitive_scores["b"] > result.primitive_scores["c"]
+
+    @pytest.mark.asyncio
+    async def test_uniform_symbolic_yields_llm_dominance(self) -> None:
+        # When the symbolic side is uniform over the same whitelist
+        # and the LLM is sharply peaked, the combined distribution
+        # should still preserve the LLM's argmax (the keystone test
+        # for the mixer being well-behaved at low symbolic confidence).
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                _llm_response({"a": 0.9, "b": 0.05, "c": 0.05}, hint=0.8),
+            ]
+        )
+        llm = LLMPriorClient(backend, primitive_whitelist=["a", "b", "c"])
+        sym = UniformSymbolicPrior(primitive_whitelist=["a", "b", "c"])
+        mixer = DualPriorMixer(llm, sym)
+        result = await mixer.get_prior(_examples())
+        argmax = max(result.primitive_scores, key=result.primitive_scores.__getitem__)
+        assert argmax == "a"
+
+    @pytest.mark.asyncio
+    async def test_config_override_propagates_to_alpha(self) -> None:
+        # Tighter α band (e.g. [0.6, 0.9] · [0.6, 1.0]) yields a higher
+        # α floor than the spec default of 0.25.
+        config = Phase2Config(
+            alpha_entropy_lower=0.6,
+            alpha_entropy_upper=0.9,
+            alpha_performance_lower=0.6,
+            alpha_performance_upper=1.0,
+        )
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                _llm_response({"a": 1.0}, hint=0.0),  # → clamps to 0.6
+            ]
+        )
+        llm = LLMPriorClient(backend, primitive_whitelist=["a"], config=config)
+        sym = _FakeSymbolic(scores={"a": 1.0}, confidence=0.0)  # → 0.6
+        mixer = DualPriorMixer(llm, sym, config=config)
+        result = await mixer.get_prior(_examples())
+        # α = 0.6 · 0.6 = 0.36, well above the spec-default floor 0.25.
+        assert abs(result.alpha - 0.36) < 1e-9


### PR DESCRIPTION
## Summary
Seventh Sprint-1 PR. Wires Module A's two priors together (spec v1.4 §4 + §4.4.4):

\`\`\`
α = α_entropy · α_performance ∈ [0.25, 0.85]
π_combined = α · π_llm + (1 − α) · π_symbolic
\`\`\`

### New
- \`phase2/symbolic_prior.py\` — \`SymbolicPrior\` ABC + \`SymbolicPriorResult\` + \`UniformSymbolicPrior\` Sprint-1 stub. The heuristic catalog (~20 rules) carries over from spec v1.3 and lands in a follow-up sprint; the stub keeps the mixer testable end-to-end now.
- \`phase2/dual_prior.py\` — \`DualPriorMixer\` runs both priors (sequential — symbolic is cheap, LLM dominates wall-clock), reads α_entropy from the LLM and α_performance from the symbolic confidence, multiplies via \`mix_alpha\`, and returns the convex-combined distribution renormalised to 1.0. Disjoint-key handling: union of both sides; missing keys treated as zero.

### Why this matters
This closes the Module-A surface contract: the search engine consumes a single \`DualPriorResult\`. When Module B's MCTS controller adopts it, the LLM prior and the symbolic catalog can swap independently behind the same interface.

## Test plan
- [x] **9 new tests** in \`phase2/test_dual_prior.py\`:
  - UniformSymbolicPrior: flat distribution, sample-size dampening, zero-examples edge case, empty whitelist rejection.
  - DualPriorMixer: normal blend with α=0.56, α-clamping at band floor, disjoint-key union, LLM dominance under uniform symbolic, config override propagating to α.
- [x] PSE suite: **912 passed, 10 skipped** (was 898 + carry from #239/#240 → +14 total here).
- [x] \`mypy --strict\` clean (56 source files, +2 dual_prior + symbolic_prior).
- [x] \`ruff check\`, \`ruff format --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)