### PR TITLE
feat(pse): Phase-2 Sprint-1 — Benchmark runner (plan task 12, §12.3 / §12.4)

### DIFF
--- a/src/cognithor/channels/program_synthesis/synthesis/__init__.py
+++ b/src/cognithor/channels/program_synthesis/synthesis/__init__.py
@@ -11,12 +11,22 @@ Re-exports the engine + result types so callers can simply::
 
 from __future__ import annotations
 
+from cognithor.channels.program_synthesis.synthesis.benchmark import (
+    BenchmarkSummary,
+    BenchmarkTask,
+    BenchmarkTaskResult,
+    run_benchmark,
+)
 from cognithor.channels.program_synthesis.synthesis.engine import (
     Phase2SynthesisEngine,
     Phase2SynthesisResult,
 )
 
 __all__ = [
+    "BenchmarkSummary",
+    "BenchmarkTask",
+    "BenchmarkTaskResult",
     "Phase2SynthesisEngine",
     "Phase2SynthesisResult",
+    "run_benchmark",
 ]

--- a/src/cognithor/channels/program_synthesis/synthesis/benchmark.py
+++ b/src/cognithor/channels/program_synthesis/synthesis/benchmark.py
@@ -1,0 +1,249 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Spec §12.3 / §12.4 — Phase-2 benchmark runner (Sprint-1 plan task 12).
+
+A thin orchestrator that runs a list of tasks through the
+:class:`Phase2SynthesisEngine` and aggregates per-task results
+into a :class:`BenchmarkSummary`. Sprint-1 ships:
+
+* :class:`BenchmarkTask` — one task spec + the budget to run it
+  under, plus a stable id used by the report.
+* :class:`BenchmarkTaskResult` — per-task outcome (status, score,
+  elapsed seconds, refinement path).
+* :class:`BenchmarkSummary` — aggregate over a run (success rate,
+  P50/P95 wall-clock, refinement uplift).
+* :func:`run_benchmark` — async driver.
+
+The full Sprint-2 benchmark (20-Task Leak-Free-Held-Out subset +
+Streamlit dashboard + nightly CI cron) lands in a follow-up PR;
+the *driver* shipped here is the production entry point — once
+the held-out fixtures are curated, they're handed in via the
+``tasks`` argument and the driver runs unchanged.
+
+The runner is engine-agnostic: any object with an
+``async synthesize(spec, budget, *, wall_clock_budget_seconds,
+current_alpha) -> Phase2SynthesisResult`` method is compatible
+(structural typing). Tests inject a stub.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from cognithor.channels.program_synthesis.phase2.datatypes import (
+        PartitionedBudget,
+    )
+    from cognithor.channels.program_synthesis.synthesis.engine import (
+        Phase2SynthesisResult,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class BenchmarkTask:
+    """One task in the benchmark suite.
+
+    ``task_id`` is a stable string the report keys results by
+    (matches the leak-free-set filename stem in production —
+    ``"0001_rotate90"`` etc.).
+
+    ``spec`` is the :class:`TaskSpec` (or any object the engine
+    accepts) the engine receives. ``budget`` is the partitioned
+    budget; ``wall_clock_budget_seconds`` is the per-task
+    wall-clock limit.
+
+    ``current_alpha`` is the Search-α the engine should start
+    with — production reads this from the live AlphaController;
+    the benchmark may pin it (default 0.6 — middle of the band)
+    so runs are reproducible.
+    """
+
+    task_id: str
+    spec: Any
+    budget: PartitionedBudget
+    wall_clock_budget_seconds: float
+    current_alpha: float = 0.6
+
+
+@dataclass(frozen=True)
+class BenchmarkTaskResult:
+    """Per-task outcome — one row in the benchmark report."""
+
+    task_id: str
+    score: float
+    elapsed_seconds: float
+    terminated_by: str
+    cache_hit: bool
+    refined: bool
+    refinement_path: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class BenchmarkSummary:
+    """Aggregate over a benchmark run.
+
+    ``n_tasks`` is the count of tasks that ran (excludes ones the
+    engine raised on — those are recorded separately in
+    ``errors``).
+
+    ``success_rate`` is the fraction of tasks whose ``score >=
+    success_threshold`` (the threshold is parameterised so the
+    same tasks can be re-graded under a stricter bar without
+    re-running).
+
+    ``cache_hit_rate`` and ``refined_rate`` track Stage-0 / Stage-2
+    activation. ``refinement_uplift_rate`` is the fraction of
+    refined tasks whose refinement actually crossed the success
+    threshold (so the spec §6 refiner uplift can be measured).
+
+    ``p50_seconds`` / ``p95_seconds`` are wall-clock percentiles.
+    """
+
+    n_tasks: int
+    success_rate: float
+    cache_hit_rate: float
+    refined_rate: float
+    refinement_uplift_rate: float
+    p50_seconds: float
+    p95_seconds: float
+    per_task_results: tuple[BenchmarkTaskResult, ...] = field(default_factory=tuple)
+    errors: tuple[tuple[str, str], ...] = field(default_factory=tuple)
+
+
+# ---------------------------------------------------------------------------
+# Engine protocol
+# ---------------------------------------------------------------------------
+
+
+class _SynthesizeCapable(Protocol):
+    """Structural type for any engine the benchmark accepts."""
+
+    async def synthesize(
+        self,
+        spec: Any,
+        budget: PartitionedBudget,
+        *,
+        wall_clock_budget_seconds: float,
+        current_alpha: float = ...,
+    ) -> Phase2SynthesisResult: ...
+
+
+# ---------------------------------------------------------------------------
+# Driver
+# ---------------------------------------------------------------------------
+
+
+async def run_benchmark(
+    engine: _SynthesizeCapable,
+    tasks: Iterable[BenchmarkTask],
+    *,
+    success_threshold: float = 0.95,
+) -> BenchmarkSummary:
+    """Run every task in ``tasks`` through ``engine``; aggregate the results.
+
+    The driver does *not* parallelise — Sprint-1 runs strictly
+    sequentially so the benchmark is reproducible. Sprint-2 may add
+    parallel-task execution gated by a CLI flag.
+
+    A task that raises is recorded in the summary's ``errors`` list;
+    other tasks continue. The summary's ``n_tasks`` excludes errored
+    tasks so the success rate is over completed runs only.
+    """
+    materialised = list(tasks)
+    per_task: list[BenchmarkTaskResult] = []
+    errors: list[tuple[str, str]] = []
+
+    for task in materialised:
+        try:
+            result = await engine.synthesize(
+                task.spec,
+                task.budget,
+                wall_clock_budget_seconds=task.wall_clock_budget_seconds,
+                current_alpha=task.current_alpha,
+            )
+        except Exception as exc:
+            errors.append((task.task_id, type(exc).__name__))
+            continue
+        per_task.append(
+            BenchmarkTaskResult(
+                task_id=task.task_id,
+                score=result.score,
+                elapsed_seconds=result.elapsed_seconds,
+                terminated_by=result.terminated_by,
+                cache_hit=result.cache_hit,
+                refined=result.refined,
+                refinement_path=result.refinement_path,
+            )
+        )
+
+    return _summarise(per_task, errors, success_threshold=success_threshold)
+
+
+def _summarise(
+    rows: list[BenchmarkTaskResult],
+    errors: list[tuple[str, str]],
+    *,
+    success_threshold: float,
+) -> BenchmarkSummary:
+    n = len(rows)
+    if n == 0:
+        return BenchmarkSummary(
+            n_tasks=0,
+            success_rate=0.0,
+            cache_hit_rate=0.0,
+            refined_rate=0.0,
+            refinement_uplift_rate=0.0,
+            p50_seconds=0.0,
+            p95_seconds=0.0,
+            per_task_results=tuple(rows),
+            errors=tuple(errors),
+        )
+    successes = sum(1 for r in rows if r.score >= success_threshold)
+    cache_hits = sum(1 for r in rows if r.cache_hit)
+    refined = sum(1 for r in rows if r.refined)
+    refined_uplift = sum(1 for r in rows if r.refined and r.score >= success_threshold)
+    return BenchmarkSummary(
+        n_tasks=n,
+        success_rate=successes / n,
+        cache_hit_rate=cache_hits / n,
+        refined_rate=refined / n,
+        refinement_uplift_rate=(refined_uplift / refined) if refined else 0.0,
+        p50_seconds=_percentile([r.elapsed_seconds for r in rows], 0.5),
+        p95_seconds=_percentile([r.elapsed_seconds for r in rows], 0.95),
+        per_task_results=tuple(rows),
+        errors=tuple(errors),
+    )
+
+
+def _percentile(values: list[float], p: float) -> float:
+    """Linear-interpolated percentile — small-N safe."""
+    if not values:
+        return 0.0
+    if not 0.0 <= p <= 1.0:
+        raise ValueError(f"percentile p must be in [0, 1]; got {p}")
+    sorted_values = sorted(values)
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = p * (len(sorted_values) - 1)
+    lo = math.floor(rank)
+    hi = math.ceil(rank)
+    if lo == hi:
+        return sorted_values[lo]
+    weight = rank - lo
+    return sorted_values[lo] * (1 - weight) + sorted_values[hi] * weight
+
+
+__all__ = [
+    "BenchmarkSummary",
+    "BenchmarkTask",
+    "BenchmarkTaskResult",
+    "run_benchmark",
+]

--- a/tests/test_channels/test_program_synthesis/phase2/test_benchmark.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_benchmark.py
@@ -1,0 +1,254 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Phase-2 benchmark runner tests (Sprint-1 plan task 12, spec §12.3 / §12.4)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.phase2.datatypes import PartitionedBudget
+from cognithor.channels.program_synthesis.synthesis.benchmark import (
+    BenchmarkSummary,
+    BenchmarkTask,
+    BenchmarkTaskResult,
+    run_benchmark,
+)
+from cognithor.channels.program_synthesis.synthesis.engine import (
+    Phase2SynthesisResult,
+)
+
+
+def _budget() -> PartitionedBudget:
+    return PartitionedBudget.from_spec_default()
+
+
+def _task(task_id: str = "t0", *, wall_clock: float = 5.0) -> BenchmarkTask:
+    return BenchmarkTask(
+        task_id=task_id,
+        spec={"task": task_id},
+        budget=_budget(),
+        wall_clock_budget_seconds=wall_clock,
+    )
+
+
+def _result(
+    *,
+    score: float = 0.5,
+    elapsed: float = 0.1,
+    terminated_by: str = "search_exhausted",
+    cache_hit: bool = False,
+    refined: bool = False,
+    refinement_path: tuple[str, ...] = (),
+) -> Phase2SynthesisResult:
+    return Phase2SynthesisResult(
+        program=None,
+        score=score,
+        cache_hit=cache_hit,
+        refined=refined,
+        terminated_by=terminated_by,  # type: ignore[arg-type]
+        elapsed_seconds=elapsed,
+        candidates_evaluated=1,
+        refinement_path=refinement_path,
+    )
+
+
+class _StubEngine:
+    """Engine stub: hands back a queued list of results, one per task."""
+
+    def __init__(self, results: list[Phase2SynthesisResult]) -> None:
+        self._results = list(results)
+        self.calls: list[tuple[Any, float, float]] = []
+
+    async def synthesize(
+        self,
+        spec: Any,
+        budget: PartitionedBudget,
+        *,
+        wall_clock_budget_seconds: float,
+        current_alpha: float = 0.6,
+    ) -> Phase2SynthesisResult:
+        self.calls.append((spec, wall_clock_budget_seconds, current_alpha))
+        if not self._results:
+            raise AssertionError("stub engine ran out of queued results")
+        return self._results.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# Driver — runs every task, captures every row
+# ---------------------------------------------------------------------------
+
+
+class TestRunBenchmark:
+    @pytest.mark.asyncio
+    async def test_runs_every_task_and_returns_summary(self) -> None:
+        engine = _StubEngine(
+            [
+                _result(score=0.99, elapsed=0.1, terminated_by="search_success"),
+                _result(score=0.4, elapsed=0.2, terminated_by="search_exhausted"),
+                _result(score=0.97, elapsed=0.3, terminated_by="refined_success", refined=True),
+            ]
+        )
+        tasks = [_task(f"t{i}") for i in range(3)]
+        summary = await run_benchmark(engine, tasks)
+
+        assert isinstance(summary, BenchmarkSummary)
+        assert summary.n_tasks == 3
+        # 2 of 3 cleared 0.95 → 2/3 success rate.
+        assert abs(summary.success_rate - 2 / 3) < 1e-9
+        # 1 of 3 was refined → 1/3 refined rate; uplift 1/1 = 1.0.
+        assert abs(summary.refined_rate - 1 / 3) < 1e-9
+        assert summary.refinement_uplift_rate == 1.0
+        # Cache hit rate 0%.
+        assert summary.cache_hit_rate == 0.0
+        # All three rows captured.
+        assert {r.task_id for r in summary.per_task_results} == {"t0", "t1", "t2"}
+        # Every spec was forwarded with the per-task budget.
+        assert engine.calls == [
+            ({"task": "t0"}, 5.0, 0.6),
+            ({"task": "t1"}, 5.0, 0.6),
+            ({"task": "t2"}, 5.0, 0.6),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_passes_per_task_alpha(self) -> None:
+        engine = _StubEngine([_result(score=0.5)])
+        task = BenchmarkTask(
+            task_id="custom",
+            spec={"task": "x"},
+            budget=_budget(),
+            wall_clock_budget_seconds=2.0,
+            current_alpha=0.42,
+        )
+        await run_benchmark(engine, [task])
+        assert engine.calls[0][2] == 0.42
+
+    @pytest.mark.asyncio
+    async def test_empty_task_list_yields_zero_summary(self) -> None:
+        engine = _StubEngine([])
+        summary = await run_benchmark(engine, [])
+        assert summary.n_tasks == 0
+        assert summary.success_rate == 0.0
+        assert summary.p50_seconds == 0.0
+        assert summary.p95_seconds == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Aggregation — success, cache, refinement, percentiles
+# ---------------------------------------------------------------------------
+
+
+class TestAggregation:
+    @pytest.mark.asyncio
+    async def test_cache_hit_rate(self) -> None:
+        engine = _StubEngine(
+            [
+                _result(score=0.99, cache_hit=True, terminated_by="cache_hit"),
+                _result(score=0.5, cache_hit=False),
+                _result(score=0.97, cache_hit=True, terminated_by="cache_hit"),
+                _result(score=0.4, cache_hit=False),
+            ]
+        )
+        tasks = [_task(f"t{i}") for i in range(4)]
+        summary = await run_benchmark(engine, tasks)
+        assert summary.cache_hit_rate == 0.5
+
+    @pytest.mark.asyncio
+    async def test_refinement_uplift_rate_excludes_non_refined(self) -> None:
+        # 2 refined: 1 winning, 1 not. Uplift = 1/2 = 0.5.
+        engine = _StubEngine(
+            [
+                _result(score=0.99, refined=True, terminated_by="refined_success"),
+                _result(score=0.5, refined=True, terminated_by="search_exhausted"),
+                _result(score=0.99, refined=False, terminated_by="search_success"),
+            ]
+        )
+        tasks = [_task(f"t{i}") for i in range(3)]
+        summary = await run_benchmark(engine, tasks)
+        assert summary.refinement_uplift_rate == 0.5
+
+    @pytest.mark.asyncio
+    async def test_uplift_rate_zero_when_no_refinement(self) -> None:
+        engine = _StubEngine([_result(score=0.99) for _ in range(3)])
+        tasks = [_task(f"t{i}") for i in range(3)]
+        summary = await run_benchmark(engine, tasks)
+        assert summary.refinement_uplift_rate == 0.0
+
+    @pytest.mark.asyncio
+    async def test_percentiles_p50_p95(self) -> None:
+        elapsed = [0.1, 0.5, 1.0, 2.0, 5.0]
+        engine = _StubEngine([_result(elapsed=t) for t in elapsed])
+        tasks = [_task(f"t{i}") for i in range(5)]
+        summary = await run_benchmark(engine, tasks)
+        # P50 of [0.1, 0.5, 1.0, 2.0, 5.0] = 1.0.
+        assert abs(summary.p50_seconds - 1.0) < 1e-9
+        # P95 lies between 2.0 and 5.0; with linear interp on rank 3.8:
+        #   lo=3, hi=4 → 2.0·(1-0.8) + 5.0·0.8 = 4.4
+        assert abs(summary.p95_seconds - 4.4) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Errors — one task crashes, others continue
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    @pytest.mark.asyncio
+    async def test_failing_task_recorded_in_errors(self) -> None:
+        class _PartialEngine:
+            def __init__(self) -> None:
+                self._calls = 0
+
+            async def synthesize(
+                self,
+                spec: Any,
+                budget: PartitionedBudget,
+                *,
+                wall_clock_budget_seconds: float,
+                current_alpha: float = 0.6,
+            ) -> Phase2SynthesisResult:
+                self._calls += 1
+                if self._calls == 2:
+                    raise RuntimeError("boom")
+                return _result(score=0.99, terminated_by="search_success")
+
+        engine = _PartialEngine()
+        tasks = [_task(f"t{i}") for i in range(3)]
+        summary = await run_benchmark(engine, tasks)
+        # 2 successful + 1 errored.
+        assert summary.n_tasks == 2
+        assert len(summary.errors) == 1
+        assert summary.errors[0] == ("t1", "RuntimeError")
+        # Success rate = 2/2 = 1.0 (excludes errored tasks).
+        assert summary.success_rate == 1.0
+
+
+# ---------------------------------------------------------------------------
+# Dataclass contract
+# ---------------------------------------------------------------------------
+
+
+class TestDataclasses:
+    def test_task_with_hashable_spec(self) -> None:
+        # Frozen dataclass — hashable when fields are hashable.
+        t = BenchmarkTask(
+            task_id="x",
+            spec="some_string_spec",
+            budget=_budget(),
+            wall_clock_budget_seconds=5.0,
+        )
+        assert hash(t) == hash(t)
+
+    def test_task_result_is_frozen(self) -> None:
+        r = BenchmarkTaskResult(
+            task_id="x",
+            score=0.5,
+            elapsed_seconds=0.1,
+            terminated_by="search_exhausted",
+            cache_hit=False,
+            refined=False,
+        )
+        assert hash(r) == hash(r)


### PR DESCRIPTION
## Summary

Plan-Task 12 — **Benchmark runner** (spec §12.3 / §12.4): Sprint-1 minimal driver that runs a list of tasks through the \`Phase2SynthesisEngine\` and aggregates per-task results. Engine-agnostic via structural typing — any \`Phase2SynthesisEngine\`-compatible object works.

This ships the *driver*; the full Sprint-2 benchmark (20-Task Leak-Free-Held-Out fixtures + Streamlit dashboard + nightly CI cron) lands later — the driver here is the production entry point.

## Surface

\`synthesis/benchmark.py\`:
- \`BenchmarkTask(task_id, spec, budget, wall_clock_budget_seconds, current_alpha=0.6)\`
- \`BenchmarkTaskResult(task_id, score, elapsed_seconds, terminated_by, cache_hit, refined, refinement_path)\`
- \`BenchmarkSummary(n_tasks, success_rate, cache_hit_rate, refined_rate, refinement_uplift_rate, p50_seconds, p95_seconds, per_task_results, errors)\`
- \`run_benchmark(engine, tasks, *, success_threshold=0.95)\` → \`BenchmarkSummary\`

## Aggregation semantics

- \`success_rate\` = #(score ≥ success_threshold) / n_tasks
- \`refinement_uplift_rate\` = #(refined AND won) / #(refined) — directly measures spec §6 "Refiner uplift"
- P50 / P95 via linear-interpolated percentiles (small-N safe)
- Per-task errors recorded separately; \`n_tasks\` excludes them so success rate is over completed runs only

## Tests (10 new)

- Driver runs every task; forwards spec / budget / per-task α
- Per-task α override
- Empty task list → zero-summary
- \`cache_hit_rate\` / \`refined_rate\` aggregation
- \`refinement_uplift_rate\` excludes non-refined; zero when no refinement
- P50/P95 numerical correctness on \`[0.1, 0.5, 1.0, 2.0, 5.0]\` (P50=1.0, P95=4.4 via linear interp)
- One-task-crashes-others-continue error handling
- Frozen-dataclass contract

mypy --strict clean. ruff lint + format clean. **PSE suite: 1219 passed**, 10 skipped (= 1209 baseline + 10 new).

## Sprint-1 plan complete after this PR

| # | Status |
|---|---|
| 1 — YAML config-loader | ✅ #243 |
| 2 — Datentypen | ✅ #244 |
| 4 — Symbolic-Prior heuristic catalog | ✅ #257 |
| 6 — α-Controller | ✅ #246 |
| 7 — MCTS controller | ✅ #258 |
| 8 — Score / triviality / pixel-match | ✅ #245, #247, #248 |
| 9 — Critic & Refiner pipeline | ✅ #251–#256 |
| 10 — synthesis/engine.py top-level | ✅ #259 |
| 11 — Wechselwirkungs-Tests E1×E2/E3×E1/E6×E7 | ✅ #242 |
| **12 — Benchmark + CI driver** | **this PR** |

**All 12 Sprint-1 plan tasks shipped.**

## Test plan

- [x] \`pytest tests/test_channels/test_program_synthesis/phase2/test_benchmark.py -q\` — 10 passed
- [x] \`pytest tests/test_channels/test_program_synthesis/ -q\` — 1219 passed, 10 skipped
- [x] \`mypy --strict src/cognithor/channels/program_synthesis/synthesis/\`
- [x] \`ruff check\` + \`ruff format --check\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)