### PR TITLE
feat(pse): Sprint-10 Wave-4 — crop_to_least_common_color_cells (+2 solves)

### DIFF
--- a/docs/channels/program_synthesis/benchmarks.md
+++ b/docs/channels/program_synthesis/benchmarks.md
@@ -64,7 +64,7 @@ pre-conditions for the success threshold above.
 
 | Metric | Value |
 |---|---|
-| Base primitives | **75** (56 base + 5 Phase-1.5 higher-order + 5 Sprint-8 object-level + 9 Sprint-10) |
+| Base primitives | **76** (56 base + 5 Phase-1.5 higher-order + 5 Sprint-8 object-level + 10 Sprint-10) |
 | Predicate constructors | **13** (10 leaf + 3 combinators) |
 | Lambda constructors | **4** (`identity`, `recolor`, `shift`, `branch`) |
 | Higher-order primitives | **5** (`map_objects`, `filter_objects`, `align_to`, `sort_objects`, `branch`) |

--- a/docs/channels/program_synthesis/dsl_reference.md
+++ b/docs/channels/program_synthesis/dsl_reference.md
@@ -2,7 +2,7 @@
 
 _Auto-generated. PSE version `1.2.0`, DSL version `1.2.0`._
 
-**75 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
+**76 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
 
 Run `cognithor pse dsl describe <name>` for any primitive to see its full record (signature + cost + description + examples).
 
@@ -21,6 +21,7 @@ Run `cognithor pse dsl describe <name>` for any primitive to see its full record
 | `crop_bbox` | `(Grid) → Grid` | 1.50 | Crop to the bounding box of all non-background pixels (background = most-common color). Returns a 1×1 grid containing the background color if the grid is uniformly background. |
 | `crop_largest_component` | `(Grid) → Grid` | 2.50 | Find the largest 4-connected non-zero component and return its bounding-box subgrid (other cells in the bbox stay zero). Differs from `crop_bbox` (which crops to the bbox of every non-background cell jointly): solves ARC tasks where the rule is 'extract the dominant shape, drop the rest'. |
 | `crop_smallest_component` | `(Grid) → Grid` | 2.50 | Find the smallest 4-connected non-zero component and return its bounding-box subgrid. Mirror of `crop_largest_component`. Solves ARC tasks where the rule is 'extract the rare/marker shape, drop the noise'. |
+| `crop_to_least_common_color_cells` | `(Grid) → Grid` | 2.50 | Find the rarest non-zero colour and return the bounding-box subgrid of cells of that colour (other cells in the bbox stay in their original colour). The rarest colour breaks ties by lowest index. Solves ARC tasks where the rule is 'find the marker / odd one out and crop around it'. |
 | `fill_with_most_common_color` | `(Grid) → Grid` | 1.50 | Return a grid of the same shape as the input, filled with its most-frequent colour (ties broken by lowest index, matching `most_common_color`). Solves ARC tasks of the 5582e5ca family where the rule is 'collapse the input to its dominant colour'. |
 | `frame` | `(Grid, Color) → Grid` | 1.80 | Draw a 1-pixel border of *color* around the grid edge, leaving the interior unchanged. Grid must be at least 1×1. |
 | `gravity_down` | `(Grid) → Grid` | 2.00 | Pull all non-background pixels in each column toward the bottom edge. |

--- a/src/cognithor/channels/program_synthesis/dsl/primitives.py
+++ b/src/cognithor/channels/program_synthesis/dsl/primitives.py
@@ -649,6 +649,41 @@ def neighbor_count_grid(grid: _Grid) -> _Grid:
 
 
 @primitive(
+    name="crop_to_least_common_color_cells",
+    signature=Signature(inputs=("Grid",), output="Grid"),
+    cost=2.5,
+    description=(
+        "Find the rarest non-zero colour and return the bounding-box "
+        "subgrid of cells of that colour (other cells in the bbox stay "
+        "in their original colour). The rarest colour breaks ties by "
+        "lowest index. Solves ARC tasks where the rule is 'find the "
+        "marker / odd one out and crop around it'."
+    ),
+    examples=(("[[2,2,2],[2,1,2],[2,2,2]]", "[[1]]"),),
+)
+def crop_to_least_common_color_cells(grid: _Grid) -> _Grid:
+    _check_grid(grid, "crop_to_least_common_color_cells")
+    counts = np.bincount(grid.ravel(), minlength=10)
+    counts_orig = counts.copy()
+    counts_masked = counts.copy()
+    counts_masked[0] = np.iinfo(np.int64).max
+    counts_masked = np.where(counts_masked == 0, np.iinfo(np.int64).max, counts_masked)
+    least = int(np.argmin(counts_masked))
+    if int(counts_orig[least]) == 0:
+        return grid.copy()
+    mask = grid == least
+    if not mask.any():
+        return grid.copy()
+    rows = np.any(mask, axis=1)
+    cols = np.any(mask, axis=0)
+    r0 = int(np.argmax(rows))
+    r1 = int(len(rows) - np.argmax(rows[::-1]))
+    c0 = int(np.argmax(cols))
+    c1 = int(len(cols) - np.argmax(cols[::-1]))
+    return grid[r0:r1, c0:c1].copy()
+
+
+@primitive(
     name="remove_singletons",
     signature=Signature(inputs=("Grid",), output="Grid"),
     cost=2.5,

--- a/tests/test_channels/test_program_synthesis/dsl/test_sprint10_wave4_crop_rare.py
+++ b/tests/test_channels/test_program_synthesis/dsl/test_sprint10_wave4_crop_rare.py
@@ -1,0 +1,73 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-10 Wave-4 — ``crop_to_least_common_color_cells``.
+
+Single new high-impact primitive: find the rarest non-zero colour and
+return the bounding box of its cells. Solves ARC tasks 0b148d64 and
+c909285e.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.dsl.primitives import (
+    crop_to_least_common_color_cells,
+)
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+REAL_CORPUS_ROOT = Path(__file__).resolve().parents[4] / "cognithor_bench" / "arc_agi3_real"
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+class TestUnit:
+    def test_basic_single_marker(self) -> None:
+        # 8 cells of color 2, 1 cell of color 1 → rarest = 1 → bbox 1×1.
+        out = crop_to_least_common_color_cells(_g([[2, 2, 2], [2, 1, 2], [2, 2, 2]]))
+        assert out.tolist() == [[1]]
+
+    def test_marker_block(self) -> None:
+        # 8 cells of color 2, 2 cells of color 5 → rarest = 5 → bbox of 5s.
+        out = crop_to_least_common_color_cells(_g([[2, 2, 2], [5, 2, 5], [2, 2, 2]]))
+        # 5s at (1,0) and (1,2) → bbox rows=[1..2), cols=[0..3) → grid[1:2, 0:3].
+        assert out.tolist() == [[5, 2, 5]]
+
+    def test_all_zero_returns_input_copy(self) -> None:
+        inp = _g([[0, 0], [0, 0]])
+        out = crop_to_least_common_color_cells(inp)
+        assert out.tolist() == inp.tolist()
+
+    def test_preserves_int8_dtype(self) -> None:
+        out = crop_to_least_common_color_cells(_g([[2, 2, 1]]))
+        assert out.dtype == np.int8
+
+
+class TestRegistry:
+    def test_registered(self) -> None:
+        assert "crop_to_least_common_color_cells" in REGISTRY.names()
+
+
+class TestRealARC:
+    @pytest.mark.parametrize("task_id", ["0b148d64", "c909285e"])
+    def test_solves(self, task_id: str) -> None:
+        path = REAL_CORPUS_ROOT / "tasks" / "training" / f"{task_id}.json"
+        if not path.exists():
+            pytest.skip(f"real ARC corpus not present at {REAL_CORPUS_ROOT}")
+        data = json.loads(path.read_text(encoding="utf-8"))
+        for i, demo in enumerate(data["train"]):
+            inp = np.array(demo["input"], dtype=np.int8)
+            expected = np.array(demo["output"], dtype=np.int8)
+            np.testing.assert_array_equal(
+                crop_to_least_common_color_cells(inp),
+                expected,
+                err_msg=f"{task_id} demo {i}",
+            )


### PR DESCRIPTION
## Summary

Single new high-impact primitive: find the rarest non-zero colour and return the bounding-box subgrid of cells of that colour. **Solves real-ARC training tasks `0b148d64` and `c909285e`**.

## Sprint-10 cumulative

| Wave | PRs | Primitives | New training solves |
|---|---|---|---|
| 1 | #274–#276 | self_tile_by_mask, complete_symmetry_*, fill_with_most_common_color | 4 |
| 2 | #277 | crop_largest_component | 2 (+1 composition) |
| 3 | #279 | crop_smallest_component, neighbor_count_grid | 3 |
| **4** | **this** | **crop_to_least_common_color_cells** | **2** |
| **TOTAL** | | **10 primitives** | **12 measured-or-predicted** |

Real-ARC training: 4.5 % → measured 7.0 % (post-Wave-3) → ~7.5 % expected post-merge.
Catalog: 66 → 76.

## Test plan
- [x] 7/7 Wave-4 tests pass; full PSE suite 1457 passed
- [x] 0b148d64 + c909285e existence proofs reproduce
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)