### PR TITLE
feat(pse): Phase-2 Sprint-2 Track A — Verifier §7.3.3 evaluator

### DIFF
--- a/src/cognithor/channels/program_synthesis/phase2/__init__.py
+++ b/src/cognithor/channels/program_synthesis/phase2/__init__.py
@@ -85,6 +85,11 @@ from cognithor.channels.program_synthesis.phase2.verifier import (
     SuspicionScore,
     compute_suspicion,
 )
+from cognithor.channels.program_synthesis.phase2.verifier_evaluator import (
+    InvariantsCheck,
+    VerifierEvaluation,
+    VerifierEvaluator,
+)
 
 __all__ = [
     "DEFAULT_HEURISTICS_PATH",
@@ -100,6 +105,7 @@ __all__ = [
     "FeatureWithConfidence",
     "HeuristicRule",
     "HeuristicSymbolicPrior",
+    "InvariantsCheck",
     "LLMPrior",
     "LLMPriorClient",
     "LLMPriorError",
@@ -118,6 +124,8 @@ __all__ = [
     "SymbolicPrior",
     "SymbolicPriorResult",
     "UniformSymbolicPrior",
+    "VerifierEvaluation",
+    "VerifierEvaluator",
     "VerifierScoreInputs",
     "VerifierScoreWeights",
     "aggregate_verifier_score",

--- a/src/cognithor/channels/program_synthesis/phase2/verifier_evaluator.py
+++ b/src/cognithor/channels/program_synthesis/phase2/verifier_evaluator.py
@@ -1,0 +1,266 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Spec §7.3.3 — End-to-end Verifier evaluator (Sprint-2 plan task 4).
+
+Wires every individual Phase-2 verifier sub-score into a single
+synchronous evaluator. Given a candidate :class:`Program` plus a
+:class:`TaskSpec`, the evaluator computes:
+
+* ``demo_pass_rate`` — fraction of demo examples the program
+  produces correctly (the dominant signal).
+* ``partial_pixel_match`` — average graduated pixel-level match
+  across demos (shipped in :mod:`phase2.pixel_match`).
+* ``invariants_satisfied`` — pass-through hook for the Sprint-3
+  property-based invariant tests; defaults to ``1.0`` (no
+  invariants) so Sprint-2 callers can wire it later.
+* ``triviality_score`` — high when the program is non-trivial
+  (shipped in :mod:`phase2.triviality`).
+* ``suspicion_score`` — high when the (program, score) pair is
+  not suspicious (shipped via :func:`compute_suspicion`).
+
+The five values feed :func:`aggregate_verifier_score` to produce
+the final score in ``[0, 1]``, with weights from
+``Phase2Config.verifier_score_weights``.
+
+The evaluator is executor-agnostic: the caller injects any
+:class:`Executor` (e.g. ``InProcessExecutor`` for tests, sandboxed
+worker for production). Spec §7.3.3 acceptance: end-to-end Verifier
+evaluation produces a score in ``[0, 1]`` by construction.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.phase2.config import (
+    DEFAULT_PHASE2_CONFIG,
+    Phase2Config,
+)
+from cognithor.channels.program_synthesis.phase2.pixel_match import (
+    average_partial_pixel_match,
+)
+from cognithor.channels.program_synthesis.phase2.scoring import (
+    VerifierScoreInputs,
+    aggregate_verifier_score,
+)
+from cognithor.channels.program_synthesis.phase2.triviality import (
+    triviality_score,
+)
+from cognithor.channels.program_synthesis.phase2.verifier import (
+    compute_suspicion,
+)
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.search.candidate import (
+        ProgramNode,
+    )
+    from cognithor.channels.program_synthesis.search.executor import (
+        Executor,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class VerifierEvaluation:
+    """Outcome of one :meth:`VerifierEvaluator.evaluate` call.
+
+    ``final_score`` is the aggregated score in ``[0, 1]`` per spec
+    §7.2 / §7.3.3. ``inputs`` carries every sub-score so callers
+    can introspect *why* the score landed where it did (telemetry,
+    A/B-test tags, refinement decisions).
+
+    ``actual_outputs`` is the per-demo program output, parallel to
+    ``spec.examples`` order. ``ok_per_demo`` records whether each
+    individual execution succeeded — useful for the Refiner pipeline
+    to mine partial-failure context.
+    """
+
+    final_score: float
+    inputs: VerifierScoreInputs
+    actual_outputs: tuple[Any, ...]
+    ok_per_demo: tuple[bool, ...]
+
+
+# ---------------------------------------------------------------------------
+# Optional invariants hook
+# ---------------------------------------------------------------------------
+
+
+# Property-based invariants are a Sprint-3 deliverable; the hook
+# here lets earlier sprints wire stub callables when the test suite
+# exercises invariant-driven scoring. The callable receives the same
+# arguments as :meth:`evaluate` and returns a fraction in ``[0, 1]``.
+InvariantsCheck = Callable[
+    ["ProgramNode", "Any", tuple[Any, ...], tuple[Any, ...]],
+    float,
+]
+
+
+def _no_invariants(
+    _program: ProgramNode,
+    _spec: Any,
+    _actual_outputs: tuple[Any, ...],
+    _expected_outputs: tuple[Any, ...],
+) -> float:
+    """Default: report 1.0 (full pass) so the formula reduces to the four other terms."""
+    return 1.0
+
+
+# ---------------------------------------------------------------------------
+# Evaluator
+# ---------------------------------------------------------------------------
+
+
+class VerifierEvaluator:
+    """End-to-end Phase-2 Verifier — wires every sub-score into one number.
+
+    Stateless across calls. The executor is fully injectable so
+    tests can pin determinism without booting the sandbox; production
+    wires the subprocess sandbox.
+
+    The default ``invariants_check`` returns ``1.0`` (no invariants
+    failing); callers that ship Sprint-3 property tests pass a real
+    callable.
+    """
+
+    def __init__(
+        self,
+        executor: Executor,
+        *,
+        invariants_check: InvariantsCheck = _no_invariants,
+        config: Phase2Config = DEFAULT_PHASE2_CONFIG,
+    ) -> None:
+        self._executor = executor
+        self._invariants_check = invariants_check
+        self._config = config
+
+    def evaluate(
+        self,
+        program: ProgramNode,
+        spec: Any,
+    ) -> VerifierEvaluation:
+        """Compute every sub-score, aggregate, return the result.
+
+        ``spec`` must expose an ``examples`` attribute that is an
+        iterable of ``(input, output)`` pairs. The evaluator does
+        not require a full :class:`TaskSpec` — duck-typing keeps
+        this module decoupled from ``core.types``.
+        """
+        examples = list(spec.examples)
+        actual_outputs: list[Any] = []
+        ok_per_demo: list[bool] = []
+        demo_correct = 0
+
+        for inp, expected in examples:
+            result = self._executor.execute(program, inp)
+            ok_per_demo.append(result.ok)
+            if not result.ok:
+                actual_outputs.append(None)
+                continue
+            actual_outputs.append(result.value)
+            if _outputs_equal(result.value, expected):
+                demo_correct += 1
+
+        n_demos = len(examples)
+        demo_pass_rate = demo_correct / n_demos if n_demos else 0.0
+
+        # partial_pixel_match — only for demos where execution succeeded
+        # AND outputs are array-shaped. Failed demos count as 0.0
+        # contribution; non-array outputs (e.g. a Color value) are
+        # likewise neutral 0.0.
+        partial_match_pairs: list[tuple[Any, Any]] = []
+        for actual, expected in zip(actual_outputs, (e for _i, e in examples), strict=False):
+            if actual is None:
+                # Use a deliberately mismatched array so the pixel
+                # match contribution is zero for this demo.
+                partial_match_pairs.append((np.zeros((1, 1), dtype=np.int8), expected))
+            else:
+                partial_match_pairs.append((actual, expected))
+        if partial_match_pairs:
+            partial_pixel = average_partial_pixel_match(
+                actual_grids=[a for a, _ in partial_match_pairs],
+                expected_grids=[e for _, e in partial_match_pairs],
+            )
+        else:
+            partial_pixel = 0.0
+
+        # Triviality — operates on the actuals + inputs + expecteds.
+        inputs_arr = [_as_array(inp) for inp, _ in examples]
+        expecteds_arr = [_as_array(e) for _, e in examples]
+        actuals_arr = [
+            _as_array(actual) if actual is not None else _as_array(inp)
+            for actual, (inp, _) in zip(actual_outputs, examples, strict=False)
+        ]
+        triv = triviality_score(actuals_arr, expecteds_arr, inputs_arr) if examples else 1.0
+
+        # Suspicion — uses partial_pixel as the "partial score" feed.
+        # Spec v1.4 §7.3.2: suspicion = partial · (1 - syntactic_complexity).
+        # We lift the suspicion *score* (1 - suspicion-penalty) so the
+        # weighted-sum formula stays "high = good" for every term.
+        susp = compute_suspicion(program, partial_score=partial_pixel, config=self._config)
+        suspicion_score = 1.0 - max(0.0, min(1.0, susp.value))
+
+        # Invariants — optional hook.
+        invariants = self._invariants_check(
+            program,
+            spec,
+            tuple(actual_outputs),
+            tuple(expected for _i, expected in examples),
+        )
+        if not 0.0 <= invariants <= 1.0:
+            raise ValueError(f"invariants_check returned {invariants}; must be in [0, 1]")
+
+        inputs_obj = VerifierScoreInputs(
+            demo_pass_rate=demo_pass_rate,
+            partial_pixel_match=partial_pixel,
+            invariants_satisfied=invariants,
+            triviality_score=triv,
+            suspicion_score=suspicion_score,
+        )
+        final = aggregate_verifier_score(inputs_obj, config=self._config)
+        return VerifierEvaluation(
+            final_score=final,
+            inputs=inputs_obj,
+            actual_outputs=tuple(actual_outputs),
+            ok_per_demo=tuple(ok_per_demo),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _outputs_equal(actual: Any, expected: Any) -> bool:
+    if isinstance(actual, np.ndarray) or isinstance(expected, np.ndarray):
+        try:
+            return bool(np.array_equal(actual, expected))
+        except (TypeError, ValueError):
+            return False
+    try:
+        return bool(actual == expected)
+    except Exception:
+        return False
+
+
+def _as_array(x: Any) -> np.ndarray[Any, Any]:
+    if isinstance(x, np.ndarray):
+        return x
+    try:
+        return np.asarray(x, dtype=np.int8)
+    except (TypeError, ValueError):
+        return np.zeros((1, 1), dtype=np.int8)
+
+
+__all__ = [
+    "InvariantsCheck",
+    "VerifierEvaluation",
+    "VerifierEvaluator",
+]

--- a/tests/test_channels/test_program_synthesis/phase2/test_verifier_evaluator.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_verifier_evaluator.py
@@ -1,0 +1,228 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""End-to-end Verifier evaluator tests (Sprint-2 plan task 4, spec §7.3.3)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.phase2.config import Phase2Config
+from cognithor.channels.program_synthesis.phase2.verifier_evaluator import (
+    VerifierEvaluation,
+    VerifierEvaluator,
+)
+from cognithor.channels.program_synthesis.search.candidate import (
+    InputRef,
+    Program,
+    ProgramNode,
+)
+from cognithor.channels.program_synthesis.search.executor import (
+    InProcessExecutor,
+)
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+class _SyntheticSpec:
+    """Minimal duck-typed TaskSpec — only `examples` is read."""
+
+    def __init__(self, examples: list[tuple[Any, Any]]) -> None:
+        self.examples = tuple(examples)
+
+
+def _identity_program() -> Program:
+    return Program(primitive="identity", children=(InputRef(),), output_type="Grid")
+
+
+# ---------------------------------------------------------------------------
+# Output bound — score in [0, 1] by construction (acceptance criterion)
+# ---------------------------------------------------------------------------
+
+
+class TestScoreBoundedInUnitInterval:
+    def test_perfect_program_scores_high(self) -> None:
+        evaluator = VerifierEvaluator(InProcessExecutor())
+        spec = _SyntheticSpec([(_g([[1, 2]]), _g([[1, 2]]))])
+        # identity(input) returns input → demo_pass=1.0
+        result = evaluator.evaluate(_identity_program(), spec)
+        assert isinstance(result, VerifierEvaluation)
+        assert 0.0 <= result.final_score <= 1.0
+        assert result.inputs.demo_pass_rate == 1.0
+
+    def test_failing_program_scores_low(self) -> None:
+        evaluator = VerifierEvaluator(InProcessExecutor())
+        # rotate90 on a non-square grid — actual won't equal expected.
+        spec = _SyntheticSpec([(_g([[1, 2, 3]]), _g([[1, 2, 3]]))])
+        program = Program(primitive="rotate90", children=(InputRef(),), output_type="Grid")
+        result = evaluator.evaluate(program, spec)
+        assert 0.0 <= result.final_score <= 1.0
+        assert result.inputs.demo_pass_rate == 0.0
+
+    def test_score_always_in_unit_interval_across_random_demos(self) -> None:
+        evaluator = VerifierEvaluator(InProcessExecutor())
+        rng = np.random.default_rng(seed=42)
+        for _ in range(20):
+            shape = (int(rng.integers(1, 4)), int(rng.integers(1, 4)))
+            inp = rng.integers(0, 10, size=shape, dtype=np.int8)
+            expected = rng.integers(0, 10, size=shape, dtype=np.int8)
+            spec = _SyntheticSpec([(inp, expected)])
+            result = evaluator.evaluate(_identity_program(), spec)
+            assert 0.0 <= result.final_score <= 1.0
+
+
+# ---------------------------------------------------------------------------
+# Sub-score wiring
+# ---------------------------------------------------------------------------
+
+
+class TestSubScoreWiring:
+    def test_demo_pass_rate_proportional(self) -> None:
+        # Two demos, identity gets one right, one wrong.
+        evaluator = VerifierEvaluator(InProcessExecutor())
+        spec = _SyntheticSpec(
+            [
+                (_g([[1, 2]]), _g([[1, 2]])),  # identity correct
+                (_g([[1, 2]]), _g([[3, 4]])),  # identity wrong
+            ]
+        )
+        result = evaluator.evaluate(_identity_program(), spec)
+        assert result.inputs.demo_pass_rate == 0.5
+
+    def test_failed_execution_marks_ok_false(self) -> None:
+        # rotate90 on a 1-D grid → executor raises.
+        class _BrokenExec:
+            def execute(self, program: ProgramNode, input_grid: Any) -> Any:
+                from cognithor.channels.program_synthesis.search.executor import (
+                    ExecutionResult,
+                )
+
+                return ExecutionResult(ok=False, error="StubError")
+
+        evaluator = VerifierEvaluator(_BrokenExec())  # type: ignore[arg-type]
+        spec = _SyntheticSpec([(_g([[1]]), _g([[1]]))])
+        result = evaluator.evaluate(_identity_program(), spec)
+        assert result.ok_per_demo == (False,)
+        assert result.actual_outputs == (None,)
+        # demo_pass_rate is 0; everything else valid.
+        assert result.inputs.demo_pass_rate == 0.0
+        assert 0.0 <= result.final_score <= 1.0
+
+    def test_actual_outputs_recorded_per_demo(self) -> None:
+        evaluator = VerifierEvaluator(InProcessExecutor())
+        spec = _SyntheticSpec([(_g([[1, 2]]), _g([[3, 4]]))])
+        result = evaluator.evaluate(_identity_program(), spec)
+        # identity returns the input grid.
+        assert len(result.actual_outputs) == 1
+        assert np.array_equal(result.actual_outputs[0], _g([[1, 2]]))
+
+
+# ---------------------------------------------------------------------------
+# Aggregation honours config weights (Plan-Task 8 acceptance kept)
+# ---------------------------------------------------------------------------
+
+
+class TestAggregation:
+    def test_uses_default_weights(self) -> None:
+        evaluator = VerifierEvaluator(InProcessExecutor())
+        spec = _SyntheticSpec([(_g([[1, 2]]), _g([[1, 2]]))])
+        result = evaluator.evaluate(_identity_program(), spec)
+        # demo_pass = 1.0 → contributes 0.55 to final.
+        assert result.final_score >= 0.55  # other terms only add
+
+    def test_custom_weights_override(self) -> None:
+        # All weight on demo_pass_rate.
+        from cognithor.channels.program_synthesis.phase2.config import (
+            VerifierScoreWeights,
+        )
+
+        cfg = Phase2Config(
+            verifier_score_weights=VerifierScoreWeights(
+                demo_pass_rate=1.0,
+                partial_pixel_match=0.0,
+                invariants_satisfied=0.0,
+                triviality_score=0.0,
+                suspicion_score=0.0,
+            )
+        )
+        evaluator = VerifierEvaluator(InProcessExecutor(), config=cfg)
+        spec = _SyntheticSpec([(_g([[1, 2]]), _g([[1, 2]]))])
+        result = evaluator.evaluate(_identity_program(), spec)
+        assert abs(result.final_score - 1.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# Optional invariants hook
+# ---------------------------------------------------------------------------
+
+
+class TestInvariantsHook:
+    def test_default_invariants_returns_one(self) -> None:
+        evaluator = VerifierEvaluator(InProcessExecutor())
+        spec = _SyntheticSpec([(_g([[1, 2]]), _g([[1, 2]]))])
+        result = evaluator.evaluate(_identity_program(), spec)
+        assert result.inputs.invariants_satisfied == 1.0
+
+    def test_custom_invariants_callable_used(self) -> None:
+        seen: list[tuple[Any, ...]] = []
+
+        def my_invariant(
+            _program: ProgramNode,
+            _spec: Any,
+            actual: tuple[Any, ...],
+            expected: tuple[Any, ...],
+        ) -> float:
+            seen.append((actual, expected))
+            return 0.5
+
+        evaluator = VerifierEvaluator(InProcessExecutor(), invariants_check=my_invariant)
+        spec = _SyntheticSpec([(_g([[1, 2]]), _g([[1, 2]]))])
+        result = evaluator.evaluate(_identity_program(), spec)
+        assert result.inputs.invariants_satisfied == 0.5
+        assert len(seen) == 1
+
+    def test_out_of_range_invariants_raises(self) -> None:
+        def bad(*_args: Any, **_kw: Any) -> float:
+            return 1.5
+
+        evaluator = VerifierEvaluator(InProcessExecutor(), invariants_check=bad)
+        spec = _SyntheticSpec([(_g([[1, 2]]), _g([[1, 2]]))])
+        with pytest.raises(ValueError, match="invariants_check"):
+            evaluator.evaluate(_identity_program(), spec)
+
+
+# ---------------------------------------------------------------------------
+# Empty examples corner-case
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyExamples:
+    def test_zero_examples_yields_well_defined_score(self) -> None:
+        evaluator = VerifierEvaluator(InProcessExecutor())
+        spec = _SyntheticSpec([])
+        result = evaluator.evaluate(_identity_program(), spec)
+        # demo_pass_rate = 0.0; partial_pixel = 0.0; triviality = 1.0;
+        # invariants = 1.0 (default); suspicion remains in [0, 1].
+        assert 0.0 <= result.final_score <= 1.0
+        assert result.inputs.demo_pass_rate == 0.0
+
+
+# ---------------------------------------------------------------------------
+# VerifierEvaluation dataclass contract
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluationDataclass:
+    def test_is_frozen(self) -> None:
+        evaluator = VerifierEvaluator(InProcessExecutor())
+        spec = _SyntheticSpec([(_g([[1]]), _g([[1]]))])
+        result = evaluator.evaluate(_identity_program(), spec)
+        # Frozen → immutable.
+        with pytest.raises(Exception):  # noqa: B017
+            result.final_score = 0.0  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Sprint-2 Track A — **End-to-end Verifier evaluator** (spec §7.3.3): wires every individual Phase-2 verifier sub-score into a single synchronous evaluator. Given a Program + duck-typed TaskSpec, computes all 5 sub-scores, runs them through \`aggregate_verifier_score\` (already shipped in #245), returns final score in [0, 1] by construction.

This is the orchestrator the Production-Wiring (Track B, next PR) needs to feed scores back into the search engine + refiner.

## Surface

\`phase2/verifier_evaluator.py\`:
- \`VerifierEvaluation(final_score, inputs, actual_outputs, ok_per_demo)\` — frozen dataclass
- \`VerifierEvaluator(executor, *, invariants_check, config)\`
  - \`evaluate(program, spec)\` → \`VerifierEvaluation\`
- \`InvariantsCheck\` Callable type — Sprint-3 property-test integration point

The invariants hook returns 1.0 by default so Sprint-2 callers can ignore it; Sprint-3 wires real property tests later.

## Sub-score wiring

| Sub-score | Source |
|---|---|
| \`demo_pass_rate\` | injected \`Executor\` + \`np.array_equal\` |
| \`partial_pixel_match\` | \`phase2.pixel_match.average_partial_pixel_match\` |
| \`invariants_satisfied\` | optional \`InvariantsCheck\` callable (default 1.0) |
| \`triviality_score\` | \`phase2.triviality.triviality_score\` |
| \`suspicion_score\` | \`1 - compute_suspicion(...).value\` clamped |

Aggregation = \`VerifierScoreWeights\` from \`Phase2Config\` (default 0.55/0.13/0.08/0.12/0.12).

## Tests (13 new)

- Score ∈ [0, 1] for perfect / failing / 20 random demos (**acceptance criterion: bounded by construction**)
- Sub-score wiring: demo_pass proportional / failed exec marks ok=False / actual_outputs per-demo
- Aggregation: default weights / custom weights override
- Invariants hook: default 1.0 / custom callable used / out-of-range raises
- Empty examples corner-case
- Frozen dataclass

mypy --strict clean. ruff lint + format clean. **Phase-2 suite: 439 passed** (= 426 baseline + 13 new).

## Sprint-2 progress

| Track | Aufgabe | Status |
|---|---|---|
| **A** | **Verifier §7.3.3 evaluator** | **this PR** |
| B | Production-Wiring (EnumerativeSearch + DualPriorMixer + RefinerEscalator) | next |
| C | 20-Task Leak-Free fixtures | next (parallel) |
| D | Streamlit dashboard + nightly CI | week 2 |
| E | MCTS parallel + restart + diversity | week 3 |

## Test plan

- [x] \`pytest tests/test_channels/test_program_synthesis/phase2/test_verifier_evaluator.py -q\` — 13 passed
- [x] \`pytest tests/test_channels/test_program_synthesis/phase2/ -q\` — 439 passed
- [x] \`mypy --strict src/cognithor/channels/program_synthesis/phase2/verifier_evaluator.py\`
- [x] \`ruff check\` + \`ruff format --check\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)