### PR TITLE
feat(pse): Phase-2 Sprint-1 — typed datatypes (plan task 2, spec §9)

### DIFF
--- a/src/cognithor/channels/program_synthesis/phase2/__init__.py
+++ b/src/cognithor/channels/program_synthesis/phase2/__init__.py
@@ -29,6 +29,13 @@ from cognithor.channels.program_synthesis.phase2.config_loader import (
     LoadedHeuristics,
     load_heuristics,
 )
+from cognithor.channels.program_synthesis.phase2.datatypes import (
+    FeatureWithConfidence,
+    MCTSNode,
+    MCTSState,
+    MixedPolicy,
+    PartitionedBudget,
+)
 from cognithor.channels.program_synthesis.phase2.dual_prior import (
     DualPriorMixer,
     DualPriorResult,
@@ -59,10 +66,15 @@ __all__ = [
     "ConfigLoadError",
     "DualPriorMixer",
     "DualPriorResult",
+    "FeatureWithConfidence",
     "LLMPrior",
     "LLMPriorClient",
     "LLMPriorError",
     "LoadedHeuristics",
+    "MCTSNode",
+    "MCTSState",
+    "MixedPolicy",
+    "PartitionedBudget",
     "Phase2Config",
     "SuspicionScore",
     "SymbolicPrior",

--- a/src/cognithor/channels/program_synthesis/phase2/datatypes.py
+++ b/src/cognithor/channels/program_synthesis/phase2/datatypes.py
@@ -1,0 +1,244 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Phase-2 typed datatypes (Sprint-1 plan task 2, spec §9).
+
+The Sprint-1 plan calls for the full set of frozen dataclasses the
+Phase-2 modules read. This module ships the ones that aren't already
+covered by Phase-1 (TaskSpec, Demo, Program, ProgramState) or by
+earlier Sprint-1 work (DSLPrimitive flags, LLMPrior, SymbolicPriorResult,
+DualPriorResult, SuspicionScore):
+
+* :class:`FeatureWithConfidence` — symbolic-prior input slot. Carries
+  a value and the number of demos that produced it; its
+  ``effective_confidence`` reads :class:`Phase2Config` to apply the
+  spec §4.4 sample-size dampening.
+* :class:`PartitionedBudget` — spec §13.4 budget split across the four
+  pipeline stages (pre-processing, MCTS, refiner, CEGIS). Validates
+  that the four fractions sum to 1.0 at construction time.
+* :class:`MixedPolicy` — light alias around the
+  ``(primitive_scores, alpha)`` tuple. The dual-prior mixer's
+  :class:`DualPriorResult` carries strictly more (per-side priors for
+  telemetry), but Module B's MCTS controller only needs the mixed view.
+* :class:`MCTSNode` — mutable PUCT node. Tracks visit count, total
+  value, prior, and parent/children edges. ``puct_score`` property
+  follows spec §5.2.
+* :class:`MCTSState` — top-level search state holding the root node
+  plus the live budget snapshot.
+
+Spec §9 (v1.4, "unverändert ggü v1.3") does not pin every field of
+the MCTS types verbatim — the dataclasses below are the smallest
+shape the Sprint-2 controller will read and write. They're typed,
+documented, and Hypothesis-friendly (hashable where frozen).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from math import sqrt
+
+from cognithor.channels.program_synthesis.phase2.alpha_mixer import (
+    apply_sample_size_dampening,
+)
+from cognithor.channels.program_synthesis.phase2.config import (
+    DEFAULT_PHASE2_CONFIG,
+    Phase2Config,
+)
+
+# ---------------------------------------------------------------------------
+# Symbolic-prior input slot
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FeatureWithConfidence:
+    """One feature observation feeding the symbolic-prior catalog.
+
+    ``name`` is a stable string label used by the heuristic catalog to
+    look the feature up. ``value`` is the observed quantity (any
+    immutable scalar — int / float / str / bool / tuple). ``n_demos``
+    is how many demo pairs the observation rests on; the symbolic-
+    prior dampens its confidence by ``n / (n + n0)`` per spec §4.4.
+
+    The frozen dataclass is hashable so feature snapshots can be used
+    as dict keys for the symbolic-prior cache. Sprint-1 plan acceptance
+    criterion: *FeatureWithConfidence.confidence korrekt skaliert via
+    Sample-Size.*
+    """
+
+    name: str
+    value: object
+    n_demos: int
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("FeatureWithConfidence.name must be non-empty")
+        if self.n_demos < 0:
+            raise ValueError(f"FeatureWithConfidence.n_demos must be >= 0; got {self.n_demos}")
+
+    def effective_confidence(
+        self,
+        *,
+        base_confidence: float = 1.0,
+        config: Phase2Config = DEFAULT_PHASE2_CONFIG,
+    ) -> float:
+        """Spec §4.4 sample-size-dampened confidence in ``[0, 1]``.
+
+        ``base_confidence`` defaults to 1.0 (the heuristic gives the
+        full signal at saturation). The symbolic-prior catalog can
+        pass a per-rule base when the rule itself only contributes a
+        partial confidence even at infinite demos.
+        """
+        return apply_sample_size_dampening(
+            base_confidence=base_confidence,
+            n_samples=self.n_demos,
+            config=config,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Budget partition
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PartitionedBudget:
+    """Spec §13.4 strict budget partition.
+
+    Each field is the fraction of the total wall-clock budget assigned
+    to a pipeline stage. The four fractions must sum to ``1.0`` at
+    construction time — the engine reclaims unused fractions back to
+    MCTS only at runtime, not at construction.
+    """
+
+    pre_processing: float
+    mcts: float
+    refiner: float
+    cegis: float
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("pre_processing", self.pre_processing),
+            ("mcts", self.mcts),
+            ("refiner", self.refiner),
+            ("cegis", self.cegis),
+        ):
+            if value < 0.0:
+                raise ValueError(f"PartitionedBudget.{name} must be >= 0; got {value}")
+        total = self.pre_processing + self.mcts + self.refiner + self.cegis
+        # Allow a tiny floating-point slack so YAML round-trips don't
+        # fail on the obvious 1.0 sum.
+        if abs(total - 1.0) > 1e-9:
+            raise ValueError(f"PartitionedBudget fractions must sum to 1.0; got {total}")
+
+    @classmethod
+    def from_spec_default(cls) -> PartitionedBudget:
+        """Spec §13.4 defaults: 0.07 / 0.70 / 0.18 / 0.05."""
+        return cls(pre_processing=0.07, mcts=0.70, refiner=0.18, cegis=0.05)
+
+
+# ---------------------------------------------------------------------------
+# Module-A output projection
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MixedPolicy:
+    """Spec §3.2 — what Module B's MCTS controller reads from Module A.
+
+    ``primitive_scores`` is the convex-combined per-primitive
+    distribution; ``alpha`` is the resolved Search-α (in the
+    [0.25, 0.85] band by default). Drop-in projection of
+    :class:`DualPriorResult` with the per-side telemetry stripped.
+    """
+
+    primitive_scores: tuple[tuple[str, float], ...]
+    alpha: float
+
+    @classmethod
+    def from_dict(
+        cls,
+        primitive_scores: dict[str, float],
+        *,
+        alpha: float,
+    ) -> MixedPolicy:
+        """Build a frozen MixedPolicy from the mixer's dict output."""
+        ordered = tuple(sorted(primitive_scores.items()))
+        return cls(primitive_scores=ordered, alpha=alpha)
+
+    def as_dict(self) -> dict[str, float]:
+        return dict(self.primitive_scores)
+
+
+# ---------------------------------------------------------------------------
+# MCTS node + state
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MCTSNode:
+    """Mutable PUCT node — spec §5.2.
+
+    Sprint-1 ships the smallest shape Module B's controller will need;
+    the full-feature node (virtual-loss bookkeeping, equivalence
+    fingerprint cache, diversity bonus tally) is a Sprint-2 PR that
+    extends this dataclass without breaking the existing field set.
+
+    ``visit_count`` and ``total_value`` increment as the search
+    progresses; ``prior`` is the prior probability the parent Action
+    taken to reach this node carried (read off the mixer). ``children``
+    maps action label → child node, populated lazily on expansion.
+    """
+
+    primitive: str
+    prior: float = 0.0
+    visit_count: int = 0
+    total_value: float = 0.0
+    parent: MCTSNode | None = None
+    children: dict[str, MCTSNode] = field(default_factory=dict)
+
+    @property
+    def mean_value(self) -> float:
+        if self.visit_count == 0:
+            return 0.0
+        return self.total_value / self.visit_count
+
+    def puct_score(self, *, c_puct: float, parent_visit_count: int) -> float:
+        """Spec §5.2 — UCB-style PUCT score the parent uses to pick a child.
+
+        ``Q(s,a) + c_puct · prior · sqrt(N_parent) / (1 + N_self)``.
+        ``c_puct`` is the spec exploration constant (default 3.5 per
+        the heuristics YAML).
+        """
+        if parent_visit_count <= 0:
+            # Square-root degenerates; fall back to the prior alone.
+            exploration = self.prior
+        else:
+            exploration = c_puct * self.prior * sqrt(parent_visit_count) / (1 + self.visit_count)
+        return self.mean_value + exploration
+
+    def record_visit(self, value: float) -> None:
+        """Increment visit count + accumulate value (back-prop step)."""
+        self.visit_count += 1
+        self.total_value += value
+
+
+@dataclass
+class MCTSState:
+    """Top-level search state."""
+
+    root: MCTSNode
+    budget: PartitionedBudget
+    iteration: int = 0
+    best_so_far: MCTSNode | None = None
+
+    def step(self) -> None:
+        """Advance the iteration counter — controller calls per loop."""
+        self.iteration += 1
+
+
+__all__ = [
+    "FeatureWithConfidence",
+    "MCTSNode",
+    "MCTSState",
+    "MixedPolicy",
+    "PartitionedBudget",
+]

--- a/tests/test_channels/test_program_synthesis/phase2/test_datatypes.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_datatypes.py
@@ -1,0 +1,188 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Phase-2 datatypes tests (Sprint-1 plan task 2, spec §9)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.phase2 import (
+    FeatureWithConfidence,
+    MCTSNode,
+    MCTSState,
+    MixedPolicy,
+    PartitionedBudget,
+    Phase2Config,
+)
+
+# ---------------------------------------------------------------------------
+# FeatureWithConfidence
+# ---------------------------------------------------------------------------
+
+
+class TestFeatureWithConfidence:
+    def test_construction_round_trip(self) -> None:
+        f = FeatureWithConfidence(name="size_ratio", value=2.0, n_demos=4)
+        assert f.name == "size_ratio"
+        assert f.value == 2.0
+        assert f.n_demos == 4
+
+    def test_is_hashable(self) -> None:
+        # Frozen dataclass + immutable value — safe as a dict key.
+        f1 = FeatureWithConfidence(name="x", value=1, n_demos=3)
+        f2 = FeatureWithConfidence(name="x", value=1, n_demos=3)
+        assert hash(f1) == hash(f2)
+        assert {f1: "ok"}[f2] == "ok"
+
+    def test_empty_name_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            FeatureWithConfidence(name="", value=1, n_demos=1)
+
+    def test_negative_n_demos_rejected(self) -> None:
+        with pytest.raises(ValueError, match="n_demos must be >= 0"):
+            FeatureWithConfidence(name="x", value=1, n_demos=-1)
+
+    def test_effective_confidence_dampens_with_n(self) -> None:
+        # Spec §4.4: at n=n0=4, factor = 0.5.
+        f = FeatureWithConfidence(name="x", value=1, n_demos=4)
+        assert f.effective_confidence() == 0.5
+
+    def test_effective_confidence_zero_at_no_demos(self) -> None:
+        f = FeatureWithConfidence(name="x", value=1, n_demos=0)
+        assert f.effective_confidence() == 0.0
+
+    def test_effective_confidence_uses_config_n0(self) -> None:
+        config = Phase2Config(sample_size_dampening_n0=8)
+        f = FeatureWithConfidence(name="x", value=1, n_demos=8)
+        assert f.effective_confidence(config=config) == 0.5
+
+    def test_base_confidence_scales_through(self) -> None:
+        f = FeatureWithConfidence(name="x", value=1, n_demos=4)
+        assert f.effective_confidence(base_confidence=0.6) == 0.3
+
+
+# ---------------------------------------------------------------------------
+# PartitionedBudget
+# ---------------------------------------------------------------------------
+
+
+class TestPartitionedBudget:
+    def test_spec_default_sums_to_one(self) -> None:
+        b = PartitionedBudget.from_spec_default()
+        assert b.pre_processing == 0.07
+        assert b.mcts == 0.70
+        assert b.refiner == 0.18
+        assert b.cegis == 0.05
+
+    def test_construction_rejects_non_unit_sum(self) -> None:
+        with pytest.raises(ValueError, match="must sum to 1.0"):
+            PartitionedBudget(pre_processing=0.10, mcts=0.70, refiner=0.10, cegis=0.05)
+
+    def test_construction_rejects_negative_fraction(self) -> None:
+        with pytest.raises(ValueError, match="must be >= 0"):
+            PartitionedBudget(
+                pre_processing=-0.05,
+                mcts=0.85,
+                refiner=0.15,
+                cegis=0.05,
+            )
+
+    def test_floating_point_slack_tolerated(self) -> None:
+        # Sum = 1.0 ± 1e-9 — must construct cleanly.
+        PartitionedBudget(
+            pre_processing=0.07,
+            mcts=0.70 + 1e-12,
+            refiner=0.18,
+            cegis=0.05,
+        )
+
+    def test_is_frozen(self) -> None:
+        from dataclasses import FrozenInstanceError
+
+        b = PartitionedBudget.from_spec_default()
+        with pytest.raises(FrozenInstanceError):
+            b.mcts = 0.5  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# MixedPolicy
+# ---------------------------------------------------------------------------
+
+
+class TestMixedPolicy:
+    def test_from_dict_orders_keys(self) -> None:
+        p = MixedPolicy.from_dict({"b": 0.5, "a": 0.3, "c": 0.2}, alpha=0.5)
+        # Sorted by key for determinism.
+        assert p.primitive_scores == (("a", 0.3), ("b", 0.5), ("c", 0.2))
+        assert p.alpha == 0.5
+
+    def test_round_trip_through_dict(self) -> None:
+        original = {"a": 0.4, "b": 0.6}
+        p = MixedPolicy.from_dict(original, alpha=0.7)
+        assert p.as_dict() == original
+
+    def test_is_hashable(self) -> None:
+        p1 = MixedPolicy.from_dict({"a": 1.0}, alpha=0.5)
+        p2 = MixedPolicy.from_dict({"a": 1.0}, alpha=0.5)
+        assert hash(p1) == hash(p2)
+
+
+# ---------------------------------------------------------------------------
+# MCTSNode + MCTSState
+# ---------------------------------------------------------------------------
+
+
+class TestMCTSNode:
+    def test_default_visit_count_zero(self) -> None:
+        n = MCTSNode(primitive="rotate90")
+        assert n.visit_count == 0
+        assert n.total_value == 0.0
+        assert n.mean_value == 0.0
+
+    def test_record_visit_accumulates(self) -> None:
+        n = MCTSNode(primitive="rotate90")
+        n.record_visit(0.5)
+        n.record_visit(0.7)
+        assert n.visit_count == 2
+        assert n.total_value == 1.2
+        assert abs(n.mean_value - 0.6) < 1e-9
+
+    def test_puct_score_blends_value_and_exploration(self) -> None:
+        n = MCTSNode(primitive="rotate90", prior=0.4)
+        # No visits yet → mean_value=0; exploration term dominates.
+        score = n.puct_score(c_puct=3.5, parent_visit_count=10)
+        # 3.5 · 0.4 · sqrt(10) / 1 ≈ 4.427
+        assert 4.4 < score < 4.5
+
+    def test_puct_handles_zero_parent_visits(self) -> None:
+        n = MCTSNode(primitive="x", prior=0.6)
+        # Degenerate case: parent_visit_count=0 → sqrt(0)=0, fall
+        # back to the prior alone (the spec rationale: a freshly-
+        # spawned root has no exploration bonus to compute).
+        score = n.puct_score(c_puct=3.5, parent_visit_count=0)
+        assert score == 0.6  # prior, no mean_value
+
+    def test_children_dict_is_per_instance(self) -> None:
+        # Sanity: dataclass field(default_factory=dict) avoids the
+        # mutable-default-argument trap.
+        a = MCTSNode(primitive="x")
+        b = MCTSNode(primitive="y")
+        a.children["k"] = b
+        assert "k" not in MCTSNode(primitive="z").children
+
+
+class TestMCTSState:
+    def test_step_increments_iteration(self) -> None:
+        root = MCTSNode(primitive="root")
+        s = MCTSState(root=root, budget=PartitionedBudget.from_spec_default())
+        assert s.iteration == 0
+        s.step()
+        s.step()
+        assert s.iteration == 2
+
+    def test_best_so_far_starts_none(self) -> None:
+        root = MCTSNode(primitive="root")
+        s = MCTSState(root=root, budget=PartitionedBudget.from_spec_default())
+        assert s.best_so_far is None


### PR DESCRIPTION
## Summary
Closes **Sprint-1 plan task 2** (Datentypen). Ships the dataclass surface the Sprint-2 MCTS controller + symbolic-prior catalog will read.

### New
- \`FeatureWithConfidence\` (frozen) — name + immutable value + n_demos. \`effective_confidence(*, base_confidence, config)\` returns the spec §4.4 sample-size-dampened confidence. Hashable.
- \`PartitionedBudget\` (frozen) — spec §13.4 split. Sum-to-1.0 invariant at construction. \`from_spec_default()\` for the 0.07/0.70/0.18/0.05 shape.
- \`MixedPolicy\` (frozen) — projection of \`DualPriorResult\` that the MCTS controller consumes (primitive_scores as sorted tuple + alpha). \`from_dict\`/\`as_dict\` round-trip.
- \`MCTSNode\` (mutable) — smallest PUCT-aware node (visit_count, total_value, prior, parent, children, mean_value, puct_score per spec §5.2).
- \`MCTSState\` (mutable) — root + budget + iteration + best_so_far.

### Plan acceptance criteria (task 2)
- [x] All frozen-Dataclasses hashable.
- [x] DSLPrimitive rejects mutual flags (already shipped in #235).
- [x] PartitionedBudget summiert immer auf 1.0 — invariant at construction.
- [x] FeatureWithConfidence.confidence korrekt skaliert via Sample-Size.

## Test plan
- [x] **23 new tests** in \`phase2/test_datatypes.py\` cover construction, hashability, post-init validation, sample-size dampening (default + custom n0 + custom base_confidence), PUCT score math, zero-visit edge case, frozen-instance enforcement.
- [x] PSE suite: **960 passed, 10 skipped** (was 937 + 10 → +23).
- [x] \`mypy --strict\` clean (58 source files, +1 datatypes.py).
- [x] \`ruff check\`, \`ruff format --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)