### PR TITLE
feat(pse): Sprint-11 Wave-4 — Sprint10DSLAgent + DSLActionDecoder

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
@@ -29,6 +29,10 @@ from cognithor.channels.program_synthesis.arc_agi3.agent import (
     CognithorPSEAgent,
     RandomActionAgent,
 )
+from cognithor.channels.program_synthesis.arc_agi3.dsl_action_decoder import (
+    DSLActionDecoder,
+)
+from cognithor.channels.program_synthesis.arc_agi3.dsl_agent import Sprint10DSLAgent
 from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
     ChangeDetector,
     EpisodeMemory,
@@ -52,6 +56,7 @@ __all__ = [
     "ChangeDetector",
     "ClampPolicy",
     "CognithorPSEAgent",
+    "DSLActionDecoder",
     "EpisodeMemory",
     "EpisodeStep",
     "FrameBridge",
@@ -60,6 +65,7 @@ __all__ = [
     "GameActionProtocol",
     "GameStateProtocol",
     "RandomActionAgent",
+    "Sprint10DSLAgent",
     "StuckDetector",
     "UniformActionDecoder",
     "count_actions",

--- a/src/cognithor/channels/program_synthesis/arc_agi3/dsl_action_decoder.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/dsl_action_decoder.py
@@ -1,0 +1,97 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 Wave-4 — DSL-aware action decoder.
+
+The Wave-4 :class:`DSLActionDecoder` is the first decoder that uses
+the Sprint-10 DSL + the Wave-3 episode memory to score the
+available actions. The policy is intentionally simple — it's the
+strong baseline against which Wave-5's LLM-driven decoder will be
+measured.
+
+Policy (in order of priority):
+
+1. **Reset on stuck**: if the :class:`StuckDetector` flags the
+   episode as stuck AND ``RESET`` is available, pick it. Cheap escape
+   from a dead loop.
+2. **Least-tried among non-RESET actions**: pick the action that has
+   the lowest historical pick count in this episode, preferring the
+   first such action when ties occur. Penalises over-explored
+   actions and prevents the agent from spending the entire 80-action
+   budget on a single move.
+3. **Fall back to first available** if step 2 produces no candidate
+   (e.g. only RESET is available).
+
+Wave-5 will subclass this with an LLM-prior-weighted score; the
+core "explore the unexplored" policy stays the same.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cognithor.channels.program_synthesis.arc_agi3.action_decoder import ActionDecoder
+from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
+    EpisodeMemory,
+    StuckDetector,
+    count_actions,
+)
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.arc_agi3.protocol import (
+        FrameDataProtocol,
+        GameActionProtocol,
+    )
+
+
+class DSLActionDecoder(ActionDecoder):
+    """Stateful decoder over an :class:`EpisodeMemory`.
+
+    The decoder reads from the memory but never mutates it — the
+    agent is responsible for appending new steps after each call.
+    """
+
+    def __init__(
+        self,
+        *,
+        memory: EpisodeMemory,
+        stuck_detector: StuckDetector | None = None,
+    ) -> None:
+        self._memory = memory
+        self._stuck = stuck_detector if stuck_detector is not None else StuckDetector()
+
+    @property
+    def memory(self) -> EpisodeMemory:
+        return self._memory
+
+    def pick_action(
+        self,
+        frames: list[FrameDataProtocol],
+        latest_frame: FrameDataProtocol,
+        available_actions: list[GameActionProtocol],
+    ) -> tuple[GameActionProtocol, str]:
+        # Step 1 — reset on stuck if RESET is available.
+        if self._stuck.is_stuck(self._memory):
+            for action in available_actions:
+                if action.name == "RESET":
+                    return action, (
+                        f"DSLActionDecoder: stuck for ≥{self._stuck.threshold} steps; "
+                        "RESET to escape the loop"
+                    )
+
+        # Step 2 — least-tried non-RESET action.
+        counts = count_actions(self._memory)
+        candidates = [a for a in available_actions if a.name != "RESET"]
+        if candidates:
+            # Pick the candidate with the smallest historical count.
+            # ``min`` is stable, so the first candidate with the
+            # minimum count wins on ties.
+            best = min(candidates, key=lambda a: counts.get(a.name, 0))
+            best_count = counts.get(best.name, 0)
+            return best, (
+                f"DSLActionDecoder: least-tried non-RESET ({best.name} picked {best_count}× so far)"
+            )
+
+        # Step 3 — fall back to first available (likely RESET only).
+        return available_actions[0], ("DSLActionDecoder: only RESET available, picking it")
+
+
+__all__ = ["DSLActionDecoder"]

--- a/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
@@ -1,0 +1,116 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 Wave-4 — Sprint10DSLAgent: stateful DSL-aware ARC-AGI-3 agent.
+
+The Wave-4 agent wires Wave-1's :class:`CognithorPSEAgent` ABC,
+Wave-2's :class:`FrameBridge` + :class:`ActionDecoder`, and Wave-3's
+:class:`EpisodeMemory` + :class:`StuckDetector` into a complete
+runnable agent. It's the first concrete agent that uses the
+Sprint-10 DSL surface (via :class:`FrameBridge`) AND maintains
+episode state for multi-frame reasoning.
+
+The agent's ``choose_action`` flow:
+
+1. Bridge the current ``FrameData`` to a Cognithor int8 grid.
+2. Append the previous step's ``(grid, action_name, levels_completed)``
+   to the memory — but only after the second frame, since step 1's
+   "previous action" is meaningless before the agent has acted once.
+3. Delegate to the :class:`DSLActionDecoder`, which scores actions
+   against the memory state.
+4. Track the just-chosen action's name so step 2 can record it on
+   the next frame.
+
+The agent stops on WIN. Subclasses can override :meth:`is_done` for
+GAME_OVER policies (e.g. retry loops).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cognithor.channels.program_synthesis.arc_agi3.agent import CognithorPSEAgent
+from cognithor.channels.program_synthesis.arc_agi3.dsl_action_decoder import (
+    DSLActionDecoder,
+)
+from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
+    EpisodeMemory,
+    StuckDetector,
+)
+from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import FrameBridge
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.arc_agi3.protocol import (
+        FrameDataProtocol,
+        GameActionProtocol,
+    )
+
+
+class Sprint10DSLAgent(CognithorPSEAgent):
+    """Stateful agent that uses the Sprint-10 DSL (via FrameBridge)
+    and maintains an :class:`EpisodeMemory` to drive a least-tried-
+    non-RESET action policy with stuck-detection.
+
+    Sprint-11 Wave-4 baseline. The Wave-5 LLM agent subclasses this
+    and replaces the decoder with an LLM-prior-weighted scorer; the
+    memory + stuck plumbing stays the same.
+    """
+
+    def __init__(
+        self,
+        *,
+        bridge: FrameBridge | None = None,
+        memory: EpisodeMemory | None = None,
+        stuck_detector: StuckDetector | None = None,
+    ) -> None:
+        self._bridge = bridge if bridge is not None else FrameBridge()
+        self._memory = memory if memory is not None else EpisodeMemory()
+        self._stuck = stuck_detector if stuck_detector is not None else StuckDetector()
+        self._decoder = DSLActionDecoder(memory=self._memory, stuck_detector=self._stuck)
+        # Tracks the most-recently-chosen action's name so we can
+        # record it in the memory when the next frame arrives.
+        # ``None`` until the first ``choose_action`` call.
+        self._pending_action_name: str | None = None
+        self._pending_levels: int | None = None
+
+    @property
+    def memory(self) -> EpisodeMemory:
+        """Read-only access for tests + downstream Wave-5 wiring."""
+        return self._memory
+
+    def is_done(
+        self,
+        frames: list[FrameDataProtocol],
+        latest_frame: FrameDataProtocol,
+    ) -> bool:
+        return latest_frame.state.name in {"WIN", "GAME_OVER"}
+
+    def choose_action(
+        self,
+        frames: list[FrameDataProtocol],
+        latest_frame: FrameDataProtocol,
+    ) -> GameActionProtocol:
+        # Step 1 — bridge the current frame to a Cognithor grid.
+        # Errors (out-of-range, wrong shape) propagate; the upstream
+        # harness logs and retries one frame later if this happens.
+        current_grid = self._bridge.extract_grid(latest_frame)
+
+        # Step 2 — record the previous step in the memory if we
+        # already chose an action. The grid we pair with the
+        # previous action is the *current* grid (i.e. the frame
+        # that resulted from that action).
+        if self._pending_action_name is not None:
+            self._memory.append(
+                grid=current_grid,
+                action_name=self._pending_action_name,
+                levels_completed=latest_frame.levels_completed,
+            )
+
+        # Step 3 — delegate to the DSL decoder.
+        chosen = self._decoder.decode(frames, latest_frame)
+
+        # Step 4 — remember the choice for the next call.
+        self._pending_action_name = chosen.name
+        self._pending_levels = latest_frame.levels_completed
+        return chosen
+
+
+__all__ = ["Sprint10DSLAgent"]

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_dsl_agent.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_dsl_agent.py
@@ -1,0 +1,269 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 Wave-4 — Sprint10DSLAgent + DSLActionDecoder tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.arc_agi3.dsl_action_decoder import (
+    DSLActionDecoder,
+)
+from cognithor.channels.program_synthesis.arc_agi3.dsl_agent import Sprint10DSLAgent
+from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
+    EpisodeMemory,
+    StuckDetector,
+)
+from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import FrameBridge
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+@dataclass
+class _StubGameState:
+    name: str = "NOT_FINISHED"
+
+
+@dataclass
+class _StubAction:
+    name: str
+    value: int
+    reasoning: str = ""
+    _data: dict[str, Any] = field(default_factory=dict)
+    _is_simple: bool = True
+
+    def is_simple(self) -> bool:
+        return self._is_simple
+
+    def is_complex(self) -> bool:
+        return not self._is_simple
+
+    def set_data(self, data: dict[str, Any]) -> None:
+        self._data = dict(data)
+
+
+@dataclass
+class _StubFrame:
+    game_id: str = "ls20"
+    state: _StubGameState = field(default_factory=_StubGameState)
+    levels_completed: int = 0
+    win_levels: int = 1
+    guid: str = ""
+    full_reset: bool = False
+    frame: list[Any] = field(default_factory=list)
+    available_actions: list[_StubAction] = field(default_factory=list)
+
+
+def _frame(grid: np.ndarray, **kwargs: Any) -> _StubFrame:
+    actions = kwargs.pop(
+        "available_actions",
+        [
+            _StubAction(name="RESET", value=0),
+            _StubAction(name="ACTION1", value=1),
+            _StubAction(name="ACTION2", value=2),
+            _StubAction(name="ACTION3", value=3),
+        ],
+    )
+    return _StubFrame(frame=[grid], available_actions=actions, **kwargs)
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int_)
+
+
+# ---------------------------------------------------------------------------
+# DSLActionDecoder
+# ---------------------------------------------------------------------------
+
+
+class TestDSLActionDecoder:
+    def test_picks_least_tried_non_reset(self) -> None:
+        memory = EpisodeMemory()
+        # ACTION1 used 2x, ACTION2 used 1x. With ACTION3 also
+        # available and never used (count=0), ACTION3 wins as
+        # least-tried. Restrict to ACTION1+ACTION2 to test the
+        # tie-break-on-min behaviour cleanly.
+        np_grid = np.array([[1]], dtype=np.int8)
+        memory.append(grid=np_grid, action_name="ACTION1", levels_completed=0)
+        memory.append(grid=np_grid, action_name="ACTION1", levels_completed=0)
+        memory.append(grid=np_grid, action_name="ACTION2", levels_completed=0)
+        decoder = DSLActionDecoder(memory=memory)
+        frame = _frame(
+            _g([[1]]),
+            available_actions=[
+                _StubAction(name="RESET", value=0),
+                _StubAction(name="ACTION1", value=1),
+                _StubAction(name="ACTION2", value=2),
+            ],
+        )
+        chosen = decoder.decode([frame], frame)
+        # Without ACTION3 in the pool, the least-used non-RESET is ACTION2 (count 1).
+        assert chosen.name == "ACTION2"
+
+    def test_prefers_never_tried_action(self) -> None:
+        """When some actions have count > 0 and one has count 0,
+        the never-tried one wins."""
+        memory = EpisodeMemory()
+        np_grid = np.array([[1]], dtype=np.int8)
+        memory.append(grid=np_grid, action_name="ACTION1", levels_completed=0)
+        decoder = DSLActionDecoder(memory=memory)
+        frame = _frame(
+            _g([[1]]),
+            available_actions=[
+                _StubAction(name="ACTION1", value=1),
+                _StubAction(name="ACTION3", value=3),
+            ],
+        )
+        chosen = decoder.decode([frame], frame)
+        assert chosen.name == "ACTION3"
+
+    def test_resets_on_stuck(self) -> None:
+        memory = EpisodeMemory()
+        # 6 identical no-progress steps → stuck (default threshold 5).
+        np_grid = np.array([[1]], dtype=np.int8)
+        for _ in range(6):
+            memory.append(grid=np_grid, action_name="ACTION1", levels_completed=0)
+        decoder = DSLActionDecoder(memory=memory)
+        frame = _frame(_g([[1]]))
+        chosen = decoder.decode([frame], frame)
+        assert chosen.name == "RESET"
+        assert "stuck" in chosen.reasoning.lower()
+
+    def test_does_not_reset_when_reset_unavailable(self) -> None:
+        memory = EpisodeMemory()
+        np_grid = np.array([[1]], dtype=np.int8)
+        for _ in range(6):
+            memory.append(grid=np_grid, action_name="ACTION1", levels_completed=0)
+        decoder = DSLActionDecoder(memory=memory)
+        # No RESET in available actions; must fall back to least-tried.
+        frame = _frame(
+            _g([[1]]),
+            available_actions=[
+                _StubAction(name="ACTION1", value=1),
+                _StubAction(name="ACTION2", value=2),
+            ],
+        )
+        chosen = decoder.decode([frame], frame)
+        assert chosen.name == "ACTION2"
+
+    def test_picks_first_when_only_reset_available(self) -> None:
+        decoder = DSLActionDecoder(memory=EpisodeMemory())
+        frame = _frame(_g([[1]]), available_actions=[_StubAction(name="RESET", value=0)])
+        chosen = decoder.decode([frame], frame)
+        assert chosen.name == "RESET"
+        assert "only RESET" in chosen.reasoning
+
+    def test_custom_stuck_threshold(self) -> None:
+        memory = EpisodeMemory()
+        # Threshold 2 → stuck after 3 no-progress steps.
+        np_grid = np.array([[1]], dtype=np.int8)
+        for _ in range(3):
+            memory.append(grid=np_grid, action_name="ACTION1", levels_completed=0)
+        decoder = DSLActionDecoder(memory=memory, stuck_detector=StuckDetector(threshold=2))
+        frame = _frame(_g([[1]]))
+        chosen = decoder.decode([frame], frame)
+        assert chosen.name == "RESET"
+
+
+# ---------------------------------------------------------------------------
+# Sprint10DSLAgent — end-to-end loop
+# ---------------------------------------------------------------------------
+
+
+class TestSprint10DSLAgent:
+    def test_runs_full_episode(self) -> None:
+        agent = Sprint10DSLAgent()
+        frames: list[_StubFrame] = []
+        for i in range(10):
+            state_name = "WIN" if i >= 5 else "NOT_FINISHED"
+            frame = _frame(_g([[i % 9]]), state=_StubGameState(name=state_name))
+            frames.append(frame)
+            if agent.is_done(frames, frame):
+                break
+            chosen = agent.choose_action(frames, frame)
+            assert chosen.name in {"RESET", "ACTION1", "ACTION2", "ACTION3"}
+        assert frames[-1].state.name == "WIN"
+
+    def test_memory_grows_with_actions(self) -> None:
+        agent = Sprint10DSLAgent()
+        for i in range(5):
+            frame = _frame(_g([[i % 9]]))
+            agent.choose_action([frame], frame)
+        # The first call has no previous action to record; subsequent
+        # 4 calls each push one step. So memory length is 4.
+        assert len(agent.memory) == 4
+
+    def test_reset_after_stuck(self) -> None:
+        # Use a tight threshold so stuck triggers fast.
+        memory = EpisodeMemory()
+        agent = Sprint10DSLAgent(memory=memory, stuck_detector=StuckDetector(threshold=2))
+        # Feed 5 identical frames so the memory builds up "stuck".
+        for _ in range(5):
+            frame = _frame(_g([[1]]))
+            agent.choose_action([frame], frame)
+        # The 5th call's chosen action should be RESET because the
+        # memory now shows 4 identical steps (threshold 2 +
+        # comparison window).
+        last_step = agent.memory.last
+        assert last_step is not None
+        # The last recorded action is from the 4th choose_action call,
+        # because the 5th call records the previous step before deciding.
+        # The 5th call's RESET will be recorded on the (hypothetical) 6th call.
+        # So we just verify the agent eventually picks RESET.
+        # Run one more round and check that's RESET.
+        frame = _frame(_g([[1]]))
+        chosen = agent.choose_action([frame], frame)
+        assert chosen.name == "RESET"
+
+    def test_is_done_on_win(self) -> None:
+        agent = Sprint10DSLAgent()
+        frame = _frame(_g([[1]]), state=_StubGameState(name="WIN"))
+        assert agent.is_done([frame], frame) is True
+
+    def test_is_done_on_game_over(self) -> None:
+        agent = Sprint10DSLAgent()
+        frame = _frame(_g([[1]]), state=_StubGameState(name="GAME_OVER"))
+        assert agent.is_done([frame], frame) is True
+
+    def test_is_done_returns_false_otherwise(self) -> None:
+        agent = Sprint10DSLAgent()
+        frame = _frame(_g([[1]]), state=_StubGameState(name="NOT_FINISHED"))
+        assert agent.is_done([frame], frame) is False
+
+    def test_palette_clamp_through_bridge(self) -> None:
+        """Frames with values 10..15 get clamped to 9 by the default
+        SATURATE policy. Verify the agent doesn't error out on a wide-
+        palette frame.
+        """
+        agent = Sprint10DSLAgent()
+        frame = _frame(_g([[10, 11, 15]]))
+        chosen = agent.choose_action([frame], frame)
+        assert chosen is not None  # didn't raise
+
+    def test_custom_bridge(self) -> None:
+        from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import ClampPolicy
+
+        agent = Sprint10DSLAgent(bridge=FrameBridge(clamp_policy=ClampPolicy.MODULO))
+        frame = _frame(_g([[10]]))  # 10 % 10 == 0 under MODULO
+        agent.choose_action([frame], frame)
+        # Just verify it ran and recorded the step.
+        # First call doesn't record, so no assertion on memory yet —
+        # next round will.
+        frame2 = _frame(_g([[10]]))
+        agent.choose_action([frame2], frame2)
+        last = agent.memory.last
+        assert last is not None
+        # Under MODULO, both grids became [[0]].
+        assert last.grid.tolist() == [[0]]
+
+    def test_strict_clamp_propagates_error(self) -> None:
+        from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import ClampPolicy
+
+        agent = Sprint10DSLAgent(bridge=FrameBridge(clamp_policy=ClampPolicy.STRICT))
+        frame = _frame(_g([[10]]))
+        with pytest.raises(ValueError, match="STRICT"):
+            agent.choose_action([frame], frame)


### PR DESCRIPTION
## Summary

Wave-4 of the ARC-AGI-3 Game-Agent integration. **First runnable agent** that wires Wave-1 + Wave-2 + Wave-3 into a complete stateful policy.

## What's added

### `DSLActionDecoder` — stateful action decoder over `EpisodeMemory`

Policy in priority order:

1. **Reset on stuck** — if `StuckDetector` flags the episode AND `RESET` is available, pick it. Cheap escape from a dead loop.
2. **Least-tried non-RESET** — pick the action with the lowest historical pick count. Penalises over-explored actions.
3. **Fall back to first available** — when only `RESET` is available.

### `Sprint10DSLAgent` — `CognithorPSEAgent` subclass

Per `choose_action`:
1. Bridge the current frame to a Cognithor `int8 [0..9]` grid via `FrameBridge`
2. Record the previous step into `EpisodeMemory` (since the previous action's effect is what produced this frame)
3. Delegate to `DSLActionDecoder`
4. Remember the choice for the next call

Wave-5 `LLMReasoningAgent` will subclass `Sprint10DSLAgent` and replace the decoder with an LLM-prior-weighted scorer; the memory + stuck plumbing stays the same.

## Test plan
- [x] 15 new tests pass (DSLActionDecoder: 6, Sprint10DSLAgent end-to-end: 9)
- [x] Total Sprint-11 tests: 74 (Wave-1 13 + Wave-2 22 + Wave-3 24 + Wave-4 15)
- [x] Full PSE suite: 1538 passed, 10 skipped — no regressions
- [x] `mypy --strict` clean across all 8 `arc_agi3/` source files
- [x] `ruff check` + `ruff format --check` clean
- [x] Branch on top of main post-#284

## Wave-plan progress

| Wave | PR | Status |
|---|---|---|
| 1 — Foundation | #282 | ✅ merged |
| 2 — FrameBridge + ActionDecoder | #283 | ✅ merged |
| 3 — Episode-state primitives | #284 | ✅ merged |
| **4 — Sprint10DSLAgent + DSLActionDecoder** | **this** | open |
| 5 — LLMReasoningAgent (vLLM/qwen3.6:27b) | next | – |
| 6 — arcengine adapter + live API scorecards | – | – |

🤖 Generated with [Claude Code](https://claude.com/claude-code)