### PR TITLE
feat(pse): Phase-2 Sprint-1 — Trace-Replay (plan task 9 slice, §6.4)

### DIFF
--- a/src/cognithor/channels/program_synthesis/refiner/__init__.py
+++ b/src/cognithor/channels/program_synthesis/refiner/__init__.py
@@ -38,6 +38,12 @@ from cognithor.channels.program_synthesis.refiner.symbolic_repair import (
     RepairSuggestion,
     advise_repairs,
 )
+from cognithor.channels.program_synthesis.refiner.trace_replay import (
+    TraceStep,
+    find_divergence,
+    find_first_failure,
+    replay_trace,
+)
 
 __all__ = [
     "CEGISLoop",
@@ -56,6 +62,10 @@ __all__ = [
     "RepairKind",
     "RepairSuggestion",
     "StructureDiff",
+    "TraceStep",
     "advise_repairs",
     "analyze_diff",
+    "find_divergence",
+    "find_first_failure",
+    "replay_trace",
 ]

--- a/src/cognithor/channels/program_synthesis/refiner/trace_replay.py
+++ b/src/cognithor/channels/program_synthesis/refiner/trace_replay.py
@@ -1,0 +1,172 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Spec §6.4 — Trace-Replay (Sprint-1 plan task 9 slice).
+
+Trace-Replay walks a candidate :class:`Program` tree in post-order
+on a given input grid, capturing every intermediate value the
+executor produces along the way. The Critic uses this trace to
+localise *where* the candidate diverges from the expected output —
+which subtree the Refiner should target first.
+
+The module is executor-agnostic: the caller hands in any object
+satisfying :class:`Executor` from
+:mod:`cognithor.channels.program_synthesis.search.executor`. The
+default helper :func:`replay_trace` defaults to
+:class:`InProcessExecutor`.
+
+Two public surfaces:
+
+* :func:`replay_trace` — given ``(program, input_grid)``, return a
+  ``tuple[TraceStep, ...]`` covering every node in post-order. The
+  *last* step is the root (the program's final output).
+* :func:`find_divergence` — given a trace and an ``expected``
+  grid, return the deepest subtree whose output equals the
+  expected value. Falls back to ``None`` when no subtree matches —
+  the caller treats that as "the entire program is wrong".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.search.candidate import Program
+from cognithor.channels.program_synthesis.search.executor import (
+    InProcessExecutor,
+)
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.search.candidate import (
+        ProgramNode,
+    )
+    from cognithor.channels.program_synthesis.search.executor import Executor
+
+
+@dataclass(frozen=True)
+class TraceStep:
+    """One entry in the trace: the result of executing a single node.
+
+    ``path`` is the root-relative index path. The root program has
+    ``path=()``; its first child is ``(0,)``, its first child's
+    second child is ``(0, 1)``, etc. The Refiner treats the path
+    as a stable address for "go re-write the subtree at this
+    location".
+
+    ``ok`` is ``True`` iff the node produced a value (no exception
+    propagated). ``value`` carries that value (often a numpy array,
+    sometimes a primitive return type — int, tuple, etc.). When
+    ``ok=False``, ``value`` is ``None`` and ``error`` carries the
+    exception type name as a tag (so two failures of the same kind
+    share a fingerprint).
+    """
+
+    path: tuple[int, ...]
+    node: ProgramNode
+    ok: bool
+    value: Any
+    error: str | None
+
+
+def replay_trace(
+    program: ProgramNode,
+    input_grid: Any,
+    *,
+    executor: Executor | None = None,
+) -> tuple[TraceStep, ...]:
+    """Walk ``program`` post-order; execute each subtree on ``input_grid``.
+
+    Returns the steps in **post-order** — children before their
+    parent. The last step is therefore always the root. Failed
+    subtrees still appear; their parent simply records ``ok=False``
+    when its own evaluation raised because of them.
+
+    The ``executor`` defaults to :class:`InProcessExecutor` —
+    sandbox-free, fast, suitable for in-loop refinement. The caller
+    can swap in the subprocess executor for production paths.
+    """
+    exe = executor if executor is not None else InProcessExecutor()
+    steps: list[TraceStep] = []
+    _walk(program, input_grid, (), exe, steps)
+    return tuple(steps)
+
+
+def _walk(
+    node: ProgramNode,
+    input_grid: Any,
+    path: tuple[int, ...],
+    executor: Executor,
+    out: list[TraceStep],
+) -> None:
+    """Recurse post-order; append a TraceStep for ``node``."""
+    if isinstance(node, Program):
+        for idx, child in enumerate(node.children):
+            _walk(child, input_grid, (*path, idx), executor, out)
+    result = executor.execute(node, input_grid)
+    out.append(
+        TraceStep(
+            path=path,
+            node=node,
+            ok=result.ok,
+            value=result.value if result.ok else None,
+            error=result.error,
+        )
+    )
+
+
+def find_divergence(
+    trace: tuple[TraceStep, ...],
+    expected: Any,
+) -> TraceStep | None:
+    """Return the *deepest* subtree whose output equals ``expected``.
+
+    Used by the Critic to decide: if some subtree already produces
+    the expected output, the program is over-shooting (extra
+    primitives applied on top); the Refiner should snip *above*
+    that subtree.
+
+    "Equality" is :func:`numpy.array_equal` for arrays, plain ``==``
+    otherwise. Failed steps (``ok=False``) are skipped. Returns
+    ``None`` when no step matches — the caller treats this as
+    "the divergence is at the root, the whole program is wrong".
+    """
+    candidates = [step for step in trace if step.ok and _values_equal(step.value, expected)]
+    if not candidates:
+        return None
+    # Paths are unique within a tree; deepest = longest path.
+    return max(candidates, key=lambda s: len(s.path))
+
+
+def find_first_failure(trace: tuple[TraceStep, ...]) -> TraceStep | None:
+    """Return the first failing step in execution order, or ``None``.
+
+    A program that aborts mid-way leaves all its ancestors as
+    failures too — but the *innermost* failing leaf is the one the
+    Refiner cares about, because that's where the bug originated.
+    """
+    failures = [step for step in trace if not step.ok]
+    if not failures:
+        return None
+    # Earliest failure in post-order = innermost (children before parents).
+    return failures[0]
+
+
+def _values_equal(actual: Any, expected: Any) -> bool:
+    """Equality that handles numpy arrays without surprises."""
+    if isinstance(actual, np.ndarray) or isinstance(expected, np.ndarray):
+        try:
+            return bool(np.array_equal(actual, expected))
+        except (TypeError, ValueError):
+            return False
+    try:
+        return bool(actual == expected)
+    except Exception:
+        return False
+
+
+__all__ = [
+    "TraceStep",
+    "find_divergence",
+    "find_first_failure",
+    "replay_trace",
+]

--- a/tests/test_channels/test_program_synthesis/phase2/test_trace_replay.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_trace_replay.py
@@ -1,0 +1,267 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Trace-Replay tests (Sprint-1 plan task 9 slice, spec §6.4)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.refiner import (
+    TraceStep,
+    find_divergence,
+    find_first_failure,
+    replay_trace,
+)
+from cognithor.channels.program_synthesis.search.candidate import (
+    Const,
+    InputRef,
+    Program,
+    ProgramNode,
+)
+from cognithor.channels.program_synthesis.search.executor import (
+    ExecutionResult,
+    InProcessExecutor,
+)
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+# ---------------------------------------------------------------------------
+# Replay — basic post-order walk
+# ---------------------------------------------------------------------------
+
+
+class TestReplayTrace:
+    def test_input_ref_alone_yields_one_step(self) -> None:
+        grid = _g([[1, 2], [3, 4]])
+        trace = replay_trace(InputRef(), grid)
+        assert len(trace) == 1
+        step = trace[0]
+        assert step.path == ()
+        assert step.ok is True
+        assert np.array_equal(step.value, grid)
+        assert step.error is None
+
+    def test_const_alone_yields_one_step(self) -> None:
+        node = Const(value=7, output_type="Color")
+        trace = replay_trace(node, _g([[0]]))
+        assert len(trace) == 1
+        assert trace[0].value == 7
+
+    def test_post_order_for_unary_program(self) -> None:
+        # rotate90(input)
+        program = Program(
+            primitive="rotate90",
+            children=(InputRef(),),
+            output_type="Grid",
+        )
+        grid = _g([[1, 2], [3, 4]])
+        trace = replay_trace(program, grid)
+        # 2 steps: child first, then root.
+        assert len(trace) == 2
+        # Child = InputRef at path (0,)
+        assert trace[0].path == (0,)
+        assert isinstance(trace[0].node, InputRef)
+        # Root = Program at path ()
+        assert trace[1].path == ()
+        assert isinstance(trace[1].node, Program)
+        # Final root output == np.rot90(grid, k=-1).
+        assert np.array_equal(trace[1].value, np.rot90(grid, k=-1))
+
+    def test_post_order_for_three_arg_program(self) -> None:
+        # recolor(input, 1, 5) — 4 steps total (3 children + root).
+        program = Program(
+            primitive="recolor",
+            children=(
+                InputRef(),
+                Const(value=1, output_type="Color"),
+                Const(value=5, output_type="Color"),
+            ),
+            output_type="Grid",
+        )
+        grid = _g([[1, 2], [1, 3]])
+        trace = replay_trace(program, grid)
+        assert [s.path for s in trace] == [(0,), (1,), (2,), ()]
+        # Root output: every 1 → 5.
+        expected = _g([[5, 2], [5, 3]])
+        assert trace[-1].ok
+        assert np.array_equal(trace[-1].value, expected)
+
+
+class TestReplayTraceNested:
+    def test_nested_program_paths(self) -> None:
+        # rotate180(rotate90(input)) = rotate270(input).
+        inner = Program(
+            primitive="rotate90",
+            children=(InputRef(),),
+            output_type="Grid",
+        )
+        outer = Program(
+            primitive="rotate180",
+            children=(inner,),
+            output_type="Grid",
+        )
+        grid = _g([[1, 2], [3, 4]])
+        trace = replay_trace(outer, grid)
+        # Steps in post-order: InputRef(0,0), rotate90(0), rotate180().
+        assert [s.path for s in trace] == [(0, 0), (0,), ()]
+        # Innermost subtree is just the input grid.
+        assert np.array_equal(trace[0].value, grid)
+        # Middle subtree = np.rot90(grid, k=-1).
+        assert np.array_equal(trace[1].value, np.rot90(grid, k=-1))
+        # Root = rotate180 of that = rot90(rot90(grid)).
+        # rotate180(rotate90(grid)) = np.rot90(grid, k=-1+2) = np.rot90(grid, k=1)
+        assert np.array_equal(trace[2].value, np.rot90(grid, k=1))
+
+
+# ---------------------------------------------------------------------------
+# find_divergence — locates the deepest matching subtree
+# ---------------------------------------------------------------------------
+
+
+class TestFindDivergence:
+    def test_root_matches_when_program_is_correct(self) -> None:
+        program = Program(
+            primitive="rotate90",
+            children=(InputRef(),),
+            output_type="Grid",
+        )
+        grid = _g([[1, 2], [3, 4]])
+        expected = np.rot90(grid, k=-1)
+        trace = replay_trace(program, grid)
+        d = find_divergence(trace, expected)
+        assert d is not None
+        # The root step matches.
+        assert d.path == ()
+
+    def test_inner_subtree_matches_when_program_overshoots(self) -> None:
+        # rotate180(rotate90(input)) — but the *expected* output is
+        # what rotate90 alone produces. The deepest matching subtree
+        # is the inner rotate90.
+        inner = Program(
+            primitive="rotate90",
+            children=(InputRef(),),
+            output_type="Grid",
+        )
+        outer = Program(
+            primitive="rotate180",
+            children=(inner,),
+            output_type="Grid",
+        )
+        grid = _g([[1, 2], [3, 4]])
+        expected = np.rot90(grid, k=-1)
+        trace = replay_trace(outer, grid)
+        d = find_divergence(trace, expected)
+        assert d is not None
+        assert d.path == (0,)  # the inner rotate90
+
+    def test_input_ref_matches_when_program_is_overcomplicated(self) -> None:
+        # rotate90 applied but expected == input → InputRef matches.
+        program = Program(
+            primitive="rotate90",
+            children=(InputRef(),),
+            output_type="Grid",
+        )
+        grid = _g([[1, 2], [3, 4]])
+        trace = replay_trace(program, grid)
+        d = find_divergence(trace, grid)
+        assert d is not None
+        # The InputRef leaf at path (0,) is the deepest match.
+        assert d.path == (0,)
+        assert isinstance(d.node, InputRef)
+
+    def test_no_match_returns_none(self) -> None:
+        program = Program(
+            primitive="rotate90",
+            children=(InputRef(),),
+            output_type="Grid",
+        )
+        grid = _g([[1, 2], [3, 4]])
+        unrelated = _g([[9, 9], [9, 9]])
+        trace = replay_trace(program, grid)
+        assert find_divergence(trace, unrelated) is None
+
+
+# ---------------------------------------------------------------------------
+# find_first_failure — innermost broken subtree
+# ---------------------------------------------------------------------------
+
+
+class _AlwaysFailExecutor:
+    """Executor stub: every Program node raises; leaves succeed."""
+
+    _real = InProcessExecutor()
+
+    def execute(self, program: ProgramNode, input_grid: Any) -> ExecutionResult:
+        if isinstance(program, Program):
+            return ExecutionResult(ok=False, error="StubError")
+        return self._real.execute(program, input_grid)
+
+
+class TestFindFirstFailure:
+    def test_returns_none_for_clean_run(self) -> None:
+        program = Program(
+            primitive="rotate90",
+            children=(InputRef(),),
+            output_type="Grid",
+        )
+        trace = replay_trace(program, _g([[1, 2], [3, 4]]))
+        assert find_first_failure(trace) is None
+
+    def test_returns_innermost_failure_first(self) -> None:
+        # Outer → inner program. Both Program nodes fail under the stub.
+        # The inner one runs first in post-order, so it should be
+        # returned.
+        inner = Program(
+            primitive="rotate90",
+            children=(InputRef(),),
+            output_type="Grid",
+        )
+        outer = Program(
+            primitive="rotate180",
+            children=(inner,),
+            output_type="Grid",
+        )
+        executor = _AlwaysFailExecutor()
+        trace = replay_trace(outer, _g([[1, 2]]), executor=executor)
+        first_fail = find_first_failure(trace)
+        assert first_fail is not None
+        assert first_fail.path == (0,)  # inner, not outer
+        assert first_fail.error == "StubError"
+
+
+# ---------------------------------------------------------------------------
+# Type contract — TraceStep is frozen / hashable
+# ---------------------------------------------------------------------------
+
+
+class TestTraceStepDataclass:
+    def test_step_is_hashable_when_value_hashable(self) -> None:
+        step = TraceStep(
+            path=(),
+            node=InputRef(),
+            ok=True,
+            value=7,  # hashable scalar
+            error=None,
+        )
+        # Frozen dataclass → hashable. (For numpy values the test
+        # would have to exclude `value` from the hash; we don't do
+        # that here — the contract says the dataclass *is* frozen,
+        # not that every Value is hashable.)
+        assert hash(step) == hash(step)
+
+    def test_step_path_is_tuple(self) -> None:
+        step = TraceStep(
+            path=(0, 1, 2),
+            node=InputRef(),
+            ok=True,
+            value=None,
+            error=None,
+        )
+        assert step.path == (0, 1, 2)


### PR DESCRIPTION
## Summary

Plan-Task 9 slice — **Trace-Replay** (spec §6.4): step-by-step localisation of where a candidate program diverges from the expected output.

Walks the Program tree post-order, executing each subtree on the input grid and capturing every intermediate value. The Critic uses this trace to identify which subtree should be targeted by the Refiner — overshoot vs. underspecified vs. mid-tree failure.

## Surface

- `refiner/trace_replay.py`
  - `TraceStep` — frozen dataclass `(path, node, ok, value, error)`
  - `replay_trace(program, input_grid, *, executor=None)` → `tuple[TraceStep, ...]` in post-order (children before parents)
  - `find_divergence(trace, expected)` → deepest matching subtree, or `None`
  - `find_first_failure(trace)` → innermost failing subtree
- Executor-agnostic: defaults to `InProcessExecutor`; production paths inject the subprocess sandbox.

## Tests (13 new)

- Post-order walk for InputRef, Const, unary, three-arg, and nested programs (path tuples verified)
- `find_divergence`: root match / inner subtree match (overshoot) / InputRef match (overcomplicated) / no match → None
- `find_first_failure`: clean run → None; stub executor → innermost (path `(0,)`) returned, not the outer failure
- `TraceStep` is frozen / hashable

mypy --strict clean. ruff lint + format clean. Phase-2 suite: 278 passed.

## Plan-Task 9 ladder

| slice | status |
|---|---|
| `diff_analyzer.py` (#251) | merged |
| `symbolic_repair.py` (#252) | in CI |
| **`trace_replay.py`** | **this PR** |
| `llm_repair_two_stage.py` | next |
| `hybrid_repair.py` | next |
| `escalation.py` | next |

## Test plan

- [x] `pytest tests/test_channels/test_program_synthesis/phase2/test_trace_replay.py -q` — 13 passed
- [x] `pytest tests/test_channels/test_program_synthesis/phase2/ -q` — 278 passed
- [x] `mypy --strict src/cognithor/channels/program_synthesis/refiner/trace_replay.py`
- [x] `ruff check` + `ruff format --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)