### PR TITLE
feat(pse): Phase-2 Sprint-1 — Symbolic-Repair Advisor (plan task 9 slice, §6.5.2)

### DIFF
--- a/src/cognithor/channels/program_synthesis/refiner/__init__.py
+++ b/src/cognithor/channels/program_synthesis/refiner/__init__.py
@@ -27,6 +27,11 @@ from cognithor.channels.program_synthesis.refiner.mode_controller import (
     RefinerMode,
     RefinerModeController,
 )
+from cognithor.channels.program_synthesis.refiner.symbolic_repair import (
+    RepairKind,
+    RepairSuggestion,
+    advise_repairs,
+)
 
 __all__ = [
     "CEGISLoop",
@@ -38,6 +43,9 @@ __all__ = [
     "PixelDiff",
     "RefinerMode",
     "RefinerModeController",
+    "RepairKind",
+    "RepairSuggestion",
     "StructureDiff",
+    "advise_repairs",
     "analyze_diff",
 ]

--- a/src/cognithor/channels/program_synthesis/refiner/symbolic_repair.py
+++ b/src/cognithor/channels/program_synthesis/refiner/symbolic_repair.py
@@ -1,0 +1,256 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Spec §6.5.2 — Symbolic-Repair Advisor (Sprint-1 plan task 9 slice).
+
+The Symbolic-Repair stage takes a candidate's actual output, the
+demo's expected output, and the :class:`DiffReport` from
+:mod:`refiner.diff_analyzer`, and returns prioritised
+:class:`RepairSuggestion` items the (Sprint-2) repair driver can
+turn into concrete program-tree mutations.
+
+The five Sprint-1 rules (spec §6.5.2 narrative):
+
+* **R1 ColorRepair** — fires when the diff has any missing/introduced
+  colors. Suggests a ``recolor`` primitive.
+* **R2 ScaleRepair** — fires on shape mismatch where one dimension is
+  an integer multiple of the other. Suggests a ``scale_up``/``scale_down``.
+* **R3 RotationRepair** — fires when expected equals a 90/180/270°
+  rotation of actual. Suggests a ``rotate`` primitive.
+* **R4 MirrorRepair** — fires when expected is the horizontal or
+  vertical flip of actual. Suggests a ``mirror_horizontal`` /
+  ``mirror_vertical`` primitive.
+* **R5 LocalRepair** — fires when the pixel-diff is small (≤ 5 cells)
+  with matching shape. Suggests delegating to the
+  :class:`LocalEditMutator` for cell-level mutations.
+
+Each rule has its own confidence in ``[0, 1]``; the advisor sorts
+suggestions by confidence descending. Caller takes as many or as few
+as the budget allows.
+
+The module is pure-numpy; no Phase2Config dependency. The caller
+gates the rule firing using :class:`DiffReport` flags.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.refiner.diff_analyzer import (
+        DiffReport,
+    )
+
+
+RepairKind = Literal[
+    "color_repair",
+    "scale_repair",
+    "rotation_repair",
+    "mirror_repair",
+    "local_repair",
+]
+
+
+@dataclass(frozen=True)
+class RepairSuggestion:
+    """One suggested repair direction.
+
+    ``kind`` identifies which rule fired. ``primitive_hint`` is the
+    DSL primitive name the rule recommends inserting (or ``None``
+    for ``local_repair`` which delegates back to :class:`LocalEditMutator`).
+    ``confidence`` is in ``[0, 1]`` — higher means more likely to
+    succeed.
+
+    ``detail`` is a free-form note for telemetry (e.g. "swap colors
+    {1, 2}" for a color-repair).
+    """
+
+    kind: RepairKind
+    primitive_hint: str | None
+    confidence: float
+    detail: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Individual rules
+# ---------------------------------------------------------------------------
+
+
+def r1_color_repair(diff: DiffReport) -> RepairSuggestion | None:
+    """Fires iff the diff has any missing OR introduced color."""
+    if diff.identical:
+        return None
+    if not diff.colors.introduced and not diff.colors.missing:
+        return None
+    # Confidence scales with how localised the color disagreement is.
+    # If only colors differ (no structural mismatch, all pixels are
+    # off because of color) → high confidence.
+    if diff.structure.shape_mismatch:
+        confidence = 0.4  # color repair won't fix shape; lower
+    elif not diff.colors.introduced or not diff.colors.missing:  # one-sided
+        confidence = 0.6
+    else:
+        confidence = 0.8
+    detail = f"introduced={sorted(diff.colors.introduced)}, missing={sorted(diff.colors.missing)}"
+    return RepairSuggestion(
+        kind="color_repair",
+        primitive_hint="recolor",
+        confidence=confidence,
+        detail=detail,
+    )
+
+
+def r2_scale_repair(diff: DiffReport) -> RepairSuggestion | None:
+    """Fires iff shapes differ AND one dim is integer-multiple of other."""
+    if not diff.structure.shape_mismatch:
+        return None
+    a_shape = diff.structure.actual_shape
+    e_shape = diff.structure.expected_shape
+    if len(a_shape) != 2 or len(e_shape) != 2:
+        return None
+    if a_shape[0] == 0 or a_shape[1] == 0 or e_shape[0] == 0 or e_shape[1] == 0:
+        return None
+    # Integer up-scale: expected = k · actual.
+    if e_shape[0] % a_shape[0] == 0 and e_shape[1] % a_shape[1] == 0:
+        kr = e_shape[0] // a_shape[0]
+        kc = e_shape[1] // a_shape[1]
+        if kr == kc and kr in (2, 3):
+            return RepairSuggestion(
+                kind="scale_repair",
+                primitive_hint=f"scale_up_{kr}x",
+                confidence=0.85,
+                detail=f"upscale {kr}x ({a_shape} → {e_shape})",
+            )
+    # Integer down-scale: actual = k · expected.
+    if a_shape[0] % e_shape[0] == 0 and a_shape[1] % e_shape[1] == 0:
+        kr = a_shape[0] // e_shape[0]
+        kc = a_shape[1] // e_shape[1]
+        if kr == kc and kr in (2,):
+            return RepairSuggestion(
+                kind="scale_repair",
+                primitive_hint=f"scale_down_{kr}x",
+                confidence=0.85,
+                detail=f"downscale {kr}x ({a_shape} → {e_shape})",
+            )
+    return None
+
+
+def r3_rotation_repair(
+    actual: np.ndarray[Any, Any],
+    expected: np.ndarray[Any, Any],
+    diff: DiffReport,
+) -> RepairSuggestion | None:
+    """Fires iff expected equals 90/180/270 of actual."""
+    if diff.identical:
+        return None
+    if diff.structure.shape_mismatch and actual.shape != expected.shape[::-1]:
+        # 90 / 270 swap dimensions — that's still a candidate.
+        # Only bail if neither shape match works.
+        return None
+    if actual.size == 0 or expected.size == 0:
+        return None
+    for k, primitive in ((1, "rotate90"), (2, "rotate180"), (3, "rotate270")):
+        try:
+            rotated = np.rot90(actual, k=k)
+        except (ValueError, TypeError):
+            continue
+        if rotated.shape == expected.shape and np.array_equal(rotated, expected):
+            return RepairSuggestion(
+                kind="rotation_repair",
+                primitive_hint=primitive,
+                confidence=0.95,
+                detail=f"k={k}",
+            )
+    return None
+
+
+def r4_mirror_repair(
+    actual: np.ndarray[Any, Any],
+    expected: np.ndarray[Any, Any],
+    diff: DiffReport,
+) -> RepairSuggestion | None:
+    """Fires iff expected is horizontal or vertical flip of actual."""
+    if diff.identical:
+        return None
+    if diff.structure.shape_mismatch:
+        return None
+    if actual.size == 0 or expected.size == 0:
+        return None
+    flipped_h = np.fliplr(actual)
+    if flipped_h.shape == expected.shape and np.array_equal(flipped_h, expected):
+        return RepairSuggestion(
+            kind="mirror_repair",
+            primitive_hint="mirror_horizontal",
+            confidence=0.95,
+            detail="fliplr",
+        )
+    flipped_v = np.flipud(actual)
+    if flipped_v.shape == expected.shape and np.array_equal(flipped_v, expected):
+        return RepairSuggestion(
+            kind="mirror_repair",
+            primitive_hint="mirror_vertical",
+            confidence=0.95,
+            detail="flipud",
+        )
+    return None
+
+
+def r5_local_repair(diff: DiffReport, *, max_diff_pixels: int = 5) -> RepairSuggestion | None:
+    """Fires iff pixel diff is small (≤ max_diff_pixels) and shapes match."""
+    if diff.identical:
+        return None
+    if diff.structure.shape_mismatch:
+        return None
+    if diff.pixels.count == 0 or diff.pixels.count > max_diff_pixels:
+        return None
+    return RepairSuggestion(
+        kind="local_repair",
+        primitive_hint=None,
+        confidence=0.7,
+        detail=f"{diff.pixels.count} pixel(s) differ",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Advisor — runs every rule, sorts by confidence
+# ---------------------------------------------------------------------------
+
+
+def advise_repairs(
+    actual: np.ndarray[Any, Any],
+    expected: np.ndarray[Any, Any],
+    diff: DiffReport,
+) -> list[RepairSuggestion]:
+    """Run the 5 Sprint-1 symbolic-repair rules + sort by confidence.
+
+    Rules that don't fire on the given diff are simply absent from
+    the result. Caller iterates in order; high-confidence suggestions
+    typically run first.
+    """
+    suggestions: list[RepairSuggestion] = []
+    for sugg in (
+        r1_color_repair(diff),
+        r2_scale_repair(diff),
+        r3_rotation_repair(actual, expected, diff),
+        r4_mirror_repair(actual, expected, diff),
+        r5_local_repair(diff),
+    ):
+        if sugg is not None:
+            suggestions.append(sugg)
+    # Stable sort: equal confidence preserves rule order so tests can
+    # pin the canonical order R1-R5 within a confidence tier.
+    suggestions.sort(key=lambda s: -s.confidence)
+    return suggestions
+
+
+__all__ = [
+    "RepairKind",
+    "RepairSuggestion",
+    "advise_repairs",
+    "r1_color_repair",
+    "r2_scale_repair",
+    "r3_rotation_repair",
+    "r4_mirror_repair",
+    "r5_local_repair",
+]

--- a/tests/test_channels/test_program_synthesis/phase2/test_symbolic_repair.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_symbolic_repair.py
@@ -1,0 +1,236 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Symbolic-Repair Advisor tests (Sprint-1 plan task 9 slice, §6.5.2)."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.refiner import (
+    RepairSuggestion,
+    advise_repairs,
+    analyze_diff,
+)
+from cognithor.channels.program_synthesis.refiner.symbolic_repair import (
+    r1_color_repair,
+    r2_scale_repair,
+    r3_rotation_repair,
+    r4_mirror_repair,
+    r5_local_repair,
+)
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+# ---------------------------------------------------------------------------
+# R1 — color repair
+# ---------------------------------------------------------------------------
+
+
+class TestR1ColorRepair:
+    def test_fires_on_introduced_and_missing(self) -> None:
+        a = _g([[1, 2], [9, 9]])  # actual has 9 instead of 5
+        e = _g([[1, 2], [5, 5]])
+        diff = analyze_diff(a, e)
+        s = r1_color_repair(diff)
+        assert s is not None
+        assert s.kind == "color_repair"
+        assert s.primitive_hint == "recolor"
+        assert s.confidence == 0.8
+
+    def test_lower_confidence_on_shape_mismatch(self) -> None:
+        a = _g([[9]])
+        e = _g([[5, 5]])  # shape differs AND color differs
+        diff = analyze_diff(a, e)
+        s = r1_color_repair(diff)
+        assert s is not None
+        assert s.confidence == 0.4
+
+    def test_does_not_fire_when_colors_identical(self) -> None:
+        a = _g([[1, 2], [3, 4]])
+        e = _g([[4, 3], [2, 1]])  # same colors, different positions
+        diff = analyze_diff(a, e)
+        assert r1_color_repair(diff) is None
+
+
+# ---------------------------------------------------------------------------
+# R2 — scale repair
+# ---------------------------------------------------------------------------
+
+
+class TestR2ScaleRepair:
+    def test_fires_on_2x_upscale(self) -> None:
+        a = _g([[1, 2]])
+        e = _g([[1, 2, 1, 2], [1, 2, 1, 2]])
+        diff = analyze_diff(a, e)
+        s = r2_scale_repair(diff)
+        assert s is not None
+        assert s.primitive_hint == "scale_up_2x"
+
+    def test_fires_on_3x_upscale(self) -> None:
+        a = _g([[1]])
+        e = _g([[1, 1, 1], [1, 1, 1], [1, 1, 1]])
+        diff = analyze_diff(a, e)
+        s = r2_scale_repair(diff)
+        assert s is not None
+        assert s.primitive_hint == "scale_up_3x"
+
+    def test_fires_on_2x_downscale(self) -> None:
+        a = _g([[1, 1], [1, 1]])
+        e = _g([[1]])
+        diff = analyze_diff(a, e)
+        s = r2_scale_repair(diff)
+        assert s is not None
+        assert s.primitive_hint == "scale_down_2x"
+
+    def test_does_not_fire_on_non_integer_ratio(self) -> None:
+        a = _g([[1, 2]])  # 1×2
+        e = _g([[1, 2, 3]])  # 1×3 (not 2× or 3×)
+        diff = analyze_diff(a, e)
+        assert r2_scale_repair(diff) is None
+
+
+# ---------------------------------------------------------------------------
+# R3 — rotation repair
+# ---------------------------------------------------------------------------
+
+
+class TestR3RotationRepair:
+    def test_fires_on_90_rotation(self) -> None:
+        a = _g([[1, 2], [3, 4]])
+        e = np.rot90(a, k=1)
+        diff = analyze_diff(a, e)
+        s = r3_rotation_repair(a, e, diff)
+        assert s is not None
+        assert s.primitive_hint == "rotate90"
+
+    def test_fires_on_180_rotation(self) -> None:
+        a = _g([[1, 2], [3, 4]])
+        e = np.rot90(a, k=2)
+        diff = analyze_diff(a, e)
+        s = r3_rotation_repair(a, e, diff)
+        assert s is not None
+        assert s.primitive_hint == "rotate180"
+
+    def test_does_not_fire_on_unrelated_diff(self) -> None:
+        a = _g([[1, 2], [3, 4]])
+        e = _g([[9, 9], [9, 9]])
+        diff = analyze_diff(a, e)
+        assert r3_rotation_repair(a, e, diff) is None
+
+
+# ---------------------------------------------------------------------------
+# R4 — mirror repair
+# ---------------------------------------------------------------------------
+
+
+class TestR4MirrorRepair:
+    def test_fires_on_horizontal_flip(self) -> None:
+        a = _g([[1, 2, 3], [4, 5, 6]])
+        e = np.fliplr(a)
+        diff = analyze_diff(a, e)
+        s = r4_mirror_repair(a, e, diff)
+        assert s is not None
+        assert s.primitive_hint == "mirror_horizontal"
+
+    def test_fires_on_vertical_flip(self) -> None:
+        a = _g([[1, 2], [3, 4]])
+        e = np.flipud(a)
+        diff = analyze_diff(a, e)
+        s = r4_mirror_repair(a, e, diff)
+        assert s is not None
+        assert s.primitive_hint == "mirror_vertical"
+
+    def test_does_not_fire_on_shape_mismatch(self) -> None:
+        a = _g([[1, 2]])
+        e = _g([[1], [2]])
+        diff = analyze_diff(a, e)
+        assert r4_mirror_repair(a, e, diff) is None
+
+
+# ---------------------------------------------------------------------------
+# R5 — local repair
+# ---------------------------------------------------------------------------
+
+
+class TestR5LocalRepair:
+    def test_fires_on_small_pixel_diff(self) -> None:
+        a = _g([[1, 2], [3, 4]])
+        e = _g([[1, 2], [3, 9]])  # one pixel differs
+        diff = analyze_diff(a, e)
+        s = r5_local_repair(diff)
+        assert s is not None
+        assert s.primitive_hint is None  # local-edit, not a primitive
+        assert "1 pixel" in s.detail
+
+    def test_does_not_fire_on_large_pixel_diff(self) -> None:
+        a = np.zeros((10, 10), dtype=np.int8)
+        e = np.ones((10, 10), dtype=np.int8)  # 100 pixels differ
+        diff = analyze_diff(a, e)
+        assert r5_local_repair(diff) is None
+
+    def test_does_not_fire_on_shape_mismatch(self) -> None:
+        a = _g([[1]])
+        e = _g([[1, 2]])
+        diff = analyze_diff(a, e)
+        assert r5_local_repair(diff) is None
+
+
+# ---------------------------------------------------------------------------
+# Advisor — sorts by confidence
+# ---------------------------------------------------------------------------
+
+
+class TestAdviseRepairs:
+    def test_pure_rotation_yields_only_rotation_repair(self) -> None:
+        a = _g([[1, 2], [3, 4]])
+        e = np.rot90(a, k=1)
+        diff = analyze_diff(a, e)
+        suggestions = advise_repairs(a, e, diff)
+        kinds = [s.kind for s in suggestions]
+        assert "rotation_repair" in kinds
+        # Top suggestion should be rotation (highest confidence 0.95).
+        assert suggestions[0].kind == "rotation_repair"
+
+    def test_color_only_diff_yields_color_repair(self) -> None:
+        a = _g([[1, 2], [9, 9]])
+        e = _g([[1, 2], [5, 5]])
+        diff = analyze_diff(a, e)
+        suggestions = advise_repairs(a, e, diff)
+        assert any(s.kind == "color_repair" for s in suggestions)
+
+    def test_identical_grids_yield_no_suggestions(self) -> None:
+        a = _g([[1, 2]])
+        e = _g([[1, 2]])
+        diff = analyze_diff(a, e)
+        suggestions = advise_repairs(a, e, diff)
+        assert suggestions == []
+
+    def test_sorted_by_confidence_descending(self) -> None:
+        # Build a diff that fires multiple rules.
+        a = _g([[1, 2], [3, 4]])
+        # rotation 90 → also color set differs vs ... no actually rotation
+        # preserves colors. Let me build a small-pixel diff (R5) +
+        # color repair (R1).
+        e = _g([[1, 2], [3, 9]])  # one pixel differs, color {9} introduced
+        diff = analyze_diff(a, e)
+        from itertools import pairwise
+
+        suggestions = advise_repairs(a, e, diff)
+        # All confidences must be non-increasing.
+        for prev, nxt in pairwise(suggestions):
+            assert prev.confidence >= nxt.confidence
+
+    def test_suggestion_dataclass_is_hashable(self) -> None:
+        s = RepairSuggestion(
+            kind="color_repair",
+            primitive_hint="recolor",
+            confidence=0.5,
+            detail="x",
+        )
+        # Frozen dataclass → hashable.
+        assert hash(s) == hash(s)


### PR DESCRIPTION
## Summary
Closes the **Symbolic-Repair slice of Sprint-1 plan task 9**. Spec §6.5.2 calls for \"5 Heuristik-Regeln\". The Advisor takes a candidate's actual output, the demo's expected output, and the DiffReport from #251, and returns prioritised \`RepairSuggestion\` items.

### Five rules
| Rule | Fires on | Hint | Confidence |
|---|---|---|---|
| R1 \`r1_color_repair\` | introduced or missing colors | \`recolor\` | 0.4 / 0.6 / 0.8 |
| R2 \`r2_scale_repair\` | integer-ratio shape mismatch | \`scale_up_NX\` / \`scale_down_NX\` | 0.85 |
| R3 \`r3_rotation_repair\` | expected = rot(actual, 90/180/270) | \`rotate90/180/270\` | 0.95 |
| R4 \`r4_mirror_repair\` | expected = fliplr/flipud of actual | \`mirror_horizontal/vertical\` | 0.95 |
| R5 \`r5_local_repair\` | small pixel diff ≤ 5 cells | None (delegate to LocalEditMutator) | 0.7 |

\`advise_repairs(actual, expected, diff)\` runs all 5 rules and returns suggestions sorted by descending confidence.

## Test plan
- [x] **21 new tests** cover every rule's positive + negative cases plus the advisor's identical-yields-empty, sorted-by-confidence-descending, and pure-rotation-yields-rotation-repair invariants.
- [x] PSE suite: **1079 passed, 10 skipped** (was 1058 + 10 → +21).
- [x] \`mypy --strict\` clean (66 source files).
- [x] \`ruff check\`, \`ruff format --check\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)