### PR TITLE
feat(pse): Sprint-10 Wave-2 PR-4 — crop_largest_component (+2 real-ARC solves)

### DIFF
--- a/docs/channels/program_synthesis/benchmarks.md
+++ b/docs/channels/program_synthesis/benchmarks.md
@@ -64,7 +64,7 @@ pre-conditions for the success threshold above.
 
 | Metric | Value |
 |---|---|
-| Base primitives | **72** (56 base + 5 Phase-1.5 higher-order + 5 Sprint-8 object-level + 1 Sprint-10 fractal + 4 Sprint-10 symmetry-completion + 1 Sprint-10 majority-fill) |
+| Base primitives | **73** (56 base + 5 Phase-1.5 higher-order + 5 Sprint-8 object-level + 1 Sprint-10 fractal + 4 Sprint-10 symmetry-completion + 1 Sprint-10 majority-fill + 1 Sprint-10 component-crop) |
 | Predicate constructors | **13** (10 leaf + 3 combinators) |
 | Lambda constructors | **4** (`identity`, `recolor`, `shift`, `branch`) |
 | Higher-order primitives | **5** (`map_objects`, `filter_objects`, `align_to`, `sort_objects`, `branch`) |

--- a/docs/channels/program_synthesis/dsl_reference.md
+++ b/docs/channels/program_synthesis/dsl_reference.md
@@ -2,7 +2,7 @@
 
 _Auto-generated. PSE version `1.2.0`, DSL version `1.2.0`._
 
-**72 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
+**73 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
 
 Run `cognithor pse dsl describe <name>` for any primitive to see its full record (signature + cost + description + examples).
 
@@ -19,6 +19,7 @@ Run `cognithor pse dsl describe <name>` for any primitive to see its full record
 | `complete_symmetry_v` | `(Grid) → Grid` | 2.50 | Fill in the grid so it is symmetric across its horizontal axis (top-bottom mirror). Existing non-zero cells are preserved; zero cells are filled from their vertical partner if that partner is non-zero. Solves ARC tasks with vertically-defaced symmetric figures. |
 | `count_components` | `(Grid) → Grid` | 2.50 | Count the number of 4-connected non-zero components and return a 1×1 grid containing that count as its single colour. Counts saturate at 9 (the ARC colour range). |
 | `crop_bbox` | `(Grid) → Grid` | 1.50 | Crop to the bounding box of all non-background pixels (background = most-common color). Returns a 1×1 grid containing the background color if the grid is uniformly background. |
+| `crop_largest_component` | `(Grid) → Grid` | 2.50 | Find the largest 4-connected non-zero component and return its bounding-box subgrid (other cells in the bbox stay zero). Differs from `crop_bbox` (which crops to the bbox of every non-background cell jointly): solves ARC tasks where the rule is 'extract the dominant shape, drop the rest'. |
 | `fill_with_most_common_color` | `(Grid) → Grid` | 1.50 | Return a grid of the same shape as the input, filled with its most-frequent colour (ties broken by lowest index, matching `most_common_color`). Solves ARC tasks of the 5582e5ca family where the rule is 'collapse the input to its dominant colour'. |
 | `frame` | `(Grid, Color) → Grid` | 1.80 | Draw a 1-pixel border of *color* around the grid edge, leaving the interior unchanged. Grid must be at least 1×1. |
 | `gravity_down` | `(Grid) → Grid` | 2.00 | Pull all non-background pixels in each column toward the bottom edge. |

--- a/src/cognithor/channels/program_synthesis/dsl/primitives.py
+++ b/src/cognithor/channels/program_synthesis/dsl/primitives.py
@@ -516,6 +516,59 @@ def fill_with_most_common_color(grid: _Grid) -> _Grid:
 
 
 @primitive(
+    name="crop_largest_component",
+    signature=Signature(inputs=("Grid",), output="Grid"),
+    cost=2.5,
+    description=(
+        "Find the largest 4-connected non-zero component and return "
+        "its bounding-box subgrid (other cells in the bbox stay zero). "
+        "Differs from `crop_bbox` (which crops to the bbox of every "
+        "non-background cell jointly): solves ARC tasks where the rule "
+        "is 'extract the dominant shape, drop the rest'."
+    ),
+    examples=(("[[0,1,0,2],[0,1,0,0]]", "[[1],[1]]"),),
+)
+def crop_largest_component(grid: _Grid) -> _Grid:
+    _check_grid(grid, "crop_largest_component")
+    rows, cols = grid.shape
+    visited = np.zeros_like(grid, dtype=bool)
+    components: list[list[tuple[int, int]]] = []
+    for r0 in range(rows):
+        for c0 in range(cols):
+            if visited[r0, c0] or int(grid[r0, c0]) == 0:
+                continue
+            colour = int(grid[r0, c0])
+            stack: list[tuple[int, int]] = [(r0, c0)]
+            visited[r0, c0] = True
+            cells: list[tuple[int, int]] = [(r0, c0)]
+            while stack:
+                r, c = stack.pop()
+                for dr, dc in ((-1, 0), (1, 0), (0, -1), (0, 1)):
+                    nr, nc = r + dr, c + dc
+                    if (
+                        0 <= nr < rows
+                        and 0 <= nc < cols
+                        and not visited[nr, nc]
+                        and int(grid[nr, nc]) == colour
+                    ):
+                        visited[nr, nc] = True
+                        stack.append((nr, nc))
+                        cells.append((nr, nc))
+            components.append(cells)
+    if not components:
+        return grid.copy()
+    largest = max(components, key=len)
+    rs = [r for r, _ in largest]
+    cs = [c for _, c in largest]
+    r0, r1 = min(rs), max(rs) + 1
+    c0, c1 = min(cs), max(cs) + 1
+    out = np.zeros((r1 - r0, c1 - c0), dtype=np.int8)
+    for r, c in largest:
+        out[r - r0, c - c0] = grid[r, c]
+    return out
+
+
+@primitive(
     name="remove_singletons",
     signature=Signature(inputs=("Grid",), output="Grid"),
     cost=2.5,

--- a/tests/test_channels/test_program_synthesis/dsl/test_sprint10_crop_largest_component.py
+++ b/tests/test_channels/test_program_synthesis/dsl/test_sprint10_crop_largest_component.py
@@ -1,0 +1,80 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-10 Wave-2 PR-4 — ``crop_largest_component`` primitive.
+
+Single new high-impact primitive: extract the largest 4-connected
+non-zero component and return its bounding-box subgrid. Solves real
+ARC tasks ``1f85a75f`` and ``be94b721`` directly.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.dsl.primitives import crop_largest_component
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+REAL_CORPUS_ROOT = Path(__file__).resolve().parents[4] / "cognithor_bench" / "arc_agi3_real"
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+class TestCropLargestComponentUnit:
+    def test_basic_two_components_keeps_largest(self) -> None:
+        # Two single-cell components (size 1 each) — first found wins.
+        # Replace with a clear two-component grid: a 2-cell column vs 1-cell.
+        out = crop_largest_component(_g([[0, 1, 0, 2], [0, 1, 0, 0]]))
+        # Largest = the 2-cell column of 1s. Its bbox is 2×1, content [[1],[1]].
+        assert out.tolist() == [[1], [1]]
+
+    def test_single_component_returns_its_bbox(self) -> None:
+        # Single L-shaped component → bbox is 2×2.
+        out = crop_largest_component(_g([[0, 0, 0], [0, 5, 5], [0, 5, 0]]))
+        assert out.tolist() == [[5, 5], [5, 0]]
+
+    def test_all_zero_input_returns_input_copy(self) -> None:
+        inp = _g([[0, 0], [0, 0]])
+        out = crop_largest_component(inp)
+        assert out.tolist() == inp.tolist()
+
+    def test_separate_components_different_colors(self) -> None:
+        # 1×1 of color 3 and 2×1 of color 7 → return the 2×1.
+        out = crop_largest_component(_g([[3, 0], [0, 7], [0, 7]]))
+        assert out.tolist() == [[7], [7]]
+
+    def test_preserves_int8_dtype(self) -> None:
+        out = crop_largest_component(_g([[1, 0], [1, 0]]))
+        assert out.dtype == np.int8
+
+
+class TestRegistryIntegration:
+    def test_registered(self) -> None:
+        assert "crop_largest_component" in REGISTRY.names()
+        spec = REGISTRY.get("crop_largest_component")
+        assert spec.signature.arity == 1
+        assert spec.signature.output == "Grid"
+
+
+class TestRealARCExistenceProofs:
+    @pytest.mark.parametrize("task_id", ["1f85a75f", "be94b721"])
+    def test_solves(self, task_id: str) -> None:
+        path = REAL_CORPUS_ROOT / "tasks" / "training" / f"{task_id}.json"
+        if not path.exists():
+            pytest.skip(f"real ARC corpus not present at {REAL_CORPUS_ROOT}")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        for i, demo in enumerate(data["train"]):
+            inp = np.array(demo["input"], dtype=np.int8)
+            expected = np.array(demo["output"], dtype=np.int8)
+            np.testing.assert_array_equal(
+                crop_largest_component(inp),
+                expected,
+                err_msg=f"{task_id} demo {i}",
+            )


### PR DESCRIPTION
## Summary

Adds `crop_largest_component` — extract the largest 4-connected non-zero component and return its bounding-box subgrid. Differs from `crop_bbox` (joint bbox of all non-background cells) by isolating the dominant shape only.

**Solves real ARC training tasks `1f85a75f` and `be94b721`** — both have multiple components, output keeps only the largest.

## Sprint-10 cumulative impact

| Wave | PR | Primitiv(en) | Neue Tasks |
|---|---|---|---|
| 1 | #274 ✅ | `self_tile_by_mask` | 007bbfb7 |
| 1 | #275 | `complete_symmetry_h/v/d/antidiag` | 496994bd, f25ffba3 |
| 1 | #276 | `fill_with_most_common_color` | 5582e5ca |
| **2** | **#277 (this)** | **`crop_largest_component`** | **1f85a75f, be94b721** |
| **Total** | | **7 Primitiven** | **+6 Tasks → 24/400 = 6.0 %** |

## Test plan
- [x] 8/8 new tests pass (0.40 s)
- [x] Real-ARC existence proofs: 1f85a75f + be94b721 reproduce all train demos exactly
- [x] Full PSE suite: 1410 passed, 10 skipped — no regressions
- [x] `ruff check` + `ruff format --check` clean
- [x] Branch on top of `main` post-#274

## Catalog change

`67 → 68` base primitives. Doc-drift updates auto-applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)