### PR TITLE
feat(pse): Sprint-10 Track B — vLLM/qwen3.6:27b LLM-Prior wiring (infrastructure)

### DIFF
--- a/docs/superpowers/reports/sprint10_track_b_vllm_deployment.md
+++ b/docs/superpowers/reports/sprint10_track_b_vllm_deployment.md
@@ -1,0 +1,141 @@
+# Sprint-10 Track B — vLLM / qwen3.6:27b Deployment Guide
+
+**Date:** 2026-05-01
+**Status:** wiring infrastructure-ready; runtime validation requires hardware
+
+## TL;DR
+
+Sprint-10 Track B wires the **production LLM-Prior over a vLLM
+OpenAI-compat endpoint** into the PSE benchmark runner. The
+`DualPriorMixer` combines an `LLMPriorClient(VLLMBackend)` with a
+`UniformSymbolicPrior` and feeds the live α to the
+`WiredPhase2Engine`'s search loop.
+
+**The wiring is fully constructed and tested at module level.** What's
+missing is a *running* vLLM server with `Qwen/Qwen3.6-27B-Instruct`
+loaded — that requires a 32+ GB GPU (RTX 5090 / A100 / H100) and is
+out of scope for the autonomous-mode session.
+
+## CLI surface
+
+```
+python -m cognithor.channels.program_synthesis.synthesis.benchmark_runner \
+    --arc-corpus cognithor_bench/arc_agi3_real \
+    --arc-subset training \
+    --phase2 \
+    --llm-prior \
+    --llm-base-url http://localhost:8000/v1 \
+    --llm-model Qwen/Qwen3.6-27B-Instruct \
+    --output sprint10_track_b_training.json
+```
+
+Flags introduced this PR:
+
+- `--llm-prior` — opt-in switch. Without it, `--phase2` runs without an LLM (cold-start α, identical to pre-Track-B behaviour).
+- `--llm-base-url` — vLLM endpoint URL. Default `http://localhost:8000/v1`.
+- `--llm-model` — model name as registered with vLLM. Default `Qwen/Qwen3.6-27B-Instruct`.
+
+## Server-side deployment
+
+### Hardware
+
+- **Recommended**: NVIDIA RTX 5090 (32 GB VRAM), Linux, CUDA 12+
+- **Alternative**: A100 / H100 / multi-GPU
+- **Model VRAM** at FP16: ~54 GB (won't fit single 5090). Use a quantised build:
+  - **Q5_K_M (default)**: ~22 GB, strongly recommended
+  - **Q4_K_M (fallback)**: ~17 GB, smaller VRAM headroom
+
+### Install vLLM
+
+```bash
+pip install vllm==0.6.3
+# or build from source for cutting-edge model support
+```
+
+### Launch the server
+
+```bash
+# Q5_K_M quantisation (preferred):
+vllm serve Qwen/Qwen3.6-27B-Instruct \
+    --quantization awq \
+    --port 8000 \
+    --max-model-len 8192 \
+    --gpu-memory-utilization 0.92
+
+# Or Q4_K_M fallback for tighter VRAM:
+vllm serve Qwen/Qwen3.6-27B-Instruct-AWQ \
+    --quantization awq \
+    --port 8000 \
+    --max-model-len 4096 \
+    --gpu-memory-utilization 0.85
+```
+
+Verify:
+
+```bash
+curl http://localhost:8000/v1/models
+# expected: list with Qwen/Qwen3.6-27B-Instruct
+curl http://localhost:8000/health
+# expected: 200 OK
+```
+
+## Two-stage prompting (spec §4.7)
+
+The `LLMPriorClient` runs each task through:
+
+1. **Stage 1 — free-form CoT** at `temperature=0.7` to explore which DSL primitives might apply.
+2. **Stage 2 — constrained JSON** at `temperature=0.1` to extract a structured prior + α-entropy hint, with one retry on parse failure.
+
+The resulting `LLMPrior.primitive_scores` weights the candidate enumeration in the search engine. The `α-entropy hint` and the symbolic prior's confidence are mixed by `mix_alpha()` per spec §4.5.
+
+Per-call wall-clock cap: 8 s (`Phase2Config.llm_call_timeout_seconds`). On timeout / parse failure, the engine falls back to cold-start α (telemetry event `wired.alpha_fallback`).
+
+## Expected score-lift
+
+Sprint-9's reality-check estimated **+5-10 PP** from LLM-Prior wiring on the real fchollet/ARC-AGI training subset.
+
+Sprint-10 DSL (Wave-1+2+3+4) measured: **4.5 % → 7.5 %** (+3.0 PP, 30/400 training).
+
+Track B target: **7.5 % → 12-17 %** training (rough order-of-magnitude per Sprint-9 §"Sprint-10+ priorities" estimate).
+
+## Validation flow once vLLM is running
+
+```bash
+# Step 1: Without LLM-Prior (cold-start α) — should match the
+# committed .ci/arc_real_sprint10_*.json baselines.
+python -m cognithor.channels.program_synthesis.synthesis.benchmark_runner \
+    --arc-corpus cognithor_bench/arc_agi3_real \
+    --arc-subset training \
+    --phase2 \
+    --output baseline_no_llm.json
+
+# Step 2: With LLM-Prior — measure the lift.
+python -m cognithor.channels.program_synthesis.synthesis.benchmark_runner \
+    --arc-corpus cognithor_bench/arc_agi3_real \
+    --arc-subset training \
+    --phase2 \
+    --llm-prior \
+    --output baseline_with_llm.json
+
+# Step 3: diff success_rate fields.
+```
+
+A real lift (+3 PP or more) on training validates the wiring; a flat
+or negative result indicates the prompts need spec-§4.7-tuning
+against the chosen quantisation.
+
+## What this PR does NOT do
+
+- **Run the actual vLLM server.** The Track B PR is wiring + flags; the deployment is operator-side.
+- **Tune the prompts against quantisation drift.** Q4_K_M may degrade Stage-2 JSON parsing — measure first, then adjust if needed.
+- **Validate end-to-end score lift.** That happens in Sprint-11 once a vLLM instance is provisioned, OR can be run manually with this PR's flags and the documented deployment above.
+
+## Code references
+
+- Wiring helper: `_build_dual_prior_stack(base_url, model_name)` in `synthesis/benchmark_runner.py`
+- Engine integration: `_build_phase2_engine(dual_prior=...)` in same module
+- LLM client: `phase2/llm_prior.py::LLMPriorClient` (Sprint-1)
+- Mixer: `phase2/dual_prior.py::DualPriorMixer` (Sprint-1)
+- Backend: `core/vllm_backend.py::VLLMBackend`
+- Config defaults: `phase2/config.py::Phase2Config.llm_*`
+- Wiring tests: `tests/test_channels/test_program_synthesis/synthesis/test_track_b_llm_prior_wiring.py`

--- a/src/cognithor/channels/program_synthesis/synthesis/benchmark_runner.py
+++ b/src/cognithor/channels/program_synthesis/synthesis/benchmark_runner.py
@@ -116,7 +116,47 @@ def _build_phase1_engine(success_threshold: float) -> Phase2SynthesisEngine:
 # ---------------------------------------------------------------------------
 
 
-def _build_phase2_engine(*, refiner_min_score: float = 0.0) -> WiredPhase2Engine:
+def _build_dual_prior_stack(
+    *,
+    base_url: str,
+    model_name: str,
+) -> Any:
+    """Construct the production LLM-Prior stack: vLLM → LLMPriorClient → DualPriorMixer.
+
+    Sprint-10 Track B (Owner-Direktive 2026-05-01): wires the
+    `Qwen/Qwen3.6-27B-Instruct` LLM-Prior over a vLLM OpenAI-compat
+    endpoint into the Phase-2 search loop. The mixer combines the
+    LLM signal with the canonical `UniformSymbolicPrior` from Sprint-1
+    until a richer symbolic catalog lands.
+
+    Note: requires a vLLM server actually running with the named model.
+    Without one, the LLM-Prior calls will fail at first task and the
+    `WiredPhase2Engine` falls back to cold-start α (telemetry event
+    ``wired.alpha_fallback``). The wiring is correct either way.
+    """
+    from cognithor.channels.program_synthesis.phase2 import (
+        DualPriorMixer,
+        LLMPriorClient,
+        UniformSymbolicPrior,
+    )
+    from cognithor.channels.program_synthesis.phase2.config import Phase2Config
+    from cognithor.core.vllm_backend import VLLMBackend
+
+    backend = VLLMBackend(base_url=base_url)
+    config = Phase2Config(
+        llm_base_url=base_url,
+        llm_model_name=model_name,
+    )
+    llm_client = LLMPriorClient(backend, config=config)
+    symbolic = UniformSymbolicPrior(config=config)
+    return DualPriorMixer(llm_client, symbolic, config=config)
+
+
+def _build_phase2_engine(
+    *,
+    refiner_min_score: float = 0.0,
+    dual_prior: Any = None,
+) -> WiredPhase2Engine:
     """Build a :class:`WiredPhase2Engine` with the full Sprint-2 stack.
 
     The wiring:
@@ -199,7 +239,7 @@ def _build_phase2_engine(*, refiner_min_score: float = 0.0) -> WiredPhase2Engine
 
     return WiredPhase2Engine(
         phase1_search=phase1_search,
-        dual_prior=None,
+        dual_prior=dual_prior,
         refiner=refiner,
         verifier=evaluator,
         refiner_min_score=refiner_min_score,
@@ -216,9 +256,13 @@ async def _run_phase2_benchmark(
     success_threshold: float,
     *,
     refiner_min_score: float = 0.0,
+    dual_prior: Any = None,
 ) -> BenchmarkSummary:
     """Run the Phase-2 wired engine over every task; aggregate results."""
-    engine = _build_phase2_engine(refiner_min_score=refiner_min_score)
+    engine = _build_phase2_engine(
+        refiner_min_score=refiner_min_score,
+        dual_prior=dual_prior,
+    )
     rows: list[BenchmarkTaskResult] = []
     errors: list[tuple[str, str]] = []
     for task in tasks:
@@ -326,12 +370,20 @@ async def _run_benchmark_async(args: argparse.Namespace) -> int:
         )
         corpus_label = "leak_free"
     if args.phase2:
+        dual_prior = None
+        engine_label = "phase2_wired"
+        if args.llm_prior:
+            dual_prior = _build_dual_prior_stack(
+                base_url=args.llm_base_url,
+                model_name=args.llm_model,
+            )
+            engine_label = f"phase2_wired_llm_prior({args.llm_model})"
         summary = await _run_phase2_benchmark(
             tasks,
             args.success_threshold,
             refiner_min_score=args.refiner_min_score,
+            dual_prior=dual_prior,
         )
-        engine_label = "phase2_wired"
     else:
         engine = _build_phase1_engine(args.success_threshold)
         summary = await run_benchmark(engine, tasks, success_threshold=args.success_threshold)
@@ -470,6 +522,33 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
             "Minimum Phase-1 score that triggers refinement (default: 0.0 — "
             "always refine PARTIAL results; raise to e.g. 0.3 to mimic the "
             "spec §6.6 default)."
+        ),
+    )
+    parser.add_argument(
+        "--llm-prior",
+        action="store_true",
+        default=False,
+        help=(
+            "Sprint-10 Track B: wire the LLM-Prior over a vLLM OpenAI-"
+            "compat endpoint via DualPriorMixer. Requires --phase2. "
+            "Defaults to qwen3.6:27b at http://localhost:8000/v1; "
+            "override via --llm-base-url and --llm-model. Without a "
+            "running vLLM server the LLM call falls back to cold-start alpha."
+        ),
+    )
+    parser.add_argument(
+        "--llm-base-url",
+        type=str,
+        default="http://localhost:8000/v1",
+        help="vLLM OpenAI-compat endpoint URL (default: http://localhost:8000/v1).",
+    )
+    parser.add_argument(
+        "--llm-model",
+        type=str,
+        default="Qwen/Qwen3.6-27B-Instruct",
+        help=(
+            "LLM model name as registered with the vLLM server "
+            "(default: Qwen/Qwen3.6-27B-Instruct)."
         ),
     )
     return parser.parse_args(argv)

--- a/tests/test_channels/test_program_synthesis/synthesis/test_track_b_llm_prior_wiring.py
+++ b/tests/test_channels/test_program_synthesis/synthesis/test_track_b_llm_prior_wiring.py
@@ -1,0 +1,93 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-10 Track B — LLM-Prior wiring smoke tests.
+
+Validates that the benchmark runner constructs the production
+LLM-Prior stack (vLLM → LLMPriorClient → DualPriorMixer) without
+requiring a running vLLM server. Runtime correctness against an
+actual qwen3.6:27b instance is out of scope for unit tests — this
+module proves the wiring is *constructable* and that the CLI flags
+parse and reach the engine.
+"""
+
+from __future__ import annotations
+
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+from cognithor.channels.program_synthesis.synthesis.benchmark_runner import (
+    _build_dual_prior_stack,
+    _build_phase2_engine,
+    _parse_args,
+)
+
+
+class TestDualPriorStackConstruction:
+    def test_constructs_with_default_qwen_endpoint(self) -> None:
+        # Default vLLM endpoint + qwen3.6:27b. No actual call is made.
+        mixer = _build_dual_prior_stack(
+            base_url="http://localhost:8000/v1",
+            model_name="Qwen/Qwen3.6-27B-Instruct",
+        )
+        # Mixer wraps an LLMPriorClient + UniformSymbolicPrior; both
+        # private but we can check it's the right class.
+        from cognithor.channels.program_synthesis.phase2 import DualPriorMixer
+
+        assert isinstance(mixer, DualPriorMixer)
+
+    def test_constructs_with_alternate_endpoint(self) -> None:
+        mixer = _build_dual_prior_stack(
+            base_url="http://gpu-host:9000/v1",
+            model_name="Qwen/Qwen3.6-27B-Instruct-AWQ",
+        )
+        from cognithor.channels.program_synthesis.phase2 import DualPriorMixer
+
+        assert isinstance(mixer, DualPriorMixer)
+
+
+class TestPhase2EngineAcceptsDualPrior:
+    def test_engine_built_with_dual_prior(self) -> None:
+        mixer = _build_dual_prior_stack(
+            base_url="http://localhost:8000/v1",
+            model_name="Qwen/Qwen3.6-27B-Instruct",
+        )
+        engine = _build_phase2_engine(dual_prior=mixer)
+        # WiredPhase2Engine — exact class assertion via private attr.
+        assert engine._dual_prior is mixer  # type: ignore[attr-defined]
+
+    def test_engine_built_without_dual_prior_defaults_to_none(self) -> None:
+        engine = _build_phase2_engine()
+        assert engine._dual_prior is None  # type: ignore[attr-defined]
+
+
+class TestCLIFlags:
+    def test_default_flags(self) -> None:
+        args = _parse_args(["--output", "out.json"])
+        assert args.llm_prior is False
+        assert args.llm_base_url == "http://localhost:8000/v1"
+        assert args.llm_model == "Qwen/Qwen3.6-27B-Instruct"
+
+    def test_llm_prior_flag(self) -> None:
+        args = _parse_args(
+            [
+                "--output",
+                "out.json",
+                "--phase2",
+                "--llm-prior",
+            ]
+        )
+        assert args.llm_prior is True
+        assert args.phase2 is True
+
+    def test_llm_endpoint_override(self) -> None:
+        args = _parse_args(
+            [
+                "--output",
+                "out.json",
+                "--llm-base-url",
+                "http://gpu-host:9000/v1",
+                "--llm-model",
+                "Qwen/Qwen3.6-27B-Instruct-AWQ",
+            ]
+        )
+        assert args.llm_base_url == "http://gpu-host:9000/v1"
+        assert args.llm_model == "Qwen/Qwen3.6-27B-Instruct-AWQ"


### PR DESCRIPTION
## Summary

Sprint-10 Track B (Owner-Direktive 2026-05-01: \"vllm backend mit modell qwen3.6:27b nutzen\"). Wires the production LLM-Prior over a vLLM OpenAI-compat endpoint into the PSE benchmark runner.

## What's added

- **`_build_dual_prior_stack(base_url, model_name)`** helper in `benchmark_runner.py`: `VLLMBackend → LLMPriorClient → UniformSymbolicPrior → DualPriorMixer`
- **`_build_phase2_engine(dual_prior=...)`** accepts the mixer and passes it to `WiredPhase2Engine`
- **3 new CLI flags** on the benchmark runner:
  - `--llm-prior` — opt-in switch (requires `--phase2`)
  - `--llm-base-url URL` — vLLM endpoint, default `http://localhost:8000/v1`
  - `--llm-model NAME` — model name, default `Qwen/Qwen3.6-27B-Instruct`
- **7 new wiring tests** proving the stack constructs cleanly without a running vLLM
- **Deployment guide** at `docs/superpowers/reports/sprint10_track_b_vllm_deployment.md` (vLLM install, server launch, validation flow, expected score-lift, hardware reqs)

## What's NOT in this PR (out of autonomous-mode scope)

- A running vLLM server with qwen3.6:27b loaded — needs RTX 5090 / A100 + ~22 GB VRAM at Q5_K_M
- End-to-end real-ARC score-lift validation
- Prompt tuning against Q4_K_M/Q5_K_M quantisation drift

Without a running vLLM, `--llm-prior` triggers a call that fails at first task and the engine falls back to cold-start α (telemetry: `wired.alpha_fallback`). **The wiring is correct either way — it's hardware-gated, not code-gated.**

## Reproduction once vLLM is running

```bash
# Start the vLLM server (operator-side):
vllm serve Qwen/Qwen3.6-27B-Instruct --quantization awq --port 8000

# Without LLM-Prior — should match committed .ci/arc_real_sprint10_*.json:
python -m cognithor.channels.program_synthesis.synthesis.benchmark_runner \
    --arc-corpus cognithor_bench/arc_agi3_real --arc-subset training \
    --phase2 --output baseline_no_llm.json

# With LLM-Prior:
python -m cognithor.channels.program_synthesis.synthesis.benchmark_runner \
    --arc-corpus cognithor_bench/arc_agi3_real --arc-subset training \
    --phase2 --llm-prior --output baseline_with_llm.json
```

## Sprint-10 cumulative status (with this PR)

| Track | What | Real-ARC training |
|---|---|---|
| DSL Wave 1-4 | 10 new primitives (#274–#280) | 4.5 % → **7.5 %** measured |
| **Track B (this)** | LLM-Prior wiring + flags | requires vLLM hardware |
| **Target** combined | once vLLM/qwen3.6:27b runs | **12-17 %** per Sprint-9 estimate |

## Test plan
- [x] 7/7 new wiring tests pass — `_build_dual_prior_stack` constructs both endpoints, `_build_phase2_engine(dual_prior=mixer)` accepts mixer, all 3 CLI flags parse correctly
- [x] Full PSE suite: 1464 passed, 10 skipped — no regressions
- [x] `ruff check` + `ruff format --check` clean
- [x] Branch on top of main post-#280

🤖 Generated with [Claude Code](https://claude.com/claude-code)