### PR TITLE
feat(pse): Sprint-10 Wave-3 — crop_smallest_component + neighbor_count_grid (+3 solves)

### DIFF
--- a/docs/channels/program_synthesis/benchmarks.md
+++ b/docs/channels/program_synthesis/benchmarks.md
@@ -64,7 +64,7 @@ pre-conditions for the success threshold above.
 
 | Metric | Value |
 |---|---|
-| Base primitives | **73** (56 base + 5 Phase-1.5 higher-order + 5 Sprint-8 object-level + 1 Sprint-10 fractal + 4 Sprint-10 symmetry-completion + 1 Sprint-10 majority-fill + 1 Sprint-10 component-crop) |
+| Base primitives | **75** (56 base + 5 Phase-1.5 higher-order + 5 Sprint-8 object-level + 9 Sprint-10) |
 | Predicate constructors | **13** (10 leaf + 3 combinators) |
 | Lambda constructors | **4** (`identity`, `recolor`, `shift`, `branch`) |
 | Higher-order primitives | **5** (`map_objects`, `filter_objects`, `align_to`, `sort_objects`, `branch`) |

--- a/docs/channels/program_synthesis/dsl_reference.md
+++ b/docs/channels/program_synthesis/dsl_reference.md
@@ -2,7 +2,7 @@
 
 _Auto-generated. PSE version `1.2.0`, DSL version `1.2.0`._
 
-**73 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
+**75 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
 
 Run `cognithor pse dsl describe <name>` for any primitive to see its full record (signature + cost + description + examples).
 
@@ -20,6 +20,7 @@ Run `cognithor pse dsl describe <name>` for any primitive to see its full record
 | `count_components` | `(Grid) → Grid` | 2.50 | Count the number of 4-connected non-zero components and return a 1×1 grid containing that count as its single colour. Counts saturate at 9 (the ARC colour range). |
 | `crop_bbox` | `(Grid) → Grid` | 1.50 | Crop to the bounding box of all non-background pixels (background = most-common color). Returns a 1×1 grid containing the background color if the grid is uniformly background. |
 | `crop_largest_component` | `(Grid) → Grid` | 2.50 | Find the largest 4-connected non-zero component and return its bounding-box subgrid (other cells in the bbox stay zero). Differs from `crop_bbox` (which crops to the bbox of every non-background cell jointly): solves ARC tasks where the rule is 'extract the dominant shape, drop the rest'. |
+| `crop_smallest_component` | `(Grid) → Grid` | 2.50 | Find the smallest 4-connected non-zero component and return its bounding-box subgrid. Mirror of `crop_largest_component`. Solves ARC tasks where the rule is 'extract the rare/marker shape, drop the noise'. |
 | `fill_with_most_common_color` | `(Grid) → Grid` | 1.50 | Return a grid of the same shape as the input, filled with its most-frequent colour (ties broken by lowest index, matching `most_common_color`). Solves ARC tasks of the 5582e5ca family where the rule is 'collapse the input to its dominant colour'. |
 | `frame` | `(Grid, Color) → Grid` | 1.80 | Draw a 1-pixel border of *color* around the grid edge, leaving the interior unchanged. Grid must be at least 1×1. |
 | `gravity_down` | `(Grid) → Grid` | 2.00 | Pull all non-background pixels in each column toward the bottom edge. |
@@ -32,6 +33,7 @@ Run `cognithor pse dsl describe <name>` for any primitive to see its full record
 | `mirror_diagonal` | `(Grid) → Grid` | 1.20 | Mirror across the main diagonal. Equivalent to transpose for square grids. |
 | `mirror_horizontal` | `(Grid) → Grid` | 1.00 | Flip the grid left-to-right (mirror across the vertical axis). |
 | `mirror_vertical` | `(Grid) → Grid` | 1.00 | Flip the grid top-to-bottom (mirror across the horizontal axis). |
+| `neighbor_count_grid` | `(Grid) → Grid` | 2.00 | Replace each cell with the count of its 8-connected non-zero neighbours (including itself if non-zero), capped at 9. Output has the same shape as the input. Solves ARC tasks where the rule is 'mark each cell with its local density'. |
 | `overlay` | `(Grid, Grid, Color) → Grid` | 2.50 | Overlay *top* onto *base*: cells of *top* equal to *transparent_color* are skipped, all other cells overwrite *base*. Both grids must have the same shape. |
 | `pad_with` | `(Grid, Color, Int) → Grid` | 1.80 | Pad the grid on all four sides with *width* pixels of *color*. Width must be ≥ 0. |
 | `recolor` | `(Grid, Color, Color) → Grid` | 1.50 | Replace every occurrence of color *src* with color *dst*. |

--- a/src/cognithor/channels/program_synthesis/dsl/primitives.py
+++ b/src/cognithor/channels/program_synthesis/dsl/primitives.py
@@ -569,6 +569,86 @@ def crop_largest_component(grid: _Grid) -> _Grid:
 
 
 @primitive(
+    name="crop_smallest_component",
+    signature=Signature(inputs=("Grid",), output="Grid"),
+    cost=2.5,
+    description=(
+        "Find the smallest 4-connected non-zero component and return "
+        "its bounding-box subgrid. Mirror of `crop_largest_component`. "
+        "Solves ARC tasks where the rule is 'extract the rare/marker "
+        "shape, drop the noise'."
+    ),
+    examples=(("[[0,1,0,2,2],[0,1,0,2,0]]", "[[1],[1]]"),),
+)
+def crop_smallest_component(grid: _Grid) -> _Grid:
+    _check_grid(grid, "crop_smallest_component")
+    rows, cols = grid.shape
+    visited = np.zeros_like(grid, dtype=bool)
+    components: list[list[tuple[int, int]]] = []
+    for r0 in range(rows):
+        for c0 in range(cols):
+            if visited[r0, c0] or int(grid[r0, c0]) == 0:
+                continue
+            colour = int(grid[r0, c0])
+            stack: list[tuple[int, int]] = [(r0, c0)]
+            visited[r0, c0] = True
+            cells: list[tuple[int, int]] = [(r0, c0)]
+            while stack:
+                r, c = stack.pop()
+                for dr, dc in ((-1, 0), (1, 0), (0, -1), (0, 1)):
+                    nr, nc = r + dr, c + dc
+                    if (
+                        0 <= nr < rows
+                        and 0 <= nc < cols
+                        and not visited[nr, nc]
+                        and int(grid[nr, nc]) == colour
+                    ):
+                        visited[nr, nc] = True
+                        stack.append((nr, nc))
+                        cells.append((nr, nc))
+            components.append(cells)
+    if not components:
+        return grid.copy()
+    smallest = min(components, key=len)
+    rs = [r for r, _ in smallest]
+    cs = [c for _, c in smallest]
+    r0, r1 = min(rs), max(rs) + 1
+    c0, c1 = min(cs), max(cs) + 1
+    out = np.zeros((r1 - r0, c1 - c0), dtype=np.int8)
+    for r, c in smallest:
+        out[r - r0, c - c0] = grid[r, c]
+    return out
+
+
+@primitive(
+    name="neighbor_count_grid",
+    signature=Signature(inputs=("Grid",), output="Grid"),
+    cost=2.0,
+    description=(
+        "Replace each cell with the count of its 8-connected non-zero "
+        "neighbours (including itself if non-zero), capped at 9. "
+        "Output has the same shape as the input. Solves ARC tasks "
+        "where the rule is 'mark each cell with its local density'."
+    ),
+    examples=(("[[1,0,0],[0,1,0],[0,0,1]]", "[[2,2,1],[2,3,2],[1,2,2]]"),),
+)
+def neighbor_count_grid(grid: _Grid) -> _Grid:
+    _check_grid(grid, "neighbor_count_grid")
+    h, w = grid.shape
+    out = np.zeros_like(grid, dtype=np.int8)
+    for r in range(h):
+        for c in range(w):
+            cnt = 0
+            for dr in (-1, 0, 1):
+                for dc in (-1, 0, 1):
+                    nr, nc = r + dr, c + dc
+                    if 0 <= nr < h and 0 <= nc < w and int(grid[nr, nc]) != 0:
+                        cnt += 1
+            out[r, c] = min(cnt, 9)
+    return out
+
+
+@primitive(
     name="remove_singletons",
     signature=Signature(inputs=("Grid",), output="Grid"),
     cost=2.5,

--- a/tests/test_channels/test_program_synthesis/dsl/test_sprint10_wave3_spatial.py
+++ b/tests/test_channels/test_program_synthesis/dsl/test_sprint10_wave3_spatial.py
@@ -1,0 +1,137 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-10 Wave-3 — spatial primitives.
+
+Two new primitives:
+
+- ``crop_smallest_component`` — bbox of the smallest 4-connected
+  non-zero component (mirror of ``crop_largest_component``)
+- ``neighbor_count_grid`` — each cell becomes the count of 8-connected
+  non-zero neighbours (including self), capped at 9
+
+Real-ARC existence proofs:
+- ``crop_smallest_component`` solves 23b5c85d, d9fac9be
+- ``neighbor_count_grid`` solves ce22a75a
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.dsl.primitives import (
+    crop_smallest_component,
+    neighbor_count_grid,
+)
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+REAL_CORPUS_ROOT = Path(__file__).resolve().parents[4] / "cognithor_bench" / "arc_agi3_real"
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+# ---------------------------------------------------------------------------
+# crop_smallest_component
+# ---------------------------------------------------------------------------
+
+
+class TestCropSmallestComponent:
+    def test_basic_two_components(self) -> None:
+        # 1-cell of color 1, 2-cell of color 2 → return the 1-cell bbox.
+        out = crop_smallest_component(_g([[0, 1, 0, 2, 2], [0, 0, 0, 2, 0]]))
+        assert out.tolist() == [[1]]
+
+    def test_single_component_returns_its_bbox(self) -> None:
+        out = crop_smallest_component(_g([[0, 0, 0], [0, 5, 5], [0, 5, 0]]))
+        # Single component → smallest = it.
+        assert out.tolist() == [[5, 5], [5, 0]]
+
+    def test_all_zero_returns_input_copy(self) -> None:
+        inp = _g([[0, 0], [0, 0]])
+        out = crop_smallest_component(inp)
+        assert out.tolist() == inp.tolist()
+
+    def test_preserves_int8_dtype(self) -> None:
+        out = crop_smallest_component(_g([[1, 0], [1, 0]]))
+        assert out.dtype == np.int8
+
+
+# ---------------------------------------------------------------------------
+# neighbor_count_grid
+# ---------------------------------------------------------------------------
+
+
+class TestNeighborCountGrid:
+    def test_diagonal_pattern(self) -> None:
+        # 3 isolated diagonal cells. Counts: corners see 2, mid sees 3, off-diag see 1 or 2.
+        out = neighbor_count_grid(_g([[1, 0, 0], [0, 1, 0], [0, 0, 1]]))
+        assert out.tolist() == [[2, 2, 1], [2, 3, 2], [1, 2, 2]]
+
+    def test_all_zero_yields_all_zero(self) -> None:
+        out = neighbor_count_grid(_g([[0, 0], [0, 0]]))
+        assert out.tolist() == [[0, 0], [0, 0]]
+
+    def test_full_grid_caps_at_nine(self) -> None:
+        # 4×4 all-1 grid: corner sees 4, edge sees 6, interior sees 9.
+        out = neighbor_count_grid(np.ones((4, 4), dtype=np.int8))
+        assert out[0, 0] == 4  # corner: self + 3 neighbours
+        assert out[0, 1] == 6  # edge: self + 5 neighbours
+        assert out[1, 1] == 9  # interior: self + 8 neighbours
+
+    def test_preserves_shape(self) -> None:
+        out = neighbor_count_grid(_g([[1, 2, 3, 4, 5]]))
+        assert out.shape == (1, 5)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryIntegration:
+    @pytest.mark.parametrize("name", ["crop_smallest_component", "neighbor_count_grid"])
+    def test_registered(self, name: str) -> None:
+        assert name in REGISTRY.names()
+        spec = REGISTRY.get(name)
+        assert spec.signature.arity == 1
+        assert spec.signature.output == "Grid"
+
+
+# ---------------------------------------------------------------------------
+# Real-ARC existence proofs
+# ---------------------------------------------------------------------------
+
+
+class TestRealARCExistenceProofs:
+    @staticmethod
+    def _load(task_id: str) -> dict:
+        path = REAL_CORPUS_ROOT / "tasks" / "training" / f"{task_id}.json"
+        if not path.exists():
+            pytest.skip(f"real ARC corpus not present at {REAL_CORPUS_ROOT}")
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    @pytest.mark.parametrize("task_id", ["23b5c85d", "d9fac9be"])
+    def test_crop_smallest_component_solves(self, task_id: str) -> None:
+        task = self._load(task_id)
+        for i, demo in enumerate(task["train"]):
+            inp = np.array(demo["input"], dtype=np.int8)
+            expected = np.array(demo["output"], dtype=np.int8)
+            np.testing.assert_array_equal(
+                crop_smallest_component(inp), expected, err_msg=f"{task_id} demo {i}"
+            )
+
+    def test_neighbor_count_grid_solves_ce22a75a(self) -> None:
+        task = self._load("ce22a75a")
+        for i, demo in enumerate(task["train"]):
+            inp = np.array(demo["input"], dtype=np.int8)
+            expected = np.array(demo["output"], dtype=np.int8)
+            np.testing.assert_array_equal(
+                neighbor_count_grid(inp), expected, err_msg=f"ce22a75a demo {i}"
+            )


### PR DESCRIPTION
## Summary

Two new primitives, **+3 new real-ARC training solves**:

- `crop_smallest_component` — bbox of smallest 4-conn non-zero component (mirror of `crop_largest_component`). Solves `23b5c85d`, `d9fac9be`.
- `neighbor_count_grid` — each cell = count of 8-conn non-zero neighbours (incl. self), capped at 9. Solves `ce22a75a`.

## Cumulative Sprint-10 progress

| Wave | PR | Primitiv(en) | Real-ARC training |
|---|---|---|---|
| 1 | #274 ✅ | self_tile_by_mask | 18 → 19 |
| 1 | #275 ✅ | complete_symmetry_h/v/d/antidiag | 19 → 21 |
| 1 | #276 ✅ | fill_with_most_common_color | 21 → 22 |
| 2 | #277 ✅ | crop_largest_component | 22 → 24 |
| | (composition) | — | 24 → 25 |
| 3 | **this** | crop_smallest_component, neighbor_count_grid | **25 → 28** (predicted) |

**Catalog: 66 → 75** (+9 Sprint-10 primitives).
**Real-ARC training: 4.5 % → ~7.0 %** (predicted post-merge).

## Test plan
- [x] 13/13 new Wave-3 tests pass
- [x] Real-ARC existence proofs: 23b5c85d, d9fac9be, ce22a75a all reproduce exactly
- [x] Full PSE suite: 1450 passed, 10 skipped — no regressions
- [x] `ruff check` + `ruff format --check` clean
- [x] Branch on top of main post-#277

🤖 Generated with [Claude Code](https://claude.com/claude-code)