### PR TITLE
fix(pse): Qwen3.6-27B has no instruct variant — switch defaults to FP8 base

### DIFF
--- a/configs/synthesis/heuristics.yaml
+++ b/configs/synthesis/heuristics.yaml
@@ -33,12 +33,16 @@ llm_prior:
   # llama.cpp paths kept for posterity / fallback.
   backend: "vllm"
   base_url: "http://localhost:8000/v1"
-  model_name: "Qwen/Qwen3.6-27B-Instruct"
-  fallback_model_name: "Qwen/Qwen3.6-27B-Instruct-AWQ"
+  # No instruct variant of Qwen3.6-27B exists upstream — base + FP8
+  # quantisation are the canonical HuggingFace repos. FP8 fits in 32 GB
+  # VRAM (RTX 5090) with KV-cache headroom; base BF16 is ~54 GB and
+  # only fits on multi-GPU / A100-class hardware.
+  model_name: "Qwen/Qwen3.6-27B-FP8"
+  fallback_model_name: "Qwen/Qwen3.6-27B"
   call_timeout_seconds: 8.0
   # llama.cpp-specific paths, kept for the alternate-backend
   # contingency the plan called out.
-  model_path: "./models/Qwen3.6-27B-Instruct-Q5_K_M.gguf"
+  model_path: "./models/Qwen3.6-27B-FP8"
   fallback_model_path: "./models/Qwen3.5-7B-Coder-Q5_K_M.gguf"
 
   inference:

--- a/docs/superpowers/plans/2026-04-30-pse-phase2-heuristics.yaml
+++ b/docs/superpowers/plans/2026-04-30-pse-phase2-heuristics.yaml
@@ -27,7 +27,11 @@ spec_version: "phase2_spec_v1.4"
 # ════════════════════════════════════════════════════════════════════
 
 llm_prior:
-  model_path: "./models/Qwen3.6-27B-Instruct-Q5_K_M.gguf"
+  # vLLM-preferred fields (HuggingFace repo ids).
+  model_name: "Qwen/Qwen3.6-27B-FP8"
+  fallback_model_name: "Qwen/Qwen3.6-27B"
+  # llama.cpp-style fallbacks (kept for backend-swap without YAML rewrite).
+  model_path: "./models/Qwen3.6-27B-FP8"
   fallback_model_path: "./models/Qwen3.5-7B-Coder-Q5_K_M.gguf"
   
   inference:

--- a/docs/superpowers/reports/sprint10_track_b_vllm_deployment.md
+++ b/docs/superpowers/reports/sprint10_track_b_vllm_deployment.md
@@ -12,7 +12,7 @@ OpenAI-compat endpoint** into the PSE benchmark runner. The
 `WiredPhase2Engine`'s search loop.
 
 **The wiring is fully constructed and tested at module level.** What's
-missing is a *running* vLLM server with `Qwen/Qwen3.6-27B-Instruct`
+missing is a *running* vLLM server with `Qwen/Qwen3.6-27B-FP8`
 loaded — that requires a 32+ GB GPU (RTX 5090 / A100 / H100) and is
 out of scope for the autonomous-mode session.
 
@@ -25,7 +25,7 @@ python -m cognithor.channels.program_synthesis.synthesis.benchmark_runner \
     --phase2 \
     --llm-prior \
     --llm-base-url http://localhost:8000/v1 \
-    --llm-model Qwen/Qwen3.6-27B-Instruct \
+    --llm-model Qwen/Qwen3.6-27B-FP8 \
     --output sprint10_track_b_training.json
 ```
 
@@ -33,7 +33,7 @@ Flags introduced this PR:
 
 - `--llm-prior` — opt-in switch. Without it, `--phase2` runs without an LLM (cold-start α, identical to pre-Track-B behaviour).
 - `--llm-base-url` — vLLM endpoint URL. Default `http://localhost:8000/v1`.
-- `--llm-model` — model name as registered with vLLM. Default `Qwen/Qwen3.6-27B-Instruct`.
+- `--llm-model` — model name as registered with vLLM. Default `Qwen/Qwen3.6-27B-FP8`.
 
 ## Server-side deployment
 
@@ -56,14 +56,14 @@ pip install vllm==0.6.3
 
 ```bash
 # Q5_K_M quantisation (preferred):
-vllm serve Qwen/Qwen3.6-27B-Instruct \
+vllm serve Qwen/Qwen3.6-27B-FP8 \
     --quantization awq \
     --port 8000 \
     --max-model-len 8192 \
     --gpu-memory-utilization 0.92
 
 # Or Q4_K_M fallback for tighter VRAM:
-vllm serve Qwen/Qwen3.6-27B-Instruct-AWQ \
+vllm serve Qwen/Qwen3.6-27B \
     --quantization awq \
     --port 8000 \
     --max-model-len 4096 \
@@ -74,7 +74,7 @@ Verify:
 
 ```bash
 curl http://localhost:8000/v1/models
-# expected: list with Qwen/Qwen3.6-27B-Instruct
+# expected: list with Qwen/Qwen3.6-27B-FP8
 curl http://localhost:8000/health
 # expected: 200 OK
 ```

--- a/docs/superpowers/reports/sprint11_arc_agi_3_complete.md
+++ b/docs/superpowers/reports/sprint11_arc_agi_3_complete.md
@@ -103,7 +103,7 @@ uv run main.py --agent=cognithor_llm    --game=ls20
 ## Hardware-gated wiring (Wave-5)
 
 The LLM agent's call adapter `build_vllm_choice_fn` is hardware-gated
-on a running vLLM server with `Qwen/Qwen3.6-27B-Instruct` loaded —
+on a running vLLM server with `Qwen/Qwen3.6-27B-FP8` loaded —
 same constraint as Sprint-10 Track B. **Without one, the first call
 raises and the decoder transparently falls back to Wave-4's
 DSLActionDecoder policy.** Tests use deterministic stub `choice_fn`

--- a/scripts/arc_agi3_live_validation.md
+++ b/scripts/arc_agi3_live_validation.md
@@ -1,0 +1,186 @@
+# ARC-AGI-3 Live Validation Runbook
+
+**Hardware:** RTX 5090 (32 GB VRAM), Linux + CUDA 12+ recommended.
+**Model:** `Qwen/Qwen3.6-27B-FP8` (no `Instruct` variant exists upstream — base + FP8 are the canonical Qwen3.6-27B repos).
+
+This runbook drives the first end-to-end Sprint-11 validation: three Cognithor agents (Random / DSL / LLM) playing 3-5 ARC-AGI-3 games, with frozen scorecards committed back as `.ci/arc_agi3_scorecards/*.json` regression baselines.
+
+## Step 1 — vLLM server
+
+```bash
+# Install vLLM (OpenAI-compatible server)
+pip install vllm>=0.6.3
+
+# Launch the FP8 model on the RTX 5090. Reserve 92 % of VRAM for
+# weights + KV-cache; reduce to 0.85 if you also need the GPU for
+# something else simultaneously.
+vllm serve Qwen/Qwen3.6-27B-FP8 \
+    --port 8000 \
+    --max-model-len 16384 \
+    --gpu-memory-utilization 0.92 \
+    --dtype auto
+```
+
+Verify in another shell:
+
+```bash
+curl http://localhost:8000/v1/models
+# expected: list with Qwen/Qwen3.6-27B-FP8
+
+curl -X POST http://localhost:8000/v1/chat/completions \
+    -H "Content-Type: application/json" \
+    -d '{
+      "model": "Qwen/Qwen3.6-27B-FP8",
+      "messages": [{"role": "user", "content": "Reply with the single word OK."}],
+      "max_tokens": 8
+    }'
+# expected: a JSON response with content "OK" (or similar)
+```
+
+If the model has no chat template baked into its tokenizer (base models sometimes don't), add `--chat-template <path>` pointing to a Qwen2-style chat template. Most modern Qwen base models ship the template; check the HF model card.
+
+## Step 2 — ARC-AGI-3 harness setup
+
+```bash
+git clone https://github.com/arcprize/ARC-AGI-3-Agents.git
+cd ARC-AGI-3-Agents
+uv sync
+
+# .env
+cp .env.example .env
+echo "ARC_API_KEY=<your_key_from_three.arcprize.org>" >> .env
+
+# Install Cognithor as an editable dep
+uv pip install -e /path/to/cognithor
+```
+
+## Step 3 — Cognithor agent registration
+
+Drop this into `agents/templates/cognithor_agents.py`:
+
+```python
+"""Cognithor PSE agents (Sprint-11) registered for the ARC-AGI-3 harness."""
+from cognithor.channels.program_synthesis.arc_agi3 import (
+    LLMReasoningAgent,
+    RandomActionAgent,
+    Sprint10DSLAgent,
+    build_vllm_choice_fn,
+    cognithor_agent_factory,
+)
+from cognithor.core.vllm_backend import VLLMBackend
+
+
+# Lower-bound baseline.
+CognithorRandom = cognithor_agent_factory(delegate=RandomActionAgent(seed=42))
+
+# Sprint-10 DSL heuristic — deterministic, no GPU needed.
+CognithorDSL = cognithor_agent_factory(delegate=Sprint10DSLAgent())
+
+# LLM-driven, requires the running vLLM from Step 1.
+_backend = VLLMBackend(base_url="http://localhost:8000/v1")
+_choice_fn = build_vllm_choice_fn(
+    backend=_backend,
+    model_name="Qwen/Qwen3.6-27B-FP8",
+    temperature=0.3,
+)
+CognithorLLM = cognithor_agent_factory(
+    delegate=LLMReasoningAgent(choice_fn=_choice_fn),
+)
+```
+
+Then add to `agents/__init__.py`'s `AVAILABLE_AGENTS`:
+
+```python
+from agents.templates.cognithor_agents import (
+    CognithorRandom, CognithorDSL, CognithorLLM,
+)
+
+AVAILABLE_AGENTS = {
+    # ... existing entries ...
+    "cognithor_random": CognithorRandom,
+    "cognithor_dsl": CognithorDSL,
+    "cognithor_llm": CognithorLLM,
+}
+```
+
+## Step 4 — Execute the validation runs
+
+Pick 3-5 representative games from the ARC-AGI-3 catalogue. The locksmith / ls20 family is a good starter set (small grids, clear win conditions).
+
+```bash
+# Random baseline (the lower bound)
+uv run main.py --agent=cognithor_random --game=ls20      | tee /tmp/random_ls20.log
+uv run main.py --agent=cognithor_random --game=locksmith | tee /tmp/random_locksmith.log
+
+# Sprint-10 DSL heuristic
+uv run main.py --agent=cognithor_dsl --game=ls20      | tee /tmp/dsl_ls20.log
+uv run main.py --agent=cognithor_dsl --game=locksmith | tee /tmp/dsl_locksmith.log
+
+# LLM-reasoning agent (vLLM/Qwen3.6-27B-FP8 — slower per action)
+uv run main.py --agent=cognithor_llm --game=ls20      | tee /tmp/llm_ls20.log
+uv run main.py --agent=cognithor_llm --game=locksmith | tee /tmp/llm_locksmith.log
+```
+
+Each run prints a scorecard URL + dumps the scorecard JSON to stdout.
+
+## Step 5 — Freeze baselines
+
+Capture the scorecards into Cognithor's `.ci/`:
+
+```bash
+mkdir -p /path/to/cognithor/.ci/arc_agi3_scorecards
+# Save each agent's combined scorecard. The harness writes them
+# under recordings/ — pick them up:
+cp recordings/*cognithor_random*.scorecard.json \
+   /path/to/cognithor/.ci/arc_agi3_scorecards/random.json
+cp recordings/*cognithor_dsl*.scorecard.json \
+   /path/to/cognithor/.ci/arc_agi3_scorecards/dsl.json
+cp recordings/*cognithor_llm*.scorecard.json \
+   /path/to/cognithor/.ci/arc_agi3_scorecards/llm.json
+```
+
+## Step 6 — Aggregate + report
+
+```bash
+cd /path/to/cognithor
+python -c "
+from cognithor.channels.program_synthesis.arc_agi3 import (
+    parse_scorecard, summarise,
+)
+import json, pathlib
+for f in sorted(pathlib.Path('.ci/arc_agi3_scorecards').glob('*.json')):
+    results = parse_scorecard(json.loads(f.read_text()))
+    s = summarise(results)
+    print(f'{f.stem:>10}: n={s.n_games}, won={s.n_won}, '
+          f'win_rate={s.win_rate:.0%}, '
+          f'mean_progress={s.mean_progress_ratio:.0%}, '
+          f'total_actions={s.total_actions}')
+"
+```
+
+Expected shape — Random ≈ 0 % win, DSL marginal, LLM hopefully 1-2 wins on simple games. Anything below Random is a regression; the LLM-vs-DSL gap is the real signal.
+
+## Step 7 — Commit + open a Sprint-12 PR
+
+```bash
+cd /path/to/cognithor
+git checkout -b feat/sprint12-arc-agi3-live-baselines
+git add .ci/arc_agi3_scorecards/
+git add docs/superpowers/reports/sprint12_live_validation.md  # write a short report
+git commit -m "feat(pse): Sprint-12 — first live ARC-AGI-3 scorecards on RTX 5090"
+git push -u origin feat/sprint12-arc-agi3-live-baselines
+gh pr create --title "feat(pse): Sprint-12 — live ARC-AGI-3 baselines (Random/DSL/LLM)" --body "..."
+```
+
+## Failure modes + remediation
+
+- **vLLM crashes on launch with OOM**: drop `--gpu-memory-utilization` to 0.85, or `--max-model-len` to 8192.
+- **Agent throws `ImportError: ARC-AGI-3-Agents harness is not installed`**: you're running outside the harness venv. `uv run` from inside the cloned harness directory.
+- **LLM falls back to DSL on every frame** (telemetry: `LLMActionDecoder fallback`): inspect the LLM response — usually invalid JSON. Try lowering temperature to 0.1 or adjusting the system prompt in `arc_agi3/llm_agent.py`.
+- **All three agents score 0 on every game**: the games may need richer state-tracking than Sprint-11 ships. That's Sprint-12+ DSL-program-synthesis territory.
+
+## Hardware constraint summary
+
+- 27B BF16: ~54 GB → does not fit on 5090
+- 27B FP8 (this runbook): ~27 GB → fits with KV-cache headroom on 32 GB VRAM
+- 27B AWQ-Q4: ~14 GB → fits with lots of room (use this if VRAM is contested)

--- a/src/cognithor/channels/program_synthesis/arc_agi3/llm_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/llm_agent.py
@@ -67,7 +67,7 @@ def _build_user_prompt(ctx: FrameContext) -> str:
 def build_vllm_choice_fn(
     *,
     backend: LLMBackend,
-    model_name: str = "Qwen/Qwen3.6-27B-Instruct",
+    model_name: str = "Qwen/Qwen3.6-27B-FP8",
     temperature: float = 0.3,
     timeout_seconds: float = 8.0,
 ) -> ChoiceFn:

--- a/src/cognithor/channels/program_synthesis/phase2/config.py
+++ b/src/cognithor/channels/program_synthesis/phase2/config.py
@@ -149,8 +149,8 @@ class Phase2Config:
     # RTX 5090 (32 GB VRAM); Q5_K_M is the default quantisation,
     # Q4_K_M is the fallback for tighter VRAM budgets.
     llm_base_url: str = "http://localhost:8000/v1"
-    llm_model_name: str = "Qwen/Qwen3.6-27B-Instruct"
-    llm_fallback_model_name: str = "Qwen/Qwen3.6-27B-Instruct-AWQ"
+    llm_model_name: str = "Qwen/Qwen3.6-27B-FP8"
+    llm_fallback_model_name: str = "Qwen/Qwen3.6-27B"
     # Two-Stage prompting (spec §4.7): Stage-1 free-form CoT, Stage-2
     # constrained JSON. Different temperatures because Stage-1 wants
     # exploration (default 0.7) and Stage-2 wants determinism (0.1).

--- a/src/cognithor/channels/program_synthesis/phase2/config_loader.py
+++ b/src/cognithor/channels/program_synthesis/phase2/config_loader.py
@@ -169,12 +169,12 @@ def _project_to_phase2_config(raw: dict[str, Any]) -> Phase2Config:
             llm_model_name=_first_str(
                 llm,
                 ("model_name", "model_path"),
-                default="Qwen/Qwen3.6-27B-Instruct",
+                default="Qwen/Qwen3.6-27B-FP8",
             ),
             llm_fallback_model_name=_first_str(
                 llm,
                 ("fallback_model_name", "fallback_model_path"),
-                default="Qwen/Qwen3.6-27B-Instruct-AWQ",
+                default="Qwen/Qwen3.6-27B",
             ),
             llm_temperature_stage1=_expect_float(
                 llm_sampling, "temperature_repair_cot", parent="llm_prior.sampling"

--- a/src/cognithor/channels/program_synthesis/synthesis/benchmark_runner.py
+++ b/src/cognithor/channels/program_synthesis/synthesis/benchmark_runner.py
@@ -124,7 +124,7 @@ def _build_dual_prior_stack(
     """Construct the production LLM-Prior stack: vLLM → LLMPriorClient → DualPriorMixer.
 
     Sprint-10 Track B (Owner-Direktive 2026-05-01): wires the
-    `Qwen/Qwen3.6-27B-Instruct` LLM-Prior over a vLLM OpenAI-compat
+    `Qwen/Qwen3.6-27B-FP8` LLM-Prior over a vLLM OpenAI-compat
     endpoint into the Phase-2 search loop. The mixer combines the
     LLM signal with the canonical `UniformSymbolicPrior` from Sprint-1
     until a richer symbolic catalog lands.
@@ -545,11 +545,8 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--llm-model",
         type=str,
-        default="Qwen/Qwen3.6-27B-Instruct",
-        help=(
-            "LLM model name as registered with the vLLM server "
-            "(default: Qwen/Qwen3.6-27B-Instruct)."
-        ),
+        default="Qwen/Qwen3.6-27B-FP8",
+        help=("LLM model name as registered with the vLLM server (default: Qwen/Qwen3.6-27B-FP8)."),
     )
     return parser.parse_args(argv)
 

--- a/tests/test_channels/test_program_synthesis/phase2/test_config_loader.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_config_loader.py
@@ -70,8 +70,8 @@ class TestDefaultHeuristicsYaml:
         # ``model_path``.
         cfg = load_heuristics().phase2_config
         assert cfg.llm_base_url == "http://localhost:8000/v1"
-        assert cfg.llm_model_name == "Qwen/Qwen3.6-27B-Instruct"
-        assert cfg.llm_fallback_model_name == "Qwen/Qwen3.6-27B-Instruct-AWQ"
+        assert cfg.llm_model_name == "Qwen/Qwen3.6-27B-FP8"
+        assert cfg.llm_fallback_model_name == "Qwen/Qwen3.6-27B"
         # llm.sampling.temperature_repair_cot / .temperature_repair_edit
         # populate the Phase2Config stage temperatures.
         assert cfg.llm_temperature_stage1 == 0.3
@@ -181,7 +181,7 @@ reserved_fixes:
 
 llm_prior:
   base_url: "http://localhost:8000/v1"
-  model_name: "Qwen/Qwen3.6-27B-Instruct"
+  model_name: "Qwen/Qwen3.6-27B-FP8"
   inference: {}
   sampling:
     temperature_repair_cot: 0.3

--- a/tests/test_channels/test_program_synthesis/phase2/test_dual_prior.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_dual_prior.py
@@ -67,7 +67,7 @@ class _StubBackend(LLMBackend):
         return True
 
     async def list_models(self) -> list[str]:
-        return ["Qwen/Qwen3.6-27B-Instruct"]
+        return ["Qwen/Qwen3.6-27B-FP8"]
 
     async def close(self) -> None:
         pass

--- a/tests/test_channels/test_program_synthesis/phase2/test_interactions_f3.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_interactions_f3.py
@@ -86,7 +86,7 @@ class _StubBackend(LLMBackend):
         return True
 
     async def list_models(self) -> list[str]:
-        return ["Qwen/Qwen3.6-27B-Instruct"]
+        return ["Qwen/Qwen3.6-27B-FP8"]
 
     async def close(self) -> None:
         pass

--- a/tests/test_channels/test_program_synthesis/phase2/test_llm_prior.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_llm_prior.py
@@ -83,7 +83,7 @@ class _StubBackend(LLMBackend):
         return True
 
     async def list_models(self) -> list[str]:
-        return ["Qwen/Qwen3.6-27B-Instruct"]
+        return ["Qwen/Qwen3.6-27B-FP8"]
 
     async def close(self) -> None:
         pass
@@ -157,10 +157,10 @@ class TestTwoStageHappyPath:
         backend = _StubBackend(
             queued=["reasoning", json.dumps({"recolor": 1.0, "alpha_entropy_hint": 0.5})]
         )
-        config = Phase2Config(llm_model_name="Qwen/Qwen3.6-27B-Instruct-AWQ")
+        config = Phase2Config(llm_model_name="Qwen/Qwen3.6-27B")
         client = LLMPriorClient(backend, primitive_whitelist=["recolor"], config=config)
         await client.get_prior(_examples())
-        assert all(call["model"] == "Qwen/Qwen3.6-27B-Instruct-AWQ" for call in backend.calls)
+        assert all(call["model"] == "Qwen/Qwen3.6-27B" for call in backend.calls)
 
 
 # ---------------------------------------------------------------------------
@@ -348,6 +348,6 @@ class TestConfigValidation:
             DEFAULT_PHASE2_CONFIG,
         )
 
-        assert DEFAULT_PHASE2_CONFIG.llm_model_name == "Qwen/Qwen3.6-27B-Instruct"
-        assert DEFAULT_PHASE2_CONFIG.llm_fallback_model_name == "Qwen/Qwen3.6-27B-Instruct-AWQ"
+        assert DEFAULT_PHASE2_CONFIG.llm_model_name == "Qwen/Qwen3.6-27B-FP8"
+        assert DEFAULT_PHASE2_CONFIG.llm_fallback_model_name == "Qwen/Qwen3.6-27B"
         assert DEFAULT_PHASE2_CONFIG.llm_base_url == "http://localhost:8000/v1"

--- a/tests/test_channels/test_program_synthesis/phase2/test_llm_repair_two_stage.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_llm_repair_two_stage.py
@@ -86,7 +86,7 @@ class _StubBackend(LLMBackend):
         return True
 
     async def list_models(self) -> list[str]:
-        return ["Qwen/Qwen3.6-27B-Instruct"]
+        return ["Qwen/Qwen3.6-27B-FP8"]
 
     async def close(self) -> None:
         pass

--- a/tests/test_channels/test_program_synthesis/synthesis/test_track_b_llm_prior_wiring.py
+++ b/tests/test_channels/test_program_synthesis/synthesis/test_track_b_llm_prior_wiring.py
@@ -26,7 +26,7 @@ class TestDualPriorStackConstruction:
         # Default vLLM endpoint + qwen3.6:27b. No actual call is made.
         mixer = _build_dual_prior_stack(
             base_url="http://localhost:8000/v1",
-            model_name="Qwen/Qwen3.6-27B-Instruct",
+            model_name="Qwen/Qwen3.6-27B-FP8",
         )
         # Mixer wraps an LLMPriorClient + UniformSymbolicPrior; both
         # private but we can check it's the right class.
@@ -37,7 +37,7 @@ class TestDualPriorStackConstruction:
     def test_constructs_with_alternate_endpoint(self) -> None:
         mixer = _build_dual_prior_stack(
             base_url="http://gpu-host:9000/v1",
-            model_name="Qwen/Qwen3.6-27B-Instruct-AWQ",
+            model_name="Qwen/Qwen3.6-27B",
         )
         from cognithor.channels.program_synthesis.phase2 import DualPriorMixer
 
@@ -48,7 +48,7 @@ class TestPhase2EngineAcceptsDualPrior:
     def test_engine_built_with_dual_prior(self) -> None:
         mixer = _build_dual_prior_stack(
             base_url="http://localhost:8000/v1",
-            model_name="Qwen/Qwen3.6-27B-Instruct",
+            model_name="Qwen/Qwen3.6-27B-FP8",
         )
         engine = _build_phase2_engine(dual_prior=mixer)
         # WiredPhase2Engine — exact class assertion via private attr.
@@ -64,7 +64,7 @@ class TestCLIFlags:
         args = _parse_args(["--output", "out.json"])
         assert args.llm_prior is False
         assert args.llm_base_url == "http://localhost:8000/v1"
-        assert args.llm_model == "Qwen/Qwen3.6-27B-Instruct"
+        assert args.llm_model == "Qwen/Qwen3.6-27B-FP8"
 
     def test_llm_prior_flag(self) -> None:
         args = _parse_args(
@@ -86,8 +86,8 @@ class TestCLIFlags:
                 "--llm-base-url",
                 "http://gpu-host:9000/v1",
                 "--llm-model",
-                "Qwen/Qwen3.6-27B-Instruct-AWQ",
+                "Qwen/Qwen3.6-27B",
             ]
         )
         assert args.llm_base_url == "http://gpu-host:9000/v1"
-        assert args.llm_model == "Qwen/Qwen3.6-27B-Instruct-AWQ"
+        assert args.llm_model == "Qwen/Qwen3.6-27B"


### PR DESCRIPTION
## Summary

Owner-Korrektur 2026-05-02: \"es gibt noch keine instruct variante von qwen3.6:27b\". The HuggingFace catalogue confirms only base + FP8 quantisation are published:

| Repo | Size | Fits RTX 5090 (32 GB)? |
|---|---|---|
| `Qwen/Qwen3.6-27B` (base BF16) | ~54 GB | ❌ multi-GPU only |
| **`Qwen/Qwen3.6-27B-FP8`** | **~27 GB** | **✅ with KV-cache headroom** |

Sprint-1 + Sprint-10 + Sprint-11 had hardcoded `Qwen/Qwen3.6-27B-Instruct[-AWQ]` in 13 source/doc/test files. **None of those repos exist** — running against vLLM would fail at model-load. This PR fixes every actually-used reference.

## Renames

- `Qwen/Qwen3.6-27B-Instruct` → **`Qwen/Qwen3.6-27B-FP8`** (production default, fits 5090)
- `Qwen/Qwen3.6-27B-Instruct-AWQ` → **`Qwen/Qwen3.6-27B`** (fallback / multi-GPU)
- `Qwen3.6-27B-Instruct-Q5_K_M.gguf` → `Qwen3.6-27B-FP8` (path strings in posterity-only llama.cpp config)

Touched: `configs/synthesis/heuristics.yaml` (the live one!), the frozen plan copy, `Phase2Config` defaults, `build_vllm_choice_fn`, `--llm-model` CLI default, 6 test files asserting defaults, Sprint-10 Track B + Sprint-11 closure reports.

**NOT touched:** Ollama-tag references like `qwen3.6:27b` in `model_router.py` / `model_installer.py` / Ollama-using tests — those are local Ollama tags the user names freely, not HuggingFace repo ids.

## Plus: live validation runbook

`scripts/arc_agi3_live_validation.md` — 7-step runbook the operator follows on the RTX 5090:

1. `vllm serve Qwen/Qwen3.6-27B-FP8 --port 8000 --max-model-len 16384 --gpu-memory-utilization 0.92`
2. Clone `arcprize/ARC-AGI-3-Agents` + `uv sync` + `ARC_API_KEY` setup
3. Drop a 25-line `agents/templates/cognithor_agents.py` registering 3 agents (Random / DSL / LLM)
4. Run each agent against 3-5 games → scorecard JSON
5. Freeze scorecards as `.ci/arc_agi3_scorecards/{random,dsl,llm}.json`
6. Aggregate via `parse_scorecard` + `summarise` — print Random vs DSL vs LLM win rates
7. Open Sprint-12 PR with the frozen baselines

## Test plan
- [x] Full PSE suite: 1569 passed, 10 skipped — no regressions
- [x] `ruff check` + `ruff format --check` clean
- [x] HuggingFace catalogue verified — `Qwen/Qwen3.6-27B-FP8` and `Qwen/Qwen3.6-27B` are real repos
- [x] No `Qwen/Qwen3.6-27B-Instruct*` references remain in source / docs / tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)