### PR TITLE
feat(pse): Sprint-11 Wave-1 — ARC-AGI-3 Game-Agent foundation

### DIFF
--- a/docs/channels/program_synthesis/arc_agi3.md
+++ b/docs/channels/program_synthesis/arc_agi3.md
@@ -1,0 +1,91 @@
+# Cognithor PSE — ARC-AGI-3 Game-Agent Integration
+
+**Sprint-11 (started 2026-05-02), Wave-1 foundation.**
+
+ARC-AGI-3 is the interactive-game successor to the static input/output ARC-AGI-1 benchmark Cognithor's PSE channel covered through Sprint-10. ARC-AGI-3 puts the agent in a **game loop**: per frame, the agent reads a `FrameData` (multi-layer grid + state + available actions) and emits a `GameAction`, until the level is won or the action budget runs out.
+
+This page documents the Cognithor side of the integration. The official harness lives at [`arcprize/ARC-AGI-3-Agents`](https://github.com/arcprize/ARC-AGI-3-Agents) (MIT).
+
+## Architecture
+
+```
+Official ARC-AGI-3-Agents harness
+            │
+            ├─ Agent ABC (is_done, choose_action)
+            │
+            └─ Cognithor's CognithorPSEAgent subclass
+                       │
+                       ├─ FrameBridge      (Wave-2)  — FrameData → Cognithor Grid
+                       ├─ Phase-1 search   (Sprint-10 DSL, 76 primitives)
+                       ├─ ActionDecoder    (Wave-2)  — Programm → GameAction
+                       └─ vLLM/qwen3.6:27b (Wave-4)  — Stage-1+2 reasoning per frame
+```
+
+## Wave-1 surface (this PR)
+
+`src/cognithor/channels/program_synthesis/arc_agi3/`:
+
+- `protocol.py` — `FrameDataProtocol`, `GameActionProtocol`, `GameStateProtocol`. Mirror the upstream `arcengine` API surface as of ARC-AGI-3-Agents 0.9.3 (post-2026-01-29 field rename: `score`→`levels_completed`, `win_score`→`win_levels`).
+- `agent.py` — `CognithorPSEAgent` ABC + `RandomActionAgent` smoke baseline.
+
+Cognithor's code is typed against the local `Protocol`s, not directly against `arcengine`. The package imports cleanly without `arc-agi`/`arcengine` installed; a Wave-5 thin adapter (`arcengine_adapter.py`) plugs in the live types when running against the official harness.
+
+## How to run inside the official harness
+
+Once you have a clone of `arcprize/ARC-AGI-3-Agents` set up per its quickstart:
+
+```bash
+# 1. Install Cognithor as an editable dep in the harness venv:
+cd /path/to/ARC-AGI-3-Agents
+uv pip install -e /path/to/cognithor
+
+# 2. Drop a thin shim into agents/templates/cognithor_agent.py:
+```
+
+```python
+# agents/templates/cognithor_agent.py
+from typing import Any
+from arcengine import GameAction, FrameData
+from agents.agent import Agent  # the official harness ABC
+
+from cognithor.channels.program_synthesis.arc_agi3 import RandomActionAgent
+
+
+class CognithorRandom(Agent):
+    """Wave-1 smoke baseline — uniform random over available actions."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self._delegate = RandomActionAgent()
+
+    def is_done(self, frames: list[FrameData], latest_frame: FrameData) -> bool:
+        return self._delegate.is_done(frames, latest_frame)
+
+    def choose_action(self, frames: list[FrameData], latest_frame: FrameData) -> GameAction:
+        return self._delegate.choose_action(frames, latest_frame)
+```
+
+```bash
+# 3. Register the agent in agents/__init__.py's AVAILABLE_AGENTS dict.
+
+# 4. Run against a game:
+uv run main.py --agent=cognithor_random --game=ls20
+```
+
+The `RandomActionAgent` is a lower-bound score — anything below it is broken, anything above it starts measuring real ability. Subsequent waves replace it with DSL-driven and LLM-driven agents.
+
+## Subsequent waves
+
+| Wave | PR | Adds |
+|---|---|---|
+| 1 (this) | foundation | Protocol + ABC + RandomActionAgent |
+| 2 | bridge | `FrameBridge` (FrameData → Grid) + `ActionDecoder` (Programm → Action) |
+| 3 | DSL search | `Sprint10DSLAgent` — Phase-1 search per frame, 76 Sprint-10 primitives |
+| 4 | LLM reasoning | `LLMReasoningAgent` over vLLM/qwen3.6:27b — Stage-1+2 per frame |
+| 5 | live validation | `arcengine_adapter` + scorecards against `https://three.arcprize.org/` |
+
+## See also
+
+- Sprint-11 spec: `docs/superpowers/specs/2026-05-02-sprint11-arc-agi-3-foundation.md`
+- Sprint-10 closure: `project_pse_phase2_sprint10_complete.md` (memory)
+- Sprint-9 reality-check: `docs/superpowers/reports/sprint9_real_arc_findings.md`

--- a/docs/superpowers/specs/2026-05-02-sprint11-arc-agi-3-foundation.md
+++ b/docs/superpowers/specs/2026-05-02-sprint11-arc-agi-3-foundation.md
@@ -1,0 +1,123 @@
+# Sprint-11 — ARC-AGI-3 Game-Agent Foundation
+
+**Date:** 2026-05-02
+**Owner-Direktive:** "sprint 11 go" (nach "erst sprint 10 abschliessen dann auf offizielle aktuelle arc agi 3 umbauen")
+**Builds on:** Sprint-10 closed (main HEAD `5d99560a`)
+
+## Was ARC-AGI-3 tatsächlich ist
+
+ARC-AGI-3 ist **kein statischer Grid-Korpus** wie ARC-AGI-1/2 — es ist eine **interaktive Game-Challenge**:
+
+- Repo: `arcprize/ARC-AGI-3-Agents` (MIT)
+- Pakete: `arc-agi>=0.9.1` (Environment-Wrapper) und `arcengine` (FrameData / GameAction / GameState)
+- Online-API: `https://three.arcprize.org/` (braucht `ARC_API_KEY`)
+- Offline-Mode: `arc-agi` Package erlaubt lokale Game-Execution (seit 0.9.3)
+- Agent-ABC: `is_done(frames, latest_frame) -> bool` + `choose_action(frames, latest_frame) -> GameAction`
+- MAX_ACTIONS = 80 pro Game
+- States: `NOT_PLAYED`, `WIN`, `GAME_OVER`, etc.
+- Actions: `RESET`, `ACTION1..ACTION7` (manche `is_simple()`, manche `is_complex()` mit `set_data()`)
+
+## Was sich gegenüber ARC-AGI-1 fundamental ändert
+
+| Aspekt | ARC-AGI-1 (unser Sprint-10) | ARC-AGI-3 |
+|---|---|---|
+| Format | Statisches Input/Output-Mapping | Interaktive Game-Loop |
+| Eingang | `examples: list[(input, output)]` Demos | `frames: list[FrameData]` Episode |
+| Antwort | Programm das Output produziert | Sequenz von `GameAction` |
+| Bewertung | Exakte Grid-Gleichheit | `levels_completed / win_levels` Score |
+| Suchraum | Phase-1 Programmenumeration | Game-Tree (depth = bis 80 actions) |
+| LLM-Rolle | Prior für Programm-Synthesis | Action-Auswahl pro Frame |
+
+## Architektur-Strategie für Cognithor
+
+**Insight:** Sprint-10's Phase-1-DSL bleibt nutzbar als **Frame-Transformations-Library**. Sie wird nicht das Top-Level mehr — sondern ein Werkzeug, das pro Frame die nächste sinnvolle Action vorschlägt.
+
+```
+ARC-AGI-3 FrameData  ─→ FrameBridge ─→ Phase-1 Spec
+                                          ↓
+                                    EnumerativeSearch
+                                    (mit Sprint-10 DSL)
+                                          ↓
+                                       Programm
+                                          ↓
+                                  ActionDecoder
+                                          ↓
+                                     GameAction
+```
+
+Plus eine Episode-State-Schicht:
+```
+Episode-Memory (alle bisherigen Frames + ihre Programme)
+               ↓
+         ProgressDetector  (sind wir näher am Goal?)
+               ↓
+         BacktrackPolicy   (RESET wenn stuck?)
+```
+
+## Sprint-11 Wave-Plan
+
+**Wave-1 (foundation, this PR):** Skelett ohne Drittanbieter-Abhängigkeit
+- Protocol-Klassen die `FrameData` / `GameAction` / `GameState` API spiegeln
+- Abstrakter `CognithorPSEAgent` mit `is_done()` + `choose_action()`
+- Dummy `RandomActionAgent` als Smoke-Baseline
+- Unit-Tests dass Protocol + Action-Selection funktioniert
+- README erklärt, wie man unseren Code in den offiziellen Harness plugged
+
+**Wave-2 (bridge):** Frame → DSL Bridge
+- `FrameBridge`: FrameData.frame → Cognithor Grid-Tensor (np.int8)
+- `ActionDecoder`: DSL-Programm-Output → GameAction (mit Heuristiken für ACTION1..7)
+- Tests gegen synthetische Frame-Sequenzen
+
+**Wave-3 (search):** Phase-1-DSL als Frame-Transformer
+- `Sprint10DSLAgent`: nutzt EnumerativeSearch um pro Frame eine Transformation zu finden, dann Action ableiten
+- Episode-State: track which actions wurden bisher probiert, vermeide Loops
+- Tests an offline arc-agi-3 environments (wenn Hardware vorhanden)
+
+**Wave-4 (LLM-driven):** vLLM-qwen3.6:27b im Action-Loop
+- `LLMReasoningAgent`: Pro Frame Stage-1 (free-form) + Stage-2 (constrained Action JSON)
+- Reused: Sprint-10 Track B vLLM-Backend
+- Telemetry: Action-Latency P50/P95
+
+**Wave-5 (validation):** Live ARC-AGI-3 Score
+- Cognithor against `https://three.arcprize.org/` API
+- Frozen Score-Baselines pro Game-ID
+- v0.97.0 Release
+
+## Sprint-11 PR-1 Scope (this PR)
+
+Ziel: Eine **klar definierte API-Surface** auf der nachfolgende Wellen aufbauen, **ohne** sofort die Drittanbieter-Pakete `arc-agi` und `arcengine` als harte Abhängigkeit zu erzwingen.
+
+Konkret:
+
+1. **`src/cognithor/channels/program_synthesis/arc_agi3/protocol.py`** — Protocol-Klassen die exakt das API-Surface von `arcengine.FrameData` / `arcengine.GameAction` / `arcengine.GameState` spiegeln. Cognithor's eigene Code ist gegen diese Protocols typed; eine spätere Wave fügt einen `arcengine`-Adapter hinzu.
+
+2. **`src/cognithor/channels/program_synthesis/arc_agi3/agent.py`** — `CognithorPSEAgent(ABC)` mit denselben zwei Abstract-Methods wie der offizielle ABC (`is_done`, `choose_action`). Plus eine concrete `RandomActionAgent` für Smoke-Tests.
+
+3. **`tests/test_channels/test_program_synthesis/arc_agi3/test_protocol.py`** — Unit-Tests die Protocol-Konformität prüfen.
+
+4. **`tests/test_channels/test_program_synthesis/arc_agi3/test_random_agent.py`** — Smoke-Test: RandomActionAgent läuft eine Mock-Episode bis WIN.
+
+5. **`docs/channels/program_synthesis/arc_agi3.md`** — Channel-Doc, wie man Cognithor's PSE in den offiziellen `ARC-AGI-3-Agents` Harness plugged.
+
+**Nicht in PR-1:** keine arc-agi/arcengine pip-Dependency, kein Live-API-Call, keine echte DSL-Integration (kommt in Wave-2/3).
+
+## Akzeptanz-Kriterien
+
+- [x] Protocol-Klassen klar dokumentiert mit der exakten Field-Liste vom offiziellen ABC
+- [x] `CognithorPSEAgent` ABC kann ohne arc-agi installiert importiert werden
+- [x] `RandomActionAgent` läuft gegen Mock-Frames bis Episode-Ende
+- [x] mypy --strict clean auf den neuen Files
+- [x] ruff check + ruff format clean
+- [x] keine Regressions in der bestehenden 1464-Test-PSE-Suite
+
+## Production-Ready-Pfad
+
+1. PR-1 (this) — Foundation
+2. PR-2 — `FrameBridge` + `ActionDecoder` (Wave-2)
+3. PR-3 — `Sprint10DSLAgent` mit Phase-1-Search im Loop (Wave-3)
+4. PR-4 — `LLMReasoningAgent` mit qwen3.6:27b (Wave-4)
+5. PR-5 — `arcengine`-Adapter + Live-API-Smoke-Tests (Wave-5)
+6. PR-6 — Frozen Score-Baselines pro Game-ID (Wave-5)
+7. v0.97.0 Release mit Sprint-11-Inhalt
+
+Sprint-11-Gesamtdauer geschätzt: 5-7 Tage Entwickler-Zeit pro Wave (parallelisierbar zwischen DSL- und LLM-Tracks).

--- a/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
@@ -1,0 +1,40 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Cognithor PSE — ARC-AGI-3 Game-Agent integration (Sprint-11).
+
+ARC-AGI-3 is the interactive-game successor to the static
+input/output ARC-AGI-1 benchmark we covered in Sprint-9/10. This
+sub-package is the Cognithor side of the integration: protocol
+classes that mirror the official ``arcengine`` API surface, an
+abstract :class:`CognithorPSEAgent` that subclasses the official
+``Agent`` ABC contract, and concrete agents that build on the
+Sprint-10 DSL + the Sprint-1 LLM-Prior.
+
+Wave-1 (foundation) ships protocol + abstract base + a smoke-baseline
+``RandomActionAgent``. Subsequent waves (PR-2..6) add the
+:class:`FrameBridge`, :class:`ActionDecoder`, the DSL-search agent,
+and the LLM-reasoning agent.
+
+Cognithor's code is typed against the local :mod:`.protocol` types,
+not directly against ``arcengine`` — so the package imports cleanly
+without ``arc-agi``/``arcengine`` installed. A thin adapter (Wave-5)
+plugs in the live arcengine types when running against the official
+harness.
+"""
+
+from cognithor.channels.program_synthesis.arc_agi3.agent import (
+    CognithorPSEAgent,
+    RandomActionAgent,
+)
+from cognithor.channels.program_synthesis.arc_agi3.protocol import (
+    FrameDataProtocol,
+    GameActionProtocol,
+    GameStateProtocol,
+)
+
+__all__ = [
+    "CognithorPSEAgent",
+    "FrameDataProtocol",
+    "GameActionProtocol",
+    "GameStateProtocol",
+    "RandomActionAgent",
+]

--- a/src/cognithor/channels/program_synthesis/arc_agi3/agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/agent.py
@@ -1,0 +1,132 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 — Cognithor PSE agent base + smoke-baseline.
+
+:class:`CognithorPSEAgent` is the abstract base every Cognithor
+ARC-AGI-3 agent inherits from. It mirrors the upstream
+``arcprize.ARC-AGI-3-Agents.agents.Agent`` ABC contract: two abstract
+methods ``is_done`` and ``choose_action``.
+
+When running inside the official harness the upstream wrapper calls
+:meth:`is_done` after every frame and :meth:`choose_action` to get
+the next move; Cognithor's only contract with the harness is that
+these two methods return the right types.
+
+This module deliberately has **no dependency on arc-agi or
+arcengine** — Cognithor's :class:`CognithorPSEAgent` is a thin local
+abstraction that the Wave-5 :mod:`arcengine_adapter` plugs into the
+real harness. That keeps the import graph clean for the 90 % of
+Cognithor that doesn't care about ARC-AGI-3.
+
+:class:`RandomActionAgent` is a concrete smoke-baseline that picks a
+uniformly random action per frame. It exists so that Wave-1 has at
+least one runnable agent; Wave-3 ships the real :class:`Sprint10DSLAgent`.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import random
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.arc_agi3.protocol import (
+        FrameDataProtocol,
+        GameActionProtocol,
+    )
+
+
+class CognithorPSEAgent(ABC):
+    """Abstract base for every Cognithor PSE agent that plays ARC-AGI-3.
+
+    Subclass contract:
+
+    * :meth:`is_done` — given the full episode history and the latest
+      frame, decide whether to stop. The official harness calls this
+      every iteration; returning True ends the game.
+    * :meth:`choose_action` — return the next :class:`GameActionProtocol`
+      to send to the game.
+
+    The base class is otherwise empty by design — the official
+    upstream :class:`Agent` ABC owns the game-loop, recording, and
+    network glue. Cognithor's job is just the two pure decisions.
+    """
+
+    @abstractmethod
+    def is_done(
+        self,
+        frames: list[FrameDataProtocol],
+        latest_frame: FrameDataProtocol,
+    ) -> bool:
+        """Return True to stop the episode.
+
+        Cognithor's default policy is: stop on WIN. The harness has
+        its own MAX_ACTIONS guard, so we don't need a separate timeout
+        here. Subclasses may override to also stop on GAME_OVER (e.g.
+        for one-shot evaluation runs).
+        """
+
+    @abstractmethod
+    def choose_action(
+        self,
+        frames: list[FrameDataProtocol],
+        latest_frame: FrameDataProtocol,
+    ) -> GameActionProtocol:
+        """Return the next action to send to the game.
+
+        Must respect ``latest_frame.available_actions`` — picking an
+        action outside that whitelist is undefined behaviour
+        upstream. Implementations should set ``action.reasoning`` to
+        a short natural-language string (used by the recorder).
+        """
+
+
+class RandomActionAgent(CognithorPSEAgent):
+    """Smoke-baseline: picks one of the available actions at random.
+
+    Sprint-11 Wave-1's only concrete agent. Useful for:
+
+    * proving the :class:`CognithorPSEAgent` ABC contract is sound;
+    * smoke-testing the frame ↔ action plumbing once Wave-2 lands;
+    * a lower-bound score on each ARC-AGI-3 game (anything below
+      this is broken, anything above starts measuring real ability).
+
+    The agent stops on WIN. It does *not* RESET on GAME_OVER —
+    Cognithor's evaluation runs are one-shot per game, not retry
+    loops. (Subclasses can override :meth:`is_done` to keep playing.)
+    """
+
+    def __init__(self, seed: int | None = None) -> None:
+        self._rng = random.Random(seed)
+
+    def is_done(
+        self,
+        frames: list[FrameDataProtocol],
+        latest_frame: FrameDataProtocol,
+    ) -> bool:
+        return latest_frame.state.name in {"WIN", "GAME_OVER"}
+
+    def choose_action(
+        self,
+        frames: list[FrameDataProtocol],
+        latest_frame: FrameDataProtocol,
+    ) -> GameActionProtocol:
+        actions = list(latest_frame.available_actions)
+        if not actions:
+            raise RuntimeError(
+                f"RandomActionAgent: latest frame for {latest_frame.game_id!r} "
+                "has no available_actions; cannot pick a move."
+            )
+        choice = self._rng.choice(actions)
+        # The harness reads `reasoning` from the action object before
+        # transmitting it. Some stub implementations may make the field
+        # read-only; the harness still works without it set.
+        with contextlib.suppress(AttributeError):
+            choice.reasoning = "RandomActionAgent: uniform random over available actions"
+        return choice
+
+
+__all__ = [
+    "CognithorPSEAgent",
+    "RandomActionAgent",
+]

--- a/src/cognithor/channels/program_synthesis/arc_agi3/protocol.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/protocol.py
@@ -1,0 +1,105 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 — Protocol classes that mirror the official ARC-AGI-3 API.
+
+These :class:`Protocol` definitions describe the exact fields
+Cognithor's PSE agents read from / write to when running inside the
+official ``arcprize/ARC-AGI-3-Agents`` harness. They are intentionally
+duck-typed: any object with the right attributes satisfies the
+protocol, so ``arcengine.FrameData`` / ``arcengine.GameAction`` /
+``arcengine.GameState`` (the real types) can be passed in without an
+explicit adapter.
+
+The protocols mirror the upstream ``arcengine`` package as of
+ARC-AGI-3-Agents 0.9.3 (2026-01-29). Field changes:
+
+* ``score`` → ``levels_completed``
+* ``win_score`` → ``win_levels``
+
+Cognithor sticks to the post-0.9.3 names. Older 0.9.1 / 0.9.2 frames
+won't satisfy the protocol; the Wave-5 adapter can normalise if
+needed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+@runtime_checkable
+class GameStateProtocol(Protocol):
+    """Subset of ``arcengine.GameState`` that Cognithor agents read.
+
+    GameState is an enum upstream; the protocol only needs the
+    ``name`` accessor and equality semantics. Cognithor compares
+    against string literals (``"WIN"``, ``"GAME_OVER"``,
+    ``"NOT_PLAYED"``, ``"NOT_FINISHED"``) rather than importing the
+    enum, so the agent code remains import-clean.
+    """
+
+    @property
+    def name(self) -> str:  # pragma: no cover — Protocol body
+        ...
+
+
+@runtime_checkable
+class GameActionProtocol(Protocol):
+    """Subset of ``arcengine.GameAction`` that Cognithor agents emit.
+
+    Upstream ``GameAction`` is an enum with members ``RESET``,
+    ``ACTION1``..``ACTION7``. ``is_simple()`` returns True for
+    parameter-less actions (RESET, ACTION1..ACTION5); ``is_complex()``
+    returns True for actions that need ``set_data({"x": .., "y": ..})``
+    (ACTION6, ACTION7). The ``reasoning`` field carries the agent's
+    natural-language justification.
+
+    Cognithor's :class:`ActionDecoder` (Wave-2) emits objects that
+    satisfy this protocol — either real ``arcengine.GameAction``
+    instances when running inside the official harness, or
+    plain :class:`dataclass`-style stubs in unit tests.
+    """
+
+    name: str
+    value: int
+    reasoning: str
+
+    def is_simple(self) -> bool: ...
+    def is_complex(self) -> bool: ...
+    def set_data(self, data: dict[str, Any]) -> None: ...
+
+
+@runtime_checkable
+class FrameDataProtocol(Protocol):
+    """Subset of ``arcengine.FrameData`` that Cognithor agents read.
+
+    ``frame`` is a list of 2-D grids (one per "layer" / channel,
+    typically length 1 for the visible play-field but sometimes >1 for
+    games with multiple semantic planes). Each grid is upstream a
+    ``numpy.ndarray`` of shape ``(H, W)`` with int values 0..15
+    (ARC-AGI-3 uses a 16-colour palette, wider than ARC-AGI-1's 0..9).
+
+    Cognithor's :class:`FrameBridge` (Wave-2) selects the relevant
+    layer, clamps to the Phase-1 ``int8 [0..9]`` range or extends
+    Phase-1 to the wider palette (Wave-2 design decision).
+
+    ``available_actions`` is the per-frame whitelist of allowed
+    GameActions (Sprint-11 prereq for action enumeration).
+    """
+
+    game_id: str
+    state: GameStateProtocol
+    levels_completed: int
+    win_levels: int
+    guid: str
+    full_reset: bool
+    frame: Sequence[Any]  # list[NDArray] upstream, opaque to Cognithor
+    available_actions: Sequence[GameActionProtocol]
+
+
+__all__ = [
+    "FrameDataProtocol",
+    "GameActionProtocol",
+    "GameStateProtocol",
+]

--- a/tests/test_channels/test_program_synthesis/arc_agi3/__init__.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/__init__.py
@@ -1,0 +1,1 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_protocol.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_protocol.py
@@ -1,0 +1,92 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 Wave-1 — Protocol-conformance tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from cognithor.channels.program_synthesis.arc_agi3.protocol import (
+    FrameDataProtocol,
+    GameActionProtocol,
+    GameStateProtocol,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+@dataclass
+class _StubGameState:
+    name: str
+
+
+@dataclass
+class _StubGameAction:
+    name: str
+    value: int
+    reasoning: str = ""
+    _data: dict[str, Any] = field(default_factory=dict)
+    _is_simple: bool = True
+
+    def is_simple(self) -> bool:
+        return self._is_simple
+
+    def is_complex(self) -> bool:
+        return not self._is_simple
+
+    def set_data(self, data: dict[str, Any]) -> None:
+        self._data = dict(data)
+
+
+@dataclass
+class _StubFrameData:
+    game_id: str
+    state: _StubGameState
+    levels_completed: int
+    win_levels: int
+    guid: str
+    full_reset: bool
+    frame: list[Any]
+    available_actions: list[_StubGameAction]
+
+
+class TestProtocolConformance:
+    def test_stub_state_satisfies_protocol(self) -> None:
+        s = _StubGameState(name="WIN")
+        assert isinstance(s, GameStateProtocol)
+        assert s.name == "WIN"
+
+    def test_stub_action_satisfies_protocol(self) -> None:
+        a = _StubGameAction(name="ACTION1", value=1, reasoning="test")
+        assert isinstance(a, GameActionProtocol)
+        assert a.is_simple() is True
+        assert a.is_complex() is False
+        a.set_data({"x": 1})
+        assert a._data == {"x": 1}
+
+    def test_stub_frame_satisfies_protocol(self) -> None:
+        f = _StubFrameData(
+            game_id="ls20",
+            state=_StubGameState(name="NOT_FINISHED"),
+            levels_completed=0,
+            win_levels=3,
+            guid="test-guid",
+            full_reset=False,
+            frame=[[[0, 1], [2, 3]]],
+            available_actions=[
+                _StubGameAction(name="ACTION1", value=1),
+                _StubGameAction(name="RESET", value=0),
+            ],
+        )
+        assert isinstance(f, FrameDataProtocol)
+        assert f.game_id == "ls20"
+        assert f.state.name == "NOT_FINISHED"
+        assert len(f.available_actions) == 2
+
+    def test_complex_action_set_data_idempotent(self) -> None:
+        a = _StubGameAction(name="ACTION6", value=6, _is_simple=False)
+        a.set_data({"x": 5, "y": 7})
+        assert a.is_complex() is True
+        a.set_data({"x": 0, "y": 0})
+        assert a._data == {"x": 0, "y": 0}

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_random_agent.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_random_agent.py
@@ -1,0 +1,166 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 Wave-1 — RandomActionAgent smoke test."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from cognithor.channels.program_synthesis.arc_agi3.agent import (
+    CognithorPSEAgent,
+    RandomActionAgent,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+@dataclass
+class _StubGameState:
+    name: str
+
+
+@dataclass
+class _StubGameAction:
+    name: str
+    value: int
+    reasoning: str = ""
+    _data: dict[str, Any] = field(default_factory=dict)
+
+    def is_simple(self) -> bool:
+        return True
+
+    def is_complex(self) -> bool:
+        return False
+
+    def set_data(self, data: dict[str, Any]) -> None:
+        self._data = dict(data)
+
+
+@dataclass
+class _StubFrameData:
+    game_id: str
+    state: _StubGameState
+    levels_completed: int = 0
+    win_levels: int = 1
+    guid: str = ""
+    full_reset: bool = False
+    frame: list[Any] = field(default_factory=list)
+    available_actions: list[_StubGameAction] = field(default_factory=list)
+
+
+def _make_actions() -> list[_StubGameAction]:
+    return [
+        _StubGameAction(name="RESET", value=0),
+        _StubGameAction(name="ACTION1", value=1),
+        _StubGameAction(name="ACTION2", value=2),
+    ]
+
+
+class TestRandomActionAgent:
+    def test_inherits_from_cognithor_pse_agent(self) -> None:
+        agent = RandomActionAgent(seed=42)
+        assert isinstance(agent, CognithorPSEAgent)
+
+    def test_is_done_returns_true_on_win(self) -> None:
+        agent = RandomActionAgent(seed=42)
+        frame = _StubFrameData(
+            game_id="ls20",
+            state=_StubGameState(name="WIN"),
+            available_actions=_make_actions(),
+        )
+        assert agent.is_done([frame], frame) is True
+
+    def test_is_done_returns_true_on_game_over(self) -> None:
+        agent = RandomActionAgent(seed=42)
+        frame = _StubFrameData(
+            game_id="ls20",
+            state=_StubGameState(name="GAME_OVER"),
+            available_actions=_make_actions(),
+        )
+        assert agent.is_done([frame], frame) is True
+
+    def test_is_done_returns_false_on_in_progress(self) -> None:
+        agent = RandomActionAgent(seed=42)
+        frame = _StubFrameData(
+            game_id="ls20",
+            state=_StubGameState(name="NOT_FINISHED"),
+            available_actions=_make_actions(),
+        )
+        assert agent.is_done([frame], frame) is False
+
+    def test_choose_action_returns_one_of_available(self) -> None:
+        agent = RandomActionAgent(seed=42)
+        actions = _make_actions()
+        frame = _StubFrameData(
+            game_id="ls20",
+            state=_StubGameState(name="NOT_FINISHED"),
+            available_actions=actions,
+        )
+        choice = agent.choose_action([frame], frame)
+        assert choice in actions
+
+    def test_choose_action_sets_reasoning(self) -> None:
+        agent = RandomActionAgent(seed=42)
+        actions = _make_actions()
+        frame = _StubFrameData(
+            game_id="ls20",
+            state=_StubGameState(name="NOT_FINISHED"),
+            available_actions=actions,
+        )
+        choice = agent.choose_action([frame], frame)
+        assert "RandomActionAgent" in choice.reasoning
+
+    def test_choose_action_is_deterministic_given_seed(self) -> None:
+        a1 = RandomActionAgent(seed=42)
+        a2 = RandomActionAgent(seed=42)
+        actions1 = _make_actions()
+        actions2 = _make_actions()
+        f1 = _StubFrameData(
+            game_id="ls20",
+            state=_StubGameState(name="NOT_FINISHED"),
+            available_actions=actions1,
+        )
+        f2 = _StubFrameData(
+            game_id="ls20",
+            state=_StubGameState(name="NOT_FINISHED"),
+            available_actions=actions2,
+        )
+        # Same seed → same action index. Compare by name to avoid
+        # comparing across two _make_actions() lists.
+        assert a1.choose_action([f1], f1).name == a2.choose_action([f2], f2).name
+
+    def test_choose_action_raises_on_empty_available_actions(self) -> None:
+        agent = RandomActionAgent(seed=42)
+        frame = _StubFrameData(
+            game_id="ls20",
+            state=_StubGameState(name="NOT_FINISHED"),
+            available_actions=[],
+        )
+        with pytest.raises(RuntimeError, match="no available_actions"):
+            agent.choose_action([frame], frame)
+
+    def test_runs_full_episode_until_win(self) -> None:
+        """Smoke-loop: agent picks actions; we mock the harness by
+        flipping the state to WIN after 5 actions. Mirrors the upstream
+        ``Agent.main()`` loop without the network glue.
+        """
+        agent = RandomActionAgent(seed=42)
+        frames: list[_StubFrameData] = []
+        for i in range(10):
+            state_name = "WIN" if i >= 5 else "NOT_FINISHED"
+            frame = _StubFrameData(
+                game_id="ls20",
+                state=_StubGameState(name=state_name),
+                levels_completed=i,
+                available_actions=_make_actions(),
+            )
+            frames.append(frame)
+            if agent.is_done(frames, frame):
+                break
+            _ = agent.choose_action(frames, frame)
+        # Agent must terminate at frame index 5 (state=WIN).
+        assert len(frames) == 6
+        assert frames[-1].state.name == "WIN"


### PR DESCRIPTION
## Summary

Sprint-11 starts the architecture pivot from **static ARC-AGI-1 grids** (Sprint-9/10) to **interactive ARC-AGI-3 game environments** (Owner-Direktive 2026-05-01).

**Wave-1 ships the foundation** so subsequent waves can build on a stable API surface.

## What ARC-AGI-3 actually is

| Aspect | ARC-AGI-1 (Sprint-10) | ARC-AGI-3 |
|---|---|---|
| Format | Static input/output mapping | Interactive game loop |
| Input | `examples: list[(in, out)]` | `frames: list[FrameData]` episode |
| Output | Program → grid | `GameAction` per frame |
| Score | Exact grid equality | `levels_completed / win_levels` |
| Search | Phase-1 program enumeration | Game-tree (≤ 80 actions) |
| LLM role | Prior for synthesis | Action selection per frame |

Repo: `arcprize/ARC-AGI-3-Agents` (MIT). Online API at `https://three.arcprize.org/`.

## Wave-1 surface (this PR)

**`src/cognithor/channels/program_synthesis/arc_agi3/`:**

- `protocol.py` — `FrameDataProtocol`, `GameActionProtocol`, `GameStateProtocol`. Mirror the upstream `arcengine` API surface as of ARC-AGI-3-Agents 0.9.3 (post-2026-01-29: `score`→`levels_completed`, `win_score`→`win_levels`).
- `agent.py` — `CognithorPSEAgent` ABC (`is_done`, `choose_action`) + `RandomActionAgent` smoke baseline.

**Cognithor's code is typed against local Protocols, not directly against `arcengine`** — the package imports cleanly without `arc-agi`/`arcengine` installed. A Wave-5 thin adapter plugs in the live types.

## Architecture target

```
Official ARC-AGI-3-Agents harness
         │
         └─ Cognithor's CognithorPSEAgent subclass
                    │
                    ├─ FrameBridge      (Wave-2)  — FrameData → Cognithor Grid
                    ├─ Phase-1 search   (Sprint-10 DSL, 76 primitives)
                    ├─ ActionDecoder    (Wave-2)  — Programm → GameAction
                    └─ vLLM/qwen3.6:27b (Wave-4)  — Stage-1+2 reasoning per frame
```

## Wave-Plan

| Wave | What |
|---|---|
| 1 (this) | Foundation: protocol + ABC + RandomActionAgent |
| 2 | `FrameBridge` (FrameData → Grid) + `ActionDecoder` (Programm → Action) |
| 3 | `Sprint10DSLAgent` — Phase-1 search per frame, 76 Sprint-10 primitives |
| 4 | `LLMReasoningAgent` over vLLM/qwen3.6:27b |
| 5 | `arcengine`-adapter + live API scorecards |

## Test plan
- [x] 13/13 new tests pass (4 protocol-conformance + 9 RandomActionAgent smoke)
- [x] Full PSE suite: 1477 passed, 10 skipped — no regressions
- [x] `mypy --strict` clean across all 3 new source files
- [x] `ruff check` + `ruff format --check` clean

## Channel doc

`docs/channels/program_synthesis/arc_agi3.md` documents the harness shim recipe — how to drop a thin `agents/templates/cognithor_agent.py` into the official ARC-AGI-3-Agents repo and run `uv run main.py --agent=cognithor_random --game=ls20`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)