### PR TITLE
feat(pse): Sprint-10 Wave-1 PR-3 — fill_with_most_common_color (solves 5582e5ca)

### DIFF
--- a/docs/channels/program_synthesis/benchmarks.md
+++ b/docs/channels/program_synthesis/benchmarks.md
@@ -64,7 +64,7 @@ pre-conditions for the success threshold above.
 
 | Metric | Value |
 |---|---|
-| Base primitives | **71** (56 base + 5 Phase-1.5 higher-order + 5 Sprint-8 object-level + 1 Sprint-10 fractal + 4 Sprint-10 symmetry-completion) |
+| Base primitives | **72** (56 base + 5 Phase-1.5 higher-order + 5 Sprint-8 object-level + 1 Sprint-10 fractal + 4 Sprint-10 symmetry-completion + 1 Sprint-10 majority-fill) |
 | Predicate constructors | **13** (10 leaf + 3 combinators) |
 | Lambda constructors | **4** (`identity`, `recolor`, `shift`, `branch`) |
 | Higher-order primitives | **5** (`map_objects`, `filter_objects`, `align_to`, `sort_objects`, `branch`) |

--- a/docs/channels/program_synthesis/dsl_reference.md
+++ b/docs/channels/program_synthesis/dsl_reference.md
@@ -2,7 +2,7 @@
 
 _Auto-generated. PSE version `1.2.0`, DSL version `1.2.0`._
 
-**71 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
+**72 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
 
 Run `cognithor pse dsl describe <name>` for any primitive to see its full record (signature + cost + description + examples).
 
@@ -19,6 +19,7 @@ Run `cognithor pse dsl describe <name>` for any primitive to see its full record
 | `complete_symmetry_v` | `(Grid) → Grid` | 2.50 | Fill in the grid so it is symmetric across its horizontal axis (top-bottom mirror). Existing non-zero cells are preserved; zero cells are filled from their vertical partner if that partner is non-zero. Solves ARC tasks with vertically-defaced symmetric figures. |
 | `count_components` | `(Grid) → Grid` | 2.50 | Count the number of 4-connected non-zero components and return a 1×1 grid containing that count as its single colour. Counts saturate at 9 (the ARC colour range). |
 | `crop_bbox` | `(Grid) → Grid` | 1.50 | Crop to the bounding box of all non-background pixels (background = most-common color). Returns a 1×1 grid containing the background color if the grid is uniformly background. |
+| `fill_with_most_common_color` | `(Grid) → Grid` | 1.50 | Return a grid of the same shape as the input, filled with its most-frequent colour (ties broken by lowest index, matching `most_common_color`). Solves ARC tasks of the 5582e5ca family where the rule is 'collapse the input to its dominant colour'. |
 | `frame` | `(Grid, Color) → Grid` | 1.80 | Draw a 1-pixel border of *color* around the grid edge, leaving the interior unchanged. Grid must be at least 1×1. |
 | `gravity_down` | `(Grid) → Grid` | 2.00 | Pull all non-background pixels in each column toward the bottom edge. |
 | `gravity_left` | `(Grid) → Grid` | 2.00 | Pull all non-background pixels in each row toward the left edge. |

--- a/src/cognithor/channels/program_synthesis/dsl/primitives.py
+++ b/src/cognithor/channels/program_synthesis/dsl/primitives.py
@@ -497,6 +497,25 @@ def self_tile_by_mask(grid: _Grid) -> _Grid:
 
 
 @primitive(
+    name="fill_with_most_common_color",
+    signature=Signature(inputs=("Grid",), output="Grid"),
+    cost=1.5,
+    description=(
+        "Return a grid of the same shape as the input, filled with its "
+        "most-frequent colour (ties broken by lowest index, matching "
+        "`most_common_color`). Solves ARC tasks of the 5582e5ca family "
+        "where the rule is 'collapse the input to its dominant colour'."
+    ),
+    examples=(("[[4,4,8],[6,4,3],[6,3,0]]", "[[4,4,4],[4,4,4],[4,4,4]]"),),
+)
+def fill_with_most_common_color(grid: _Grid) -> _Grid:
+    _check_grid(grid, "fill_with_most_common_color")
+    counts = np.bincount(grid.ravel(), minlength=10)
+    color = int(np.argmax(counts))
+    return np.full_like(grid, color, dtype=np.int8)
+
+
+@primitive(
     name="remove_singletons",
     signature=Signature(inputs=("Grid",), output="Grid"),
     cost=2.5,

--- a/tests/test_channels/test_program_synthesis/dsl/test_sprint10_fill_majority.py
+++ b/tests/test_channels/test_program_synthesis/dsl/test_sprint10_fill_majority.py
@@ -1,0 +1,88 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-10 Wave-1 PR-3 — ``fill_with_most_common_color`` primitive.
+
+Single new high-impact primitive: fill the entire grid with its
+most-frequent colour. Solves ARC task ``5582e5ca`` where the rule is
+"collapse the input grid to its dominant colour".
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.dsl.primitives import fill_with_most_common_color
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+REAL_CORPUS_ROOT = Path(__file__).resolve().parents[4] / "cognithor_bench" / "arc_agi3_real"
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+class TestFillWithMostCommonColor:
+    def test_basic_dominant_fill(self) -> None:
+        out = fill_with_most_common_color(_g([[4, 4, 8], [6, 4, 3], [6, 3, 0]]))
+        # Most common is 4 (count 3). Output is 3×3 of 4s.
+        assert out.tolist() == [[4, 4, 4], [4, 4, 4], [4, 4, 4]]
+
+    def test_preserves_shape(self) -> None:
+        out = fill_with_most_common_color(_g([[1, 2, 3, 4, 5]]))
+        assert out.shape == (1, 5)
+
+    def test_preserves_int8_dtype(self) -> None:
+        out = fill_with_most_common_color(_g([[1, 1]]))
+        assert out.dtype == np.int8
+
+    def test_zero_is_dominant_yields_all_zero(self) -> None:
+        out = fill_with_most_common_color(_g([[0, 0, 0], [0, 1, 0]]))
+        assert out.tolist() == [[0, 0, 0], [0, 0, 0]]
+
+    def test_tie_broken_by_lowest_index(self) -> None:
+        # Colours 1 and 2 each appear twice; 1 wins on lowest-index tie-break.
+        out = fill_with_most_common_color(_g([[1, 2], [1, 2]]))
+        assert out.tolist() == [[1, 1], [1, 1]]
+
+
+class TestRegistryIntegration:
+    def test_registered_in_global_registry(self) -> None:
+        assert "fill_with_most_common_color" in REGISTRY.names()
+        spec = REGISTRY.get("fill_with_most_common_color")
+        assert spec.signature.arity == 1
+        assert spec.signature.output == "Grid"
+
+
+class TestSolves5582e5ca:
+    """Existence proof on real fchollet/ARC-AGI training task 5582e5ca."""
+
+    @staticmethod
+    def _load() -> dict:
+        path = REAL_CORPUS_ROOT / "tasks" / "training" / "5582e5ca.json"
+        if not path.exists():
+            pytest.skip(f"real ARC corpus not present at {REAL_CORPUS_ROOT}")
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def test_all_train_demos_solved(self) -> None:
+        task = self._load()
+        for i, demo in enumerate(task["train"]):
+            inp = np.array(demo["input"], dtype=np.int8)
+            expected = np.array(demo["output"], dtype=np.int8)
+            np.testing.assert_array_equal(
+                fill_with_most_common_color(inp),
+                expected,
+                err_msg=f"5582e5ca demo {i}",
+            )
+
+    def test_test_demo_solved(self) -> None:
+        task = self._load()
+        demo = task["test"][0]
+        inp = np.array(demo["input"], dtype=np.int8)
+        expected = np.array(demo["output"], dtype=np.int8)
+        np.testing.assert_array_equal(fill_with_most_common_color(inp), expected)


### PR DESCRIPTION
## Summary

Adds `fill_with_most_common_color` — single new high-impact primitive that collapses the input grid to its dominant colour. **Solves real ARC training task 5582e5ca** with all 3 train demos + 1 test demo reproducing exactly.

## Implementation

`numpy.bincount` + `argmax`, lowest-index tie-break (matches existing `most_common_color` semantics). Pure NumPy, `int8`, no shared state. Cost = 1.5.

## Why this primitive

The 5582e5ca task family asks "what's the most common colour, fill the grid with it". One-step rule, no composition needed. Failed pre-Sprint-10 because the existing `most_common_color` returns a `Color` (int), not a `Grid` — Phase-1 search couldn't trivially compose color→grid.

## Sprint-10 Wave-1 cumulative impact

| PR | Primitiv(en) | Neue Tasks | Korpus-Stand |
|---|---|---|---|
| #274 (merged) | `self_tile_by_mask` | 007bbfb7 | +1 |
| #275 (open, rebased) | `complete_symmetry_h/v/d/antidiag` | 496994bd, f25ffba3 | +2 |
| **#276 (this)** | `fill_with_most_common_color` | 5582e5ca | +1 |
| **Wave-1 total** | **6 Primitiven** | **4 neue Tasks** | **18→22/400 = 5.5 %** |

## Test plan
- [x] 8/8 new tests pass (0.39 s) — unit semantics + 5582e5ca existence proof
- [x] Full PSE suite: 1410 passed, 10 skipped — no regressions
- [x] `ruff check` + `ruff format --check` clean
- [x] Branch on top of `main` post-#274

## Catalog change

`67 → 68` base primitives. Doc-drift updates auto-applied to `dsl_reference.md` and `benchmarks.md`.

## Sprint-10 context

Owner-Direktive 2026-05-01: \"DSL massiv vertiefen und erweitern, außerdem vLLM-Backend mit qwen3.6:27b\".

This PR closes Wave-1 of the DSL track (PRs #274, #275, #276 — six primitives, four real-ARC solves). Next: Wave-2 anchor/position detection, conditional fills, pattern recognition. Then Track B: vLLM/qwen3.6:27b LLM-Prior wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)