### PR TITLE
feat(pse): Sprint-11 Wave-2 — FrameBridge + ActionDecoder

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
@@ -21,9 +21,17 @@ plugs in the live arcengine types when running against the official
 harness.
 """
 
+from cognithor.channels.program_synthesis.arc_agi3.action_decoder import (
+    ActionDecoder,
+    UniformActionDecoder,
+)
 from cognithor.channels.program_synthesis.arc_agi3.agent import (
     CognithorPSEAgent,
     RandomActionAgent,
+)
+from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import (
+    ClampPolicy,
+    FrameBridge,
 )
 from cognithor.channels.program_synthesis.arc_agi3.protocol import (
     FrameDataProtocol,
@@ -32,9 +40,13 @@ from cognithor.channels.program_synthesis.arc_agi3.protocol import (
 )
 
 __all__ = [
+    "ActionDecoder",
+    "ClampPolicy",
     "CognithorPSEAgent",
+    "FrameBridge",
     "FrameDataProtocol",
     "GameActionProtocol",
     "GameStateProtocol",
     "RandomActionAgent",
+    "UniformActionDecoder",
 ]

--- a/src/cognithor/channels/program_synthesis/arc_agi3/action_decoder.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/action_decoder.py
@@ -1,0 +1,135 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 Wave-2 — Programm output → GameAction decoder.
+
+The DSL Cognithor inherited from Sprint-10 transforms a *grid* into
+another *grid*. ARC-AGI-3 expects the agent to emit a *GameAction*
+(one of ``RESET``, ``ACTION1``..``ACTION7``) per frame. Bridging the
+two requires a policy that picks the action most likely to drive the
+current frame towards a desired target.
+
+This module ships the abstraction (:class:`ActionDecoder`) and a
+spec-default :class:`UniformActionDecoder` that simply picks the
+first available action per frame. The DSL- and LLM-driven decoders
+land in Wave-3 and Wave-4 respectively; both subclass
+:class:`ActionDecoder` and override :meth:`pick_action`.
+
+The decoder is responsible for three things:
+
+1. **Filtering** — only choose from ``frame.available_actions``.
+   Picking outside that whitelist is undefined upstream.
+2. **Reasoning text** — set ``action.reasoning`` to a short
+   natural-language string. The harness records this for replay.
+3. **Complex-action data** — for actions where ``is_complex()`` is
+   ``True``, the decoder must call ``set_data({"x": .., "y": ..})``
+   before returning; ``ACTION6`` and ``ACTION7`` need x/y target
+   coordinates. Wave-2's :class:`UniformActionDecoder` defaults to
+   ``(0, 0)`` for complex actions; subclasses override.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.arc_agi3.protocol import (
+        FrameDataProtocol,
+        GameActionProtocol,
+    )
+
+
+class ActionDecoder(ABC):
+    """Abstract: pick one of ``frame.available_actions`` per frame.
+
+    Subclasses implement :meth:`pick_action`. The base class handles
+    the surrounding contract (filter + reasoning text + complex-action
+    data wiring) by calling the subclass and then post-processing the
+    returned action.
+    """
+
+    DEFAULT_REASONING: str = "Cognithor PSE: action picked by decoder"
+
+    def decode(
+        self,
+        frames: list[FrameDataProtocol],
+        latest_frame: FrameDataProtocol,
+    ) -> GameActionProtocol:
+        """Return the next :class:`GameActionProtocol` for the harness.
+
+        Raises :class:`RuntimeError` if the frame has no available
+        actions. The returned action has ``reasoning`` set to the
+        decoder's per-call justification, and (for complex actions)
+        ``set_data`` already invoked.
+        """
+        actions = list(latest_frame.available_actions)
+        if not actions:
+            raise RuntimeError(
+                f"{type(self).__name__}: latest frame for "
+                f"{latest_frame.game_id!r} has no available_actions"
+            )
+        action, reasoning = self.pick_action(frames, latest_frame, actions)
+        if action not in actions:
+            raise RuntimeError(
+                f"{type(self).__name__}: pick_action returned an action "
+                f"({action.name!r}) that's not in available_actions"
+            )
+        # Read-only stubs may reject the assignment; safe to skip.
+        with contextlib.suppress(AttributeError):
+            action.reasoning = reasoning or self.DEFAULT_REASONING
+        if action.is_complex():
+            self._wire_complex_action_data(action, frames, latest_frame)
+        return action
+
+    @abstractmethod
+    def pick_action(
+        self,
+        frames: list[FrameDataProtocol],
+        latest_frame: FrameDataProtocol,
+        available_actions: list[GameActionProtocol],
+    ) -> tuple[GameActionProtocol, str]:
+        """Return ``(chosen_action, reasoning_text)``.
+
+        ``available_actions`` is a copy of
+        ``latest_frame.available_actions`` for convenience and to
+        guarantee the subclass can iterate without exhausting an
+        iterator. The chosen action MUST be ``in available_actions``.
+        """
+
+    def _wire_complex_action_data(
+        self,
+        action: GameActionProtocol,
+        frames: list[FrameDataProtocol],
+        latest_frame: FrameDataProtocol,
+    ) -> None:
+        """Default: ``(0, 0)`` target coordinates for complex actions.
+
+        Subclasses override to derive coordinates from the current
+        frame (e.g. centre of largest object, position of marker).
+        """
+        del frames, latest_frame  # unused in the default policy
+        action.set_data({"x": 0, "y": 0})
+
+
+class UniformActionDecoder(ActionDecoder):
+    """Wave-2 baseline: always pick the first available action.
+
+    Useful as a deterministic smoke baseline for the Wave-3 DSL
+    decoder and the Wave-4 LLM decoder — when those regress, the
+    test harness compares against ``UniformActionDecoder`` to
+    isolate the regression to the policy layer.
+    """
+
+    def pick_action(
+        self,
+        frames: list[FrameDataProtocol],
+        latest_frame: FrameDataProtocol,
+        available_actions: list[GameActionProtocol],
+    ) -> tuple[GameActionProtocol, str]:
+        return available_actions[0], "UniformActionDecoder: first available"
+
+
+__all__ = [
+    "ActionDecoder",
+    "UniformActionDecoder",
+]

--- a/src/cognithor/channels/program_synthesis/arc_agi3/frame_bridge.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/frame_bridge.py
@@ -1,0 +1,137 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 Wave-2 — FrameData → Cognithor Grid bridge.
+
+ARC-AGI-3 frames are multi-layer 2-D arrays with values in the
+16-colour ``0..15`` palette (wider than ARC-AGI-1's ``0..9``). The
+Sprint-10 DSL primitives are typed against ``int8`` grids in the
+``0..9`` range. The bridge handles two concerns:
+
+1. **Layer selection** — most ARC-AGI-3 games expose a single visible
+   play-field layer. ``layer_index=0`` is the spec default; games with
+   semantic layers (e.g. backgrounds, foregrounds, HUD) can pick
+   another index.
+
+2. **Palette mapping** — values 10..15 don't exist in the DSL.
+   Three policies are exposed:
+
+   - ``ClampPolicy.SATURATE`` (default) — clamp 10..15 to 9. Loses
+     information but every primitive runs without errors.
+   - ``ClampPolicy.MODULO`` — wrap 10..15 to 0..5. Loses semantics
+     entirely; useful only for games where the wider colours are
+     decorative.
+   - ``ClampPolicy.STRICT`` — raise on any value > 9. Useful for
+     unit tests of games that *should* stay in range, and for the
+     Wave-3 enumeration loop where surprising values flag a bug.
+
+   The Wave-3+ DSL extension to a 16-colour palette is queued for a
+   later sprint; until then, every Sprint-10 primitive that touches
+   colour explicitly runs against the clamped grid.
+
+The bridge is pure: same input → same output, no shared state.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.arc_agi3.protocol import (
+        FrameDataProtocol,
+    )
+
+_Grid = NDArray[np.int8]
+
+
+class ClampPolicy(Enum):
+    """How to handle ARC-AGI-3 colour values 10..15.
+
+    The DSL is currently typed against ``int8 [0..9]``; values
+    outside that range need explicit handling at the boundary.
+    """
+
+    SATURATE = "saturate"
+    MODULO = "modulo"
+    STRICT = "strict"
+
+
+class FrameBridge:
+    """Converts an ARC-AGI-3 :class:`FrameDataProtocol` into the
+    Cognithor Grid format the Sprint-10 DSL operates on.
+
+    Construction is parameter-light by design — runtime behaviour is
+    controlled by ``layer_index`` and ``clamp_policy``. The bridge is
+    stateless: each call to :meth:`extract_grid` is independent.
+    """
+
+    def __init__(
+        self,
+        *,
+        layer_index: int = 0,
+        clamp_policy: ClampPolicy = ClampPolicy.SATURATE,
+    ) -> None:
+        if layer_index < 0:
+            raise ValueError(f"FrameBridge: layer_index must be >= 0, got {layer_index}")
+        self._layer_index = layer_index
+        self._clamp_policy = clamp_policy
+
+    @property
+    def layer_index(self) -> int:
+        return self._layer_index
+
+    @property
+    def clamp_policy(self) -> ClampPolicy:
+        return self._clamp_policy
+
+    def extract_grid(self, frame: FrameDataProtocol) -> _Grid:
+        """Return the chosen layer of *frame* as an ``int8`` grid in [0, 9].
+
+        Raises :class:`IndexError` if ``layer_index`` is out of range
+        for this frame, :class:`ValueError` if the layer can't be
+        coerced to a 2-D array, and :class:`ValueError` for
+        out-of-range values under :attr:`ClampPolicy.STRICT`.
+        """
+        layers = list(frame.frame)
+        if self._layer_index >= len(layers):
+            raise IndexError(
+                f"FrameBridge: layer_index={self._layer_index} but frame "
+                f"{frame.game_id!r} only has {len(layers)} layer(s)"
+            )
+        raw = self._coerce_to_2d(layers[self._layer_index])
+        return self._apply_clamp_policy(raw)
+
+    @staticmethod
+    def _coerce_to_2d(layer: Any) -> NDArray[np.int_]:
+        """Accept ``np.ndarray`` or ``list[list[int]]``; return int array."""
+        if isinstance(layer, np.ndarray):
+            arr = layer
+        else:
+            arr = np.asarray(layer)
+        if arr.ndim != 2:
+            raise ValueError(
+                f"FrameBridge: layer must be 2-D (got {arr.ndim}-D, shape {arr.shape})"
+            )
+        return arr.astype(np.int_, copy=False)
+
+    def _apply_clamp_policy(self, raw: NDArray[np.int_]) -> _Grid:
+        if self._clamp_policy is ClampPolicy.STRICT:
+            if int(raw.min()) < 0 or int(raw.max()) > 9:
+                raise ValueError(
+                    f"FrameBridge[STRICT]: values out of [0, 9] "
+                    f"(min={int(raw.min())}, max={int(raw.max())})"
+                )
+            clamped = raw
+        elif self._clamp_policy is ClampPolicy.MODULO:
+            clamped = raw % 10
+        else:  # SATURATE — default
+            clamped = np.clip(raw, 0, 9)
+        return clamped.astype(np.int8, copy=False)
+
+
+__all__ = [
+    "ClampPolicy",
+    "FrameBridge",
+]

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_action_decoder.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_action_decoder.py
@@ -1,0 +1,161 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 Wave-2 — ActionDecoder + UniformActionDecoder tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import pytest
+
+from cognithor.channels.program_synthesis.arc_agi3.action_decoder import (
+    ActionDecoder,
+    UniformActionDecoder,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+@dataclass
+class _StubGameState:
+    name: str = "NOT_FINISHED"
+
+
+@dataclass
+class _StubAction:
+    name: str
+    value: int
+    reasoning: str = ""
+    _data: dict[str, Any] = field(default_factory=dict)
+    _is_simple: bool = True
+
+    def is_simple(self) -> bool:
+        return self._is_simple
+
+    def is_complex(self) -> bool:
+        return not self._is_simple
+
+    def set_data(self, data: dict[str, Any]) -> None:
+        self._data = dict(data)
+
+
+@dataclass
+class _StubFrame:
+    game_id: str = "ls20"
+    state: _StubGameState = field(default_factory=_StubGameState)
+    levels_completed: int = 0
+    win_levels: int = 1
+    guid: str = ""
+    full_reset: bool = False
+    frame: list[Any] = field(default_factory=list)
+    available_actions: list[_StubAction] = field(default_factory=list)
+
+
+def _simple_actions() -> list[_StubAction]:
+    return [
+        _StubAction(name="ACTION1", value=1),
+        _StubAction(name="ACTION2", value=2),
+        _StubAction(name="RESET", value=0),
+    ]
+
+
+def _complex_action() -> _StubAction:
+    return _StubAction(name="ACTION6", value=6, _is_simple=False)
+
+
+class TestUniformActionDecoder:
+    def test_picks_first_available(self) -> None:
+        decoder = UniformActionDecoder()
+        actions = _simple_actions()
+        frame = _StubFrame(available_actions=actions)
+        chosen = decoder.decode([frame], frame)
+        assert chosen.name == "ACTION1"
+
+    def test_sets_reasoning(self) -> None:
+        decoder = UniformActionDecoder()
+        actions = _simple_actions()
+        frame = _StubFrame(available_actions=actions)
+        chosen = decoder.decode([frame], frame)
+        assert "UniformActionDecoder" in chosen.reasoning
+
+    def test_raises_on_empty_available_actions(self) -> None:
+        decoder = UniformActionDecoder()
+        frame = _StubFrame(available_actions=[])
+        with pytest.raises(RuntimeError, match="no available_actions"):
+            decoder.decode([frame], frame)
+
+
+class TestComplexActionDataWiring:
+    def test_default_complex_data_is_origin(self) -> None:
+        decoder = UniformActionDecoder()
+        complex_first = [_complex_action(), _StubAction(name="ACTION1", value=1)]
+        frame = _StubFrame(available_actions=complex_first)
+        chosen = decoder.decode([frame], frame)
+        assert chosen.is_complex() is True
+        # set_data was called with default origin coordinates.
+        assert chosen._data == {"x": 0, "y": 0}
+
+    def test_simple_action_does_not_get_data(self) -> None:
+        decoder = UniformActionDecoder()
+        actions = _simple_actions()
+        frame = _StubFrame(available_actions=actions)
+        chosen = decoder.decode([frame], frame)
+        assert chosen.is_simple() is True
+        assert chosen._data == {}
+
+
+class TestSubclassContract:
+    def test_subclass_returns_action_outside_whitelist_raises(self) -> None:
+        """A subclass that returns an action not in `available_actions`
+        gets caught by the base class's validation, preventing the
+        upstream undefined-behaviour from leaking through.
+        """
+
+        class _BadDecoder(ActionDecoder):
+            def pick_action(
+                self,
+                frames: list[Any],
+                latest_frame: Any,
+                available_actions: list[Any],
+            ) -> tuple[Any, str]:
+                # Fabricate an action that isn't in the whitelist.
+                return _StubAction(name="ACTION999", value=999), "fabricated"
+
+        decoder = _BadDecoder()
+        frame = _StubFrame(available_actions=_simple_actions())
+        with pytest.raises(RuntimeError, match="not in available_actions"):
+            decoder.decode([frame], frame)
+
+    def test_custom_subclass_can_choose_specific_action(self) -> None:
+        class _PickResetDecoder(ActionDecoder):
+            def pick_action(
+                self,
+                frames: list[Any],
+                latest_frame: Any,
+                available_actions: list[Any],
+            ) -> tuple[Any, str]:
+                reset = next(a for a in available_actions if a.name == "RESET")
+                return reset, "test: always reset"
+
+        decoder = _PickResetDecoder()
+        frame = _StubFrame(available_actions=_simple_actions())
+        chosen = decoder.decode([frame], frame)
+        assert chosen.name == "RESET"
+        assert chosen.reasoning == "test: always reset"
+
+    def test_default_reasoning_when_subclass_returns_empty(self) -> None:
+        class _NoReasoningDecoder(ActionDecoder):
+            def pick_action(
+                self,
+                frames: list[Any],
+                latest_frame: Any,
+                available_actions: list[Any],
+            ) -> tuple[Any, str]:
+                return available_actions[0], ""
+
+        decoder = _NoReasoningDecoder()
+        frame = _StubFrame(available_actions=_simple_actions())
+        chosen = decoder.decode([frame], frame)
+        # Falls back to the class default when the subclass returns "".
+        assert chosen.reasoning == ActionDecoder.DEFAULT_REASONING

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_frame_bridge.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_frame_bridge.py
@@ -1,0 +1,138 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 Wave-2 — FrameBridge tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import (
+    ClampPolicy,
+    FrameBridge,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+@dataclass
+class _StubGameState:
+    name: str = "NOT_FINISHED"
+
+
+@dataclass
+class _StubFrame:
+    game_id: str = "ls20"
+    state: _StubGameState = field(default_factory=_StubGameState)
+    levels_completed: int = 0
+    win_levels: int = 1
+    guid: str = ""
+    full_reset: bool = False
+    frame: list[Any] = field(default_factory=list)
+    available_actions: list[Any] = field(default_factory=list)
+
+
+def _frame_with(layers: list[Any]) -> _StubFrame:
+    return _StubFrame(frame=layers)
+
+
+class TestFrameBridgeBasics:
+    def test_default_layer_index_zero(self) -> None:
+        b = FrameBridge()
+        assert b.layer_index == 0
+        assert b.clamp_policy is ClampPolicy.SATURATE
+
+    def test_negative_layer_index_rejected(self) -> None:
+        with pytest.raises(ValueError, match="layer_index"):
+            FrameBridge(layer_index=-1)
+
+    def test_extracts_first_layer(self) -> None:
+        b = FrameBridge()
+        out = b.extract_grid(_frame_with([np.array([[1, 2], [3, 4]], dtype=np.int_)]))
+        assert out.tolist() == [[1, 2], [3, 4]]
+        assert out.dtype == np.int8
+
+    def test_layer_index_out_of_range_raises(self) -> None:
+        b = FrameBridge(layer_index=2)
+        with pytest.raises(IndexError, match="only has 1 layer"):
+            b.extract_grid(_frame_with([np.array([[1]])]))
+
+    def test_accepts_list_of_lists(self) -> None:
+        b = FrameBridge()
+        out = b.extract_grid(_frame_with([[[5, 6, 7], [8, 9, 0]]]))
+        assert out.shape == (2, 3)
+        assert out.tolist() == [[5, 6, 7], [8, 9, 0]]
+
+    def test_rejects_non_2d_layer(self) -> None:
+        b = FrameBridge()
+        with pytest.raises(ValueError, match="must be 2-D"):
+            b.extract_grid(_frame_with([np.array([1, 2, 3], dtype=np.int_)]))
+
+
+class TestClampPolicies:
+    def test_saturate_clamps_above_nine(self) -> None:
+        b = FrameBridge(clamp_policy=ClampPolicy.SATURATE)
+        out = b.extract_grid(_frame_with([np.array([[10, 11, 15]], dtype=np.int_)]))
+        # 10..15 → saturated to 9.
+        assert out.tolist() == [[9, 9, 9]]
+
+    def test_saturate_clamps_below_zero(self) -> None:
+        b = FrameBridge(clamp_policy=ClampPolicy.SATURATE)
+        # ARC-AGI-3 colour values shouldn't be negative, but the clamp
+        # is symmetric. (Value -1 is unlikely upstream but robust here.)
+        out = b.extract_grid(_frame_with([np.array([[-1, 0, 5]], dtype=np.int_)]))
+        assert out.tolist() == [[0, 0, 5]]
+
+    def test_modulo_wraps(self) -> None:
+        b = FrameBridge(clamp_policy=ClampPolicy.MODULO)
+        out = b.extract_grid(_frame_with([np.array([[10, 11, 15]], dtype=np.int_)]))
+        # 10 % 10 = 0, 11 % 10 = 1, 15 % 10 = 5.
+        assert out.tolist() == [[0, 1, 5]]
+
+    def test_strict_passes_clean_grid(self) -> None:
+        b = FrameBridge(clamp_policy=ClampPolicy.STRICT)
+        out = b.extract_grid(_frame_with([np.array([[0, 5, 9]], dtype=np.int_)]))
+        assert out.tolist() == [[0, 5, 9]]
+
+    def test_strict_raises_on_value_above_nine(self) -> None:
+        b = FrameBridge(clamp_policy=ClampPolicy.STRICT)
+        with pytest.raises(ValueError, match="STRICT"):
+            b.extract_grid(_frame_with([np.array([[0, 5, 10]], dtype=np.int_)]))
+
+
+class TestMultiLayerFrame:
+    def test_picks_chosen_layer(self) -> None:
+        b = FrameBridge(layer_index=1)
+        frame = _frame_with(
+            [
+                np.array([[1, 1], [1, 1]], dtype=np.int_),  # layer 0
+                np.array([[2, 2], [2, 2]], dtype=np.int_),  # layer 1
+            ]
+        )
+        out = b.extract_grid(frame)
+        assert out.tolist() == [[2, 2], [2, 2]]
+
+    def test_first_layer_is_default(self) -> None:
+        b = FrameBridge()  # layer_index=0
+        frame = _frame_with(
+            [
+                np.array([[7, 8]], dtype=np.int_),
+                np.array([[1, 2]], dtype=np.int_),
+            ]
+        )
+        out = b.extract_grid(frame)
+        assert out.tolist() == [[7, 8]]
+
+
+class TestPurity:
+    def test_does_not_mutate_input(self) -> None:
+        original = np.array([[10, 11], [12, 13]], dtype=np.int_)
+        b = FrameBridge(clamp_policy=ClampPolicy.SATURATE)
+        b.extract_grid(_frame_with([original.copy()]))
+        # Original outside the bridge unchanged. (We pass a copy in,
+        # so this also confirms the bridge doesn't write back into
+        # the input through aliasing.)
+        assert original.tolist() == [[10, 11], [12, 13]]


### PR DESCRIPTION
## Summary

Wave-2 of the ARC-AGI-3 Game-Agent integration. Two new pure modules that bridge ARC-AGI-3's frame/action API to Cognithor's DSL world.

## What's added

### `FrameBridge` — `FrameData → int8 [0..9] Grid`

ARC-AGI-3 frames are multi-layer with values in the wider 16-colour `0..15` palette. The Sprint-10 DSL is typed against `int8 [0..9]`. The bridge handles:

- **Layer selection** — default `layer_index=0` (visible play-field). Multi-layer games can select a specific semantic plane.
- **Palette mapping** — three policies:
  - `ClampPolicy.SATURATE` (default) — 10..15 → 9
  - `ClampPolicy.MODULO` — 10..15 wrap to 0..5
  - `ClampPolicy.STRICT` — raise on any value > 9 (useful for unit tests)

Wider-palette DSL extension queued for a later sprint.

### `ActionDecoder` ABC + `UniformActionDecoder` smoke baseline

Decoders pick one of `frame.available_actions` per call. The base class enforces three invariants:

1. **Whitelist filtering** — picking outside `available_actions` is undefined upstream; the base catches violations.
2. **Reasoning text** — sets `action.reasoning` (the harness reads this for replay).
3. **Complex-action data** — for `is_complex()` actions (ACTION6/ACTION7), calls `set_data({x, y})` before returning. Default origin `(0, 0)`; subclasses override.

`UniformActionDecoder` always picks the first available action — a deterministic regression baseline for the Wave-3 (DSL) and Wave-4 (LLM) decoders.

## Properties

- Pure: no shared state, same input → same output
- Import-clean without `arc-agi`/`arcengine` installed
- Fully Protocol-typed against Wave-1's `FrameDataProtocol`/`GameActionProtocol`/`GameStateProtocol`

## Test plan
- [x] 22 new tests pass (14 FrameBridge + 8 ActionDecoder)
- [x] Total Sprint-11 tests: 35 (Wave-1 13 + Wave-2 22)
- [x] Full PSE suite: 1499 passed, 10 skipped — no regressions
- [x] `mypy --strict` clean across all 5 `arc_agi3/` source files
- [x] `ruff check` + `ruff format --check` clean
- [x] Branch on top of main post-#282

## Wave-plan progress

| Wave | PR | Status |
|---|---|---|
| 1 — Foundation | #282 | ✅ merged |
| **2 — FrameBridge + ActionDecoder** | **this** | open |
| 3 — Sprint10DSLAgent (Phase-1 search per frame) | next | – |
| 4 — LLMReasoningAgent (vLLM/qwen3.6:27b) | – | – |
| 5 — arcengine adapter + live API scorecards | – | – |

🤖 Generated with [Claude Code](https://claude.com/claude-code)