### PR TITLE
feat(pse): Phase-2 Sprint-2 Track C — 20-Task Leak-Free fixture set

### DIFF
--- a/src/cognithor/channels/program_synthesis/synthesis/__init__.py
+++ b/src/cognithor/channels/program_synthesis/synthesis/__init__.py
@@ -21,18 +21,30 @@ from cognithor.channels.program_synthesis.synthesis.engine import (
     Phase2SynthesisEngine,
     Phase2SynthesisResult,
 )
+from cognithor.channels.program_synthesis.synthesis.leak_free_fixtures import (
+    LEAK_FREE_TASKS,
+    LeakFreeTask,
+    leak_free_set_hash,
+)
+from cognithor.channels.program_synthesis.synthesis.leak_free_fixtures import (
+    benchmark_tasks as leak_free_benchmark_tasks,
+)
 from cognithor.channels.program_synthesis.synthesis.wired_engine import (
     WiredPhase2Engine,
     WiredSynthesisResult,
 )
 
 __all__ = [
+    "LEAK_FREE_TASKS",
     "BenchmarkSummary",
     "BenchmarkTask",
     "BenchmarkTaskResult",
+    "LeakFreeTask",
     "Phase2SynthesisEngine",
     "Phase2SynthesisResult",
     "WiredPhase2Engine",
     "WiredSynthesisResult",
+    "leak_free_benchmark_tasks",
+    "leak_free_set_hash",
     "run_benchmark",
 ]

--- a/src/cognithor/channels/program_synthesis/synthesis/leak_free_fixtures.py
+++ b/src/cognithor/channels/program_synthesis/synthesis/leak_free_fixtures.py
@@ -1,0 +1,473 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-2 Track C — 20-Task Leak-Free benchmark fixture set.
+
+Twenty synthetic ARC-AGI-3-shaped tasks for the Sprint-2 / Sprint-3
+benchmark drivers. Each task exposes:
+
+* a ``task_id`` — stable string keyed by category + ordinal;
+* ``examples`` — paired ``(input, output)`` numpy grids;
+* a known canonical solution primitive (in the task's ``solution_hint``
+  metadata) so unit tests can assert "Phase-1 solves at least X of these
+  by enumeration".
+
+The tasks cover every transformation category the Symbolic-Prior
+catalog (PR #257) recognises: rotation, mirror, recolor, scale,
+crop, and mixed compositions. The split is intentionally biased
+toward what Phase-1 can solve cleanly (so Sprint-2 A/B-tests can
+isolate Refiner *uplift* on the partials).
+
+Leak-Free guarantee:
+
+The :func:`leak_free_set_hash` returns a SHA-256 over the canonical
+serialisation of every task in :data:`LEAK_FREE_TASKS`. The
+synthesis cache (spec §14.1) keys on
+:meth:`TaskSpec.stable_hash`, which incorporates examples + held-out
++ test-input + constraints + domain. Because these fixtures are
+*synthetic* and never appear in the live cache (the cache is empty
+on a fresh installation, and these tasks are not part of any
+training corpus), their stable hashes are leak-free by construction.
+
+Tests assert the bundle hash is stable across runs — any drift
+fails CI.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.core.types import (
+    Budget,
+    Example,
+    Grid,
+    TaskSpec,
+)
+from cognithor.channels.program_synthesis.phase2.datatypes import (
+    PartitionedBudget,
+)
+from cognithor.channels.program_synthesis.synthesis.benchmark import (
+    BenchmarkTask,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+# ---------------------------------------------------------------------------
+# Task metadata wrapper
+# ---------------------------------------------------------------------------
+
+
+TransformationCategory = Literal["rotation", "mirror", "recolor", "scale", "crop", "mixed"]
+
+
+@dataclass(frozen=True)
+class LeakFreeTask:
+    """One synthetic ARC-AGI-3-shaped task with documented solution.
+
+    ``solution_hint`` is the canonical primitive name(s) a human
+    would expect to solve this task — used by sanity tests, NOT
+    fed to the search engine.
+    """
+
+    task_id: str
+    category: TransformationCategory
+    examples: tuple[tuple[Grid, Grid], ...]
+    solution_hint: str
+    description: str
+
+    def to_task_spec(self) -> TaskSpec:
+        return TaskSpec(examples=tuple(_typed_example(p) for p in self.examples))
+
+    def to_benchmark_task(
+        self,
+        *,
+        budget: PartitionedBudget,
+        wall_clock_budget_seconds: float,
+        current_alpha: float = 0.6,
+    ) -> BenchmarkTask:
+        return BenchmarkTask(
+            task_id=self.task_id,
+            spec=self.to_task_spec(),
+            budget=budget,
+            wall_clock_budget_seconds=wall_clock_budget_seconds,
+            current_alpha=current_alpha,
+        )
+
+
+def _typed_example(pair: tuple[Grid, Grid]) -> Example:
+    inp, out = pair
+    return (np.asarray(inp, dtype=np.int8), np.asarray(out, dtype=np.int8))
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building synthetic grids
+# ---------------------------------------------------------------------------
+
+
+def _g(rows: list[list[int]]) -> np.ndarray[Any, Any]:
+    return np.array(rows, dtype=np.int8)
+
+
+def _rotate90_cw(grid: np.ndarray[Any, Any]) -> np.ndarray[Any, Any]:
+    return np.rot90(grid, k=-1)
+
+
+def _rotate180(grid: np.ndarray[Any, Any]) -> np.ndarray[Any, Any]:
+    return np.rot90(grid, k=2)
+
+
+def _rotate270_cw(grid: np.ndarray[Any, Any]) -> np.ndarray[Any, Any]:
+    return np.rot90(grid, k=1)
+
+
+def _scale_up(grid: np.ndarray[Any, Any], factor: int) -> np.ndarray[Any, Any]:
+    return np.repeat(np.repeat(grid, factor, axis=0), factor, axis=1)
+
+
+def _scale_down_2x(grid: np.ndarray[Any, Any]) -> np.ndarray[Any, Any]:
+    # Take every other row/column.
+    return grid[::2, ::2]
+
+
+def _recolor(grid: np.ndarray[Any, Any], src: int, dst: int) -> np.ndarray[Any, Any]:
+    out = grid.copy()
+    out[grid == src] = dst
+    return out
+
+
+# ---------------------------------------------------------------------------
+# The 20 tasks
+# ---------------------------------------------------------------------------
+
+
+def _build_tasks() -> tuple[LeakFreeTask, ...]:
+    out: list[LeakFreeTask] = []
+
+    # ── Rotation (4) ─────────────────────────────────────────────
+    g1 = _g([[1, 2], [3, 4]])
+    out.append(
+        LeakFreeTask(
+            task_id="0001_rotate90_2x2",
+            category="rotation",
+            examples=(
+                (g1, _rotate90_cw(g1)),
+                (_g([[5, 6], [7, 8]]), _rotate90_cw(_g([[5, 6], [7, 8]]))),
+            ),
+            solution_hint="rotate90",
+            description="2x2 grid, 90° clockwise rotation",
+        )
+    )
+
+    g2 = _g([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    out.append(
+        LeakFreeTask(
+            task_id="0002_rotate180_3x3",
+            category="rotation",
+            examples=(
+                (g2, _rotate180(g2)),
+                (
+                    _g([[0, 1, 2], [3, 4, 5], [6, 7, 8]]),
+                    _rotate180(_g([[0, 1, 2], [3, 4, 5], [6, 7, 8]])),
+                ),
+            ),
+            solution_hint="rotate180",
+            description="3x3 grid, 180° rotation",
+        )
+    )
+
+    g3 = _g([[1, 2], [3, 4]])
+    out.append(
+        LeakFreeTask(
+            task_id="0003_rotate270_2x2",
+            category="rotation",
+            examples=((g3, _rotate270_cw(g3)),),
+            solution_hint="rotate270",
+            description="2x2 grid, 270° clockwise rotation",
+        )
+    )
+
+    g4 = _g([[1, 2, 3, 4], [5, 6, 7, 8]])
+    out.append(
+        LeakFreeTask(
+            task_id="0004_rotate90_2x4",
+            category="rotation",
+            examples=((g4, _rotate90_cw(g4)),),
+            solution_hint="rotate90",
+            description="2x4 rectangular grid, 90° clockwise (becomes 4x2)",
+        )
+    )
+
+    # ── Mirror (3) ───────────────────────────────────────────────
+    g5 = _g([[1, 2, 3], [4, 5, 6]])
+    out.append(
+        LeakFreeTask(
+            task_id="0005_mirror_horizontal",
+            category="mirror",
+            examples=((g5, np.fliplr(g5)),),
+            solution_hint="mirror_horizontal",
+            description="Left-right mirror of a 2x3 grid",
+        )
+    )
+
+    g6 = _g([[1, 2], [3, 4], [5, 6]])
+    out.append(
+        LeakFreeTask(
+            task_id="0006_mirror_vertical",
+            category="mirror",
+            examples=((g6, np.flipud(g6)),),
+            solution_hint="mirror_vertical",
+            description="Top-bottom mirror of a 3x2 grid",
+        )
+    )
+
+    g7 = _g([[1, 2], [3, 4]])
+    out.append(
+        LeakFreeTask(
+            task_id="0007_transpose_2x2",
+            category="mirror",
+            examples=((g7, g7.T),),
+            solution_hint="transpose",
+            description="Transpose of a 2x2 grid (mirror_diagonal)",
+        )
+    )
+
+    # ── Recolor (3) ──────────────────────────────────────────────
+    g8 = _g([[1, 2], [1, 3]])
+    out.append(
+        LeakFreeTask(
+            task_id="0008_recolor_1_to_5",
+            category="recolor",
+            examples=(
+                (g8, _recolor(g8, 1, 5)),
+                (_g([[1, 1], [2, 1]]), _recolor(_g([[1, 1], [2, 1]]), 1, 5)),
+            ),
+            solution_hint="recolor",
+            description="Recolor every 1 to 5",
+        )
+    )
+
+    g9 = _g([[0, 1], [2, 0]])
+    out.append(
+        LeakFreeTask(
+            task_id="0009_recolor_0_to_7",
+            category="recolor",
+            examples=((g9, _recolor(g9, 0, 7)),),
+            solution_hint="recolor",
+            description="Recolor background (0) to 7",
+        )
+    )
+
+    g10 = _g([[1, 2, 3], [3, 2, 1]])
+    out.append(
+        LeakFreeTask(
+            task_id="0010_recolor_3_to_9",
+            category="recolor",
+            examples=((g10, _recolor(g10, 3, 9)),),
+            solution_hint="recolor",
+            description="Recolor 3 to 9 in a 2x3 palette",
+        )
+    )
+
+    # ── Scale (3) ────────────────────────────────────────────────
+    g11 = _g([[1, 2]])
+    out.append(
+        LeakFreeTask(
+            task_id="0011_scale_up_2x_1x2",
+            category="scale",
+            examples=((g11, _scale_up(g11, 2)), (_g([[3, 4]]), _scale_up(_g([[3, 4]]), 2))),
+            solution_hint="scale_up_2x",
+            description="2× upscale of a 1x2 grid",
+        )
+    )
+
+    g12 = _g([[1]])
+    out.append(
+        LeakFreeTask(
+            task_id="0012_scale_up_3x_1x1",
+            category="scale",
+            examples=((g12, _scale_up(g12, 3)), (_g([[5]]), _scale_up(_g([[5]]), 3))),
+            solution_hint="scale_up_3x",
+            description="3× upscale of a 1x1 grid",
+        )
+    )
+
+    g13 = _g([[1, 1, 2, 2], [1, 1, 2, 2], [3, 3, 4, 4], [3, 3, 4, 4]])
+    out.append(
+        LeakFreeTask(
+            task_id="0013_scale_down_2x_4x4",
+            category="scale",
+            examples=((g13, _scale_down_2x(g13)),),
+            solution_hint="scale_down_2x",
+            description="2× downscale of a block-pixel 4x4 grid",
+        )
+    )
+
+    # ── Crop (3) ─────────────────────────────────────────────────
+    # crop_bbox crops to the non-background bounding box.
+    g14 = _g([[0, 0, 0], [0, 1, 0], [0, 0, 0]])
+    out.append(
+        LeakFreeTask(
+            task_id="0014_crop_bbox_single_pixel",
+            category="crop",
+            examples=((g14, _g([[1]])),),
+            solution_hint="crop_bbox",
+            description="Crop to the bounding box of a single non-zero pixel",
+        )
+    )
+
+    g15 = _g([[0, 0, 0], [0, 1, 2], [0, 3, 4]])
+    out.append(
+        LeakFreeTask(
+            task_id="0015_crop_bbox_2x2_subregion",
+            category="crop",
+            examples=((g15, _g([[1, 2], [3, 4]])),),
+            solution_hint="crop_bbox",
+            description="Crop to a 2x2 non-zero subregion",
+        )
+    )
+
+    g16 = _g([[5, 0], [0, 0]])
+    out.append(
+        LeakFreeTask(
+            task_id="0016_crop_bbox_corner",
+            category="crop",
+            examples=((g16, _g([[5]])),),
+            solution_hint="crop_bbox",
+            description="Crop to a single non-zero corner cell",
+        )
+    )
+
+    # ── Mixed (4) ────────────────────────────────────────────────
+    # rotate90 then recolor.
+    g17 = _g([[1, 2], [3, 4]])
+    expected_17 = _recolor(_rotate90_cw(g17), 1, 5)
+    out.append(
+        LeakFreeTask(
+            task_id="0017_rotate90_then_recolor",
+            category="mixed",
+            examples=((g17, expected_17),),
+            solution_hint="recolor(rotate90(input), 1, 5)",
+            description="Compose: rotate 90° clockwise then recolor 1→5",
+        )
+    )
+
+    # mirror_horizontal then rotate180 (= mirror_vertical equivalent).
+    g18 = _g([[1, 2, 3], [4, 5, 6]])
+    expected_18 = _rotate180(np.fliplr(g18))
+    out.append(
+        LeakFreeTask(
+            task_id="0018_mirror_h_then_rotate180",
+            category="mixed",
+            examples=((g18, expected_18),),
+            solution_hint="rotate180(mirror_horizontal(input))",
+            description="Compose: horizontal mirror + 180° rotation",
+        )
+    )
+
+    # scale_up_2x then recolor (background -> something).
+    g19 = _g([[1, 0]])
+    expected_19 = _recolor(_scale_up(g19, 2), 0, 7)
+    out.append(
+        LeakFreeTask(
+            task_id="0019_scale_up_then_recolor",
+            category="mixed",
+            examples=((g19, expected_19),),
+            solution_hint="recolor(scale_up_2x(input), 0, 7)",
+            description="Compose: 2× upscale + recolor 0→7",
+        )
+    )
+
+    # transpose then mirror_horizontal.
+    g20 = _g([[1, 2], [3, 4]])
+    expected_20 = np.fliplr(g20.T)
+    out.append(
+        LeakFreeTask(
+            task_id="0020_transpose_then_mirror",
+            category="mixed",
+            examples=((g20, expected_20),),
+            solution_hint="mirror_horizontal(transpose(input))",
+            description="Compose: transpose + horizontal mirror",
+        )
+    )
+
+    return tuple(out)
+
+
+LEAK_FREE_TASKS: tuple[LeakFreeTask, ...] = _build_tasks()
+"""The frozen 20-task fixture set."""
+
+
+# ---------------------------------------------------------------------------
+# Leak-free hash + bundle helpers
+# ---------------------------------------------------------------------------
+
+
+def leak_free_set_hash(tasks: Sequence[LeakFreeTask] = LEAK_FREE_TASKS) -> str:
+    """SHA-256 over the canonical (task_id, examples) serialisation.
+
+    Stable across runs and Python versions. CI test asserts the
+    expected digest so any drift fails immediately.
+    """
+    canonical: list[dict[str, Any]] = []
+    for task in tasks:
+        canonical.append(
+            {
+                "id": task.task_id,
+                "category": task.category,
+                "examples": [
+                    [
+                        np.asarray(inp, dtype=np.int8).tolist(),
+                        np.asarray(out, dtype=np.int8).tolist(),
+                    ]
+                    for inp, out in task.examples
+                ],
+            }
+        )
+    encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":"))
+    return "sha256:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+
+
+def benchmark_tasks(
+    *,
+    budget: PartitionedBudget | None = None,
+    wall_clock_budget_seconds: float = 5.0,
+    current_alpha: float = 0.6,
+) -> tuple[BenchmarkTask, ...]:
+    """Convert every leak-free task into a :class:`BenchmarkTask`.
+
+    Convenience for the benchmark driver — production flow is:
+
+        from cognithor.channels.program_synthesis.synthesis import (
+            benchmark_tasks, run_benchmark,
+        )
+        summary = await run_benchmark(engine, benchmark_tasks())
+    """
+    if budget is None:
+        budget = PartitionedBudget.from_spec_default()
+    return tuple(
+        task.to_benchmark_task(
+            budget=budget,
+            wall_clock_budget_seconds=wall_clock_budget_seconds,
+            current_alpha=current_alpha,
+        )
+        for task in LEAK_FREE_TASKS
+    )
+
+
+# Reserved for future modules; ``Budget`` from core types is not used in
+# this fixture but is exported for downstream benchmark configuration.
+_ = Budget
+
+
+__all__ = [
+    "LEAK_FREE_TASKS",
+    "LeakFreeTask",
+    "TransformationCategory",
+    "benchmark_tasks",
+    "leak_free_set_hash",
+]

--- a/tests/test_channels/test_program_synthesis/phase2/test_leak_free_fixtures.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_leak_free_fixtures.py
@@ -1,0 +1,181 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""20-Task Leak-Free fixture-set tests (Sprint-2 Track C)."""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.core.types import TaskSpec
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.synthesis.benchmark import BenchmarkTask
+from cognithor.channels.program_synthesis.synthesis.leak_free_fixtures import (
+    LEAK_FREE_TASKS,
+    LeakFreeTask,
+    benchmark_tasks,
+    leak_free_set_hash,
+)
+
+# ---------------------------------------------------------------------------
+# Bundle invariants
+# ---------------------------------------------------------------------------
+
+
+# Pin the leak-free bundle hash so any drift fails CI immediately.
+EXPECTED_BUNDLE_HASH = "sha256:d30af55c7b2a9f02253177d77278f93999623571ee974086b612575aa6cfd917"
+
+
+class TestBundleInvariants:
+    def test_bundle_size_is_twenty(self) -> None:
+        # Plan acceptance criterion: 20-Task Leak-Free Fixtures.
+        assert len(LEAK_FREE_TASKS) == 20
+
+    def test_bundle_hash_is_pinned(self) -> None:
+        # Frozen digest — any drift fails this test, forcing an explicit
+        # update of EXPECTED_BUNDLE_HASH on a fixture change.
+        assert leak_free_set_hash() == EXPECTED_BUNDLE_HASH
+
+    def test_task_ids_are_unique(self) -> None:
+        ids = [t.task_id for t in LEAK_FREE_TASKS]
+        assert len(set(ids)) == len(ids)
+
+    def test_task_ids_use_sequential_ordinals(self) -> None:
+        # 0001 .. 0020.
+        for i, task in enumerate(LEAK_FREE_TASKS, start=1):
+            assert task.task_id.startswith(f"{i:04d}_"), (
+                f"expected 0001..0020 ordering at index {i}; got {task.task_id}"
+            )
+
+    def test_categories_balance(self) -> None:
+        counts = Counter(t.category for t in LEAK_FREE_TASKS)
+        # Documented breakdown.
+        assert counts == {
+            "rotation": 4,
+            "mirror": 3,
+            "recolor": 3,
+            "scale": 3,
+            "crop": 3,
+            "mixed": 4,
+        }
+
+    def test_every_task_has_at_least_one_example(self) -> None:
+        for task in LEAK_FREE_TASKS:
+            assert len(task.examples) >= 1, f"{task.task_id} has zero examples"
+
+    def test_every_task_has_a_solution_hint(self) -> None:
+        for task in LEAK_FREE_TASKS:
+            assert task.solution_hint, f"{task.task_id} has empty solution_hint"
+
+    def test_every_task_has_a_description(self) -> None:
+        for task in LEAK_FREE_TASKS:
+            assert task.description, f"{task.task_id} has empty description"
+
+
+# ---------------------------------------------------------------------------
+# Per-task structural sanity
+# ---------------------------------------------------------------------------
+
+
+class TestPerTaskSanity:
+    def test_examples_are_int8_arrays(self) -> None:
+        for task in LEAK_FREE_TASKS:
+            for inp, out in task.examples:
+                assert isinstance(inp, np.ndarray)
+                assert isinstance(out, np.ndarray)
+                # Could be int8 directly or convertible — convert + check
+                # values fit in int8.
+                assert inp.min() >= -128 and inp.max() <= 127, task.task_id
+                assert out.min() >= -128 and out.max() <= 127, task.task_id
+
+    def test_to_task_spec_yields_valid_taskspec(self) -> None:
+        for task in LEAK_FREE_TASKS:
+            spec = task.to_task_spec()
+            assert isinstance(spec, TaskSpec)
+            # stable_hash is computable.
+            h = spec.stable_hash()
+            assert h.startswith("sha256:")
+
+    def test_taskspec_hashes_are_unique(self) -> None:
+        # Leak-free guarantee: every fixture has a distinct cache key.
+        hashes = [t.to_task_spec().stable_hash() for t in LEAK_FREE_TASKS]
+        assert len(set(hashes)) == len(hashes)
+
+
+# ---------------------------------------------------------------------------
+# benchmark_tasks() integration with the Sprint-1 benchmark driver
+# ---------------------------------------------------------------------------
+
+
+class TestBenchmarkTasksHelper:
+    def test_yields_twenty_benchmark_tasks(self) -> None:
+        tasks = benchmark_tasks()
+        assert len(tasks) == 20
+        for task in tasks:
+            assert isinstance(task, BenchmarkTask)
+
+    def test_default_budget_is_spec_partition(self) -> None:
+        tasks = benchmark_tasks()
+        first = tasks[0]
+        # PartitionedBudget.from_spec_default is 0.07 / 0.70 / 0.18 / 0.05.
+        assert abs(first.budget.mcts - 0.70) < 1e-9
+
+    def test_per_task_alpha_default(self) -> None:
+        tasks = benchmark_tasks()
+        for task in tasks:
+            assert task.current_alpha == 0.6
+
+    def test_task_id_propagates(self) -> None:
+        tasks = benchmark_tasks()
+        ids = {t.task_id for t in tasks}
+        assert ids == {t.task_id for t in LEAK_FREE_TASKS}
+
+    def test_wall_clock_budget_overridable(self) -> None:
+        tasks = benchmark_tasks(wall_clock_budget_seconds=12.5)
+        for task in tasks:
+            assert task.wall_clock_budget_seconds == 12.5
+
+
+# ---------------------------------------------------------------------------
+# Solution-hint sanity: spot-check a few tasks
+# ---------------------------------------------------------------------------
+
+
+class TestSolutionHintSanity:
+    def test_rotation_solutions_match_expected(self) -> None:
+        # 0001 should be a rotate90 task.
+        t = next(task for task in LEAK_FREE_TASKS if task.task_id == "0001_rotate90_2x2")
+        for inp, expected in t.examples:
+            assert np.array_equal(np.rot90(inp, k=-1), expected)
+
+    def test_mirror_horizontal_solution_matches(self) -> None:
+        t = next(task for task in LEAK_FREE_TASKS if task.task_id == "0005_mirror_horizontal")
+        for inp, expected in t.examples:
+            assert np.array_equal(np.fliplr(inp), expected)
+
+    def test_recolor_1_to_5_solution_matches(self) -> None:
+        t = next(task for task in LEAK_FREE_TASKS if task.task_id == "0008_recolor_1_to_5")
+        for inp, expected in t.examples:
+            mapped = inp.copy()
+            mapped[inp == 1] = 5
+            assert np.array_equal(mapped, expected)
+
+    def test_scale_up_2x_solution_matches(self) -> None:
+        t = next(task for task in LEAK_FREE_TASKS if task.task_id == "0011_scale_up_2x_1x2")
+        for inp, expected in t.examples:
+            scaled = np.repeat(np.repeat(inp, 2, axis=0), 2, axis=1)
+            assert np.array_equal(scaled, expected)
+
+
+# ---------------------------------------------------------------------------
+# LeakFreeTask dataclass contract
+# ---------------------------------------------------------------------------
+
+
+class TestDataclassContract:
+    def test_is_frozen(self) -> None:
+        # Sanity: every entry is a LeakFreeTask.
+        for task in LEAK_FREE_TASKS:
+            assert isinstance(task, LeakFreeTask)


### PR DESCRIPTION
## Summary

Sprint-2 Track C — **20-Task Leak-Free benchmark fixture set**. Twenty synthetic ARC-AGI-3-shaped tasks for Sprint-2 / Sprint-3 benchmark drivers.

## Surface

\`synthesis/leak_free_fixtures.py\`:
- \`TransformationCategory\` Literal: \`rotation\` / \`mirror\` / \`recolor\` / \`scale\` / \`crop\` / \`mixed\`
- \`LeakFreeTask(task_id, category, examples, solution_hint, description)\` — frozen dataclass; \`.to_task_spec()\` / \`.to_benchmark_task()\`
- \`LEAK_FREE_TASKS\`: frozen 20-task tuple
- \`leak_free_set_hash()\`: SHA-256 over canonical serialisation; **pinned in tests so any drift fails CI immediately**
- \`benchmark_tasks(*, budget, wall_clock_budget_seconds, current_alpha)\`: convenience for the Sprint-1 benchmark driver

## Category breakdown (asserted)

| Category | Count | Tasks |
|---|---|---|
| rotation | 4 | rotate90 2x2 / rotate180 3x3 / rotate270 2x2 / rotate90 2x4 |
| mirror | 3 | horizontal / vertical / transpose |
| recolor | 3 | 1→5 / 0→7 / 3→9 |
| scale | 3 | up_2x / up_3x / down_2x |
| crop | 3 | single_pixel / 2x2 subregion / corner |
| mixed | 4 | rotate90→recolor / mirror_h→rotate180 / scale_up→recolor / transpose→mirror_h |
| **total** | **20** | |

## Leak-Free guarantee

- All 20 fixtures are synthetic — never appear in any training corpus
- Each \`TaskSpec.stable_hash()\` distinct (asserted by \`test_taskspec_hashes_are_unique\`)
- Bundle SHA-256 pinned: \`sha256:d30af55c7b2a9f02253177d77278f93999623571ee974086b612575aa6cfd917\`

## Tests (21 new)

- Bundle: 20 tasks / hash pinned / ids unique + sequential 0001..0020 / category balance / non-empty examples + hint + description
- Per-task: int8-fittable values / valid TaskSpec hashes / distinct cache keys
- \`benchmark_tasks()\` helper: 20 BenchmarkTask, default budget = spec partition, α override, id propagation, wall-clock override
- Solution-hint sanity: 4 spot-check tasks (rotate90, mirror_h, recolor, scale_up_2x) reproduce expected outputs

mypy --strict clean. ruff lint + format clean.

## Sprint-2 progress

| Track | Aufgabe | Status |
|---|---|---|
| A | Verifier §7.3.3 evaluator | merged |
| B | Production-Wiring | open (#262) |
| **C** | **20-Task Leak-Free fixtures** | **this PR** |
| D | Streamlit dashboard + nightly CI | next |
| E | MCTS parallel + restart + diversity | week 3 |

## Test plan

- [x] \`pytest tests/test_channels/test_program_synthesis/phase2/test_leak_free_fixtures.py -q\` — 21 passed
- [x] \`mypy --strict src/cognithor/channels/program_synthesis/synthesis/leak_free_fixtures.py\`
- [x] \`ruff check\` + \`ruff format --check\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)