### PR TITLE
feat(pse): Phase-2 Sprint-1 — Refiner Escalation logic (plan task 9 final slice, §6.6)

### DIFF
--- a/src/cognithor/channels/program_synthesis/refiner/__init__.py
+++ b/src/cognithor/channels/program_synthesis/refiner/__init__.py
@@ -20,6 +20,11 @@ from cognithor.channels.program_synthesis.refiner.diff_analyzer import (
     StructureDiff,
     analyze_diff,
 )
+from cognithor.channels.program_synthesis.refiner.escalation import (
+    EscalationResult,
+    RefinementStage,
+    RefinerEscalator,
+)
 from cognithor.channels.program_synthesis.refiner.hybrid_repair import (
     CandidateOrigin,
     HybridRepairCandidate,
@@ -58,6 +63,7 @@ __all__ = [
     "ColorDiff",
     "CounterExample",
     "DiffReport",
+    "EscalationResult",
     "HybridRepairCandidate",
     "HybridRepairResult",
     "LLMRepairError",
@@ -66,6 +72,8 @@ __all__ = [
     "LLMRepairTwoStageClient",
     "LocalEditMutator",
     "PixelDiff",
+    "RefinementStage",
+    "RefinerEscalator",
     "RefinerMode",
     "RefinerModeController",
     "RepairKind",

--- a/src/cognithor/channels/program_synthesis/refiner/escalation.py
+++ b/src/cognithor/channels/program_synthesis/refiner/escalation.py
@@ -1,0 +1,266 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Spec §6.6 — Refiner Escalation logic (Sprint-1 plan task 9 final slice).
+
+The escalation orchestrator wires the four Refiner stages from
+spec §6.6 in the prescribed order:
+
+* **Stage 1 — Local-Edit ALWAYS** (`refiner.local_edit.LocalEditMutator`)
+* **Stage 2 — Mode-Dispatch when ``score ≥ 0.3``** (Drei-Zonen-Mode):
+    * ``α ≥ 0.45`` → Full-LLM (Two-Stage with retry)
+    * ``0.35 ≤ α < 0.45`` → Hybrid (parallel symbolic + single-stage LLM)
+    * ``α < 0.35`` → Symbolic-only
+* **Stage 3 — CEGIS when ``score ≥ 0.5``** (`refiner.cegis.CEGISLoop`)
+
+Between every stage the verifier re-evaluates: if the candidate
+already crosses the success threshold (default ``0.95``) the loop
+returns immediately, so we never waste budget on a winning
+program.
+
+The *strategies* (local-edit runner, the three repair modes, and
+CEGIS) are dependency-injected. Sprint-1 ships the orchestrator
+and exhaustive unit tests against stub strategies; later sprints
+wire the real backends. Keeping injection at the API surface
+means the loop is testable without an LLM, a verifier, or a
+running search engine.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Literal
+
+from cognithor.channels.program_synthesis.phase2.config import (
+    DEFAULT_PHASE2_CONFIG,
+    Phase2Config,
+)
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.refiner.mode_controller import (
+        RefinerMode,
+        RefinerModeController,
+    )
+    from cognithor.channels.program_synthesis.search.candidate import (
+        ProgramNode,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+RefinementStage = Literal["local", "repair_full_llm", "repair_hybrid", "repair_symbolic", "cegis"]
+
+
+@dataclass(frozen=True)
+class EscalationResult:
+    """Outcome of one :meth:`RefinerEscalator.refine` call.
+
+    ``program`` is the best program found across all stages — the
+    starting program if no stage produced an improvement, or the
+    last successful candidate otherwise.
+
+    ``final_score`` is the verifier's score for ``program``.
+
+    ``terminated_by`` records *why* the loop stopped:
+        * ``"success"`` — a stage produced a candidate with
+          ``score >= success_threshold``;
+        * ``"exhausted"`` — every applicable stage ran without
+          producing a new winner.
+
+    ``refinement_path`` is the ordered tuple of stage tags whose
+    candidates were *accepted* (improvement over the prior best
+    score). Stages that ran but didn't help are absent. The shape
+    matches the spec §6.6 ``refinement_path=("local", "repair_…",
+    "cegis")``.
+
+    ``mode_selected`` is the Stage-2 zone the mode controller
+    picked (or ``None`` if Stage 2 was skipped because
+    ``initial_score < mode_min_score``).
+    """
+
+    program: ProgramNode
+    final_score: float
+    terminated_by: Literal["success", "exhausted"]
+    refinement_path: tuple[RefinementStage, ...] = field(default_factory=tuple)
+    mode_selected: RefinerMode | None = None
+
+
+# ---------------------------------------------------------------------------
+# Strategy callables
+# ---------------------------------------------------------------------------
+
+
+# Each strategy returns either a fresh candidate (Program) or
+# ``None`` if it had nothing to offer. The orchestrator scores any
+# returned candidate through the injected ``verifier`` and only
+# accepts it when it improves on the running best score.
+LocalEditRunner = Callable[["ProgramNode"], Awaitable["ProgramNode | None"]]
+RepairRunner = Callable[["ProgramNode"], Awaitable["ProgramNode | None"]]
+CegisRunner = Callable[["ProgramNode"], Awaitable["ProgramNode | None"]]
+Verifier = Callable[["ProgramNode"], Awaitable[float]]
+BudgetExhaustedCheck = Callable[[], bool]
+
+
+@dataclass
+class _RunningBest:
+    program: ProgramNode
+    score: float
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+class RefinerEscalator:
+    """Spec §6.6 driver — runs Local-Edit → Mode-Dispatch → CEGIS in order.
+
+    All stages are injected at construction so the loop is testable
+    without a real verifier / LLM / search engine. The mode
+    controller is the only "real" dependency — its hysteresis state
+    persists across calls, which is the whole point.
+    """
+
+    def __init__(
+        self,
+        *,
+        mode_controller: RefinerModeController,
+        local_edit: LocalEditRunner,
+        full_llm: RepairRunner,
+        hybrid: RepairRunner,
+        symbolic: RepairRunner,
+        cegis: CegisRunner | None,
+        verifier: Verifier,
+        refiner_budget_exhausted: BudgetExhaustedCheck = lambda: False,
+        cegis_budget_exhausted: BudgetExhaustedCheck = lambda: False,
+        config: Phase2Config = DEFAULT_PHASE2_CONFIG,
+    ) -> None:
+        self._mode_controller = mode_controller
+        self._local_edit = local_edit
+        self._full_llm = full_llm
+        self._hybrid = hybrid
+        self._symbolic = symbolic
+        self._cegis = cegis
+        self._verifier = verifier
+        self._refiner_budget_exhausted = refiner_budget_exhausted
+        self._cegis_budget_exhausted = cegis_budget_exhausted
+        self._config = config
+
+    async def refine(
+        self,
+        program: ProgramNode,
+        initial_score: float,
+        current_alpha: float,
+        *,
+        success_threshold: float = 0.95,
+        mode_min_score: float = 0.3,
+        cegis_min_score: float = 0.5,
+    ) -> EscalationResult:
+        """Run Local-Edit → Mode-Dispatch → CEGIS in order; return the best.
+
+        The loop is short-circuited the moment any stage produces a
+        candidate at or above ``success_threshold``. Stages that
+        *run* but don't improve on the running best score are not
+        recorded in ``refinement_path``.
+        """
+        best = _RunningBest(program=program, score=initial_score)
+        path: list[RefinementStage] = []
+        mode_selected: RefinerMode | None = None
+
+        # ── STAGE 1: Local-Edit ALWAYS ───────────────────────────
+        candidate = await self._local_edit(best.program)
+        if candidate is not None:
+            score = await self._verifier(candidate)
+            if score >= success_threshold:
+                path.append("local")
+                return EscalationResult(
+                    program=candidate,
+                    final_score=score,
+                    terminated_by="success",
+                    refinement_path=tuple(path),
+                    mode_selected=mode_selected,
+                )
+            if score > best.score:
+                best = _RunningBest(program=candidate, score=score)
+                path.append("local")
+
+        # ── STAGE 2: Mode-Dispatch when score >= 0.3 ─────────────
+        if best.score >= mode_min_score and not self._refiner_budget_exhausted():
+            mode_selected = self._mode_controller.select_mode(current_alpha)
+            runner = self._runner_for_mode(mode_selected)
+            stage_tag = self._stage_tag_for_mode(mode_selected)
+            candidate = await runner(best.program)
+            if candidate is not None:
+                score = await self._verifier(candidate)
+                if score >= success_threshold:
+                    path.append(stage_tag)
+                    return EscalationResult(
+                        program=candidate,
+                        final_score=score,
+                        terminated_by="success",
+                        refinement_path=tuple(path),
+                        mode_selected=mode_selected,
+                    )
+                if score > best.score:
+                    best = _RunningBest(program=candidate, score=score)
+                    path.append(stage_tag)
+
+        # ── STAGE 3: CEGIS when score >= 0.5 ─────────────────────
+        if (
+            self._cegis is not None
+            and best.score >= cegis_min_score
+            and not self._cegis_budget_exhausted()
+        ):
+            candidate = await self._cegis(best.program)
+            if candidate is not None:
+                score = await self._verifier(candidate)
+                if score >= success_threshold:
+                    path.append("cegis")
+                    return EscalationResult(
+                        program=candidate,
+                        final_score=score,
+                        terminated_by="success",
+                        refinement_path=tuple(path),
+                        mode_selected=mode_selected,
+                    )
+                if score > best.score:
+                    best = _RunningBest(program=candidate, score=score)
+                    path.append("cegis")
+
+        return EscalationResult(
+            program=best.program,
+            final_score=best.score,
+            terminated_by="exhausted",
+            refinement_path=tuple(path),
+            mode_selected=mode_selected,
+        )
+
+    # -- Internals ---------------------------------------------------
+
+    def _runner_for_mode(self, mode: RefinerMode) -> RepairRunner:
+        if mode == "full_llm":
+            return self._full_llm
+        if mode == "hybrid":
+            return self._hybrid
+        return self._symbolic
+
+    def _stage_tag_for_mode(self, mode: RefinerMode) -> RefinementStage:
+        if mode == "full_llm":
+            return "repair_full_llm"
+        if mode == "hybrid":
+            return "repair_hybrid"
+        return "repair_symbolic"
+
+
+__all__ = [
+    "BudgetExhaustedCheck",
+    "CegisRunner",
+    "EscalationResult",
+    "LocalEditRunner",
+    "RefinementStage",
+    "RefinerEscalator",
+    "RepairRunner",
+    "Verifier",
+]

--- a/tests/test_channels/test_program_synthesis/phase2/test_escalation.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_escalation.py
@@ -1,0 +1,391 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Refiner Escalation tests (Sprint-1 plan task 9 final slice, spec §6.6)."""
+
+from __future__ import annotations
+
+import pytest
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.refiner.escalation import (
+    EscalationResult,
+    RefinerEscalator,
+)
+from cognithor.channels.program_synthesis.refiner.mode_controller import (
+    RefinerModeController,
+)
+from cognithor.channels.program_synthesis.search.candidate import (
+    InputRef,
+    Program,
+    ProgramNode,
+)
+
+
+def _prog(primitive: str) -> Program:
+    """Tiny helper: build a Program with a single InputRef child."""
+    return Program(primitive=primitive, children=(InputRef(),), output_type="Grid")
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _runner_returning(candidate: ProgramNode | None):
+    async def run(_: ProgramNode) -> ProgramNode | None:
+        return candidate
+
+    return run
+
+
+def _verifier_from_map(scores: dict[str, float]):
+    """Verifier that looks up a score by program primitive (or 'input' for InputRef)."""
+
+    async def verify(program: ProgramNode) -> float:
+        if isinstance(program, Program):
+            return scores.get(program.primitive, 0.0)
+        return scores.get("input", 0.0)
+
+    return verify
+
+
+def _make_escalator(
+    *,
+    local_candidate: ProgramNode | None = None,
+    full_llm_candidate: ProgramNode | None = None,
+    hybrid_candidate: ProgramNode | None = None,
+    symbolic_candidate: ProgramNode | None = None,
+    cegis_candidate: ProgramNode | None = None,
+    scores: dict[str, float],
+    refiner_budget_exhausted: bool = False,
+    cegis_budget_exhausted: bool = False,
+    cegis_enabled: bool = True,
+) -> RefinerEscalator:
+    return RefinerEscalator(
+        mode_controller=RefinerModeController(),
+        local_edit=_runner_returning(local_candidate),
+        full_llm=_runner_returning(full_llm_candidate),
+        hybrid=_runner_returning(hybrid_candidate),
+        symbolic=_runner_returning(symbolic_candidate),
+        cegis=_runner_returning(cegis_candidate) if cegis_enabled else None,
+        verifier=_verifier_from_map(scores),
+        refiner_budget_exhausted=lambda: refiner_budget_exhausted,
+        cegis_budget_exhausted=lambda: cegis_budget_exhausted,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stage 1 — Local-Edit ALWAYS first
+# ---------------------------------------------------------------------------
+
+
+class TestStage1LocalAlways:
+    @pytest.mark.asyncio
+    async def test_local_short_circuits_on_success_threshold(self) -> None:
+        starting = _prog("rotate90")
+        local_winner = _prog("rotate270")
+        esc = _make_escalator(
+            local_candidate=local_winner,
+            scores={"rotate90": 0.4, "rotate270": 0.97},  # local crosses 0.95
+        )
+        result = await esc.refine(starting, initial_score=0.4, current_alpha=0.7)
+        assert isinstance(result, EscalationResult)
+        assert result.program == local_winner
+        assert result.final_score == 0.97
+        assert result.terminated_by == "success"
+        assert result.refinement_path == ("local",)
+
+    @pytest.mark.asyncio
+    async def test_local_improves_but_not_winning_advances_best(self) -> None:
+        starting = _prog("rotate90")
+        local_better = _prog("rotate180")
+        esc = _make_escalator(
+            local_candidate=local_better,
+            full_llm_candidate=None,
+            hybrid_candidate=None,
+            symbolic_candidate=None,
+            cegis_candidate=None,
+            scores={"rotate90": 0.2, "rotate180": 0.4},
+        )
+        # initial_score 0.2 < 0.3 → mode-dispatch skipped, but local still improved best.
+        result = await esc.refine(starting, initial_score=0.2, current_alpha=0.7)
+        assert result.terminated_by == "exhausted"
+        assert result.program == local_better
+        assert result.final_score == 0.4
+        assert result.refinement_path == ("local",)
+
+    @pytest.mark.asyncio
+    async def test_local_returns_none_skips_stage(self) -> None:
+        starting = _prog("rotate90")
+        esc = _make_escalator(
+            local_candidate=None,
+            scores={"rotate90": 0.2},
+        )
+        result = await esc.refine(starting, initial_score=0.2, current_alpha=0.7)
+        assert result.program == starting
+        assert result.refinement_path == ()
+
+
+# ---------------------------------------------------------------------------
+# Stage 2 — Mode-Dispatch (Drei-Zonen)
+# ---------------------------------------------------------------------------
+
+
+class TestStage2ModeDispatch:
+    @pytest.mark.asyncio
+    async def test_alpha_high_picks_full_llm(self) -> None:
+        starting = _prog("rotate90")
+        winner = _prog("recolor")
+        esc = _make_escalator(
+            local_candidate=None,
+            full_llm_candidate=winner,
+            scores={"rotate90": 0.5, "recolor": 0.97},
+        )
+        result = await esc.refine(starting, initial_score=0.5, current_alpha=0.6)
+        assert result.terminated_by == "success"
+        assert result.refinement_path == ("repair_full_llm",)
+        assert result.mode_selected == "full_llm"
+
+    @pytest.mark.asyncio
+    async def test_alpha_grey_picks_hybrid(self) -> None:
+        starting = _prog("rotate90")
+        winner = _prog("mirror_horizontal")
+        esc = _make_escalator(
+            local_candidate=None,
+            hybrid_candidate=winner,
+            scores={"rotate90": 0.4, "mirror_horizontal": 0.96},
+        )
+        result = await esc.refine(starting, initial_score=0.4, current_alpha=0.4)
+        assert result.refinement_path == ("repair_hybrid",)
+        assert result.mode_selected == "hybrid"
+
+    @pytest.mark.asyncio
+    async def test_alpha_low_picks_symbolic(self) -> None:
+        starting = _prog("rotate90")
+        winner = _prog("flip")
+        esc = _make_escalator(
+            local_candidate=None,
+            symbolic_candidate=winner,
+            scores={"rotate90": 0.4, "flip": 0.96},
+        )
+        result = await esc.refine(starting, initial_score=0.4, current_alpha=0.2)
+        assert result.refinement_path == ("repair_symbolic",)
+        assert result.mode_selected == "symbolic"
+
+    @pytest.mark.asyncio
+    async def test_score_below_min_skips_mode_dispatch(self) -> None:
+        starting = _prog("rotate90")
+        full_llm = _prog("recolor")
+        esc = _make_escalator(
+            local_candidate=None,
+            full_llm_candidate=full_llm,
+            scores={"rotate90": 0.25, "recolor": 0.97},
+        )
+        # initial_score 0.25 < 0.3 → mode-dispatch skipped entirely.
+        result = await esc.refine(starting, initial_score=0.25, current_alpha=0.7)
+        assert result.refinement_path == ()
+        assert result.mode_selected is None
+        assert result.program == starting
+
+    @pytest.mark.asyncio
+    async def test_refiner_budget_exhausted_skips_mode_dispatch(self) -> None:
+        starting = _prog("rotate90")
+        full_llm = _prog("recolor")
+        esc = _make_escalator(
+            local_candidate=None,
+            full_llm_candidate=full_llm,
+            scores={"rotate90": 0.5, "recolor": 0.97},
+            refiner_budget_exhausted=True,
+        )
+        result = await esc.refine(starting, initial_score=0.5, current_alpha=0.7)
+        # Mode-dispatch skipped; CEGIS would still be eligible (score=0.5)
+        # but no cegis_candidate set so it adds nothing.
+        assert result.refinement_path == ()
+        assert result.mode_selected is None
+
+
+# ---------------------------------------------------------------------------
+# Stage 3 — CEGIS only when score >= 0.5
+# ---------------------------------------------------------------------------
+
+
+class TestStage3CEGIS:
+    @pytest.mark.asyncio
+    async def test_cegis_runs_when_score_above_threshold(self) -> None:
+        starting = _prog("rotate90")
+        # Local + mode-dispatch produce nothing; CEGIS fires.
+        cegis_winner = _prog("compose")
+        esc = _make_escalator(
+            local_candidate=None,
+            full_llm_candidate=None,
+            cegis_candidate=cegis_winner,
+            scores={"rotate90": 0.6, "compose": 0.97},
+        )
+        result = await esc.refine(starting, initial_score=0.6, current_alpha=0.7)
+        assert result.terminated_by == "success"
+        assert result.refinement_path == ("cegis",)
+        assert result.program == cegis_winner
+
+    @pytest.mark.asyncio
+    async def test_cegis_skipped_when_score_below_threshold(self) -> None:
+        starting = _prog("rotate90")
+        cegis_winner = _prog("compose")
+        esc = _make_escalator(
+            local_candidate=None,
+            full_llm_candidate=None,
+            symbolic_candidate=None,
+            cegis_candidate=cegis_winner,
+            scores={"rotate90": 0.4, "compose": 0.97},
+        )
+        # initial 0.4 → mode-dispatch runs but produces nothing; 0.4 < 0.5 → CEGIS skipped.
+        result = await esc.refine(starting, initial_score=0.4, current_alpha=0.7)
+        assert result.refinement_path == ()
+        assert result.terminated_by == "exhausted"
+        # Best is still the starting program.
+        assert result.program == starting
+
+    @pytest.mark.asyncio
+    async def test_cegis_budget_exhausted_skips_stage(self) -> None:
+        starting = _prog("rotate90")
+        cegis_winner = _prog("compose")
+        esc = _make_escalator(
+            local_candidate=None,
+            full_llm_candidate=None,
+            cegis_candidate=cegis_winner,
+            scores={"rotate90": 0.6, "compose": 0.97},
+            cegis_budget_exhausted=True,
+        )
+        result = await esc.refine(starting, initial_score=0.6, current_alpha=0.7)
+        assert result.refinement_path == ()
+        assert result.program == starting
+
+    @pytest.mark.asyncio
+    async def test_cegis_disabled_with_none(self) -> None:
+        starting = _prog("rotate90")
+        esc = _make_escalator(
+            local_candidate=None,
+            full_llm_candidate=None,
+            cegis_enabled=False,
+            scores={"rotate90": 0.6},
+        )
+        result = await esc.refine(starting, initial_score=0.6, current_alpha=0.7)
+        assert result.terminated_by == "exhausted"
+        assert result.refinement_path == ()
+
+
+# ---------------------------------------------------------------------------
+# Path composition — multiple stages contribute
+# ---------------------------------------------------------------------------
+
+
+class TestRefinementPathComposition:
+    @pytest.mark.asyncio
+    async def test_local_then_repair_then_cegis(self) -> None:
+        starting = _prog("rotate90")
+        local_better = _prog("rotate180")
+        repair_better = _prog("recolor")
+        cegis_winner = _prog("compose")
+        esc = _make_escalator(
+            local_candidate=local_better,
+            full_llm_candidate=repair_better,
+            cegis_candidate=cegis_winner,
+            scores={
+                "rotate90": 0.4,
+                "rotate180": 0.55,
+                "recolor": 0.7,
+                "compose": 0.99,
+            },
+        )
+        result = await esc.refine(starting, initial_score=0.4, current_alpha=0.7)
+        assert result.terminated_by == "success"
+        assert result.refinement_path == ("local", "repair_full_llm", "cegis")
+        assert result.program == cegis_winner
+        assert result.mode_selected == "full_llm"
+
+    @pytest.mark.asyncio
+    async def test_stage_run_but_no_improvement_omits_from_path(self) -> None:
+        starting = _prog("rotate90")
+        local_worse = _prog("rotate180")
+        repair_winner = _prog("recolor")
+        esc = _make_escalator(
+            local_candidate=local_worse,
+            full_llm_candidate=repair_winner,
+            scores={
+                "rotate90": 0.6,
+                "rotate180": 0.5,  # local ran but didn't improve
+                "recolor": 0.97,
+            },
+        )
+        result = await esc.refine(starting, initial_score=0.6, current_alpha=0.7)
+        # local omitted from path — it ran but didn't help.
+        assert result.refinement_path == ("repair_full_llm",)
+        assert result.program == repair_winner
+
+    @pytest.mark.asyncio
+    async def test_no_stage_helps_returns_starting_program(self) -> None:
+        starting = _prog("rotate90")
+        esc = _make_escalator(
+            local_candidate=_prog("rotate180"),
+            full_llm_candidate=_prog("recolor"),
+            cegis_candidate=_prog("compose"),
+            scores={
+                "rotate90": 0.6,
+                "rotate180": 0.5,  # worse
+                "recolor": 0.55,  # worse than 0.6
+                "compose": 0.4,  # worse
+            },
+        )
+        result = await esc.refine(starting, initial_score=0.6, current_alpha=0.7)
+        assert result.terminated_by == "exhausted"
+        assert result.refinement_path == ()
+        assert result.program == starting
+
+
+# ---------------------------------------------------------------------------
+# Mode controller hysteresis is honoured across calls
+# ---------------------------------------------------------------------------
+
+
+class TestModeControllerHysteresis:
+    @pytest.mark.asyncio
+    async def test_consecutive_calls_share_hysteresis_state(self) -> None:
+        starting = _prog("rotate90")
+        esc = _make_escalator(
+            local_candidate=None,
+            full_llm_candidate=None,
+            hybrid_candidate=None,
+            symbolic_candidate=None,
+            scores={"rotate90": 0.5},
+        )
+        # First call at α=0.5 → full_llm.
+        r1 = await esc.refine(starting, initial_score=0.5, current_alpha=0.5)
+        assert r1.mode_selected == "full_llm"
+        # Second call at α=0.4 (would be hybrid normally), but hysteresis
+        # holds full_llm for 3 calls minimum.
+        r2 = await esc.refine(starting, initial_score=0.5, current_alpha=0.4)
+        assert r2.mode_selected == "full_llm"
+        r3 = await esc.refine(starting, initial_score=0.5, current_alpha=0.4)
+        assert r3.mode_selected == "full_llm"
+        # 4th call: hysteresis released → hybrid.
+        r4 = await esc.refine(starting, initial_score=0.5, current_alpha=0.4)
+        assert r4.mode_selected == "hybrid"
+
+
+# ---------------------------------------------------------------------------
+# Result dataclass contract
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationResultDataclass:
+    def test_is_frozen(self) -> None:
+        r = EscalationResult(
+            program=_prog("rotate90"),
+            final_score=0.5,
+            terminated_by="exhausted",
+        )
+        # Default tuples preserved.
+        assert r.refinement_path == ()
+        assert r.mode_selected is None
+        # Hashable.
+        assert hash(r) == hash(r)


### PR DESCRIPTION
## Summary

Plan-Task 9 **final slice** — **Refiner Escalation logic** (spec §6.6): orchestrates the four-stage Refiner pipeline with the prescribed score gates and α-zone routing.

\`\`\`
Stage 1 — Local-Edit ALWAYS
Stage 2 — Mode-Dispatch when score >= 0.3 (Drei-Zonen)
  α >= 0.45        → Full-LLM (Two-Stage with retry)
  0.35 <= α < 0.45 → Hybrid (parallel symbolic + single-stage LLM)
  α < 0.35         → Symbolic-only
Stage 3 — CEGIS when score >= 0.5
\`\`\`

Between every stage the verifier re-evaluates; if any candidate crosses the success threshold (default 0.95) the loop returns immediately, preserving budget.

## Surface

- \`refiner/escalation.py\`
  - \`RefinerEscalator\` — all stage runners + verifier + budget checks dependency-injected at construction; the mode controller persists across calls (its hysteresis is stateful)
  - \`refine(program, initial_score, current_alpha, *, success_threshold=0.95, mode_min_score=0.3, cegis_min_score=0.5)\` → \`EscalationResult\`
  - \`EscalationResult(program, final_score, terminated_by, refinement_path, mode_selected)\` — \`refinement_path\` lists ONLY stages that actually improved the running best (stages that ran but didn't help are absent — matches spec §6.6's \`refinement_path=("local", "repair_…", "cegis")\` shape)

## Tests (17 new)

| group | coverage |
|---|---|
| Stage 1 | short-circuit on success / improves but not winning / runner returns None |
| Stage 2 | α-zone routing (full_llm / hybrid / symbolic) / score below 0.3 skips / refiner-budget-exhausted skips |
| Stage 3 | runs at score >= 0.5 / skipped at < 0.5 / cegis-budget-exhausted skips / cegis=None disables |
| Path composition | local + repair + cegis full path / stage ran but no improvement omitted / no-stage-helps returns starting program |
| Hysteresis | persisted across consecutive \`refine()\` calls — consecutive α=0.4 calls stay in full_llm for 3 calls |

mypy --strict clean. ruff lint + format clean. Phase-2 suite: **343 passed**.

## Plan-Task 9 status — **COMPLETE**

| slice | PR | status |
|---|---|---|
| \`diff_analyzer.py\` | #251 | merged |
| \`symbolic_repair.py\` | #252 | merged |
| \`trace_replay.py\` | #253 | merged |
| \`llm_repair_two_stage.py\` | #254 | merged |
| \`hybrid_repair.py\` | #255 | merged |
| **\`escalation.py\`** | **this PR** | open |

Sprint-1 plan task 9 acceptance criteria (deterministic Drei-Zonen-Selection, hysteresis, parallel hybrid, hard CEGIS budget) all covered by Phase-2 unit tests.

## Test plan

- [x] \`pytest tests/test_channels/test_program_synthesis/phase2/test_escalation.py -q\` — 17 passed
- [x] \`pytest tests/test_channels/test_program_synthesis/phase2/ -q\` — 343 passed
- [x] \`mypy --strict src/cognithor/channels/program_synthesis/refiner/escalation.py\`
- [x] \`ruff check\` + \`ruff format --check\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)