### PR TITLE
feat(pse): Phase-2 Sprint-1 — partial_pixel_match metric (plan task 8 slice)

### DIFF
--- a/src/cognithor/channels/program_synthesis/phase2/__init__.py
+++ b/src/cognithor/channels/program_synthesis/phase2/__init__.py
@@ -51,6 +51,10 @@ from cognithor.channels.program_synthesis.phase2.llm_prior import (
     LLMPriorClient,
     LLMPriorError,
 )
+from cognithor.channels.program_synthesis.phase2.pixel_match import (
+    average_partial_pixel_match,
+    partial_pixel_match,
+)
 from cognithor.channels.program_synthesis.phase2.scoring import (
     VerifierScoreInputs,
     aggregate_verifier_score,
@@ -98,9 +102,11 @@ __all__ = [
     "aggregate_verifier_score",
     "alpha_bounds",
     "apply_sample_size_dampening",
+    "average_partial_pixel_match",
     "classify_primitive_name",
     "compute_suspicion",
     "load_heuristics",
     "mix_alpha",
+    "partial_pixel_match",
     "phase2_counters",
 ]

--- a/src/cognithor/channels/program_synthesis/phase2/pixel_match.py
+++ b/src/cognithor/channels/program_synthesis/phase2/pixel_match.py
@@ -1,0 +1,88 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Phase-2 graduated pixel-match metric (spec §7.2 + plan task 8).
+
+Phase-1 verifies a candidate program by checking whether its output
+*exactly* equals the expected demo output. Phase-2 introduces a
+graduated signal: ``partial_pixel_match`` returns the fraction of
+cells that match, in ``[0, 1]``. The verifier weighs this with the
+``partial_pixel_match`` weight from :class:`VerifierScoreWeights`
+(default 0.13) when computing the final score.
+
+Behaviour:
+
+* Both inputs must be 2-D ``numpy.ndarray``. Anything else raises
+  :class:`TypeError`.
+* Size mismatch returns ``0.0``. The spec's intuition: a program
+  that produces the wrong-sized output is no closer to the answer
+  than one that produces a totally wrong same-sized output, but the
+  caller may want to apply a separate "size correctness" property.
+* Empty grids (zero cells) return ``0.0`` rather than NaN — division
+  by zero would otherwise pollute the verifier score.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def partial_pixel_match(actual: np.ndarray[Any, Any], expected: np.ndarray[Any, Any]) -> float:
+    """Return the fraction of matching cells in ``[0, 1]``.
+
+    * ``1.0`` iff both grids are pixel-identical.
+    * ``0.0`` if the shapes differ or either grid is empty.
+    * Otherwise: ``num_matching_cells / total_cells``.
+    """
+    if not isinstance(actual, np.ndarray):
+        raise TypeError(
+            f"partial_pixel_match: actual must be numpy.ndarray, got {type(actual).__name__}"
+        )
+    if not isinstance(expected, np.ndarray):
+        raise TypeError(
+            f"partial_pixel_match: expected must be numpy.ndarray, got {type(expected).__name__}"
+        )
+    if actual.ndim != 2 or expected.ndim != 2:
+        raise TypeError(
+            f"partial_pixel_match: both grids must be 2-D; got "
+            f"actual.ndim={actual.ndim}, expected.ndim={expected.ndim}"
+        )
+    if actual.shape != expected.shape:
+        return 0.0
+    if actual.size == 0:
+        return 0.0
+    matches = np.count_nonzero(actual == expected)
+    return float(matches) / float(actual.size)
+
+
+def average_partial_pixel_match(
+    actual_grids: list[np.ndarray[Any, Any]],
+    expected_grids: list[np.ndarray[Any, Any]],
+) -> float:
+    """Average :func:`partial_pixel_match` across paired grid lists.
+
+    Useful when the verifier checks the candidate program against
+    every demo example: the per-demo pixel-match average becomes the
+    aggregate signal the score weighter consumes.
+
+    Returns ``0.0`` for an empty input list (the verifier should
+    always pass at least one demo, but the function is total).
+    Raises :class:`ValueError` if the two lists have different lengths.
+    """
+    if len(actual_grids) != len(expected_grids):
+        raise ValueError(
+            f"average_partial_pixel_match: length mismatch — "
+            f"{len(actual_grids)} actual vs {len(expected_grids)} expected"
+        )
+    if not actual_grids:
+        return 0.0
+    total = sum(
+        partial_pixel_match(a, e) for a, e in zip(actual_grids, expected_grids, strict=True)
+    )
+    return total / len(actual_grids)
+
+
+__all__ = [
+    "average_partial_pixel_match",
+    "partial_pixel_match",
+]

--- a/tests/test_channels/test_program_synthesis/phase2/test_pixel_match.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_pixel_match.py
@@ -1,0 +1,116 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Phase-2 partial-pixel-match tests (plan task 8 slice, spec §7.2)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.phase2 import (
+    average_partial_pixel_match,
+    partial_pixel_match,
+)
+
+# ---------------------------------------------------------------------------
+# partial_pixel_match
+# ---------------------------------------------------------------------------
+
+
+class TestPartialPixelMatch:
+    def test_identical_grids_return_one(self) -> None:
+        a = np.array([[1, 2], [3, 4]], dtype=np.int8)
+        b = np.array([[1, 2], [3, 4]], dtype=np.int8)
+        assert partial_pixel_match(a, b) == 1.0
+
+    def test_completely_different_returns_zero(self) -> None:
+        a = np.array([[0, 0], [0, 0]], dtype=np.int8)
+        b = np.array([[1, 1], [1, 1]], dtype=np.int8)
+        assert partial_pixel_match(a, b) == 0.0
+
+    def test_half_match_returns_half(self) -> None:
+        a = np.array([[1, 2], [3, 4]], dtype=np.int8)
+        b = np.array([[1, 9], [3, 9]], dtype=np.int8)
+        # 2 / 4 cells match = 0.5.
+        assert partial_pixel_match(a, b) == 0.5
+
+    def test_one_quarter_match(self) -> None:
+        a = np.array([[1, 2, 3, 4]], dtype=np.int8)
+        b = np.array([[1, 0, 0, 0]], dtype=np.int8)
+        assert partial_pixel_match(a, b) == 0.25
+
+    def test_shape_mismatch_returns_zero(self) -> None:
+        a = np.array([[1, 2]], dtype=np.int8)
+        b = np.array([[1, 2], [3, 4]], dtype=np.int8)
+        assert partial_pixel_match(a, b) == 0.0
+
+    def test_empty_grids_return_zero(self) -> None:
+        a = np.zeros((0, 0), dtype=np.int8)
+        b = np.zeros((0, 0), dtype=np.int8)
+        assert partial_pixel_match(a, b) == 0.0
+
+    def test_non_ndarray_input_raises(self) -> None:
+        a = np.array([[1]], dtype=np.int8)
+        with pytest.raises(TypeError, match="must be numpy.ndarray"):
+            partial_pixel_match([[1]], a)  # type: ignore[arg-type]
+        with pytest.raises(TypeError, match="must be numpy.ndarray"):
+            partial_pixel_match(a, [[1]])  # type: ignore[arg-type]
+
+    def test_non_2d_input_raises(self) -> None:
+        a = np.array([1, 2, 3], dtype=np.int8)
+        b = np.array([1, 2, 3], dtype=np.int8)
+        with pytest.raises(TypeError, match="must be 2-D"):
+            partial_pixel_match(a, b)
+
+
+# ---------------------------------------------------------------------------
+# average_partial_pixel_match
+# ---------------------------------------------------------------------------
+
+
+class TestAveragePartialPixelMatch:
+    def test_all_perfect_returns_one(self) -> None:
+        actuals = [
+            np.array([[1, 2]], dtype=np.int8),
+            np.array([[3, 4]], dtype=np.int8),
+        ]
+        assert average_partial_pixel_match(actuals, list(actuals)) == 1.0
+
+    def test_mixed_pairs_average(self) -> None:
+        # First pair: 1.0 match. Second pair: 0.5 match. Average = 0.75.
+        actuals = [
+            np.array([[1, 2], [3, 4]], dtype=np.int8),
+            np.array([[1, 2], [3, 4]], dtype=np.int8),
+        ]
+        expecteds = [
+            np.array([[1, 2], [3, 4]], dtype=np.int8),
+            np.array([[1, 9], [3, 9]], dtype=np.int8),
+        ]
+        assert average_partial_pixel_match(actuals, expecteds) == 0.75
+
+    def test_empty_list_returns_zero(self) -> None:
+        assert average_partial_pixel_match([], []) == 0.0
+
+    def test_length_mismatch_raises(self) -> None:
+        with pytest.raises(ValueError, match="length mismatch"):
+            average_partial_pixel_match(
+                [np.array([[1]], dtype=np.int8)],
+                [
+                    np.array([[1]], dtype=np.int8),
+                    np.array([[2]], dtype=np.int8),
+                ],
+            )
+
+    def test_one_size_mismatch_pulls_average_down(self) -> None:
+        actuals = [
+            np.array([[1, 2]], dtype=np.int8),
+            np.array([[1]], dtype=np.int8),  # shape mismatch with expected
+        ]
+        expecteds = [
+            np.array([[1, 2]], dtype=np.int8),
+            np.array([[1, 1]], dtype=np.int8),  # different shape
+        ]
+        # Pair 1: 1.0; pair 2: 0.0 (shape mismatch). Average = 0.5.
+        assert average_partial_pixel_match(actuals, expecteds) == 0.5


### PR DESCRIPTION
## Summary
Closes the \`partial_pixel_match\` slice of **Sprint-1 plan task 8**.

Spec §7.2 lists \`partial_pixel_match\` as one of the five sub-scores the verifier weighs (default weight 0.13). Phase-1 only checked exact equality; Phase-2 needs a graduated [0, 1] signal so partial-correct programs still contribute to the search reward.

### New
- \`phase2/pixel_match.py\`:
  - \`partial_pixel_match(actual, expected) -> float\` — matching-cell fraction. 1.0 for identical, 0.0 for shape mismatch or empty grids. TypeError on non-ndarray / non-2D input.
  - \`average_partial_pixel_match(actuals, expecteds) -> float\` — averages across paired demo lists. ValueError on length mismatch.

## Test plan
- [x] **13 new tests** cover identical/disjoint/half/quarter-match cases, shape mismatch, empty grids, type guards, multi-demo averaging, length-mismatch rejection.
- [x] PSE suite: **1001 passed, 10 skipped** (was 988 + 10 → +13).
- [x] \`mypy --strict\` clean (61 source files).
- [x] \`ruff check\`, \`ruff format --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)