### PR TITLE
feat(pse): Phase-2 Sprint-1 — CEGIS Refiner stage (plan task 9 slice, §6.5.3)

### DIFF
--- a/src/cognithor/channels/program_synthesis/phase2/config.py
+++ b/src/cognithor/channels/program_synthesis/phase2/config.py
@@ -134,6 +134,15 @@ class Phase2Config:
     alpha_performance_window: int = 10
     alpha_cold_start: float = 0.85
 
+    # ── CEGIS Refiner stage (spec §6.5.3) ──────────────────────────
+    # Counter-Example-Guided Inductive Synthesis runs *after* the
+    # Drei-Zonen-Refiner if the candidate's score is in the eligible
+    # band. The loop terminates on max_iterations OR budget timeout
+    # OR all-demos-pass.
+    cegis_max_iterations: int = 5
+    cegis_eligibility_score_min: float = 0.5
+    cegis_sub_budget_per_iter_fraction: float = 0.33
+
     # ── Module A — LLM-Prior over vLLM (spec §4.2 / §4.3 / §4.7) ────
     # Backend: vLLM exposing OpenAI-compat /v1/chat/completions.
     # Default model is the spec-anchored Qwen3.6-27B-Instruct on the
@@ -227,6 +236,20 @@ class Phase2Config:
         # Phase2Config(alpha_entropy_upper=0.7) etc. constructible
         # even when the spec-default alpha_cold_start=0.85 sits
         # above a customised band.
+        if self.cegis_max_iterations < 1:
+            raise ValueError(
+                f"Phase2Config: cegis_max_iterations must be >= 1; got {self.cegis_max_iterations}."
+            )
+        if not 0.0 <= self.cegis_eligibility_score_min <= 1.0:
+            raise ValueError(
+                f"Phase2Config: cegis_eligibility_score_min must be in "
+                f"[0, 1]; got {self.cegis_eligibility_score_min}."
+            )
+        if not 0.0 < self.cegis_sub_budget_per_iter_fraction <= 1.0:
+            raise ValueError(
+                f"Phase2Config: cegis_sub_budget_per_iter_fraction must "
+                f"be in (0, 1]; got {self.cegis_sub_budget_per_iter_fraction}."
+            )
         # LLM prior validation.
         if not self.llm_model_name:
             raise ValueError("Phase2Config: llm_model_name must be non-empty.")

--- a/src/cognithor/channels/program_synthesis/refiner/__init__.py
+++ b/src/cognithor/channels/program_synthesis/refiner/__init__.py
@@ -8,6 +8,11 @@ follow in subsequent sprints.
 
 from __future__ import annotations
 
+from cognithor.channels.program_synthesis.refiner.cegis import (
+    CEGISLoop,
+    CEGISResult,
+    CounterExample,
+)
 from cognithor.channels.program_synthesis.refiner.local_edit import (
     LocalEditMutator,
 )
@@ -17,6 +22,9 @@ from cognithor.channels.program_synthesis.refiner.mode_controller import (
 )
 
 __all__ = [
+    "CEGISLoop",
+    "CEGISResult",
+    "CounterExample",
     "LocalEditMutator",
     "RefinerMode",
     "RefinerModeController",

--- a/src/cognithor/channels/program_synthesis/refiner/cegis.py
+++ b/src/cognithor/channels/program_synthesis/refiner/cegis.py
@@ -1,0 +1,208 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Spec §6.5.3 — CEGIS Refiner stage (Sprint-1 plan task 9 slice).
+
+Counter-Example-Guided Inductive Synthesis (CEGIS) is the Refiner's
+last-line repair: when the candidate's verifier score is at least
+``cegis_eligibility_score_min`` (default 0.5) but the program still
+fails *some* demos, the loop iterates:
+
+1. Identify the failing demos as **counter-examples**.
+2. Hand them to a **constrained synthesizer** (callable injected by
+   the caller — Sprint-1 leaves the actual constraint compiler as a
+   Phase-2-spec §6.5.3 detail to be filled in by the search-engine
+   integration).
+3. Replace the candidate with the synthesizer's output and re-evaluate.
+4. Stop when:
+   * every demo passes (success),
+   * ``cegis_max_iterations`` is reached (budget — default 5),
+   * the wall-clock budget is exhausted, or
+   * the synthesizer returns ``None`` (no further candidate).
+
+The loop is the **driver**: the search-side "given these
+counter-examples find a program" step is dependency-injected so this
+module is testable without a live search engine.
+
+Plan acceptance criterion (task 9): *CEGIS terminiert garantiert in
+≤ 5 Iter UND Budget-Limit* — verified in the test suite below.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from cognithor.channels.program_synthesis.phase2.config import (
+    DEFAULT_PHASE2_CONFIG,
+    Phase2Config,
+)
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.search.candidate import (
+        ProgramNode,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CounterExample:
+    """One failing demo the synthesizer must satisfy on the next pass.
+
+    ``input_grid`` and ``expected_output`` come from the demo set;
+    ``actual_output`` is what the current candidate produced. The
+    triple lets the constrained synthesizer see *what went wrong*,
+    not just "this demo failed".
+    """
+
+    input_grid: Any
+    expected_output: Any
+    actual_output: Any
+
+
+@dataclass(frozen=True)
+class CEGISResult:
+    """Outcome of one :class:`CEGISLoop.run` call.
+
+    ``program`` is the best-found candidate (or the original if the
+    loop made no progress). ``terminated_by`` is the reason the loop
+    stopped: one of ``"all_demos_pass"``, ``"max_iterations"``,
+    ``"budget_exhausted"``, or ``"synthesizer_gave_up"``.
+
+    ``iterations`` is the number of synthesizer calls actually made.
+    ``elapsed_seconds`` is the wall-clock duration of the loop.
+    """
+
+    program: ProgramNode
+    terminated_by: str
+    iterations: int
+    elapsed_seconds: float
+    counter_examples_history: tuple[tuple[CounterExample, ...], ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+# A `demo_evaluator` evaluates the candidate against every demo and
+# returns the list of failing demos as CounterExamples. An empty list
+# means "all demos pass".
+DemoEvaluator = Callable[
+    ["ProgramNode", list[tuple[Any, Any]]],
+    list[CounterExample],
+]
+
+# The constrained synthesizer takes the current candidate plus the
+# counter-examples accumulated so far and returns a fresh candidate,
+# or `None` if it gives up.
+ConstrainedSynthesizer = Callable[
+    ["ProgramNode", list[CounterExample], float],
+    "ProgramNode | None",
+]
+
+
+class CEGISLoop:
+    """Spec §6.5.3 — driver for the CEGIS refinement loop.
+
+    Stateless across runs — caller constructs once, calls :meth:`run`
+    per refinement attempt. The :class:`Phase2Config` controls the
+    max-iterations cap, eligibility threshold (caller-checked), and
+    per-iteration sub-budget fraction.
+    """
+
+    def __init__(
+        self,
+        synthesizer: ConstrainedSynthesizer,
+        evaluator: DemoEvaluator,
+        *,
+        config: Phase2Config = DEFAULT_PHASE2_CONFIG,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._synthesizer = synthesizer
+        self._evaluator = evaluator
+        self._config = config
+        self._clock = clock
+
+    def run(
+        self,
+        initial_program: ProgramNode,
+        demos: list[tuple[Any, Any]],
+        *,
+        wall_clock_budget_seconds: float,
+    ) -> CEGISResult:
+        """Run the loop until termination — see module docstring."""
+        if wall_clock_budget_seconds <= 0:
+            raise ValueError(
+                f"wall_clock_budget_seconds must be > 0; got {wall_clock_budget_seconds!r}"
+            )
+        start = self._clock()
+        deadline = start + wall_clock_budget_seconds
+        sub_budget = wall_clock_budget_seconds * self._config.cegis_sub_budget_per_iter_fraction
+        program = initial_program
+        history: list[tuple[CounterExample, ...]] = []
+
+        # Initial check — maybe the candidate already passes.
+        counter_examples = self._evaluator(program, demos)
+        if not counter_examples:
+            return CEGISResult(
+                program=program,
+                terminated_by="all_demos_pass",
+                iterations=0,
+                elapsed_seconds=self._clock() - start,
+                counter_examples_history=tuple(history),
+            )
+
+        for iteration in range(1, self._config.cegis_max_iterations + 1):
+            now = self._clock()
+            if now >= deadline:
+                return CEGISResult(
+                    program=program,
+                    terminated_by="budget_exhausted",
+                    iterations=iteration - 1,
+                    elapsed_seconds=now - start,
+                    counter_examples_history=tuple(history),
+                )
+
+            history.append(tuple(counter_examples))
+            candidate = self._synthesizer(program, list(counter_examples), sub_budget)
+            if candidate is None:
+                return CEGISResult(
+                    program=program,
+                    terminated_by="synthesizer_gave_up",
+                    iterations=iteration,
+                    elapsed_seconds=self._clock() - start,
+                    counter_examples_history=tuple(history),
+                )
+
+            program = candidate
+            counter_examples = self._evaluator(program, demos)
+            if not counter_examples:
+                return CEGISResult(
+                    program=program,
+                    terminated_by="all_demos_pass",
+                    iterations=iteration,
+                    elapsed_seconds=self._clock() - start,
+                    counter_examples_history=tuple(history),
+                )
+
+        return CEGISResult(
+            program=program,
+            terminated_by="max_iterations",
+            iterations=self._config.cegis_max_iterations,
+            elapsed_seconds=self._clock() - start,
+            counter_examples_history=tuple(history),
+        )
+
+
+__all__ = [
+    "CEGISLoop",
+    "CEGISResult",
+    "ConstrainedSynthesizer",
+    "CounterExample",
+    "DemoEvaluator",
+]

--- a/tests/test_channels/test_program_synthesis/phase2/test_cegis.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_cegis.py
@@ -1,0 +1,255 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""CEGIS-loop tests (Sprint-1 plan task 9 slice, spec §6.5.3)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.phase2 import Phase2Config
+from cognithor.channels.program_synthesis.refiner import (
+    CEGISLoop,
+    CEGISResult,
+    CounterExample,
+)
+from cognithor.channels.program_synthesis.search.candidate import (
+    InputRef,
+    Program,
+)
+
+
+def _prog(label: str) -> Program:
+    return Program(primitive=label, children=(InputRef(),), output_type="Grid")
+
+
+# ---------------------------------------------------------------------------
+# Termination paths
+# ---------------------------------------------------------------------------
+
+
+class TestCEGISLoop:
+    def test_initial_program_passes_immediately(self) -> None:
+        # Evaluator returns no counter-examples → loop exits at iter 0.
+        loop = CEGISLoop(
+            synthesizer=lambda *_: pytest.fail("synthesizer should not be called"),
+            evaluator=lambda _p, _d: [],
+        )
+        result = loop.run(
+            _prog("rotate90"),
+            demos=[(0, 0)],
+            wall_clock_budget_seconds=10.0,
+        )
+        assert isinstance(result, CEGISResult)
+        assert result.terminated_by == "all_demos_pass"
+        assert result.iterations == 0
+
+    def test_converges_after_two_iterations(self) -> None:
+        # Synthesizer's nth call returns a fresh program. The
+        # evaluator returns failing demos until iter 2.
+        synthesizer_calls = {"n": 0}
+
+        def synthesizer(_program: Any, _ce: list[CounterExample], _budget: float) -> Program:
+            synthesizer_calls["n"] += 1
+            return _prog(f"candidate_v{synthesizer_calls['n']}")
+
+        eval_count = {"n": 0}
+
+        def evaluator(_p: Any, demos: list[tuple[Any, Any]]) -> list[CounterExample]:
+            eval_count["n"] += 1
+            if eval_count["n"] >= 3:  # 1 initial + 2 post-synthesis
+                return []
+            return [
+                CounterExample(
+                    input_grid=demos[0][0], expected_output=demos[0][1], actual_output=None
+                )
+            ]
+
+        loop = CEGISLoop(synthesizer=synthesizer, evaluator=evaluator)
+        result = loop.run(
+            _prog("rotate90"),
+            demos=[(0, 1)],
+            wall_clock_budget_seconds=10.0,
+        )
+        assert result.terminated_by == "all_demos_pass"
+        assert result.iterations == 2
+        assert isinstance(result.program, Program)
+        assert result.program.primitive == "candidate_v2"
+
+    def test_max_iterations_terminates(self) -> None:
+        # Synthesizer always returns a fresh candidate; evaluator
+        # always reports failing demos. Loop hits max_iterations.
+        config = Phase2Config(cegis_max_iterations=3)
+
+        def synthesizer(_p: Any, _ce: Any, _b: float) -> Program:
+            return _prog("never_succeeds")
+
+        def evaluator(_p: Any, demos: list[tuple[Any, Any]]) -> list[CounterExample]:
+            return [
+                CounterExample(
+                    input_grid=demos[0][0], expected_output=demos[0][1], actual_output=None
+                )
+            ]
+
+        loop = CEGISLoop(synthesizer=synthesizer, evaluator=evaluator, config=config)
+        result = loop.run(
+            _prog("rotate90"),
+            demos=[(0, 1)],
+            wall_clock_budget_seconds=10.0,
+        )
+        assert result.terminated_by == "max_iterations"
+        assert result.iterations == 3
+
+    def test_synthesizer_gives_up(self) -> None:
+        # Synthesizer returns None on first call → loop exits early.
+        def synthesizer(_p: Any, _ce: Any, _b: float) -> None:
+            return None
+
+        def evaluator(_p: Any, demos: list[tuple[Any, Any]]) -> list[CounterExample]:
+            return [
+                CounterExample(
+                    input_grid=demos[0][0], expected_output=demos[0][1], actual_output=None
+                )
+            ]
+
+        loop = CEGISLoop(synthesizer=synthesizer, evaluator=evaluator)
+        result = loop.run(
+            _prog("rotate90"),
+            demos=[(0, 1)],
+            wall_clock_budget_seconds=10.0,
+        )
+        assert result.terminated_by == "synthesizer_gave_up"
+        assert result.iterations == 1
+
+    def test_budget_exhausted_terminates(self) -> None:
+        # Inject a clock that advances 100s per call. Budget=10s →
+        # the second deadline check trips.
+        clock_t = {"t": 0.0}
+
+        def fake_clock() -> float:
+            clock_t["t"] += 50.0
+            return clock_t["t"]
+
+        def synthesizer(_p: Any, _ce: Any, _b: float) -> Program:
+            return _prog("v")
+
+        def evaluator(_p: Any, demos: list[tuple[Any, Any]]) -> list[CounterExample]:
+            return [
+                CounterExample(
+                    input_grid=demos[0][0], expected_output=demos[0][1], actual_output=None
+                )
+            ]
+
+        loop = CEGISLoop(
+            synthesizer=synthesizer,
+            evaluator=evaluator,
+            clock=fake_clock,
+        )
+        result = loop.run(
+            _prog("rotate90"),
+            demos=[(0, 1)],
+            wall_clock_budget_seconds=10.0,
+        )
+        assert result.terminated_by == "budget_exhausted"
+        assert result.iterations < 5
+
+    def test_invalid_budget_raises(self) -> None:
+        loop = CEGISLoop(synthesizer=lambda *_: None, evaluator=lambda *_: [])
+        with pytest.raises(ValueError, match="must be > 0"):
+            loop.run(
+                _prog("rotate90"),
+                demos=[(0, 1)],
+                wall_clock_budget_seconds=0.0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Sub-budget propagation + history
+# ---------------------------------------------------------------------------
+
+
+class TestSubBudgetAndHistory:
+    def test_synthesizer_receives_sub_budget(self) -> None:
+        # cegis_sub_budget_per_iter_fraction default = 0.33 →
+        # 30s wall budget × 0.33 = 9.9s sub-budget per call.
+        observed: list[float] = []
+
+        def synthesizer(_p: Any, _ce: Any, sub_budget: float) -> Program:
+            observed.append(sub_budget)
+            return _prog("v")
+
+        def evaluator(_p: Any, demos: list[tuple[Any, Any]]) -> list[CounterExample]:
+            return [
+                CounterExample(
+                    input_grid=demos[0][0], expected_output=demos[0][1], actual_output=None
+                )
+            ]
+
+        loop = CEGISLoop(
+            synthesizer=synthesizer,
+            evaluator=evaluator,
+            config=Phase2Config(cegis_max_iterations=2),
+        )
+        loop.run(
+            _prog("rotate90"),
+            demos=[(0, 1)],
+            wall_clock_budget_seconds=30.0,
+        )
+        assert all(abs(b - 9.9) < 0.001 for b in observed)
+        assert len(observed) == 2
+
+    def test_history_records_counter_examples(self) -> None:
+        # Each iteration's counter-examples land in the history tuple.
+        synthesizer_calls = {"n": 0}
+
+        def synthesizer(_p: Any, _ce: Any, _b: float) -> Program:
+            synthesizer_calls["n"] += 1
+            return _prog(f"v{synthesizer_calls['n']}")
+
+        def evaluator(_p: Any, demos: list[tuple[Any, Any]]) -> list[CounterExample]:
+            if synthesizer_calls["n"] >= 2:
+                return []
+            return [
+                CounterExample(
+                    input_grid="i",
+                    expected_output="e",
+                    actual_output=f"got_{synthesizer_calls['n']}",
+                )
+            ]
+
+        loop = CEGISLoop(synthesizer=synthesizer, evaluator=evaluator)
+        result = loop.run(
+            _prog("rotate90"),
+            demos=[("i", "e")],
+            wall_clock_budget_seconds=10.0,
+        )
+        assert len(result.counter_examples_history) == 2  # 2 iter × 1 ce each
+        # First iter saw "got_0" CE, second saw "got_1".
+        assert result.counter_examples_history[0][0].actual_output == "got_0"
+        assert result.counter_examples_history[1][0].actual_output == "got_1"
+
+
+# ---------------------------------------------------------------------------
+# Phase2Config invariants for CEGIS
+# ---------------------------------------------------------------------------
+
+
+class TestCEGISConfigInvariants:
+    def test_max_iterations_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="cegis_max_iterations"):
+            Phase2Config(cegis_max_iterations=0)
+
+    def test_eligibility_score_in_unit(self) -> None:
+        with pytest.raises(ValueError, match="cegis_eligibility_score_min"):
+            Phase2Config(cegis_eligibility_score_min=1.5)
+        with pytest.raises(ValueError, match="cegis_eligibility_score_min"):
+            Phase2Config(cegis_eligibility_score_min=-0.1)
+
+    def test_sub_budget_fraction_must_be_strictly_positive(self) -> None:
+        with pytest.raises(ValueError, match="cegis_sub_budget"):
+            Phase2Config(cegis_sub_budget_per_iter_fraction=0.0)
+        with pytest.raises(ValueError, match="cegis_sub_budget"):
+            Phase2Config(cegis_sub_budget_per_iter_fraction=1.5)


### PR DESCRIPTION
## Summary
Closes the CEGIS slice of **Sprint-1 plan task 9**. CEGIS (Counter-Example-Guided Inductive Synthesis) is the Refiner's last-line repair: when the candidate's verifier score is ≥ \`cegis_eligibility_score_min\` (default 0.5) but it still fails *some* demos, the loop iterates: identify failing demos as counter-examples → ask a **constrained synthesizer** for a fresh candidate → re-evaluate → repeat.

### Driver-only design
The search-side "given these counter-examples find a program" step is **dependency-injected** so the module is testable without a live search engine. The constrained synthesizer is a callable; the demo evaluator is a callable; the clock is a callable.

### Phase2Config grew three fields
- \`cegis_max_iterations\` = 5
- \`cegis_eligibility_score_min\` = 0.5
- \`cegis_sub_budget_per_iter_fraction\` = 0.33

### Termination paths
\`all_demos_pass\` / \`max_iterations\` / \`budget_exhausted\` / \`synthesizer_gave_up\`.

## Test plan
- [x] **11 new tests** cover every termination path, invalid-budget rejection, sub-budget propagation (\`30s × 0.33 = 9.9s\`), counter-example history accumulation, and Phase2Config CEGIS invariants.
- [x] Plan acceptance criterion (task 9 CEGIS slice): \"CEGIS terminiert garantiert in ≤ 5 Iter UND Budget-Limit\" — both paths covered.
- [x] PSE suite: **1045 passed, 10 skipped** (was 1034 + 10 → +11).
- [x] \`mypy --strict\` clean (64 source files).
- [x] \`ruff check\`, \`ruff format --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)