### PR TITLE
feat(pse): Phase-2 Sprint-1 — verifier final-score aggregation (plan task 8)

### DIFF
--- a/src/cognithor/channels/program_synthesis/phase2/__init__.py
+++ b/src/cognithor/channels/program_synthesis/phase2/__init__.py
@@ -22,6 +22,7 @@ from cognithor.channels.program_synthesis.phase2.classification import (
 from cognithor.channels.program_synthesis.phase2.config import (
     DEFAULT_PHASE2_CONFIG,
     Phase2Config,
+    VerifierScoreWeights,
 )
 from cognithor.channels.program_synthesis.phase2.config_loader import (
     DEFAULT_HEURISTICS_PATH,
@@ -44,6 +45,10 @@ from cognithor.channels.program_synthesis.phase2.llm_prior import (
     LLMPrior,
     LLMPriorClient,
     LLMPriorError,
+)
+from cognithor.channels.program_synthesis.phase2.scoring import (
+    VerifierScoreInputs,
+    aggregate_verifier_score,
 )
 from cognithor.channels.program_synthesis.phase2.symbolic_prior import (
     SymbolicPrior,
@@ -80,6 +85,9 @@ __all__ = [
     "SymbolicPrior",
     "SymbolicPriorResult",
     "UniformSymbolicPrior",
+    "VerifierScoreInputs",
+    "VerifierScoreWeights",
+    "aggregate_verifier_score",
     "alpha_bounds",
     "apply_sample_size_dampening",
     "classify_primitive_name",

--- a/src/cognithor/channels/program_synthesis/phase2/config.py
+++ b/src/cognithor/channels/program_synthesis/phase2/config.py
@@ -19,7 +19,53 @@ or replace them, then update :data:`DEFAULT_PHASE2_CONFIG`.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class VerifierScoreWeights:
+    """Spec §7.2 — five-factor verifier score weights.
+
+    The final verifier score is a weighted sum of:
+
+    * ``demo_pass_rate`` — fraction of demos the program produces
+      correctly (the dominant signal).
+    * ``partial_pixel_match`` — Phase-2 graduated pixel-level match.
+    * ``invariants_satisfied`` — fraction of property-invariant tests
+      that hold.
+    * ``triviality_score`` — high when the program is non-trivial
+      (rule-based check, spec §7.3.1).
+    * ``suspicion_score`` — high when the (program, score) pair is
+      not suspicious (spec §7.3.2 — F1 multipliers feed into this).
+
+    The five weights MUST sum to 1.0 — enforced at construction.
+    """
+
+    demo_pass_rate: float = 0.55
+    partial_pixel_match: float = 0.13
+    invariants_satisfied: float = 0.08
+    triviality_score: float = 0.12
+    suspicion_score: float = 0.12
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("demo_pass_rate", self.demo_pass_rate),
+            ("partial_pixel_match", self.partial_pixel_match),
+            ("invariants_satisfied", self.invariants_satisfied),
+            ("triviality_score", self.triviality_score),
+            ("suspicion_score", self.suspicion_score),
+        ):
+            if value < 0.0 or value > 1.0:
+                raise ValueError(f"VerifierScoreWeights.{name} must be in [0, 1]; got {value}")
+        total = (
+            self.demo_pass_rate
+            + self.partial_pixel_match
+            + self.invariants_satisfied
+            + self.triviality_score
+            + self.suspicion_score
+        )
+        if abs(total - 1.0) > 1e-9:
+            raise ValueError(f"VerifierScoreWeights must sum to 1.0; got {total}")
 
 
 @dataclass(frozen=True)
@@ -96,6 +142,13 @@ class Phase2Config:
     # Wall-clock cap per LLM call (seconds). Spec §13.3 budget for
     # repair stages is sub-second; 8 s is a safe outer bound.
     llm_call_timeout_seconds: float = 8.0
+
+    # ── Verifier score weights (spec §7.2) ──────────────────────────
+    # Five-factor weighted sum that reduces a Phase-2 verifier
+    # evaluation to a single score in [0, 1]. Weights must sum to 1.0;
+    # the nested dataclass enforces that at construction time so a
+    # mis-tuned config blows up loudly.
+    verifier_score_weights: VerifierScoreWeights = field(default_factory=VerifierScoreWeights)
 
     def __post_init__(self) -> None:
         # Sanity: zones must form a non-empty graybereich.

--- a/src/cognithor/channels/program_synthesis/phase2/config_loader.py
+++ b/src/cognithor/channels/program_synthesis/phase2/config_loader.py
@@ -33,7 +33,10 @@ from typing import Any
 
 import yaml  # type: ignore[import-untyped]
 
-from cognithor.channels.program_synthesis.phase2.config import Phase2Config
+from cognithor.channels.program_synthesis.phase2.config import (
+    Phase2Config,
+    VerifierScoreWeights,
+)
 
 DEFAULT_HEURISTICS_PATH = (
     Path(__file__).resolve().parents[5] / "configs" / "synthesis" / "heuristics.yaml"
@@ -101,6 +104,7 @@ def _project_to_phase2_config(raw: dict[str, Any]) -> Phase2Config:
     """
     verifier = _expect_section(raw, "verifier")
     sc = _expect_section(verifier, "syntactic_complexity", parent="verifier")
+    score_weights_raw = _expect_section(verifier, "score_weights", parent="verifier")
     refiner = _expect_section(raw, "refiner")
     thresholds = _expect_section(refiner, "mode_thresholds", parent="refiner")
     hysteresis = _expect_section(refiner, "mode_hysteresis", parent="refiner")
@@ -180,6 +184,23 @@ def _project_to_phase2_config(raw: dict[str, Any]) -> Phase2Config:
                 llm,
                 "call_timeout_seconds",
                 default=_optional_float(llm_inference, "call_timeout_seconds", default=8.0),
+            ),
+            verifier_score_weights=VerifierScoreWeights(
+                demo_pass_rate=_expect_float(
+                    score_weights_raw, "demo_pass_rate", parent="verifier.score_weights"
+                ),
+                partial_pixel_match=_expect_float(
+                    score_weights_raw, "partial_pixel_match", parent="verifier.score_weights"
+                ),
+                invariants_satisfied=_expect_float(
+                    score_weights_raw, "invariants_satisfied", parent="verifier.score_weights"
+                ),
+                triviality_score=_expect_float(
+                    score_weights_raw, "triviality_score", parent="verifier.score_weights"
+                ),
+                suspicion_score=_expect_float(
+                    score_weights_raw, "suspicion_score", parent="verifier.score_weights"
+                ),
             ),
         )
     except ValueError as exc:

--- a/src/cognithor/channels/program_synthesis/phase2/scoring.py
+++ b/src/cognithor/channels/program_synthesis/phase2/scoring.py
@@ -1,0 +1,78 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Phase-2 verifier final-score aggregation (spec §7.2).
+
+Reduces five sub-scores to a single ``[0, 1]`` value the search
+engine reads off as the candidate's reward signal:
+
+    final = w_demo · demo_pass_rate
+          + w_partial · partial_pixel_match
+          + w_inv · invariants_satisfied
+          + w_triv · triviality_score
+          + w_susp · suspicion_score
+
+Weights live on :class:`VerifierScoreWeights` (a flat field on
+:class:`Phase2Config`) so the spec §17 D-criterion "12 % + 12 %"
+binding for triviality + suspicion can be A/B-validated in Sprint-2
+without touching code.
+
+Sprint-1 plan acceptance criterion (task 8):
+*Triviality + Suspicion gewichten korrekt im Final-Score (12 % + 12 %)*.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from cognithor.channels.program_synthesis.phase2.config import (
+    DEFAULT_PHASE2_CONFIG,
+    Phase2Config,
+)
+
+
+@dataclass(frozen=True)
+class VerifierScoreInputs:
+    """The five Phase-2 verifier sub-scores."""
+
+    demo_pass_rate: float
+    partial_pixel_match: float
+    invariants_satisfied: float
+    triviality_score: float
+    suspicion_score: float
+
+    def __post_init__(self) -> None:
+        for name, value in (
+            ("demo_pass_rate", self.demo_pass_rate),
+            ("partial_pixel_match", self.partial_pixel_match),
+            ("invariants_satisfied", self.invariants_satisfied),
+            ("triviality_score", self.triviality_score),
+            ("suspicion_score", self.suspicion_score),
+        ):
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"VerifierScoreInputs.{name} must be in [0, 1]; got {value}")
+
+
+def aggregate_verifier_score(
+    inputs: VerifierScoreInputs,
+    *,
+    config: Phase2Config = DEFAULT_PHASE2_CONFIG,
+) -> float:
+    """Compute the spec §7.2 weighted-sum final score in ``[0, 1]``.
+
+    The result is in the closed unit interval *by construction*: each
+    input is in ``[0, 1]`` (validated on construction) and the weights
+    sum to 1.0 (validated on Phase2Config construction).
+    """
+    w = config.verifier_score_weights
+    return (
+        w.demo_pass_rate * inputs.demo_pass_rate
+        + w.partial_pixel_match * inputs.partial_pixel_match
+        + w.invariants_satisfied * inputs.invariants_satisfied
+        + w.triviality_score * inputs.triviality_score
+        + w.suspicion_score * inputs.suspicion_score
+    )
+
+
+__all__ = [
+    "VerifierScoreInputs",
+    "aggregate_verifier_score",
+]

--- a/tests/test_channels/test_program_synthesis/phase2/test_config_loader.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_config_loader.py
@@ -145,6 +145,12 @@ verifier:
     high_impact_multiplier: 3.0
     structural_abstraction_multiplier: 1.5
     regular_multiplier: 1.0
+  score_weights:
+    demo_pass_rate: 0.55
+    partial_pixel_match: 0.13
+    invariants_satisfied: 0.08
+    triviality_score: 0.12
+    suspicion_score: 0.12
 
 refiner:
   mode_thresholds:

--- a/tests/test_channels/test_program_synthesis/phase2/test_scoring.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_scoring.py
@@ -1,0 +1,191 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Verifier score-aggregation tests (Sprint-1 plan task 8, spec §7.2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.phase2 import (
+    DEFAULT_PHASE2_CONFIG,
+    Phase2Config,
+    VerifierScoreInputs,
+    VerifierScoreWeights,
+    aggregate_verifier_score,
+    load_heuristics,
+)
+
+# ---------------------------------------------------------------------------
+# VerifierScoreWeights — invariants
+# ---------------------------------------------------------------------------
+
+
+class TestVerifierScoreWeights:
+    def test_default_matches_spec_anchors(self) -> None:
+        w = VerifierScoreWeights()
+        assert w.demo_pass_rate == 0.55
+        assert w.partial_pixel_match == 0.13
+        assert w.invariants_satisfied == 0.08
+        # Spec §17 D-criterion binding: 12 % triviality + 12 % suspicion.
+        assert w.triviality_score == 0.12
+        assert w.suspicion_score == 0.12
+
+    def test_default_sums_to_one(self) -> None:
+        w = VerifierScoreWeights()
+        total = (
+            w.demo_pass_rate
+            + w.partial_pixel_match
+            + w.invariants_satisfied
+            + w.triviality_score
+            + w.suspicion_score
+        )
+        assert abs(total - 1.0) < 1e-9
+
+    def test_construction_rejects_non_unit_sum(self) -> None:
+        with pytest.raises(ValueError, match="must sum to 1.0"):
+            VerifierScoreWeights(
+                demo_pass_rate=0.5,
+                partial_pixel_match=0.1,
+                invariants_satisfied=0.1,
+                triviality_score=0.1,
+                suspicion_score=0.1,
+            )
+
+    def test_construction_rejects_out_of_range_weight(self) -> None:
+        with pytest.raises(ValueError, match=r"must be in \[0, 1\]"):
+            VerifierScoreWeights(
+                demo_pass_rate=1.5,
+                partial_pixel_match=0.0,
+                invariants_satisfied=0.0,
+                triviality_score=0.0,
+                suspicion_score=0.0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# aggregate_verifier_score — math
+# ---------------------------------------------------------------------------
+
+
+class TestAggregateVerifierScore:
+    def test_perfect_inputs_yield_one(self) -> None:
+        inputs = VerifierScoreInputs(
+            demo_pass_rate=1.0,
+            partial_pixel_match=1.0,
+            invariants_satisfied=1.0,
+            triviality_score=1.0,
+            suspicion_score=1.0,
+        )
+        score = aggregate_verifier_score(inputs)
+        assert abs(score - 1.0) < 1e-9
+
+    def test_zero_inputs_yield_zero(self) -> None:
+        inputs = VerifierScoreInputs(
+            demo_pass_rate=0.0,
+            partial_pixel_match=0.0,
+            invariants_satisfied=0.0,
+            triviality_score=0.0,
+            suspicion_score=0.0,
+        )
+        score = aggregate_verifier_score(inputs)
+        assert score == 0.0
+
+    def test_demo_pass_only_weighted_at_55_percent(self) -> None:
+        inputs = VerifierScoreInputs(
+            demo_pass_rate=1.0,
+            partial_pixel_match=0.0,
+            invariants_satisfied=0.0,
+            triviality_score=0.0,
+            suspicion_score=0.0,
+        )
+        score = aggregate_verifier_score(inputs)
+        assert abs(score - 0.55) < 1e-9
+
+    def test_triviality_plus_suspicion_combined_24_percent(self) -> None:
+        # Spec §17 binding: 12 % + 12 %.
+        inputs = VerifierScoreInputs(
+            demo_pass_rate=0.0,
+            partial_pixel_match=0.0,
+            invariants_satisfied=0.0,
+            triviality_score=1.0,
+            suspicion_score=1.0,
+        )
+        score = aggregate_verifier_score(inputs)
+        assert abs(score - 0.24) < 1e-9
+
+    def test_input_out_of_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"must be in \[0, 1\]"):
+            VerifierScoreInputs(
+                demo_pass_rate=1.5,
+                partial_pixel_match=0.0,
+                invariants_satisfied=0.0,
+                triviality_score=0.0,
+                suspicion_score=0.0,
+            )
+
+    def test_custom_weights_propagate(self) -> None:
+        # Push everything into demo_pass_rate.
+        config = Phase2Config(
+            verifier_score_weights=VerifierScoreWeights(
+                demo_pass_rate=1.0,
+                partial_pixel_match=0.0,
+                invariants_satisfied=0.0,
+                triviality_score=0.0,
+                suspicion_score=0.0,
+            )
+        )
+        inputs = VerifierScoreInputs(
+            demo_pass_rate=0.7,
+            partial_pixel_match=1.0,
+            invariants_satisfied=1.0,
+            triviality_score=1.0,
+            suspicion_score=1.0,
+        )
+        # Only demo_pass_rate carries weight → score = 0.7.
+        score = aggregate_verifier_score(inputs, config=config)
+        assert abs(score - 0.7) < 1e-9
+
+    def test_default_config_used_when_none_passed(self) -> None:
+        inputs = VerifierScoreInputs(
+            demo_pass_rate=0.5,
+            partial_pixel_match=0.5,
+            invariants_satisfied=0.5,
+            triviality_score=0.5,
+            suspicion_score=0.5,
+        )
+        # Half-everything with default weights → 0.5.
+        assert aggregate_verifier_score(inputs) == aggregate_verifier_score(
+            inputs, config=DEFAULT_PHASE2_CONFIG
+        )
+        assert abs(aggregate_verifier_score(inputs) - 0.5) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# YAML loader → Phase2Config.verifier_score_weights round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestYamlRoundTrip:
+    def test_loaded_weights_match_yaml(self) -> None:
+        cfg = load_heuristics().phase2_config
+        w = cfg.verifier_score_weights
+        # Match the spec-anchored YAML values.
+        assert w.demo_pass_rate == 0.55
+        assert w.partial_pixel_match == 0.13
+        assert w.invariants_satisfied == 0.08
+        assert w.triviality_score == 0.12
+        assert w.suspicion_score == 0.12
+
+    def test_loaded_weights_sum_to_one(self) -> None:
+        cfg = load_heuristics().phase2_config
+        w = cfg.verifier_score_weights
+        total = (
+            w.demo_pass_rate
+            + w.partial_pixel_match
+            + w.invariants_satisfied
+            + w.triviality_score
+            + w.suspicion_score
+        )
+        assert abs(total - 1.0) < 1e-9


### PR DESCRIPTION
## Summary
Closes the score-aggregation slice of **Sprint-1 plan task 8**. Wires the spec §7.2 five-factor weighted sum into the channel:

\`\`\`
final = w_demo · demo_pass_rate
      + w_partial · partial_pixel_match
      + w_inv · invariants_satisfied
      + w_triv · triviality_score
      + w_susp · suspicion_score
\`\`\`

Spec §17 D-criterion binding: triviality + suspicion combined contribute exactly **24 % (12 % each)**. The new \`VerifierScoreWeights\` dataclass enforces sum-to-1.0 at construction.

### New
- \`Phase2Config.verifier_score_weights\` field — \`VerifierScoreWeights\` (defaults 0.55 / 0.13 / 0.08 / 0.12 / 0.12). Construction validates range and sum.
- \`phase2/scoring.py\` — \`VerifierScoreInputs\` + \`aggregate_verifier_score(inputs, *, config)\`. By construction the result lives in [0, 1].
- \`config_loader\` reads \`verifier.score_weights\` from \`heuristics.yaml\` and constructs the dataclass. Schema-violations propagate via \`ConfigLoadError\` as before.

## Test plan
- [x] **13 new tests** in \`phase2/test_scoring.py\` cover VerifierScoreWeights defaults + invariants, aggregate math (perfect=1, zero=0, demo-only=0.55, triv+susp=0.24 — spec D-criterion verbatim), config override, default-config equivalence, and YAML round-trip.
- [x] PSE suite: **973 passed, 10 skipped** (was 960 + 10 → +13).
- [x] \`mypy --strict\` clean (59 source files).
- [x] \`ruff check\`, \`ruff format --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)