### PR TITLE
feat(pse): Sprint-11 Wave-5 — LLMReasoningAgent over vLLM/qwen3.6:27b

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
@@ -45,6 +45,17 @@ from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import (
     ClampPolicy,
     FrameBridge,
 )
+from cognithor.channels.program_synthesis.arc_agi3.llm_action_decoder import (
+    ChoiceFn,
+    FrameContext,
+    LLMActionDecoder,
+    render_grid,
+    summarise_history,
+)
+from cognithor.channels.program_synthesis.arc_agi3.llm_agent import (
+    LLMReasoningAgent,
+    build_vllm_choice_fn,
+)
 from cognithor.channels.program_synthesis.arc_agi3.protocol import (
     FrameDataProtocol,
     GameActionProtocol,
@@ -54,6 +65,7 @@ from cognithor.channels.program_synthesis.arc_agi3.protocol import (
 __all__ = [
     "ActionDecoder",
     "ChangeDetector",
+    "ChoiceFn",
     "ClampPolicy",
     "CognithorPSEAgent",
     "DSLActionDecoder",
@@ -61,12 +73,18 @@ __all__ = [
     "EpisodeStep",
     "FrameBridge",
     "FrameChange",
+    "FrameContext",
     "FrameDataProtocol",
     "GameActionProtocol",
     "GameStateProtocol",
+    "LLMActionDecoder",
+    "LLMReasoningAgent",
     "RandomActionAgent",
     "Sprint10DSLAgent",
     "StuckDetector",
     "UniformActionDecoder",
+    "build_vllm_choice_fn",
     "count_actions",
+    "render_grid",
+    "summarise_history",
 ]

--- a/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
@@ -38,6 +38,9 @@ from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
 from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import FrameBridge
 
 if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.arc_agi3.action_decoder import (
+        ActionDecoder,
+    )
     from cognithor.channels.program_synthesis.arc_agi3.protocol import (
         FrameDataProtocol,
         GameActionProtocol,
@@ -64,7 +67,9 @@ class Sprint10DSLAgent(CognithorPSEAgent):
         self._bridge = bridge if bridge is not None else FrameBridge()
         self._memory = memory if memory is not None else EpisodeMemory()
         self._stuck = stuck_detector if stuck_detector is not None else StuckDetector()
-        self._decoder = DSLActionDecoder(memory=self._memory, stuck_detector=self._stuck)
+        self._decoder: ActionDecoder = DSLActionDecoder(
+            memory=self._memory, stuck_detector=self._stuck
+        )
         # Tracks the most-recently-chosen action's name so we can
         # record it in the memory when the next frame arrives.
         # ``None`` until the first ``choose_action`` call.

--- a/src/cognithor/channels/program_synthesis/arc_agi3/llm_action_decoder.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/llm_action_decoder.py
@@ -1,0 +1,196 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 Wave-5 — LLM-driven action decoder.
+
+The Wave-5 :class:`LLMActionDecoder` replaces Wave-4's heuristic
+"least-tried action" policy with an LLM call: per frame, format a
+prompt that describes the current grid + recent history + available
+actions, ask the LLM which action to take, and return the
+LLM-suggested action.
+
+The actual LLM call is injected as a ``prompt_to_choice`` callable.
+This keeps the decoder synchronous (mandatory — the upstream
+``Agent.choose_action`` is sync) AND testable (tests pass a stub
+callable that returns deterministic choices). A production factory
+:func:`build_vllm_choice_fn` wraps a Sprint-10 :class:`VLLMBackend`
+into the right shape, doing the async-in-sync via :func:`asyncio.run`.
+
+Without a running vLLM server, the production factory fails fast on
+the first call; the decoder then falls back to its Wave-4
+:class:`DSLActionDecoder` policy if a fallback is configured. This
+mirrors Sprint-10 Track B's hardware-gated wiring.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from cognithor.channels.program_synthesis.arc_agi3.action_decoder import ActionDecoder
+from cognithor.channels.program_synthesis.arc_agi3.dsl_action_decoder import (
+    DSLActionDecoder,
+)
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
+
+    from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
+        EpisodeMemory,
+    )
+    from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import FrameBridge
+    from cognithor.channels.program_synthesis.arc_agi3.protocol import (
+        FrameDataProtocol,
+        GameActionProtocol,
+    )
+
+    _Grid = NDArray[np.int8]
+
+
+@dataclass(frozen=True)
+class FrameContext:
+    """Bundle of inputs the LLM-prompt-builder reads.
+
+    The decoder constructs this once per :meth:`pick_action` call,
+    then hands it to the injected ``prompt_to_choice`` callable. The
+    callable returns ``(action_name, reasoning)``; the decoder
+    matches the name against ``available_actions`` and returns the
+    matching action.
+    """
+
+    grid: _Grid
+    available_action_names: list[str]
+    history_summary: str
+    levels_completed: int
+    win_levels: int
+
+
+# A callable that takes a :class:`FrameContext` and returns
+# ``(chosen_action_name, reasoning_text)``. The action name MUST be
+# one of ``ctx.available_action_names``; the decoder validates this.
+ChoiceFn = Callable[[FrameContext], tuple[str, str]]
+
+
+def render_grid(grid: _Grid) -> str:
+    """Render an ``int8`` grid as a multi-line ASCII string for the LLM.
+
+    Single-digit values mean each row is a contiguous ``012345``-style
+    string. The renderer pads with spaces between columns for readability,
+    which makes the column structure visible in the LLM's chat-window
+    rendering.
+    """
+    if grid.ndim != 2:
+        raise ValueError(f"render_grid: expected 2-D grid, got {grid.ndim}-D")
+    return "\n".join(" ".join(str(int(c)) for c in row) for row in grid)
+
+
+def summarise_history(memory: EpisodeMemory, max_steps: int = 8) -> str:
+    """Compact text description of the last ``max_steps`` actions.
+
+    Format: ``"step -3: ACTION1 (no change), step -2: RESET (level up), ..."``
+    Used in the Stage-1 prompt so the LLM knows what's been tried.
+    Empty history yields ``"(no actions yet)"``.
+    """
+    if max_steps < 1:
+        raise ValueError(f"summarise_history: max_steps must be >= 1, got {max_steps}")
+    window = memory.window(max_steps)
+    if not window:
+        return "(no actions yet)"
+    parts: list[str] = []
+    for i, step in enumerate(window):
+        # ``window`` is most-recent first; show step -1 for the
+        # most recent, step -2 for the prior, etc.
+        idx = -(i + 1)
+        levels_marker = f", level={step.levels_completed}" if step.levels_completed > 0 else ""
+        parts.append(f"step {idx}: {step.action_name}{levels_marker}")
+    return "; ".join(parts)
+
+
+class LLMActionDecoder(ActionDecoder):
+    """Stateful decoder that delegates the choice to an LLM.
+
+    Construct with:
+
+    * ``bridge`` — :class:`FrameBridge` to convert the live frame to
+      the Cognithor int8 grid that gets rendered for the prompt
+    * ``memory`` — :class:`EpisodeMemory` for the history-summary
+    * ``choice_fn`` — synchronous callable from
+      :class:`FrameContext` to ``(action_name, reasoning)``. Production
+      uses :func:`build_vllm_choice_fn`; tests pass deterministic stubs.
+    * ``fallback`` (optional) — another :class:`ActionDecoder` used
+      when ``choice_fn`` raises or returns an unknown action.
+      Default: a fresh :class:`DSLActionDecoder` over the same memory.
+    * ``history_steps`` — how many recent steps to summarise in the
+      prompt. Default 8.
+    """
+
+    def __init__(
+        self,
+        *,
+        bridge: FrameBridge,
+        memory: EpisodeMemory,
+        choice_fn: ChoiceFn,
+        fallback: ActionDecoder | None = None,
+        history_steps: int = 8,
+    ) -> None:
+        self._bridge = bridge
+        self._memory = memory
+        self._choice_fn = choice_fn
+        self._fallback = fallback if fallback is not None else DSLActionDecoder(memory=memory)
+        self._history_steps = history_steps
+
+    def pick_action(
+        self,
+        frames: list[FrameDataProtocol],
+        latest_frame: FrameDataProtocol,
+        available_actions: list[GameActionProtocol],
+    ) -> tuple[GameActionProtocol, str]:
+        # Build the prompt context.
+        try:
+            grid = self._bridge.extract_grid(latest_frame)
+        except Exception as exc:  # pragma: no cover — bridge errors propagate
+            return self._fallback.pick_action(frames, latest_frame, available_actions) + (
+                f" [LLM bridge failed: {type(exc).__name__}]",
+            )[0:0] or self._fallback.pick_action(frames, latest_frame, available_actions)
+
+        ctx = FrameContext(
+            grid=grid,
+            available_action_names=[a.name for a in available_actions],
+            history_summary=summarise_history(self._memory, self._history_steps),
+            levels_completed=latest_frame.levels_completed,
+            win_levels=latest_frame.win_levels,
+        )
+
+        # Call the LLM (or stub). Failures fall back to the DSL decoder.
+        try:
+            chosen_name, reasoning = self._choice_fn(ctx)
+        except Exception as exc:
+            fallback_action, fb_reasoning = self._fallback.pick_action(
+                frames, latest_frame, available_actions
+            )
+            return fallback_action, (
+                f"LLMActionDecoder fallback ({type(exc).__name__}): {fb_reasoning}"
+            )
+
+        # Validate the LLM's name against the whitelist.
+        for action in available_actions:
+            if action.name == chosen_name:
+                return action, reasoning or f"LLMActionDecoder chose {chosen_name}"
+
+        # LLM picked an action not in the whitelist — fall back.
+        fallback_action, fb_reasoning = self._fallback.pick_action(
+            frames, latest_frame, available_actions
+        )
+        return fallback_action, (
+            f"LLMActionDecoder fallback (LLM returned {chosen_name!r} which is "
+            f"not available): {fb_reasoning}"
+        )
+
+
+__all__ = [
+    "ChoiceFn",
+    "FrameContext",
+    "LLMActionDecoder",
+    "render_grid",
+    "summarise_history",
+]

--- a/src/cognithor/channels/program_synthesis/arc_agi3/llm_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/llm_agent.py
@@ -1,0 +1,152 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 Wave-5 — LLMReasoningAgent over vLLM/qwen3.6:27b.
+
+The Wave-5 :class:`LLMReasoningAgent` subclasses Wave-4's
+:class:`Sprint10DSLAgent` and replaces the heuristic
+:class:`DSLActionDecoder` with an LLM-driven
+:class:`LLMActionDecoder`. The memory + stuck-detection plumbing is
+inherited unchanged.
+
+Construction is parameter-light: pass a ``choice_fn`` callable that
+turns a :class:`FrameContext` into ``(action_name, reasoning)``.
+Production wires :func:`build_vllm_choice_fn` (Sprint-10 Track B's
+:class:`VLLMBackend`); tests pass deterministic stubs.
+
+Without a running vLLM server the production factory falls back to
+the Wave-4 :class:`DSLActionDecoder` policy at the first failed call.
+This mirrors Sprint-10 Track B's hardware-gated wiring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING, Any
+
+from cognithor.channels.program_synthesis.arc_agi3.dsl_agent import Sprint10DSLAgent
+from cognithor.channels.program_synthesis.arc_agi3.llm_action_decoder import (
+    FrameContext,
+    LLMActionDecoder,
+    render_grid,
+)
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
+        EpisodeMemory,
+        StuckDetector,
+    )
+    from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import FrameBridge
+    from cognithor.channels.program_synthesis.arc_agi3.llm_action_decoder import ChoiceFn
+    from cognithor.core.llm_backend import LLMBackend
+
+
+_LLM_SYSTEM_PROMPT = """You are an ARC-AGI-3 game-playing agent backed by Cognithor PSE.
+You receive a frame from a small grid-based game and a list of available actions.
+Pick the action that most likely makes progress toward winning the level.
+
+Respond with strict JSON:
+{
+  "action": "ACTIONx",   // must be one of the available actions
+  "reasoning": "<one short sentence>"
+}
+
+Do not output anything outside the JSON block."""
+
+
+def _build_user_prompt(ctx: FrameContext) -> str:
+    return (
+        f"Current grid ({ctx.grid.shape[0]}x{ctx.grid.shape[1]}):\n"
+        f"{render_grid(ctx.grid)}\n\n"
+        f"Available actions: {', '.join(ctx.available_action_names)}\n"
+        f"Recent history: {ctx.history_summary}\n"
+        f"Progress: {ctx.levels_completed}/{ctx.win_levels} levels\n\n"
+        f"Pick one action and respond as JSON."
+    )
+
+
+def build_vllm_choice_fn(
+    *,
+    backend: LLMBackend,
+    model_name: str = "Qwen/Qwen3.6-27B-Instruct",
+    temperature: float = 0.3,
+    timeout_seconds: float = 8.0,
+) -> ChoiceFn:
+    """Adapter: wrap a Sprint-10 :class:`VLLMBackend` as a synchronous
+    :class:`ChoiceFn`.
+
+    The wrapper does the async-in-sync via :func:`asyncio.run`. It
+    parses the LLM's JSON response and returns ``(action, reasoning)``;
+    on parse failure it raises, so the upstream
+    :class:`LLMActionDecoder` catches it and falls back to the Wave-4
+    DSL policy.
+
+    Without a running vLLM server, the first call raises a connection
+    error and the decoder falls back. The wiring is correct either
+    way — it's hardware-gated, not code-gated.
+    """
+
+    async def _ask(ctx: FrameContext) -> tuple[str, str]:
+        response = await asyncio.wait_for(
+            backend.chat(
+                model=model_name,
+                messages=[
+                    {"role": "system", "content": _LLM_SYSTEM_PROMPT},
+                    {"role": "user", "content": _build_user_prompt(ctx)},
+                ],
+                temperature=temperature,
+            ),
+            timeout=timeout_seconds,
+        )
+        text = response.content.strip()
+        # Find the JSON block — the model might wrap it in code fences.
+        start = text.find("{")
+        end = text.rfind("}")
+        if start < 0 or end <= start:
+            raise ValueError(f"LLM response missing JSON block: {text[:200]!r}")
+        parsed: dict[str, Any] = json.loads(text[start : end + 1])
+        action_name = str(parsed.get("action", "")).strip()
+        reasoning = str(parsed.get("reasoning", "")).strip()
+        if not action_name:
+            raise ValueError(f"LLM response missing 'action' field: {parsed!r}")
+        return action_name, reasoning
+
+    def _sync_choice(ctx: FrameContext) -> tuple[str, str]:
+        return asyncio.run(_ask(ctx))
+
+    return _sync_choice
+
+
+class LLMReasoningAgent(Sprint10DSLAgent):
+    """Wave-5: Sprint10DSLAgent with the decoder swapped for an LLM-driven one.
+
+    The agent inherits the memory + stuck-detection + frame-bridging
+    plumbing unchanged. Construction takes the same FrameBridge /
+    EpisodeMemory / StuckDetector knobs as the parent, plus a
+    mandatory ``choice_fn`` that drives the LLM call.
+    """
+
+    def __init__(
+        self,
+        *,
+        choice_fn: ChoiceFn,
+        bridge: FrameBridge | None = None,
+        memory: EpisodeMemory | None = None,
+        stuck_detector: StuckDetector | None = None,
+        history_steps: int = 8,
+    ) -> None:
+        super().__init__(bridge=bridge, memory=memory, stuck_detector=stuck_detector)
+        # Override the Wave-4 DSL decoder with the LLM-driven one.
+        # Sprint10DSLAgent's choose_action delegates to ``self._decoder``,
+        # so swapping it is sufficient — no additional override needed.
+        self._decoder = LLMActionDecoder(
+            bridge=self._bridge,
+            memory=self._memory,
+            choice_fn=choice_fn,
+            history_steps=history_steps,
+        )
+
+
+__all__ = [
+    "LLMReasoningAgent",
+    "build_vllm_choice_fn",
+]

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_llm_agent.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_llm_agent.py
@@ -1,0 +1,270 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-11 Wave-5 — LLMReasoningAgent + LLMActionDecoder tests.
+
+The LLM-call adapter (:func:`build_vllm_choice_fn`) is hardware-gated
+on a running vLLM server with qwen3.6:27b loaded — that's out of
+scope for the unit suite. These tests use deterministic stub
+``choice_fn`` callables to validate the wiring + fallback behaviour.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
+    EpisodeMemory,
+)
+from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import FrameBridge
+from cognithor.channels.program_synthesis.arc_agi3.llm_action_decoder import (
+    FrameContext,
+    LLMActionDecoder,
+    render_grid,
+    summarise_history,
+)
+from cognithor.channels.program_synthesis.arc_agi3.llm_agent import (
+    LLMReasoningAgent,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+@dataclass
+class _StubGameState:
+    name: str = "NOT_FINISHED"
+
+
+@dataclass
+class _StubAction:
+    name: str
+    value: int
+    reasoning: str = ""
+    _data: dict[str, Any] = field(default_factory=dict)
+    _is_simple: bool = True
+
+    def is_simple(self) -> bool:
+        return self._is_simple
+
+    def is_complex(self) -> bool:
+        return not self._is_simple
+
+    def set_data(self, data: dict[str, Any]) -> None:
+        self._data = dict(data)
+
+
+@dataclass
+class _StubFrame:
+    game_id: str = "ls20"
+    state: _StubGameState = field(default_factory=_StubGameState)
+    levels_completed: int = 0
+    win_levels: int = 1
+    guid: str = ""
+    full_reset: bool = False
+    frame: list[Any] = field(default_factory=list)
+    available_actions: list[_StubAction] = field(default_factory=list)
+
+
+def _frame(grid: np.ndarray, **kwargs: Any) -> _StubFrame:
+    actions = kwargs.pop(
+        "available_actions",
+        [
+            _StubAction(name="RESET", value=0),
+            _StubAction(name="ACTION1", value=1),
+            _StubAction(name="ACTION2", value=2),
+            _StubAction(name="ACTION3", value=3),
+        ],
+    )
+    return _StubFrame(frame=[grid], available_actions=actions, **kwargs)
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int_)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — render_grid + summarise_history
+# ---------------------------------------------------------------------------
+
+
+class TestRenderGrid:
+    def test_renders_2d_grid_as_lines(self) -> None:
+        out = render_grid(np.array([[1, 2], [3, 4]], dtype=np.int8))
+        assert out == "1 2\n3 4"
+
+    def test_renders_single_row(self) -> None:
+        out = render_grid(np.array([[0, 1, 2]], dtype=np.int8))
+        assert out == "0 1 2"
+
+    def test_rejects_1d_input(self) -> None:
+        with pytest.raises(ValueError, match="2-D"):
+            render_grid(np.array([1, 2, 3], dtype=np.int8))
+
+
+class TestSummariseHistory:
+    def test_empty_memory(self) -> None:
+        assert summarise_history(EpisodeMemory()) == "(no actions yet)"
+
+    def test_one_step(self) -> None:
+        m = EpisodeMemory()
+        m.append(grid=np.array([[1]], dtype=np.int8), action_name="ACTION1", levels_completed=0)
+        out = summarise_history(m)
+        assert "step -1: ACTION1" in out
+
+    def test_level_marker(self) -> None:
+        m = EpisodeMemory()
+        m.append(grid=np.array([[1]], dtype=np.int8), action_name="ACTION1", levels_completed=2)
+        out = summarise_history(m)
+        assert "level=2" in out
+
+    def test_max_steps_bounds(self) -> None:
+        m = EpisodeMemory()
+        for i in range(20):
+            m.append(
+                grid=np.array([[i % 9]], dtype=np.int8),
+                action_name=f"A{i}",
+                levels_completed=0,
+            )
+        out = summarise_history(m, max_steps=3)
+        # Only 3 most-recent steps in the summary.
+        assert out.count("step ") == 3
+
+    def test_max_steps_zero_rejected(self) -> None:
+        with pytest.raises(ValueError, match="max_steps must be >= 1"):
+            summarise_history(EpisodeMemory(), max_steps=0)
+
+
+# ---------------------------------------------------------------------------
+# LLMActionDecoder
+# ---------------------------------------------------------------------------
+
+
+class TestLLMActionDecoder:
+    def test_picks_action_from_stub(self) -> None:
+        bridge = FrameBridge()
+        memory = EpisodeMemory()
+        # Stub LLM that always picks ACTION2.
+        decoder = LLMActionDecoder(
+            bridge=bridge,
+            memory=memory,
+            choice_fn=lambda ctx: ("ACTION2", "stub picks ACTION2"),
+        )
+        frame = _frame(_g([[1]]))
+        chosen = decoder.decode([frame], frame)
+        assert chosen.name == "ACTION2"
+        assert chosen.reasoning == "stub picks ACTION2"
+
+    def test_falls_back_when_choice_fn_raises(self) -> None:
+        bridge = FrameBridge()
+        memory = EpisodeMemory()
+
+        def _raising(ctx: FrameContext) -> tuple[str, str]:
+            raise RuntimeError("simulated LLM failure")
+
+        decoder = LLMActionDecoder(bridge=bridge, memory=memory, choice_fn=_raising)
+        frame = _frame(_g([[1]]))
+        chosen = decoder.decode([frame], frame)
+        # Falls back to DSLActionDecoder, which prefers least-tried
+        # non-RESET action — ACTION1 (count 0, first in list).
+        assert chosen.name in {"ACTION1", "ACTION2", "ACTION3"}
+        assert "fallback" in chosen.reasoning.lower()
+
+    def test_falls_back_when_choice_fn_returns_unknown_action(self) -> None:
+        bridge = FrameBridge()
+        memory = EpisodeMemory()
+        decoder = LLMActionDecoder(
+            bridge=bridge,
+            memory=memory,
+            choice_fn=lambda ctx: ("ACTION_BOGUS", "made up"),
+        )
+        frame = _frame(_g([[1]]))
+        chosen = decoder.decode([frame], frame)
+        assert chosen.name in {"ACTION1", "ACTION2", "ACTION3"}
+        assert "fallback" in chosen.reasoning.lower()
+        assert "ACTION_BOGUS" in chosen.reasoning
+
+    def test_passes_full_context_to_stub(self) -> None:
+        bridge = FrameBridge()
+        memory = EpisodeMemory()
+        captured: list[FrameContext] = []
+
+        def _capturing(ctx: FrameContext) -> tuple[str, str]:
+            captured.append(ctx)
+            return "ACTION1", "ok"
+
+        decoder = LLMActionDecoder(bridge=bridge, memory=memory, choice_fn=_capturing)
+        frame = _frame(_g([[3, 4], [5, 6]]), levels_completed=1, win_levels=3)
+        decoder.decode([frame], frame)
+        assert len(captured) == 1
+        ctx = captured[0]
+        assert ctx.grid.tolist() == [[3, 4], [5, 6]]
+        assert "RESET" in ctx.available_action_names
+        assert ctx.levels_completed == 1
+        assert ctx.win_levels == 3
+
+
+# ---------------------------------------------------------------------------
+# LLMReasoningAgent — full episode loop
+# ---------------------------------------------------------------------------
+
+
+class TestLLMReasoningAgent:
+    def test_runs_with_stub_choice_fn(self) -> None:
+        # Stub picks ACTION1 always, episode ends at WIN.
+        agent = LLMReasoningAgent(choice_fn=lambda ctx: ("ACTION1", "stub"))
+        frames: list[_StubFrame] = []
+        for i in range(8):
+            state_name = "WIN" if i >= 4 else "NOT_FINISHED"
+            frame = _frame(_g([[i % 9]]), state=_StubGameState(name=state_name))
+            frames.append(frame)
+            if agent.is_done(frames, frame):
+                break
+            agent.choose_action(frames, frame)
+        assert frames[-1].state.name == "WIN"
+
+    def test_inherits_episode_memory(self) -> None:
+        agent = LLMReasoningAgent(choice_fn=lambda ctx: ("ACTION1", "stub"))
+        for _ in range(3):
+            frame = _frame(_g([[1]]))
+            agent.choose_action([frame], frame)
+        # 3 calls — first records nothing, next 2 record one each → length 2.
+        assert len(agent.memory) == 2
+
+    def test_falls_back_to_dsl_when_llm_fails(self) -> None:
+        def _always_fails(ctx: FrameContext) -> tuple[str, str]:
+            raise RuntimeError("simulated network error")
+
+        agent = LLMReasoningAgent(choice_fn=_always_fails)
+        frame = _frame(_g([[1]]))
+        chosen = agent.choose_action([frame], frame)
+        # Fell through to DSLActionDecoder (no exception).
+        assert chosen.name in {"ACTION1", "ACTION2", "ACTION3"}
+
+    def test_custom_history_steps(self) -> None:
+        captured: list[FrameContext] = []
+
+        def _cap(ctx: FrameContext) -> tuple[str, str]:
+            captured.append(ctx)
+            return "ACTION1", "stub"
+
+        agent = LLMReasoningAgent(choice_fn=_cap, history_steps=2)
+        # Run 5 frames; the 5th call's prompt should contain at most
+        # 2 history entries (the bound).
+        for _ in range(5):
+            frame = _frame(_g([[1]]))
+            agent.choose_action([frame], frame)
+        last_ctx = captured[-1]
+        # history_summary uses ", " separator + "step -X: A1" pattern
+        # Up to 2 steps shown.
+        assert last_ctx.history_summary.count("step ") <= 2
+
+    def test_is_done_inherits_win_game_over_policy(self) -> None:
+        agent = LLMReasoningAgent(choice_fn=lambda ctx: ("ACTION1", "stub"))
+        for state in ("WIN", "GAME_OVER"):
+            frame = _frame(_g([[1]]), state=_StubGameState(name=state))
+            assert agent.is_done([frame], frame) is True
+        frame = _frame(_g([[1]]), state=_StubGameState(name="NOT_FINISHED"))
+        assert agent.is_done([frame], frame) is False


### PR DESCRIPTION
## Summary

Wave-5 of the ARC-AGI-3 Game-Agent integration. Replaces Wave-4's heuristic least-tried-action policy with an **LLM-driven decoder** that reasons about each frame.

## What's added

### `llm_action_decoder.py`

- `FrameContext` — bundle of inputs the LLM prompt reads (grid, available actions, history summary, level progress)
- `ChoiceFn` — synchronous callable from `FrameContext` → `(action_name, reasoning)`
- `LLMActionDecoder` — sync `ActionDecoder` that delegates to the `choice_fn`. Falls back to `DSLActionDecoder` when the LLM raises or returns an unknown action.
- `render_grid` — `int8` grid → multi-line ASCII for prompts
- `summarise_history` — last N steps as compact text

### `llm_agent.py`

- `_LLM_SYSTEM_PROMPT` — strict-JSON system prompt
- `_build_user_prompt` — grid + actions + history + progress prompt
- **`build_vllm_choice_fn(backend, model_name=...)`** — adapter wrapping a Sprint-10 `VLLMBackend` into a sync `ChoiceFn` (does `asyncio.run` inside, parses JSON, surfaces errors)
- **`LLMReasoningAgent`** — `Sprint10DSLAgent` subclass that swaps the decoder for `LLMActionDecoder`; memory, bridge, stuck detection inherited

## Hardware-gated behaviour

The LLM call adapter is hardware-gated on a running vLLM server with `qwen3.6:27b` loaded — same constraint as Sprint-10 Track B. **Without one, the first call raises and the decoder transparently falls back to the Wave-4 DSL policy.** Tests pass deterministic stub `choice_fn` callables to validate the wiring + fallback behaviour.

## Test plan
- [x] 17 new tests pass — render_grid, summarise_history, LLMActionDecoder (4 tests, incl. fallback paths), LLMReasoningAgent (5 tests, incl. full episode loop with stub LLM)
- [x] Total Sprint-11 tests: 91 (Wave-1 13 + Wave-2 22 + Wave-3 24 + Wave-4 15 + Wave-5 17)
- [x] Full PSE suite: 1555 passed, 10 skipped — no regressions
- [x] `mypy --strict` clean across all 10 `arc_agi3/` source files
- [x] `ruff check` + `ruff format --check` clean
- [x] Branch on top of main post-#285

## Wave-plan progress

| Wave | PR | Status |
|---|---|---|
| 1 — Foundation | #282 | ✅ merged |
| 2 — FrameBridge + ActionDecoder | #283 | ✅ merged |
| 3 — Episode-state primitives | #284 | ✅ merged |
| 4 — Sprint10DSLAgent + DSLActionDecoder | #285 | ✅ merged |
| **5 — LLMReasoningAgent (vLLM/qwen3.6:27b)** | **this** | open |
| 6 — arcengine adapter + live API scorecards | next | – |

🤖 Generated with [Claude Code](https://claude.com/claude-code)