### PR TITLE
feat(pse): Sprint-11 Wave-3 — episode-state primitives

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
@@ -29,6 +29,14 @@ from cognithor.channels.program_synthesis.arc_agi3.agent import (
     CognithorPSEAgent,
     RandomActionAgent,
 )
+from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
+    ChangeDetector,
+    EpisodeMemory,
+    EpisodeStep,
+    FrameChange,
+    StuckDetector,
+    count_actions,
+)
 from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import (
     ClampPolicy,
     FrameBridge,
@@ -41,12 +49,18 @@ from cognithor.channels.program_synthesis.arc_agi3.protocol import (
 
 __all__ = [
     "ActionDecoder",
+    "ChangeDetector",
     "ClampPolicy",
     "CognithorPSEAgent",
+    "EpisodeMemory",
+    "EpisodeStep",
     "FrameBridge",
+    "FrameChange",
     "FrameDataProtocol",
     "GameActionProtocol",
     "GameStateProtocol",
     "RandomActionAgent",
+    "StuckDetector",
     "UniformActionDecoder",
+    "count_actions",
 ]

--- a/src/cognithor/channels/program_synthesis/arc_agi3/episode_memory.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/episode_memory.py
@@ -1,0 +1,236 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 Wave-3 — Episode-state tracking for ARC-AGI-3 agents.
+
+ARC-AGI-3 agents see one frame at a time. To reason about progress
+("are we still moving?", "is this an unproductive loop?", "should we
+reset?") they need a small structured memory of the recent past.
+
+This module ships three pure components, each composable on its own:
+
+- :class:`EpisodeMemory` — a ring-buffer of ``(frame, action)``
+  tuples. Bounded so it never grows unboundedly even when an agent
+  hits the upstream MAX_ACTIONS=80.
+- :class:`ChangeDetector` — compares two frames and returns a
+  structured similarity report (cells changed, level-up, full-reset).
+- :class:`StuckDetector` — flags when the agent has been stuck for
+  ``threshold`` frames (no grid change AND no level progress).
+
+Wave-4's :class:`Sprint10DSLAgent` wires all three into a stateful
+action policy.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import numpy as np
+from numpy.typing import NDArray
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.arc_agi3.protocol import (
+        FrameDataProtocol,
+    )
+
+
+_Grid = NDArray[np.int8]
+
+
+@dataclass(frozen=True)
+class EpisodeStep:
+    """A single ``(grid, action_name, levels_completed)`` snapshot.
+
+    Frozen so the memory can be safely shared between the agent and
+    the change/stuck detectors without cloning. The grid is a copy of
+    the bridge output; the action name is the upstream
+    ``GameAction.name`` string, not the enum (keeps the memory
+    arcengine-import-clean).
+    """
+
+    grid: _Grid
+    action_name: str
+    levels_completed: int
+
+
+class EpisodeMemory:
+    """Bounded ring-buffer of recent steps.
+
+    Default capacity 16 is safe — enough to detect stuck loops at
+    typical game depths, small enough that comparison ops stay cheap.
+    The buffer drops the oldest step on overflow; ``last`` and
+    ``window`` always reflect the most-recent state.
+    """
+
+    def __init__(self, capacity: int = 16) -> None:
+        if capacity < 1:
+            raise ValueError(f"EpisodeMemory: capacity must be >= 1, got {capacity}")
+        self._capacity = capacity
+        self._buffer: list[EpisodeStep] = []
+
+    @property
+    def capacity(self) -> int:
+        return self._capacity
+
+    def __len__(self) -> int:
+        return len(self._buffer)
+
+    def append(
+        self,
+        *,
+        grid: _Grid,
+        action_name: str,
+        levels_completed: int,
+    ) -> None:
+        """Add a new step and evict the oldest if at capacity."""
+        step = EpisodeStep(
+            grid=grid.copy(),
+            action_name=action_name,
+            levels_completed=levels_completed,
+        )
+        self._buffer.append(step)
+        if len(self._buffer) > self._capacity:
+            self._buffer = self._buffer[-self._capacity :]
+
+    @property
+    def last(self) -> EpisodeStep | None:
+        """The most-recent step, or None if the memory is empty."""
+        return self._buffer[-1] if self._buffer else None
+
+    def window(self, n: int) -> list[EpisodeStep]:
+        """Return the last *n* steps (most recent first), bounded by len()."""
+        if n < 0:
+            raise ValueError(f"EpisodeMemory.window: n must be >= 0, got {n}")
+        if n == 0:
+            return []
+        return list(reversed(self._buffer[-n:]))
+
+    def clear(self) -> None:
+        self._buffer = []
+
+
+@dataclass(frozen=True)
+class FrameChange:
+    """Structured diff between two consecutive frames.
+
+    - ``cells_changed`` — count of grid cells that differ
+    - ``shape_changed`` — True if the two grids have different shape
+    - ``levels_advanced`` — True if ``levels_completed`` increased
+    - ``full_reset`` — mirror of :attr:`FrameDataProtocol.full_reset`
+      (e.g. after a successful RESET action)
+    """
+
+    cells_changed: int
+    shape_changed: bool
+    levels_advanced: bool
+    full_reset: bool
+
+    @property
+    def is_change(self) -> bool:
+        """Any meaningful change occurred."""
+        return (
+            self.cells_changed > 0 or self.shape_changed or self.levels_advanced or self.full_reset
+        )
+
+
+class ChangeDetector:
+    """Diff two grids + their wrapping FrameData.
+
+    Pure: no internal state. Use case: feed the previous and current
+    frame, get a :class:`FrameChange` describing what (if anything)
+    moved.
+    """
+
+    @staticmethod
+    def diff(
+        previous_grid: _Grid,
+        current_grid: _Grid,
+        *,
+        previous_levels: int,
+        current_frame: FrameDataProtocol,
+    ) -> FrameChange:
+        if previous_grid.shape != current_grid.shape:
+            return FrameChange(
+                cells_changed=int(previous_grid.size + current_grid.size),
+                shape_changed=True,
+                levels_advanced=current_frame.levels_completed > previous_levels,
+                full_reset=current_frame.full_reset,
+            )
+        diff = np.not_equal(previous_grid, current_grid)
+        return FrameChange(
+            cells_changed=int(diff.sum()),
+            shape_changed=False,
+            levels_advanced=current_frame.levels_completed > previous_levels,
+            full_reset=current_frame.full_reset,
+        )
+
+
+class StuckDetector:
+    """Flag when the agent has been stuck for ``threshold`` frames.
+
+    "Stuck" = the last ``threshold`` consecutive steps showed
+    no cell change AND no level progress. The detector is read-only
+    against an :class:`EpisodeMemory`; it doesn't mutate state.
+
+    Wave-4's policy uses this to decide when to RESET — staying stuck
+    longer than ``threshold`` wastes the upstream MAX_ACTIONS budget.
+    """
+
+    DEFAULT_THRESHOLD: int = 5
+
+    def __init__(self, threshold: int = DEFAULT_THRESHOLD) -> None:
+        if threshold < 1:
+            raise ValueError(f"StuckDetector: threshold must be >= 1, got {threshold}")
+        self._threshold = threshold
+
+    @property
+    def threshold(self) -> int:
+        return self._threshold
+
+    def is_stuck(self, memory: EpisodeMemory) -> bool:
+        """Return True if the last ``threshold`` steps showed no change."""
+        if len(memory) < self._threshold + 1:
+            return False
+        window = memory.window(self._threshold + 1)
+        # ``window`` is most-recent-first; pair adjacent steps to
+        # detect change in either direction.
+        for i in range(len(window) - 1):
+            current = window[i]
+            previous = window[i + 1]
+            if current.levels_completed > previous.levels_completed:
+                return False
+            if current.grid.shape != previous.grid.shape:
+                return False
+            if not np.array_equal(current.grid, previous.grid):
+                return False
+        return True
+
+
+@dataclass(frozen=True)
+class _ActionFrequency:
+    """Helper for Wave-4: counts how often each action has been picked."""
+
+    counts: dict[str, int] = field(default_factory=dict)
+
+
+def count_actions(memory: EpisodeMemory) -> dict[str, int]:
+    """Return per-action-name pick counts over the current memory.
+
+    Convenience helper for Wave-4 policies that want to penalise
+    over-used actions ("explored already") without re-implementing
+    the counting loop. Returns a fresh dict on every call so callers
+    can mutate freely.
+    """
+    counts: dict[str, int] = {}
+    for step in memory.window(len(memory)):
+        counts[step.action_name] = counts.get(step.action_name, 0) + 1
+    return counts
+
+
+__all__ = [
+    "ChangeDetector",
+    "EpisodeMemory",
+    "EpisodeStep",
+    "FrameChange",
+    "StuckDetector",
+    "count_actions",
+]

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_episode_memory.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_episode_memory.py
@@ -1,0 +1,244 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 Wave-3 — EpisodeMemory + ChangeDetector + StuckDetector tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
+    ChangeDetector,
+    EpisodeMemory,
+    StuckDetector,
+    count_actions,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+@dataclass
+class _StubGameState:
+    name: str = "NOT_FINISHED"
+
+
+@dataclass
+class _StubFrame:
+    game_id: str = "ls20"
+    state: _StubGameState = field(default_factory=_StubGameState)
+    levels_completed: int = 0
+    win_levels: int = 1
+    guid: str = ""
+    full_reset: bool = False
+    frame: list[Any] = field(default_factory=list)
+    available_actions: list[Any] = field(default_factory=list)
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+# ---------------------------------------------------------------------------
+# EpisodeMemory
+# ---------------------------------------------------------------------------
+
+
+class TestEpisodeMemory:
+    def test_default_capacity_is_sixteen(self) -> None:
+        m = EpisodeMemory()
+        assert m.capacity == 16
+        assert len(m) == 0
+        assert m.last is None
+
+    def test_append_increments_length(self) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[1]]), action_name="ACTION1", levels_completed=0)
+        assert len(m) == 1
+        assert m.last is not None
+        assert m.last.action_name == "ACTION1"
+
+    def test_capacity_evicts_oldest(self) -> None:
+        m = EpisodeMemory(capacity=3)
+        for i in range(5):
+            m.append(grid=_g([[i]]), action_name=f"A{i}", levels_completed=0)
+        assert len(m) == 3
+        assert m.last is not None
+        # Last 3 are A2, A3, A4 (A0, A1 evicted).
+        assert [s.action_name for s in m.window(3)] == ["A4", "A3", "A2"]
+
+    def test_window_zero_returns_empty(self) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[1]]), action_name="ACTION1", levels_completed=0)
+        assert m.window(0) == []
+
+    def test_window_negative_raises(self) -> None:
+        m = EpisodeMemory()
+        with pytest.raises(ValueError, match="n must be >= 0"):
+            m.window(-1)
+
+    def test_window_larger_than_buffer_returns_all(self) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[1]]), action_name="A", levels_completed=0)
+        m.append(grid=_g([[2]]), action_name="B", levels_completed=0)
+        assert len(m.window(10)) == 2
+
+    def test_clear_resets(self) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[1]]), action_name="A", levels_completed=0)
+        m.clear()
+        assert len(m) == 0
+        assert m.last is None
+
+    def test_capacity_zero_rejected(self) -> None:
+        with pytest.raises(ValueError, match="capacity must be >= 1"):
+            EpisodeMemory(capacity=0)
+
+    def test_step_grid_is_isolated_copy(self) -> None:
+        m = EpisodeMemory()
+        original = _g([[1, 2], [3, 4]])
+        m.append(grid=original, action_name="A", levels_completed=0)
+        original[0, 0] = 99
+        # Memory's snapshot should not see the post-append mutation.
+        assert m.last is not None
+        assert m.last.grid[0, 0] == 1
+
+
+# ---------------------------------------------------------------------------
+# ChangeDetector
+# ---------------------------------------------------------------------------
+
+
+class TestChangeDetector:
+    def test_no_change(self) -> None:
+        prev = _g([[1, 2], [3, 4]])
+        curr = _g([[1, 2], [3, 4]])
+        diff = ChangeDetector.diff(
+            prev, curr, previous_levels=0, current_frame=_StubFrame(levels_completed=0)
+        )
+        assert diff.cells_changed == 0
+        assert diff.shape_changed is False
+        assert diff.levels_advanced is False
+        assert diff.full_reset is False
+        assert diff.is_change is False
+
+    def test_one_cell_changed(self) -> None:
+        prev = _g([[1, 2], [3, 4]])
+        curr = _g([[1, 2], [3, 9]])
+        diff = ChangeDetector.diff(
+            prev, curr, previous_levels=0, current_frame=_StubFrame(levels_completed=0)
+        )
+        assert diff.cells_changed == 1
+        assert diff.is_change is True
+
+    def test_shape_change(self) -> None:
+        prev = _g([[1, 2], [3, 4]])
+        curr = _g([[5]])
+        diff = ChangeDetector.diff(
+            prev, curr, previous_levels=0, current_frame=_StubFrame(levels_completed=0)
+        )
+        assert diff.shape_changed is True
+        assert diff.cells_changed == 5  # 4 + 1
+        assert diff.is_change is True
+
+    def test_level_advance_flagged(self) -> None:
+        prev = _g([[1]])
+        curr = _g([[1]])  # grid unchanged but levels_completed went up
+        diff = ChangeDetector.diff(
+            prev, curr, previous_levels=0, current_frame=_StubFrame(levels_completed=1)
+        )
+        assert diff.cells_changed == 0
+        assert diff.levels_advanced is True
+        assert diff.is_change is True
+
+    def test_full_reset_flagged(self) -> None:
+        prev = _g([[1]])
+        curr = _g([[1]])
+        diff = ChangeDetector.diff(
+            prev,
+            curr,
+            previous_levels=0,
+            current_frame=_StubFrame(levels_completed=0, full_reset=True),
+        )
+        assert diff.full_reset is True
+        assert diff.is_change is True
+
+
+# ---------------------------------------------------------------------------
+# StuckDetector
+# ---------------------------------------------------------------------------
+
+
+class TestStuckDetector:
+    def test_default_threshold_five(self) -> None:
+        d = StuckDetector()
+        assert d.threshold == 5
+
+    def test_threshold_zero_rejected(self) -> None:
+        with pytest.raises(ValueError, match="threshold must be >= 1"):
+            StuckDetector(threshold=0)
+
+    def test_empty_memory_not_stuck(self) -> None:
+        d = StuckDetector(threshold=3)
+        assert d.is_stuck(EpisodeMemory()) is False
+
+    def test_too_few_steps_not_stuck(self) -> None:
+        d = StuckDetector(threshold=3)
+        m = EpisodeMemory()
+        m.append(grid=_g([[1]]), action_name="A", levels_completed=0)
+        # Need threshold + 1 = 4 steps before a verdict is possible.
+        assert d.is_stuck(m) is False
+
+    def test_repeated_no_change_marks_stuck(self) -> None:
+        d = StuckDetector(threshold=3)
+        m = EpisodeMemory()
+        for _ in range(5):
+            m.append(grid=_g([[1]]), action_name="A", levels_completed=0)
+        assert d.is_stuck(m) is True
+
+    def test_level_advance_breaks_stuck(self) -> None:
+        d = StuckDetector(threshold=3)
+        m = EpisodeMemory()
+        for i in range(5):
+            # Level advances at step 2 → not stuck.
+            levels = 1 if i >= 2 else 0
+            m.append(grid=_g([[1]]), action_name="A", levels_completed=levels)
+        assert d.is_stuck(m) is False
+
+    def test_grid_change_breaks_stuck(self) -> None:
+        d = StuckDetector(threshold=3)
+        m = EpisodeMemory()
+        m.append(grid=_g([[1]]), action_name="A", levels_completed=0)
+        m.append(grid=_g([[1]]), action_name="A", levels_completed=0)
+        m.append(grid=_g([[2]]), action_name="A", levels_completed=0)  # change!
+        m.append(grid=_g([[2]]), action_name="A", levels_completed=0)
+        m.append(grid=_g([[2]]), action_name="A", levels_completed=0)
+        # window of last 4 has a grid change → not stuck.
+        assert d.is_stuck(m) is False
+
+
+# ---------------------------------------------------------------------------
+# count_actions helper
+# ---------------------------------------------------------------------------
+
+
+class TestCountActions:
+    def test_empty_memory(self) -> None:
+        assert count_actions(EpisodeMemory()) == {}
+
+    def test_counts_across_steps(self) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[1]]), action_name="ACTION1", levels_completed=0)
+        m.append(grid=_g([[1]]), action_name="ACTION1", levels_completed=0)
+        m.append(grid=_g([[1]]), action_name="ACTION2", levels_completed=0)
+        assert count_actions(m) == {"ACTION1": 2, "ACTION2": 1}
+
+    def test_returns_fresh_dict(self) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[1]]), action_name="A", levels_completed=0)
+        c1 = count_actions(m)
+        c2 = count_actions(m)
+        c1["X"] = 999
+        assert "X" not in c2


### PR DESCRIPTION
## Summary

Wave-3 of the ARC-AGI-3 Game-Agent integration. Three pure modules that give downstream agents the episode-state primitives they need to reason about progress over multiple frames.

## What's added

### `EpisodeMemory` — bounded ring-buffer of `(grid, action, levels)` tuples

Default capacity 16. Frozen `EpisodeStep` snapshots are isolated copies of the bridge output, so callers can't mutate the agent's memory through aliasing.

### `ChangeDetector.diff(prev, curr, ...)` — structured frame diff

Returns a `FrameChange` with `cells_changed`, `shape_changed`, `levels_advanced`, `full_reset`. Pure static method; no internal state.

### `StuckDetector(threshold=5)` — progress watchdog

Flags when the last `threshold` consecutive steps showed neither cell change nor level progress. Wave-4's DSL agent uses this to decide when to RESET — staying stuck longer than `threshold` wastes the upstream `MAX_ACTIONS=80` budget.

### `count_actions(memory)` helper

For Wave-4 policies that want to penalise over-used actions ("we tried that one already").

## Properties

- All three import-clean without `arc-agi`/`arcengine`
- Pure modules, 0 shared state, fully Protocol-typed against Wave-1
- `EpisodeStep` is frozen; the memory copies grids on append

## Test plan
- [x] 24 new tests pass (EpisodeMemory: 9, ChangeDetector: 5, StuckDetector: 6, count_actions: 3, plus init guards)
- [x] Total Sprint-11 tests: 59 (Wave-1 13 + Wave-2 22 + Wave-3 24)
- [x] Full PSE suite: 1523 passed, 10 skipped — no regressions
- [x] `mypy --strict` clean across all 6 `arc_agi3/` source files
- [x] `ruff check` + `ruff format --check` clean
- [x] Branch on top of main post-#283

## Wave-plan progress

| Wave | PR | Status |
|---|---|---|
| 1 — Foundation | #282 | ✅ merged |
| 2 — FrameBridge + ActionDecoder | #283 | ✅ merged |
| **3 — Episode-state primitives** | **this** | open |
| 4 — Sprint10DSLAgent + DSLActionDecoder | next | – |
| 5 — LLMReasoningAgent (vLLM/qwen3.6:27b) | – | – |
| 6 — arcengine adapter + live API scorecards | – | – |

🤖 Generated with [Claude Code](https://claude.com/claude-code)