### PR TITLE
feat(pse): Phase-2 Sprint-1 — LLM-Repair Two-Stage (plan task 9 slice, §6.5.2 Zone-1)

### DIFF
--- a/src/cognithor/channels/program_synthesis/refiner/__init__.py
+++ b/src/cognithor/channels/program_synthesis/refiner/__init__.py
@@ -20,6 +20,12 @@ from cognithor.channels.program_synthesis.refiner.diff_analyzer import (
     StructureDiff,
     analyze_diff,
 )
+from cognithor.channels.program_synthesis.refiner.llm_repair_two_stage import (
+    LLMRepairError,
+    LLMRepairResult,
+    LLMRepairSuggestion,
+    LLMRepairTwoStageClient,
+)
 from cognithor.channels.program_synthesis.refiner.local_edit import (
     LocalEditMutator,
 )
@@ -34,6 +40,10 @@ __all__ = [
     "ColorDiff",
     "CounterExample",
     "DiffReport",
+    "LLMRepairError",
+    "LLMRepairResult",
+    "LLMRepairSuggestion",
+    "LLMRepairTwoStageClient",
     "LocalEditMutator",
     "PixelDiff",
     "RefinerMode",

--- a/src/cognithor/channels/program_synthesis/refiner/llm_repair_two_stage.py
+++ b/src/cognithor/channels/program_synthesis/refiner/llm_repair_two_stage.py
@@ -1,0 +1,372 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Spec §6.5.2 Zone-1 — LLM-Repair Two-Stage with retry (Sprint-1 plan task 9).
+
+When the Refiner mode controller picks ``full_llm`` (α ≥ 0.45), this
+module runs the LLM-driven repair: a Two-Stage CoT→JSON prompt
+that asks the model to (1) reason about *why* the candidate
+program fails its demos, and (2) produce one or more replacement
+sub-program source strings the caller can substitute into the
+program tree.
+
+Pipeline mirrors :mod:`cognithor.channels.program_synthesis.phase2.llm_prior`:
+
+* Stage 1 (CoT): free-form prose. Six sentences max.
+* Stage 2 (JSON): a list of ``LLMRepairSuggestion`` objects. The
+  client retries Stage 2 once on parse failure (per spec §4.7's
+  retry-once rule).
+
+The actual mutation of the :class:`Program` tree is the *caller's*
+job — this module returns the LLM's textual suggestions plus
+confidence values, and the Refiner driver decides which to attempt
+(typically by handing each source to the search-engine source
+parser and re-verifying the resulting Program).
+
+Sprint-1 ships this independently of an actual vLLM connection;
+tests inject a fake :class:`LLMBackend` so CI never touches the
+real model.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+from cognithor.channels.program_synthesis.phase2.config import (
+    DEFAULT_PHASE2_CONFIG,
+    Phase2Config,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from cognithor.channels.program_synthesis.refiner.diff_analyzer import (
+        DiffReport,
+    )
+    from cognithor.channels.program_synthesis.search.candidate import (
+        ProgramNode,
+    )
+    from cognithor.core.llm_backend import LLMBackend
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LLMRepairSuggestion:
+    """One candidate replacement the LLM proposed.
+
+    ``replacement_source`` is the DSL source the LLM thinks would
+    fix the failing demos — e.g. ``"rotate90(rotate90(input))"`` or
+    ``"recolor(input, 1, 5)"``. The Refiner driver runs this through
+    the search-engine source parser to lift it into a Program tree;
+    if parsing fails, the suggestion is skipped.
+
+    ``confidence`` is the LLM's self-reported confidence in [0, 1],
+    clamped at parse time. ``reasoning`` is a free-form note —
+    telemetry only, never read by the search engine.
+    """
+
+    replacement_source: str
+    confidence: float
+    reasoning: str = ""
+
+
+@dataclass(frozen=True)
+class LLMRepairResult:
+    """Outcome of one Two-Stage repair call.
+
+    ``suggestions`` is the parsed list, sorted by descending
+    confidence (so the caller iterates highest-confidence first).
+    Empty when Stage 2 produced no usable entries (after parse
+    + filter + retry).
+
+    ``stage1_reasoning`` is the verbatim Stage-1 CoT response.
+    ``raw_response`` is the verbatim Stage-2 JSON string, kept for
+    replay-debugging.
+    """
+
+    suggestions: tuple[LLMRepairSuggestion, ...] = field(default_factory=tuple)
+    stage1_reasoning: str = ""
+    raw_response: str = ""
+
+
+class LLMRepairError(Exception):
+    """Raised when Stage 2 cannot produce any usable suggestions."""
+
+
+# ---------------------------------------------------------------------------
+# Prompt schema (spec §4.7 Two-Stage adapted to repair)
+# ---------------------------------------------------------------------------
+
+
+_STAGE1_SYSTEM = (
+    "You are a programmatic-synthesis repair advisor. Given an ARC-AGI "
+    "grid task, a candidate DSL program that fails some demos, and the "
+    "diff between actual and expected outputs, you reason briefly about "
+    "what the program does wrong — which subtree is misbehaving, what "
+    "transformation is missing, what is over-applied. Be concise: at "
+    "most six sentences. Do not return a program. Do not return JSON. "
+    "Return plain prose only."
+)
+
+
+_STAGE2_SYSTEM = (
+    "You are a programmatic-synthesis repair advisor. Given the prior "
+    "reasoning, the failing program, and the diff, return a JSON object "
+    'of the form {"suggestions": [...]}. Each entry is an object with '
+    "keys ``replacement_source`` (a DSL source string for the entire "
+    "replacement program), ``confidence`` (a float in [0, 1]), and an "
+    "optional ``reasoning`` (a short prose note). Return at most five "
+    "entries, sorted by descending confidence. Use only DSL primitives "
+    "from the provided whitelist. Do not include text outside the "
+    "JSON object. Do not wrap the JSON in markdown code fences."
+)
+
+
+def _format_demo_block(demos: Iterable[tuple[Any, Any, Any]]) -> str:
+    rendered: list[str] = []
+    for i, (inp, expected, actual) in enumerate(demos):
+        rendered.append(
+            f"Demo {i + 1}:\n"
+            f"  input    = {_compact_repr(inp)}\n"
+            f"  expected = {_compact_repr(expected)}\n"
+            f"  actual   = {_compact_repr(actual)}"
+        )
+    return "\n".join(rendered)
+
+
+def _compact_repr(value: Any) -> str:
+    tolist = getattr(value, "tolist", None)
+    if callable(tolist):
+        return repr(tolist())
+    return repr(value)
+
+
+def _format_diff_block(diff: DiffReport | None) -> str:
+    if diff is None:
+        return "No structured diff supplied."
+    parts: list[str] = []
+    if diff.identical:
+        parts.append("identical=True")
+    parts.append(
+        f"shape_mismatch={diff.structure.shape_mismatch}, "
+        f"actual_shape={diff.structure.actual_shape}, "
+        f"expected_shape={diff.structure.expected_shape}"
+    )
+    parts.append(
+        f"pixel_diff_count={diff.pixels.count}, "
+        f"colors_introduced={sorted(diff.colors.introduced)}, "
+        f"colors_missing={sorted(diff.colors.missing)}"
+    )
+    return " | ".join(parts)
+
+
+def _build_stage1_user(
+    program: ProgramNode,
+    demos: Iterable[tuple[Any, Any, Any]],
+    diff: DiffReport | None,
+) -> str:
+    return (
+        f"Failing program (DSL source):\n  {program.to_source()}\n\n"
+        f"Failing demos:\n{_format_demo_block(demos)}\n\n"
+        f"Diff summary:\n  {_format_diff_block(diff)}"
+    )
+
+
+def _build_stage2_user(
+    program: ProgramNode,
+    demos: Iterable[tuple[Any, Any, Any]],
+    diff: DiffReport | None,
+    *,
+    primitive_whitelist: list[str],
+    stage1_reasoning: str,
+) -> str:
+    whitelist_block = ", ".join(sorted(primitive_whitelist))
+    return (
+        f"Failing program (DSL source):\n  {program.to_source()}\n\n"
+        f"Failing demos:\n{_format_demo_block(demos)}\n\n"
+        f"Diff summary:\n  {_format_diff_block(diff)}\n\n"
+        f"Prior reasoning:\n{stage1_reasoning}\n\n"
+        f"Allowed DSL primitives: {whitelist_block}\n\n"
+        "Return the JSON object now."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+
+
+class LLMRepairTwoStageClient:
+    """Two-Stage CoT→JSON LLM-repair client over an injected ``LLMBackend``.
+
+    Mirrors :class:`LLMPriorClient` but for repair: the prompts focus
+    on *why does this program fail* and *what would fix it*. The
+    backend is the abstract :class:`LLMBackend`; production wires
+    :class:`VLLMBackend`, tests wire a stub.
+    """
+
+    def __init__(
+        self,
+        backend: LLMBackend,
+        *,
+        primitive_whitelist: list[str] | None = None,
+        config: Phase2Config = DEFAULT_PHASE2_CONFIG,
+    ) -> None:
+        self._backend = backend
+        self._explicit_whitelist = primitive_whitelist
+        self._config = config
+
+    async def repair(
+        self,
+        program: ProgramNode,
+        failing_demos: Iterable[tuple[Any, Any, Any]],
+        diff: DiffReport | None = None,
+    ) -> LLMRepairResult:
+        """Run the Two-Stage repair prompt and return parsed suggestions.
+
+        ``failing_demos`` is an iterable of ``(input, expected, actual)``
+        triples. ``diff`` is an optional pre-computed
+        :class:`DiffReport` from one of the demos — Sprint-1 hands it
+        in for prompt richness; future sprints may compute one diff
+        per demo and concatenate.
+        """
+        materialised = list(failing_demos)
+        whitelist = self._resolve_whitelist()
+        stage1_reasoning = await self._stage1(program, materialised, diff)
+        raw_json, parsed = await self._stage2_with_retry(
+            program, materialised, diff, stage1_reasoning, whitelist
+        )
+        suggestions = self._extract_suggestions(parsed)
+        return LLMRepairResult(
+            suggestions=suggestions,
+            stage1_reasoning=stage1_reasoning,
+            raw_response=raw_json,
+        )
+
+    # -- Internals ---------------------------------------------------
+
+    def _resolve_whitelist(self) -> list[str]:
+        if self._explicit_whitelist is not None:
+            return list(self._explicit_whitelist)
+        from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+
+        return list(REGISTRY.names())
+
+    async def _stage1(
+        self,
+        program: ProgramNode,
+        demos: list[tuple[Any, Any, Any]],
+        diff: DiffReport | None,
+    ) -> str:
+        response = await self._backend.chat(
+            model=self._config.llm_model_name,
+            messages=[
+                {"role": "system", "content": _STAGE1_SYSTEM},
+                {
+                    "role": "user",
+                    "content": _build_stage1_user(program, demos, diff),
+                },
+            ],
+            temperature=self._config.llm_temperature_stage1,
+        )
+        return response.content.strip()
+
+    async def _stage2_with_retry(
+        self,
+        program: ProgramNode,
+        demos: list[tuple[Any, Any, Any]],
+        diff: DiffReport | None,
+        stage1_reasoning: str,
+        whitelist: list[str],
+    ) -> tuple[str, dict[str, Any]]:
+        attempts = 1 + max(0, self._config.llm_json_max_retries)
+        last_error: Exception | None = None
+        for _ in range(attempts):
+            response = await self._backend.chat(
+                model=self._config.llm_model_name,
+                messages=[
+                    {"role": "system", "content": _STAGE2_SYSTEM},
+                    {
+                        "role": "user",
+                        "content": _build_stage2_user(
+                            program,
+                            demos,
+                            diff,
+                            primitive_whitelist=whitelist,
+                            stage1_reasoning=stage1_reasoning,
+                        ),
+                    },
+                ],
+                temperature=self._config.llm_temperature_stage2,
+                format_json=True,
+            )
+            try:
+                parsed = json.loads(response.content)
+            except json.JSONDecodeError as exc:
+                last_error = exc
+                continue
+            if not isinstance(parsed, dict):
+                last_error = LLMRepairError(
+                    f"Stage-2 returned non-object JSON: {response.content[:120]!r}"
+                )
+                continue
+            return response.content, parsed
+        raise LLMRepairError(f"Stage-2 JSON parse failed after {attempts} attempts: {last_error}")
+
+    def _extract_suggestions(
+        self,
+        parsed: dict[str, Any],
+    ) -> tuple[LLMRepairSuggestion, ...]:
+        raw_list = parsed.get("suggestions")
+        if not isinstance(raw_list, list):
+            raise LLMRepairError(
+                "Stage-2 missing 'suggestions' list (or wrong type); "
+                f"got: {type(raw_list).__name__}"
+            )
+        out: list[LLMRepairSuggestion] = []
+        for entry in raw_list:
+            if not isinstance(entry, dict):
+                continue
+            source = entry.get("replacement_source")
+            if not isinstance(source, str) or not source.strip():
+                continue
+            try:
+                confidence = float(entry.get("confidence", 0.5))
+            except (TypeError, ValueError):
+                confidence = 0.5
+            if not math.isfinite(confidence):
+                confidence = 0.5
+            confidence = _clamp(confidence, 0.0, 1.0)
+            reasoning_raw = entry.get("reasoning", "")
+            reasoning = reasoning_raw if isinstance(reasoning_raw, str) else ""
+            out.append(
+                LLMRepairSuggestion(
+                    replacement_source=source.strip(),
+                    confidence=confidence,
+                    reasoning=reasoning,
+                )
+            )
+        # Stable sort by descending confidence; ties preserve LLM order.
+        out.sort(key=lambda s: -s.confidence)
+        return tuple(out)
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    if value < lo:
+        return lo
+    if value > hi:
+        return hi
+    return value
+
+
+__all__ = [
+    "LLMRepairError",
+    "LLMRepairResult",
+    "LLMRepairSuggestion",
+    "LLMRepairTwoStageClient",
+]

--- a/tests/test_channels/test_program_synthesis/phase2/test_llm_repair_two_stage.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_llm_repair_two_stage.py
@@ -1,0 +1,394 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""LLM-Repair Two-Stage tests (Sprint-1 plan task 9 slice, spec §6.5.2 Zone-1).
+
+Exercises the prompt schema, JSON parser, retry-once rule, and
+suggestion sorting against a stub :class:`LLMBackend`. No vLLM has
+to be running.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import FrozenInstanceError, dataclass, field
+from typing import Any
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.phase2.config import Phase2Config
+from cognithor.channels.program_synthesis.refiner.diff_analyzer import analyze_diff
+from cognithor.channels.program_synthesis.refiner.llm_repair_two_stage import (
+    LLMRepairError,
+    LLMRepairResult,
+    LLMRepairSuggestion,
+    LLMRepairTwoStageClient,
+)
+from cognithor.channels.program_synthesis.search.candidate import (
+    InputRef,
+    Program,
+)
+from cognithor.core.llm_backend import (
+    ChatResponse,
+    EmbedResponse,
+    LLMBackend,
+    LLMBackendType,
+)
+
+# ---------------------------------------------------------------------------
+# Stub backend
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubBackend(LLMBackend):
+    queued: list[str] = field(default_factory=list)
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def backend_type(self) -> LLMBackendType:
+        return LLMBackendType.VLLM
+
+    async def chat(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        format_json: bool = False,
+        images: list[str] | None = None,
+        video: dict[str, Any] | None = None,
+    ) -> ChatResponse:
+        self.calls.append(
+            {
+                "model": model,
+                "messages": messages,
+                "temperature": temperature,
+                "format_json": format_json,
+            }
+        )
+        if not self.queued:
+            raise AssertionError("stub backend ran out of queued responses")
+        content = self.queued.pop(0)
+        return ChatResponse(content=content, model=model)
+
+    async def chat_stream(self, *_: Any, **__: Any) -> Any:
+        raise NotImplementedError
+
+    async def embed(self, *_: Any, **__: Any) -> EmbedResponse:
+        raise NotImplementedError
+
+    async def is_available(self) -> bool:
+        return True
+
+    async def list_models(self) -> list[str]:
+        return ["Qwen/Qwen3.6-27B-Instruct"]
+
+    async def close(self) -> None:
+        pass
+
+
+def _failing_program() -> Program:
+    # rotate90(input) — wrong for the demo we'll feed.
+    return Program(
+        primitive="rotate90",
+        children=(InputRef(),),
+        output_type="Grid",
+    )
+
+
+def _failing_demos() -> list[tuple[Any, Any, Any]]:
+    inp = np.array([[1, 2], [3, 4]], dtype=np.int8)
+    expected = np.array([[2, 4], [1, 3]], dtype=np.int8)  # actually rotate270
+    actual = np.rot90(inp, k=-1)  # what rotate90 produced
+    return [(inp, expected, actual)]
+
+
+# ---------------------------------------------------------------------------
+# Two-stage call sequence
+# ---------------------------------------------------------------------------
+
+
+class TestTwoStageHappyPath:
+    @pytest.mark.asyncio
+    async def test_returns_sorted_suggestions(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "The program rotated the grid the wrong direction.",
+                json.dumps(
+                    {
+                        "suggestions": [
+                            {"replacement_source": "rotate270(input)", "confidence": 0.9},
+                            {
+                                "replacement_source": "rotate180(rotate90(input))",
+                                "confidence": 0.4,
+                                "reasoning": "two flips compose",
+                            },
+                            {"replacement_source": "rotate90(rotate90(input))", "confidence": 0.6},
+                        ]
+                    }
+                ),
+            ]
+        )
+        client = LLMRepairTwoStageClient(
+            backend,
+            primitive_whitelist=["rotate90", "rotate180", "rotate270"],
+        )
+        result = await client.repair(_failing_program(), _failing_demos())
+        assert isinstance(result, LLMRepairResult)
+        # Stage-1 prose preserved.
+        assert "wrong direction" in result.stage1_reasoning
+        # Three suggestions parsed, sorted by descending confidence.
+        confidences = [s.confidence for s in result.suggestions]
+        assert confidences == sorted(confidences, reverse=True)
+        # Top suggestion is the 0.9 one.
+        assert result.suggestions[0].confidence == 0.9
+        assert result.suggestions[0].replacement_source == "rotate270(input)"
+        # The 0.4 entry preserves its reasoning string.
+        the_lowest = next(s for s in result.suggestions if s.confidence == 0.4)
+        assert the_lowest.reasoning == "two flips compose"
+
+    @pytest.mark.asyncio
+    async def test_stage1_and_stage2_temperatures(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps(
+                    {"suggestions": [{"replacement_source": "rotate270(input)", "confidence": 0.5}]}
+                ),
+            ]
+        )
+        config = Phase2Config(llm_temperature_stage1=0.42, llm_temperature_stage2=0.07)
+        client = LLMRepairTwoStageClient(
+            backend,
+            primitive_whitelist=["rotate270"],
+            config=config,
+        )
+        await client.repair(_failing_program(), _failing_demos())
+        assert backend.calls[0]["temperature"] == 0.42
+        assert backend.calls[1]["temperature"] == 0.07
+        assert backend.calls[0]["format_json"] is False
+        assert backend.calls[1]["format_json"] is True
+
+    @pytest.mark.asyncio
+    async def test_uses_configured_model_name(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps(
+                    {"suggestions": [{"replacement_source": "rotate270(input)", "confidence": 0.5}]}
+                ),
+            ]
+        )
+        config = Phase2Config(llm_model_name="Qwen/Qwen3.6-27B-AWQ")
+        client = LLMRepairTwoStageClient(
+            backend,
+            primitive_whitelist=["rotate270"],
+            config=config,
+        )
+        await client.repair(_failing_program(), _failing_demos())
+        assert all(call["model"] == "Qwen/Qwen3.6-27B-AWQ" for call in backend.calls)
+
+
+# ---------------------------------------------------------------------------
+# Diff is included in prompt when supplied
+# ---------------------------------------------------------------------------
+
+
+class TestDiffInPrompt:
+    @pytest.mark.asyncio
+    async def test_diff_summary_appears_in_user_messages(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps(
+                    {"suggestions": [{"replacement_source": "rotate270(input)", "confidence": 0.5}]}
+                ),
+            ]
+        )
+        client = LLMRepairTwoStageClient(backend, primitive_whitelist=["rotate270"])
+        inp = np.array([[1, 2], [3, 4]], dtype=np.int8)
+        expected = np.array([[2, 4], [1, 3]], dtype=np.int8)
+        actual = np.rot90(inp, k=-1)
+        diff = analyze_diff(actual, expected)
+        await client.repair(_failing_program(), [(inp, expected, actual)], diff=diff)
+        # User message of the stage-1 call must mention the diff summary.
+        stage1_user = backend.calls[0]["messages"][1]["content"]
+        assert "shape_mismatch=" in stage1_user
+        # Stage-2 user must too.
+        stage2_user = backend.calls[1]["messages"][1]["content"]
+        assert "shape_mismatch=" in stage2_user
+        # And the whitelist must appear in stage-2 (substring is enough).
+        assert "rotate270" in stage2_user
+
+    @pytest.mark.asyncio
+    async def test_no_diff_uses_placeholder(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps(
+                    {"suggestions": [{"replacement_source": "rotate270(input)", "confidence": 0.5}]}
+                ),
+            ]
+        )
+        client = LLMRepairTwoStageClient(backend, primitive_whitelist=["rotate270"])
+        await client.repair(_failing_program(), _failing_demos())
+        stage1_user = backend.calls[0]["messages"][1]["content"]
+        assert "No structured diff supplied." in stage1_user
+
+
+# ---------------------------------------------------------------------------
+# JSON parser robustness
+# ---------------------------------------------------------------------------
+
+
+class TestJsonParser:
+    @pytest.mark.asyncio
+    async def test_drops_entries_with_missing_source(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps(
+                    {
+                        "suggestions": [
+                            {"replacement_source": "rotate270(input)", "confidence": 0.7},
+                            {"confidence": 0.9},  # no source — drop
+                            {"replacement_source": "", "confidence": 0.5},  # empty — drop
+                            {"replacement_source": "   ", "confidence": 0.5},  # whitespace — drop
+                        ]
+                    }
+                ),
+            ]
+        )
+        client = LLMRepairTwoStageClient(backend, primitive_whitelist=["rotate270"])
+        result = await client.repair(_failing_program(), _failing_demos())
+        assert len(result.suggestions) == 1
+        assert result.suggestions[0].replacement_source == "rotate270(input)"
+
+    @pytest.mark.asyncio
+    async def test_clamps_confidence_to_unit_range(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps(
+                    {
+                        "suggestions": [
+                            {"replacement_source": "a", "confidence": 1.7},
+                            {"replacement_source": "b", "confidence": -0.3},
+                        ]
+                    }
+                ),
+            ]
+        )
+        client = LLMRepairTwoStageClient(backend, primitive_whitelist=["rotate90"])
+        result = await client.repair(_failing_program(), _failing_demos())
+        # Sorted by confidence descending: clamped 1.0 first, clamped 0.0 last.
+        assert [s.confidence for s in result.suggestions] == [1.0, 0.0]
+
+    @pytest.mark.asyncio
+    async def test_non_finite_confidence_replaced_with_default(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps(
+                    {
+                        "suggestions": [
+                            {"replacement_source": "a", "confidence": "nope"},
+                        ]
+                    }
+                ),
+            ]
+        )
+        client = LLMRepairTwoStageClient(backend, primitive_whitelist=["rotate90"])
+        result = await client.repair(_failing_program(), _failing_demos())
+        # Default 0.5 used.
+        assert result.suggestions[0].confidence == 0.5
+
+    @pytest.mark.asyncio
+    async def test_missing_suggestions_key_raises(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                json.dumps({"foo": "bar"}),  # no `suggestions`
+            ]
+        )
+        client = LLMRepairTwoStageClient(backend, primitive_whitelist=["rotate90"])
+        with pytest.raises(LLMRepairError):
+            await client.repair(_failing_program(), _failing_demos())
+
+
+# ---------------------------------------------------------------------------
+# Retry-once on parse failure
+# ---------------------------------------------------------------------------
+
+
+class TestRetryOnceRule:
+    @pytest.mark.asyncio
+    async def test_invalid_then_valid_retries_and_returns(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                "{not actually json",
+                json.dumps(
+                    {"suggestions": [{"replacement_source": "rotate270(input)", "confidence": 0.5}]}
+                ),
+            ]
+        )
+        client = LLMRepairTwoStageClient(backend, primitive_whitelist=["rotate270"])
+        result = await client.repair(_failing_program(), _failing_demos())
+        assert len(result.suggestions) == 1
+        # Stage-1 + 2 stage-2 calls = 3 total.
+        assert len(backend.calls) == 3
+
+    @pytest.mark.asyncio
+    async def test_two_consecutive_failures_raise(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                "{not json",
+                "still not json",
+            ]
+        )
+        client = LLMRepairTwoStageClient(backend, primitive_whitelist=["rotate90"])
+        with pytest.raises(LLMRepairError):
+            await client.repair(_failing_program(), _failing_demos())
+
+    @pytest.mark.asyncio
+    async def test_non_object_json_treated_as_failure(self) -> None:
+        backend = _StubBackend(
+            queued=[
+                "reasoning",
+                "[1, 2, 3]",  # array, not object
+                "[4, 5]",  # also array
+            ]
+        )
+        client = LLMRepairTwoStageClient(backend, primitive_whitelist=["rotate90"])
+        with pytest.raises(LLMRepairError):
+            await client.repair(_failing_program(), _failing_demos())
+
+
+# ---------------------------------------------------------------------------
+# Dataclass contract
+# ---------------------------------------------------------------------------
+
+
+class TestLLMRepairSuggestionDataclass:
+    def test_is_frozen_and_hashable(self) -> None:
+        s = LLMRepairSuggestion(
+            replacement_source="rotate90(input)",
+            confidence=0.5,
+            reasoning="meh",
+        )
+        # Frozen dataclass → hashable.
+        assert hash(s) == hash(s)
+        # And immutable.
+        with pytest.raises(FrozenInstanceError):
+            s.confidence = 0.9  # type: ignore[misc]
+
+    def test_default_reasoning_empty(self) -> None:
+        s = LLMRepairSuggestion(replacement_source="x", confidence=0.5)
+        assert s.reasoning == ""


### PR DESCRIPTION
## Summary

Plan-Task 9 slice — **LLM-Repair Two-Stage** (spec §6.5.2 Zone-1): when the Refiner mode controller picks ``full_llm`` (α ≥ 0.45), this module runs a CoT→JSON Two-Stage prompt that asks the model to reason about *why* the candidate fails, then produce replacement DSL source strings the caller can substitute into the program tree.

Mirrors the proven pattern from \`phase2/llm_prior.py\`:
- Stage 1 (CoT, ≤ 6 sentences) at \`temperature_stage1\`.
- Stage 2 (JSON list of suggestions) at \`temperature_stage2\` with \`format_json=True\`.
- Retry-once-on-parse-failure per spec §4.7.
- Confidence clamped to [0, 1]; empty/whitespace sources dropped.
- Output sorted by descending confidence.

## Surface

- \`refiner/llm_repair_two_stage.py\`
  - \`LLMRepairSuggestion(replacement_source, confidence, reasoning)\` — frozen dataclass
  - \`LLMRepairResult(suggestions, stage1_reasoning, raw_response)\`
  - \`LLMRepairTwoStageClient.repair(program, failing_demos, diff=None)\` → \`LLMRepairResult\`
  - \`LLMRepairError\` on Stage-2 failure after retry

The actual Program-tree substitution is the caller's job: this module returns textual suggestions plus confidence; the Refiner driver runs them through the search-engine source parser and re-verifies.

## Tests (14 new)

- Happy-path: three suggestions parsed, sorted by descending confidence; reasoning preserved.
- Plumbing: configured stage-1/stage-2 temperatures, format_json toggle, model-name routing.
- Diff-in-prompt: \`shape_mismatch=\` summary included in both stage-1 and stage-2 user messages; whitelist appears in stage-2.
- Parser robustness: missing/empty/whitespace replacement_source dropped; confidence clamped to [0, 1]; non-finite confidence replaced with 0.5; missing \`suggestions\` key raises.
- Retry-once: invalid-then-valid succeeds (3 backend calls); two consecutive parse failures raise; non-object JSON treated as failure.
- Frozen dataclass + default reasoning empty.

mypy --strict clean. ruff lint + format clean. Phase-2 suite: 279 passed.

## Plan-Task 9 ladder

| slice | status |
|---|---|
| \`diff_analyzer.py\` (#251) | merged |
| \`symbolic_repair.py\` (#252) | in CI |
| \`trace_replay.py\` (#253) | open |
| **\`llm_repair_two_stage.py\`** | **this PR** |
| \`hybrid_repair.py\` | next |
| \`escalation.py\` | next |

## Test plan

- [x] \`pytest tests/test_channels/test_program_synthesis/phase2/test_llm_repair_two_stage.py -q\` — 14 passed
- [x] \`pytest tests/test_channels/test_program_synthesis/phase2/ -q\` — 279 passed
- [x] \`mypy --strict src/cognithor/channels/program_synthesis/refiner/llm_repair_two_stage.py\`
- [x] \`ruff check\` + \`ruff format --check\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)