### PR TITLE
feat(pse): Phase-2 Sprint-1 — Hybrid-Repair (plan task 9 slice, §6.5.2 Zone-2)

### DIFF
--- a/src/cognithor/channels/program_synthesis/refiner/__init__.py
+++ b/src/cognithor/channels/program_synthesis/refiner/__init__.py
@@ -20,6 +20,12 @@ from cognithor.channels.program_synthesis.refiner.diff_analyzer import (
     StructureDiff,
     analyze_diff,
 )
+from cognithor.channels.program_synthesis.refiner.hybrid_repair import (
+    CandidateOrigin,
+    HybridRepairCandidate,
+    HybridRepairResult,
+    run_hybrid_repair,
+)
 from cognithor.channels.program_synthesis.refiner.llm_repair_two_stage import (
     LLMRepairError,
     LLMRepairResult,
@@ -48,9 +54,12 @@ from cognithor.channels.program_synthesis.refiner.trace_replay import (
 __all__ = [
     "CEGISLoop",
     "CEGISResult",
+    "CandidateOrigin",
     "ColorDiff",
     "CounterExample",
     "DiffReport",
+    "HybridRepairCandidate",
+    "HybridRepairResult",
     "LLMRepairError",
     "LLMRepairResult",
     "LLMRepairSuggestion",
@@ -68,4 +77,5 @@ __all__ = [
     "find_divergence",
     "find_first_failure",
     "replay_trace",
+    "run_hybrid_repair",
 ]

--- a/src/cognithor/channels/program_synthesis/refiner/hybrid_repair.py
+++ b/src/cognithor/channels/program_synthesis/refiner/hybrid_repair.py
@@ -1,0 +1,284 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Spec §6.5.2 Zone-2 — Hybrid-Repair (Sprint-1 plan task 9 slice).
+
+When the Refiner mode controller sits in the α-grey-band
+(``0.35 ≤ α < 0.45``), trust in the LLM is unclear: a single bad
+LLM-call could push performance-α into Symbolic territory, but
+purely symbolic repairs may lack the breadth the LLM offers.
+
+Hybrid-Repair runs **both backends in parallel**:
+
+* the **symbolic** advisor (``advise_repairs`` from
+  :mod:`refiner.symbolic_repair`) — instant, rule-based, no
+  network round-trip;
+* a **single-stage LLM** call (no CoT preamble — Stage 2 only,
+  per spec §6.5.2 latency note) that proposes additional
+  candidate replacement sources.
+
+Both produce a uniform :class:`HybridRepairCandidate`. Each
+candidate is scored by an injected ``scorer`` callable (the
+Verifier in production); the highest-scoring candidate wins.
+
+This module is the *orchestrator*. The actual evaluator is
+dependency-injected so the loop is testable without a live
+verifier or LLM.
+
+The key contract: Hybrid-Repair is **always** at least as good
+as either backend alone — when the LLM hangs or the symbolic
+advisor returns nothing, the other side still produces a result.
+``await asyncio.gather(..., return_exceptions=True)`` ensures one
+side's failure never sinks the other.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.refiner.llm_repair_two_stage import (
+        LLMRepairResult,
+    )
+    from cognithor.channels.program_synthesis.refiner.symbolic_repair import (
+        RepairSuggestion,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+CandidateOrigin = Literal["symbolic", "llm"]
+
+
+@dataclass(frozen=True)
+class HybridRepairCandidate:
+    """One repair candidate from either backend, in a uniform shape.
+
+    ``source`` is the DSL source string the candidate represents —
+    either from the symbolic advisor's ``primitive_hint`` (lifted
+    into a source by the caller) or from the LLM's
+    ``replacement_source``.
+
+    ``confidence`` is the backend's self-reported confidence,
+    clamped to ``[0, 1]``. The orchestrator does *not* re-rank by
+    confidence — it re-ranks by the scorer's verdict — but
+    confidence is preserved for tie-breaks and telemetry.
+
+    ``origin`` tags which backend produced the candidate, so the
+    Refiner can attribute wins / losses for the α-controller's
+    performance-α update.
+
+    ``detail`` is a free-form note for telemetry.
+    """
+
+    source: str
+    confidence: float
+    origin: CandidateOrigin
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class HybridRepairResult:
+    """Outcome of one :func:`run_hybrid_repair` call.
+
+    ``winner`` is the highest-scoring candidate, or ``None`` when
+    no candidate beat the ``threshold`` baseline (so the Refiner
+    falls back to the next escalation step).
+
+    ``winner_score`` is the absolute score the verifier assigned
+    to ``winner``.
+
+    ``candidates_evaluated`` is every candidate that was scored,
+    in the order they were scored — used by tests / telemetry to
+    audit how the orchestrator weighed alternatives.
+
+    ``symbolic_failed`` / ``llm_failed`` carry the exception
+    *types* (as string tags) when one side blew up, so the caller
+    can decide whether to penalise that backend's α.
+    """
+
+    winner: HybridRepairCandidate | None
+    winner_score: float
+    candidates_evaluated: tuple[HybridRepairCandidate, ...]
+    symbolic_failed: str | None = None
+    llm_failed: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+SymbolicSupplier = Callable[[], Iterable["RepairSuggestion"]]
+LLMSupplier = Callable[[], Awaitable["LLMRepairResult"]]
+Scorer = Callable[[HybridRepairCandidate], Awaitable[float]]
+
+
+async def run_hybrid_repair(
+    *,
+    symbolic_supplier: SymbolicSupplier,
+    llm_supplier: LLMSupplier,
+    scorer: Scorer,
+    symbolic_to_source: Callable[[RepairSuggestion], str | None] | None = None,
+    threshold: float = 0.0,
+) -> HybridRepairResult:
+    """Run symbolic + LLM repair in parallel, score every candidate, pick the best.
+
+    ``symbolic_supplier`` returns the :class:`RepairSuggestion` list
+    from :func:`advise_repairs`. The synchronous interface keeps the
+    advisor cheap; the orchestrator wraps it in ``asyncio.to_thread``
+    so it runs concurrent with the LLM round-trip.
+
+    ``llm_supplier`` runs the actual LLM repair (typically a
+    :class:`LLMRepairTwoStageClient.repair` configured with
+    ``llm_json_max_retries=0`` for single-stage latency).
+
+    ``symbolic_to_source`` lifts a :class:`RepairSuggestion` into a
+    DSL source string. Defaults to using the suggestion's
+    ``primitive_hint`` directly when present (so e.g.
+    ``primitive_hint="rotate90"`` becomes ``source="rotate90(input)"``);
+    if ``primitive_hint`` is ``None`` (R5 local-edit) the suggestion
+    is dropped from the candidate set.
+
+    ``scorer`` is the verifier callable; it returns a score in
+    ``[0, 1]`` (or any float — the orchestrator sorts descending).
+
+    ``threshold`` is the floor the winner must clear. When no
+    candidate beats it, ``HybridRepairResult.winner`` is ``None``.
+
+    The function never raises on backend failures — it captures
+    the exception type and continues with the surviving backend.
+    """
+    if symbolic_to_source is None:
+        symbolic_to_source = _default_symbolic_to_source
+
+    sym_task = asyncio.create_task(asyncio.to_thread(_collect_symbolic, symbolic_supplier))
+    llm_task = asyncio.create_task(_safe_llm(llm_supplier))
+
+    sym_outcome, llm_outcome = await asyncio.gather(sym_task, llm_task)
+
+    candidates: list[HybridRepairCandidate] = []
+    symbolic_failed = sym_outcome.error
+    if sym_outcome.suggestions is not None:
+        for sym_sug in sym_outcome.suggestions:
+            source = symbolic_to_source(sym_sug)
+            if source is None:
+                continue
+            candidates.append(
+                HybridRepairCandidate(
+                    source=source,
+                    confidence=_clamp_unit(sym_sug.confidence),
+                    origin="symbolic",
+                    detail=sym_sug.detail,
+                )
+            )
+
+    llm_failed = llm_outcome.error
+    if llm_outcome.result is not None:
+        for llm_sug in llm_outcome.result.suggestions:
+            candidates.append(
+                HybridRepairCandidate(
+                    source=llm_sug.replacement_source,
+                    confidence=_clamp_unit(llm_sug.confidence),
+                    origin="llm",
+                    detail=llm_sug.reasoning,
+                )
+            )
+
+    scored: list[tuple[HybridRepairCandidate, float]] = []
+    for candidate in candidates:
+        try:
+            score = await scorer(candidate)
+        except Exception:
+            continue
+        if not math.isfinite(score):
+            continue
+        scored.append((candidate, score))
+
+    # Pick the highest score above threshold; ties broken by descending confidence.
+    scored.sort(key=lambda pair: (pair[1], pair[0].confidence), reverse=True)
+    winner: HybridRepairCandidate | None = None
+    winner_score = float("-inf")
+    for cand, score in scored:
+        if score >= threshold:
+            winner = cand
+            winner_score = score
+            break
+
+    return HybridRepairResult(
+        winner=winner,
+        winner_score=winner_score if winner is not None else 0.0,
+        candidates_evaluated=tuple(c for c, _ in scored),
+        symbolic_failed=symbolic_failed,
+        llm_failed=llm_failed,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _SymbolicOutcome:
+    suggestions: tuple[RepairSuggestion, ...] | None
+    error: str | None
+
+
+@dataclass(frozen=True)
+class _LLMOutcome:
+    result: LLMRepairResult | None
+    error: str | None
+
+
+def _collect_symbolic(supplier: SymbolicSupplier) -> _SymbolicOutcome:
+    try:
+        return _SymbolicOutcome(suggestions=tuple(supplier()), error=None)
+    except Exception as exc:
+        return _SymbolicOutcome(suggestions=None, error=type(exc).__name__)
+
+
+async def _safe_llm(supplier: LLMSupplier) -> _LLMOutcome:
+    try:
+        return _LLMOutcome(result=await supplier(), error=None)
+    except Exception as exc:
+        return _LLMOutcome(result=None, error=type(exc).__name__)
+
+
+def _default_symbolic_to_source(sug: RepairSuggestion) -> str | None:
+    """Lift a RepairSuggestion to a source string via its primitive_hint."""
+    hint = sug.primitive_hint
+    if hint is None:
+        return None
+    # The primitive hint is bare ("rotate90", "scale_up_2x", "recolor"); we
+    # don't know the right argument shape without registry awareness, so
+    # default to the simplest case: ``<hint>(input)``. The Refiner driver
+    # is free to override ``symbolic_to_source`` with a registry-aware
+    # version when more context is needed.
+    return f"{hint}(input)"
+
+
+def _clamp_unit(value: float) -> float:
+    if not math.isfinite(value):
+        return 0.0
+    if value < 0.0:
+        return 0.0
+    if value > 1.0:
+        return 1.0
+    return value
+
+
+__all__ = [
+    "CandidateOrigin",
+    "HybridRepairCandidate",
+    "HybridRepairResult",
+    "LLMSupplier",
+    "Scorer",
+    "SymbolicSupplier",
+    "run_hybrid_repair",
+]

--- a/tests/test_channels/test_program_synthesis/phase2/test_hybrid_repair.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_hybrid_repair.py
@@ -1,0 +1,411 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Hybrid-Repair tests (Sprint-1 plan task 9 slice, spec §6.5.2 Zone-2)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.refiner.hybrid_repair import (
+    HybridRepairCandidate,
+    HybridRepairResult,
+    run_hybrid_repair,
+)
+from cognithor.channels.program_synthesis.refiner.llm_repair_two_stage import (
+    LLMRepairResult,
+    LLMRepairSuggestion,
+)
+from cognithor.channels.program_synthesis.refiner.symbolic_repair import (
+    RepairSuggestion,
+)
+
+
+def _symbolic_only(*sugs: RepairSuggestion):
+    def supply() -> list[RepairSuggestion]:
+        return list(sugs)
+
+    return supply
+
+
+def _llm_only(*sugs: LLMRepairSuggestion):
+    async def supply() -> LLMRepairResult:
+        return LLMRepairResult(suggestions=tuple(sugs))
+
+    return supply
+
+
+def _scorer_from_map(scores: dict[str, float]):
+    async def score(candidate: HybridRepairCandidate) -> float:
+        return scores.get(candidate.source, 0.0)
+
+    return score
+
+
+# ---------------------------------------------------------------------------
+# Happy path — best of both backends wins
+# ---------------------------------------------------------------------------
+
+
+class TestRunHybridRepair:
+    @pytest.mark.asyncio
+    async def test_picks_highest_scoring_candidate(self) -> None:
+        sym = _symbolic_only(
+            RepairSuggestion(
+                kind="rotation_repair",
+                primitive_hint="rotate90",
+                confidence=0.9,
+                detail="rotate",
+            ),
+        )
+        llm = _llm_only(
+            LLMRepairSuggestion(
+                replacement_source="rotate270(input)",
+                confidence=0.5,
+                reasoning="other rotation",
+            ),
+        )
+        scorer = _scorer_from_map(
+            {
+                "rotate90(input)": 0.6,
+                "rotate270(input)": 0.95,  # LLM wins
+            }
+        )
+
+        result = await run_hybrid_repair(
+            symbolic_supplier=sym,
+            llm_supplier=llm,
+            scorer=scorer,
+        )
+
+        assert isinstance(result, HybridRepairResult)
+        assert result.winner is not None
+        assert result.winner.source == "rotate270(input)"
+        assert result.winner.origin == "llm"
+        assert result.winner_score == 0.95
+        # Both candidates were evaluated.
+        assert len(result.candidates_evaluated) == 2
+
+    @pytest.mark.asyncio
+    async def test_threshold_filters_below_baseline(self) -> None:
+        sym = _symbolic_only(
+            RepairSuggestion(
+                kind="color_repair",
+                primitive_hint="recolor",
+                confidence=0.8,
+                detail="",
+            ),
+        )
+        llm = _llm_only(
+            LLMRepairSuggestion(
+                replacement_source="rotate90(input)",
+                confidence=0.7,
+                reasoning="",
+            ),
+        )
+        # All candidates score below 0.5 — nothing beats the threshold.
+        scorer = _scorer_from_map({"recolor(input)": 0.3, "rotate90(input)": 0.4})
+
+        result = await run_hybrid_repair(
+            symbolic_supplier=sym,
+            llm_supplier=llm,
+            scorer=scorer,
+            threshold=0.5,
+        )
+        assert result.winner is None
+        # But the candidates were still evaluated and recorded.
+        assert {c.source for c in result.candidates_evaluated} == {
+            "recolor(input)",
+            "rotate90(input)",
+        }
+
+    @pytest.mark.asyncio
+    async def test_symbolic_alone_wins_when_llm_empty(self) -> None:
+        sym = _symbolic_only(
+            RepairSuggestion(
+                kind="rotation_repair",
+                primitive_hint="rotate90",
+                confidence=0.9,
+                detail="",
+            ),
+        )
+        # Empty LLMRepairResult.
+        llm = _llm_only()
+        scorer = _scorer_from_map({"rotate90(input)": 0.7})
+
+        result = await run_hybrid_repair(
+            symbolic_supplier=sym,
+            llm_supplier=llm,
+            scorer=scorer,
+        )
+        assert result.winner is not None
+        assert result.winner.origin == "symbolic"
+
+    @pytest.mark.asyncio
+    async def test_llm_alone_wins_when_symbolic_returns_nothing(self) -> None:
+        sym = _symbolic_only()  # zero suggestions
+        llm = _llm_only(
+            LLMRepairSuggestion(
+                replacement_source="recolor(input, 1, 5)",
+                confidence=0.7,
+                reasoning="",
+            )
+        )
+        scorer = _scorer_from_map({"recolor(input, 1, 5)": 0.65})
+
+        result = await run_hybrid_repair(
+            symbolic_supplier=sym,
+            llm_supplier=llm,
+            scorer=scorer,
+        )
+        assert result.winner is not None
+        assert result.winner.origin == "llm"
+
+    @pytest.mark.asyncio
+    async def test_local_repair_suggestion_with_no_hint_dropped(self) -> None:
+        # R5 local-edit suggestion has primitive_hint=None — orchestrator
+        # drops it because the default lifter can't make a source.
+        sym = _symbolic_only(
+            RepairSuggestion(
+                kind="local_repair",
+                primitive_hint=None,
+                confidence=0.7,
+                detail="1 pixel diff",
+            ),
+            RepairSuggestion(
+                kind="rotation_repair",
+                primitive_hint="rotate90",
+                confidence=0.9,
+                detail="",
+            ),
+        )
+        llm = _llm_only()
+        scorer = _scorer_from_map({"rotate90(input)": 0.5})
+
+        result = await run_hybrid_repair(
+            symbolic_supplier=sym,
+            llm_supplier=llm,
+            scorer=scorer,
+        )
+        # Only one candidate makes it through (the rotation one).
+        assert len(result.candidates_evaluated) == 1
+        assert result.candidates_evaluated[0].source == "rotate90(input)"
+
+
+# ---------------------------------------------------------------------------
+# Failure isolation — neither side can sink the other
+# ---------------------------------------------------------------------------
+
+
+class TestFailureIsolation:
+    @pytest.mark.asyncio
+    async def test_symbolic_exception_records_tag_and_uses_llm(self) -> None:
+        def bad_sym() -> list[RepairSuggestion]:
+            raise RuntimeError("boom")
+
+        llm = _llm_only(
+            LLMRepairSuggestion(
+                replacement_source="rotate90(input)",
+                confidence=0.6,
+                reasoning="",
+            )
+        )
+        scorer = _scorer_from_map({"rotate90(input)": 0.55})
+
+        result = await run_hybrid_repair(
+            symbolic_supplier=bad_sym,
+            llm_supplier=llm,
+            scorer=scorer,
+        )
+        # LLM still wins.
+        assert result.winner is not None
+        assert result.winner.origin == "llm"
+        assert result.symbolic_failed == "RuntimeError"
+        assert result.llm_failed is None
+
+    @pytest.mark.asyncio
+    async def test_llm_exception_records_tag_and_uses_symbolic(self) -> None:
+        sym = _symbolic_only(
+            RepairSuggestion(
+                kind="rotation_repair",
+                primitive_hint="rotate90",
+                confidence=0.9,
+                detail="",
+            )
+        )
+
+        async def bad_llm() -> LLMRepairResult:
+            raise TimeoutError("vllm down")
+
+        scorer = _scorer_from_map({"rotate90(input)": 0.75})
+
+        result = await run_hybrid_repair(
+            symbolic_supplier=sym,
+            llm_supplier=bad_llm,
+            scorer=scorer,
+        )
+        assert result.winner is not None
+        assert result.winner.origin == "symbolic"
+        assert result.llm_failed == "TimeoutError"
+        assert result.symbolic_failed is None
+
+    @pytest.mark.asyncio
+    async def test_both_backends_fail_returns_none_winner(self) -> None:
+        def bad_sym() -> list[RepairSuggestion]:
+            raise ValueError("nope")
+
+        async def bad_llm() -> LLMRepairResult:
+            raise TimeoutError("nope")
+
+        result = await run_hybrid_repair(
+            symbolic_supplier=bad_sym,
+            llm_supplier=bad_llm,
+            scorer=_scorer_from_map({}),
+        )
+        assert result.winner is None
+        assert result.symbolic_failed == "ValueError"
+        assert result.llm_failed == "TimeoutError"
+
+    @pytest.mark.asyncio
+    async def test_scorer_exception_skips_candidate(self) -> None:
+        sym = _symbolic_only(
+            RepairSuggestion(
+                kind="rotation_repair",
+                primitive_hint="rotate90",
+                confidence=0.9,
+                detail="",
+            ),
+            RepairSuggestion(
+                kind="color_repair",
+                primitive_hint="recolor",
+                confidence=0.8,
+                detail="",
+            ),
+        )
+
+        async def picky_scorer(candidate: HybridRepairCandidate) -> float:
+            if candidate.source == "rotate90(input)":
+                raise ValueError("can't parse this source")
+            return 0.6
+
+        result = await run_hybrid_repair(
+            symbolic_supplier=sym,
+            llm_supplier=_llm_only(),
+            scorer=picky_scorer,
+        )
+        # Only recolor survived; it's the winner.
+        assert result.winner is not None
+        assert result.winner.source == "recolor(input)"
+
+
+# ---------------------------------------------------------------------------
+# Parallel execution — symbolic and LLM run concurrently
+# ---------------------------------------------------------------------------
+
+
+class TestParallelism:
+    @pytest.mark.asyncio
+    async def test_runs_backends_concurrently(self) -> None:
+        # Symbolic supplier sleeps 50 ms, LLM sleeps 50 ms. Total wall-
+        # clock should be ~50 ms (parallel), not ~100 ms (sequential).
+        order: list[str] = []
+
+        def slow_sym() -> list[RepairSuggestion]:
+            import time
+
+            time.sleep(0.05)
+            order.append("sym_done")
+            return [
+                RepairSuggestion(
+                    kind="rotation_repair",
+                    primitive_hint="rotate90",
+                    confidence=0.5,
+                    detail="",
+                )
+            ]
+
+        async def slow_llm() -> LLMRepairResult:
+            await asyncio.sleep(0.05)
+            order.append("llm_done")
+            return LLMRepairResult(
+                suggestions=(
+                    LLMRepairSuggestion(replacement_source="rotate270(input)", confidence=0.5),
+                )
+            )
+
+        scorer = _scorer_from_map({"rotate90(input)": 0.5, "rotate270(input)": 0.5})
+
+        loop = asyncio.get_running_loop()
+        t0 = loop.time()
+        result = await run_hybrid_repair(
+            symbolic_supplier=slow_sym,
+            llm_supplier=slow_llm,
+            scorer=scorer,
+        )
+        elapsed = loop.time() - t0
+
+        # Wall-clock < 0.09 s (well under sequential 0.1 s, with margin).
+        assert elapsed < 0.09, f"hybrid was sequential? elapsed={elapsed:.3f}s"
+        # Both candidates evaluated.
+        assert {c.origin for c in result.candidates_evaluated} == {"symbolic", "llm"}
+
+
+# ---------------------------------------------------------------------------
+# Custom symbolic_to_source override
+# ---------------------------------------------------------------------------
+
+
+class TestSymbolicToSourceOverride:
+    @pytest.mark.asyncio
+    async def test_caller_can_supply_richer_lifter(self) -> None:
+        sym = _symbolic_only(
+            RepairSuggestion(
+                kind="color_repair",
+                primitive_hint="recolor",
+                confidence=0.8,
+                detail="",
+            )
+        )
+        llm = _llm_only()
+
+        def my_lifter(sug: RepairSuggestion) -> str:
+            # Always lift recolor with placeholder color args.
+            assert sug.primitive_hint == "recolor"
+            return "recolor(input, 1, 5)"
+
+        scorer = _scorer_from_map({"recolor(input, 1, 5)": 0.7})
+
+        result = await run_hybrid_repair(
+            symbolic_supplier=sym,
+            llm_supplier=llm,
+            scorer=scorer,
+            symbolic_to_source=my_lifter,
+        )
+        assert result.winner is not None
+        assert result.winner.source == "recolor(input, 1, 5)"
+
+
+# ---------------------------------------------------------------------------
+# Dataclass contract
+# ---------------------------------------------------------------------------
+
+
+class TestDataclassesAreFrozen:
+    def test_candidate_is_hashable(self) -> None:
+        c = HybridRepairCandidate(
+            source="rotate90(input)",
+            confidence=0.5,
+            origin="symbolic",
+        )
+        assert hash(c) == hash(c)
+
+    def test_result_is_hashable(self) -> None:
+        r = HybridRepairResult(
+            winner=None,
+            winner_score=0.0,
+            candidates_evaluated=(),
+        )
+        assert hash(r) == hash(r)


### PR DESCRIPTION
## Summary

Plan-Task 9 slice — **Hybrid-Repair** (spec §6.5.2 Zone-2): the α-grey-band repair strategy that runs the symbolic advisor and a single-stage LLM call in parallel and lets the verifier pick the winner.

When the Refiner mode controller sits in ``0.35 ≤ α < 0.45``, trust in the LLM is unclear: a single bad LLM-call could push performance-α into Symbolic territory, but purely symbolic repairs may miss patterns the LLM catches. Hybrid neutralises both risks by running both backends concurrently and committing only to whichever candidate the verifier scores highest.

## Surface

- \`refiner/hybrid_repair.py\`
  - \`HybridRepairCandidate(source, confidence, origin, detail)\` — uniform shape; \`origin\` ∈ {"symbolic", "llm"}
  - \`HybridRepairResult(winner, winner_score, candidates_evaluated, symbolic_failed, llm_failed)\` — winner is None when no candidate beats threshold; failure tags let the α-controller attribute backend errors
  - \`run_hybrid_repair(*, symbolic_supplier, llm_supplier, scorer, symbolic_to_source=None, threshold=0.0)\`
  - Type aliases \`SymbolicSupplier\`, \`LLMSupplier\`, \`Scorer\`, \`CandidateOrigin\`

## Design notes

- **Concurrency**: symbolic advisor runs in \`asyncio.to_thread\` (it's sync), LLM supplier is awaited natively — both joined via \`asyncio.gather\`. Wall-clock is \`max(sym, llm)\`, not \`sym + llm\`.
- **Failure isolation**: each backend is wrapped in its own try/except; an exception on one side is recorded as a type-tag string in the result; the surviving backend still produces a winner.
- **Scorer isolation**: a scorer that throws on one candidate skips that candidate without sinking the loop.
- **Symbolic-to-source default**: lifts \`primitive_hint\` to \`<hint>(input)\`. Suggestions with \`primitive_hint=None\` (R5 LocalRepair) are dropped — the caller can override the lifter for richer registry-aware lifting.
- **Confidence vs score**: orchestrator sorts by scorer verdict; confidence is preserved only as a tie-break and for telemetry.

## Tests (13 new)

- Happy-path: highest-scoring candidate wins regardless of origin.
- Threshold filtering: candidates below threshold rejected; candidates_evaluated still records them.
- Single-backend fallback: sym-only when LLM returns empty / llm-only when symbolic returns empty.
- LocalRepair (primitive_hint=None) dropped by default lifter.
- Failure isolation: symbolic-throws / llm-throws / both-throw cases.
- Scorer-throws on one candidate: that candidate skipped, others continue.
- Parallelism: each backend sleeps 50 ms; total wall-clock < 90 ms (would be ~100 ms if sequential).
- Custom \`symbolic_to_source\` override: caller can supply a richer lifter.
- Frozen dataclass contract.

mypy --strict clean. ruff lint + format clean. Phase-2 suite: 313 passed.

## Plan-Task 9 ladder

| slice | status |
|---|---|
| \`diff_analyzer.py\` (#251) | merged |
| \`symbolic_repair.py\` (#252) | merged |
| \`trace_replay.py\` (#253) | open (rebased) |
| \`llm_repair_two_stage.py\` (#254) | merged |
| **\`hybrid_repair.py\`** | **this PR** |
| \`escalation.py\` | next |

## Test plan

- [x] \`pytest tests/test_channels/test_program_synthesis/phase2/test_hybrid_repair.py -q\` — 13 passed
- [x] \`pytest tests/test_channels/test_program_synthesis/phase2/ -q\` — 313 passed
- [x] \`mypy --strict src/cognithor/channels/program_synthesis/refiner/hybrid_repair.py\`
- [x] \`ruff check\` + \`ruff format --check\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)