### PR TITLE
feat(pse): Sprint-12 — NVFP4 model + InProcess vLLM backend (RTX 5090 validated)

### DIFF
--- a/configs/synthesis/heuristics.yaml
+++ b/configs/synthesis/heuristics.yaml
@@ -37,7 +37,7 @@ llm_prior:
   # quantisation are the canonical HuggingFace repos. FP8 fits in 32 GB
   # VRAM (RTX 5090) with KV-cache headroom; base BF16 is ~54 GB and
   # only fits on multi-GPU / A100-class hardware.
-  model_name: "Qwen/Qwen3.6-27B-FP8"
+  model_name: "sakamakismile/Qwen3.6-27B-NVFP4"
   fallback_model_name: "Qwen/Qwen3.6-27B"
   call_timeout_seconds: 8.0
   # llama.cpp-specific paths, kept for the alternate-backend

--- a/docs/superpowers/plans/2026-04-30-pse-phase2-heuristics.yaml
+++ b/docs/superpowers/plans/2026-04-30-pse-phase2-heuristics.yaml
@@ -28,7 +28,7 @@ spec_version: "phase2_spec_v1.4"
 
 llm_prior:
   # vLLM-preferred fields (HuggingFace repo ids).
-  model_name: "Qwen/Qwen3.6-27B-FP8"
+  model_name: "sakamakismile/Qwen3.6-27B-NVFP4"
   fallback_model_name: "Qwen/Qwen3.6-27B"
   # llama.cpp-style fallbacks (kept for backend-swap without YAML rewrite).
   model_path: "./models/Qwen3.6-27B-FP8"

--- a/docs/superpowers/reports/sprint10_track_b_vllm_deployment.md
+++ b/docs/superpowers/reports/sprint10_track_b_vllm_deployment.md
@@ -12,7 +12,7 @@ OpenAI-compat endpoint** into the PSE benchmark runner. The
 `WiredPhase2Engine`'s search loop.
 
 **The wiring is fully constructed and tested at module level.** What's
-missing is a *running* vLLM server with `Qwen/Qwen3.6-27B-FP8`
+missing is a *running* vLLM server with `sakamakismile/Qwen3.6-27B-NVFP4`
 loaded — that requires a 32+ GB GPU (RTX 5090 / A100 / H100) and is
 out of scope for the autonomous-mode session.
 
@@ -25,7 +25,7 @@ python -m cognithor.channels.program_synthesis.synthesis.benchmark_runner \
     --phase2 \
     --llm-prior \
     --llm-base-url http://localhost:8000/v1 \
-    --llm-model Qwen/Qwen3.6-27B-FP8 \
+    --llm-model sakamakismile/Qwen3.6-27B-NVFP4 \
     --output sprint10_track_b_training.json
 ```
 
@@ -33,7 +33,7 @@ Flags introduced this PR:
 
 - `--llm-prior` — opt-in switch. Without it, `--phase2` runs without an LLM (cold-start α, identical to pre-Track-B behaviour).
 - `--llm-base-url` — vLLM endpoint URL. Default `http://localhost:8000/v1`.
-- `--llm-model` — model name as registered with vLLM. Default `Qwen/Qwen3.6-27B-FP8`.
+- `--llm-model` — model name as registered with vLLM. Default `sakamakismile/Qwen3.6-27B-NVFP4`.
 
 ## Server-side deployment
 
@@ -56,7 +56,7 @@ pip install vllm==0.6.3
 
 ```bash
 # Q5_K_M quantisation (preferred):
-vllm serve Qwen/Qwen3.6-27B-FP8 \
+vllm serve sakamakismile/Qwen3.6-27B-NVFP4 \
     --quantization awq \
     --port 8000 \
     --max-model-len 8192 \
@@ -74,7 +74,7 @@ Verify:
 
 ```bash
 curl http://localhost:8000/v1/models
-# expected: list with Qwen/Qwen3.6-27B-FP8
+# expected: list with sakamakismile/Qwen3.6-27B-NVFP4
 curl http://localhost:8000/health
 # expected: 200 OK
 ```

--- a/docs/superpowers/reports/sprint11_arc_agi_3_complete.md
+++ b/docs/superpowers/reports/sprint11_arc_agi_3_complete.md
@@ -103,7 +103,7 @@ uv run main.py --agent=cognithor_llm    --game=ls20
 ## Hardware-gated wiring (Wave-5)
 
 The LLM agent's call adapter `build_vllm_choice_fn` is hardware-gated
-on a running vLLM server with `Qwen/Qwen3.6-27B-FP8` loaded —
+on a running vLLM server with `sakamakismile/Qwen3.6-27B-NVFP4` loaded —
 same constraint as Sprint-10 Track B. **Without one, the first call
 raises and the decoder transparently falls back to Wave-4's
 DSLActionDecoder policy.** Tests use deterministic stub `choice_fn`

--- a/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
@@ -57,6 +57,7 @@ from cognithor.channels.program_synthesis.arc_agi3.llm_action_decoder import (
 )
 from cognithor.channels.program_synthesis.arc_agi3.llm_agent import (
     LLMReasoningAgent,
+    build_inprocess_vllm_choice_fn,
     build_vllm_choice_fn,
 )
 from cognithor.channels.program_synthesis.arc_agi3.protocol import (
@@ -94,6 +95,7 @@ __all__ = [
     "Sprint10DSLAgent",
     "StuckDetector",
     "UniformActionDecoder",
+    "build_inprocess_vllm_choice_fn",
     "build_vllm_choice_fn",
     "cognithor_agent_factory",
     "count_actions",

--- a/src/cognithor/channels/program_synthesis/arc_agi3/llm_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/llm_agent.py
@@ -67,7 +67,7 @@ def _build_user_prompt(ctx: FrameContext) -> str:
 def build_vllm_choice_fn(
     *,
     backend: LLMBackend,
-    model_name: str = "Qwen/Qwen3.6-27B-FP8",
+    model_name: str = "sakamakismile/Qwen3.6-27B-NVFP4",
     temperature: float = 0.3,
     timeout_seconds: float = 8.0,
 ) -> ChoiceFn:
@@ -116,6 +116,96 @@ def build_vllm_choice_fn(
     return _sync_choice
 
 
+def build_inprocess_vllm_choice_fn(
+    *,
+    model_name: str = "sakamakismile/Qwen3.6-27B-NVFP4",
+    max_model_len: int = 32768,
+    max_num_seqs: int = 64,
+    gpu_memory_utilization: float = 0.92,
+    enforce_eager: bool = False,
+    cuda_home: str = "/usr/local/cuda-13.0",
+    temperature: float = 0.3,
+    max_tokens: int = 2048,
+) -> ChoiceFn:
+    """Sprint-12 production factory: in-process vLLM (no HTTP).
+
+    Validated 2026-05-02 on RTX 5090 + WSL2 + CUDA 13.0:
+    50 tok/s decode, 240 tok/s prefill, 370-400 W sustained. The
+    in-process path sidesteps the WSL2 mirror-mode networking quirk
+    that breaks vLLM's uvicorn HTTP server (TCP listen but accept()
+    deadlocks).
+
+    Loads the engine on first call. Subsequent calls reuse the
+    warmed-up model. Parses Qwen3.6's ``<think>...</think>{json}``
+    output format — the thinking block is stripped before JSON parse.
+
+    Use this when running Cognithor inside the same Python process as
+    vLLM (typical: WSL2 with vllm + cognithor in one venv). Use the
+    HTTP-based :func:`build_vllm_choice_fn` only if vLLM runs in a
+    separate process on a host where TCP works.
+    """
+    import os as _os
+
+    if cuda_home and _os.path.isdir(cuda_home):
+        _os.environ.setdefault("CUDA_HOME", cuda_home)
+        _os.environ["PATH"] = f"{cuda_home}/bin:{_os.environ.get('PATH', '')}"
+
+    # Heavy imports at first call to keep the module import-clean on
+    # hosts without vllm installed.
+    _engine_state: dict[str, Any] = {}
+
+    def _ensure_engine() -> tuple[Any, Any]:
+        if "llm" in _engine_state:
+            return _engine_state["llm"], _engine_state["sampling"]
+        try:
+            from vllm import LLM, SamplingParams  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise RuntimeError(
+                "vllm is not installed. Run `pip install vllm` inside a "
+                "Linux + CUDA-capable venv (WSL2 Ubuntu 24.04 verified)."
+            ) from exc
+        llm = LLM(
+            model=model_name,
+            max_model_len=max_model_len,
+            gpu_memory_utilization=gpu_memory_utilization,
+            max_num_seqs=max_num_seqs,
+            enforce_eager=enforce_eager,
+            dtype="auto",
+        )
+        sampling = SamplingParams(temperature=temperature, max_tokens=max_tokens)
+        _engine_state["llm"] = llm
+        _engine_state["sampling"] = sampling
+        return llm, sampling
+
+    def _sync_choice(ctx: FrameContext) -> tuple[str, str]:
+        llm, sampling = _ensure_engine()
+        outs = llm.chat(
+            messages=[
+                {"role": "system", "content": _LLM_SYSTEM_PROMPT},
+                {"role": "user", "content": _build_user_prompt(ctx)},
+            ],
+            sampling_params=sampling,
+        )
+        text = outs[0].outputs[0].text
+        # Qwen3.6 thinking-mode wraps reasoning in <think>…</think>{json}.
+        # Strip the thinking section before JSON parse so the action
+        # extraction is unambiguous.
+        if "</think>" in text:
+            text = text.split("</think>", 1)[1].strip()
+        start = text.find("{")
+        end = text.rfind("}")
+        if start < 0 or end <= start:
+            raise ValueError(f"LLM response missing JSON block: {text[:200]!r}")
+        parsed: dict[str, Any] = json.loads(text[start : end + 1])
+        action_name = str(parsed.get("action", "")).strip()
+        reasoning = str(parsed.get("reasoning", "")).strip()
+        if not action_name:
+            raise ValueError(f"LLM response missing 'action' field: {parsed!r}")
+        return action_name, reasoning
+
+    return _sync_choice
+
+
 class LLMReasoningAgent(Sprint10DSLAgent):
     """Wave-5: Sprint10DSLAgent with the decoder swapped for an LLM-driven one.
 
@@ -148,5 +238,6 @@ class LLMReasoningAgent(Sprint10DSLAgent):
 
 __all__ = [
     "LLMReasoningAgent",
+    "build_inprocess_vllm_choice_fn",
     "build_vllm_choice_fn",
 ]

--- a/src/cognithor/channels/program_synthesis/phase2/config.py
+++ b/src/cognithor/channels/program_synthesis/phase2/config.py
@@ -20,6 +20,7 @@ or replace them, then update :data:`DEFAULT_PHASE2_CONFIG`.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from typing import Literal
 
 
 @dataclass(frozen=True)
@@ -144,13 +145,41 @@ class Phase2Config:
     cegis_sub_budget_per_iter_fraction: float = 0.33
 
     # ── Module A — LLM-Prior over vLLM (spec §4.2 / §4.3 / §4.7) ────
-    # Backend: vLLM exposing OpenAI-compat /v1/chat/completions.
-    # Default model is the spec-anchored Qwen3.6-27B-Instruct on the
-    # RTX 5090 (32 GB VRAM); Q5_K_M is the default quantisation,
-    # Q4_K_M is the fallback for tighter VRAM budgets.
+    # Backend: vLLM with NVFP4-quantised Qwen3.6-27B on RTX 5090
+    # (32 GB VRAM, Blackwell SM_120, native FP4 tensor-cores).
+    # Validated end-to-end 2026-05-02 in WSL2 Ubuntu 24.04 + CUDA 13.0:
+    #   * NVFP4 weights = ~14 GiB VRAM, leaves headroom for KV-cache
+    #   * 50 tok/s output, 240 tok/s input prefill
+    #   * sustained 370-400 W (memory-bound at single batch)
+    # See scripts/arc_agi3_live_validation.md for the full runbook.
+    #
+    # WSL2 networking quirk: uvicorn's TCP listen socket on port 8000
+    # gets opened but `accept()` deadlocks under WSL2 mirror-mode
+    # networking. The cognithor side defaults to `inprocess` backend
+    # (vLLM Python API directly, same process) which sidesteps HTTP
+    # entirely. Set llm_backend_kind="http" only if running vLLM in a
+    # separate environment (Docker, remote host) where HTTP works.
+    llm_backend_kind: Literal["http", "inprocess"] = "inprocess"
     llm_base_url: str = "http://localhost:8000/v1"
-    llm_model_name: str = "Qwen/Qwen3.6-27B-FP8"
+    llm_model_name: str = "sakamakismile/Qwen3.6-27B-NVFP4"
     llm_fallback_model_name: str = "Qwen/Qwen3.6-27B"
+    # vLLM engine knobs validated on RTX 5090 (32 GB VRAM, Blackwell
+    # SM_120). max_num_seqs=64 is the Mamba-cache-block ceiling for
+    # this VRAM budget; raising it triggers
+    # "max_num_seqs exceeds available Mamba cache blocks" at startup.
+    # max_model_len=32768 keeps KV-cache + cudagraph capture comfortably
+    # under the 32 GB envelope; raise to 65536 only with FP8 KV-cache.
+    # gpu_memory_utilization=0.92 reserves ~1.6 GiB for the Windows
+    # display + WSL2 overhead. enforce_eager=False activates CUDA
+    # graphs (10-30× speedup at the cost of 2-3 min startup capture).
+    llm_max_num_seqs: int = 64
+    llm_max_model_len: int = 32768
+    llm_gpu_memory_utilization: float = 0.92
+    llm_enforce_eager: bool = False
+    # CUDA toolkit path for FlashInfer NVFP4 JIT compilation. Blackwell
+    # SM_120 needs CUDA 12.8+ or 13.x. Override per env if installed
+    # at a non-default location.
+    llm_cuda_home: str = "/usr/local/cuda-13.0"
     # Two-Stage prompting (spec §4.7): Stage-1 free-form CoT, Stage-2
     # constrained JSON. Different temperatures because Stage-1 wants
     # exploration (default 0.7) and Stage-2 wants determinism (0.1).

--- a/src/cognithor/channels/program_synthesis/phase2/config_loader.py
+++ b/src/cognithor/channels/program_synthesis/phase2/config_loader.py
@@ -169,7 +169,7 @@ def _project_to_phase2_config(raw: dict[str, Any]) -> Phase2Config:
             llm_model_name=_first_str(
                 llm,
                 ("model_name", "model_path"),
-                default="Qwen/Qwen3.6-27B-FP8",
+                default="sakamakismile/Qwen3.6-27B-NVFP4",
             ),
             llm_fallback_model_name=_first_str(
                 llm,

--- a/src/cognithor/channels/program_synthesis/synthesis/benchmark_runner.py
+++ b/src/cognithor/channels/program_synthesis/synthesis/benchmark_runner.py
@@ -124,7 +124,7 @@ def _build_dual_prior_stack(
     """Construct the production LLM-Prior stack: vLLM → LLMPriorClient → DualPriorMixer.
 
     Sprint-10 Track B (Owner-Direktive 2026-05-01): wires the
-    `Qwen/Qwen3.6-27B-FP8` LLM-Prior over a vLLM OpenAI-compat
+    `sakamakismile/Qwen3.6-27B-NVFP4` LLM-Prior over a vLLM OpenAI-compat
     endpoint into the Phase-2 search loop. The mixer combines the
     LLM signal with the canonical `UniformSymbolicPrior` from Sprint-1
     until a richer symbolic catalog lands.
@@ -545,8 +545,8 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--llm-model",
         type=str,
-        default="Qwen/Qwen3.6-27B-FP8",
-        help=("LLM model name as registered with the vLLM server (default: Qwen/Qwen3.6-27B-FP8)."),
+        default="sakamakismile/Qwen3.6-27B-NVFP4",
+        help=("LLM model name as registered with the vLLM server (default: sakamakismile/Qwen3.6-27B-NVFP4)."),
     )
     return parser.parse_args(argv)
 

--- a/src/cognithor/channels/program_synthesis/synthesis/benchmark_runner.py
+++ b/src/cognithor/channels/program_synthesis/synthesis/benchmark_runner.py
@@ -546,7 +546,10 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         "--llm-model",
         type=str,
         default="sakamakismile/Qwen3.6-27B-NVFP4",
-        help=("LLM model name as registered with the vLLM server (default: sakamakismile/Qwen3.6-27B-NVFP4)."),
+        help=(
+            "LLM model name as registered with the vLLM server "
+            "(default: sakamakismile/Qwen3.6-27B-NVFP4)."
+        ),
     )
     return parser.parse_args(argv)
 

--- a/src/cognithor/core/llm_backend.py
+++ b/src/cognithor/core/llm_backend.py
@@ -45,6 +45,7 @@ class LLMBackendType(StrEnum):
     CLAUDE_CODE = "claude-code"
     CLAUDE_CODE_SUPERVISED = "claude-code-supervised"
     VLLM = "vllm"
+    VLLM_INPROCESS = "vllm-inprocess"
 
 
 @dataclass

--- a/src/cognithor/core/vllm_inprocess_backend.py
+++ b/src/cognithor/core/vllm_inprocess_backend.py
@@ -1,0 +1,196 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""In-process vLLM backend — Sprint-12 (validated 2026-05-02 on RTX 5090).
+
+Wraps ``vllm.LLM`` directly in the same Python process, **bypassing
+HTTP entirely**. This was added after the WSL2 mirrored-networking
+quirk made the OpenAI-compat HTTP server unreachable from inside the
+same WSL distro: uvicorn binds the listen socket, but ``accept()``
+deadlocks. The model + GPU + engine are healthy; only the network
+layer is broken.
+
+The in-process backend solves it by skipping HTTP completely:
+``vllm.LLM(model=...)`` loads the engine in the host process, and
+``llm.chat(...)`` calls it directly. Same compute, no network.
+
+Defaults match Phase2Config (Sprint-12 Owner-validated):
+- model: ``sakamakismile/Qwen3.6-27B-NVFP4`` (Blackwell native FP4)
+- max_model_len: 32768, max_num_seqs: 64 (Mamba cache-block ceiling)
+- gpu_memory_utilization: 0.92, enforce_eager: False (CUDA graphs)
+
+Lazy import of ``vllm`` so this module loads cleanly on Windows / hosts
+without a GPU. The engine only spins up on first ``chat()`` call.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import TYPE_CHECKING, Any
+
+from cognithor.core.llm_backend import (
+    ChatResponse,
+    EmbedResponse,
+    LLMBackend,
+    LLMBackendError,
+    LLMBackendType,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+
+class VLLMInProcessBackend(LLMBackend):
+    """vLLM running in-process (no HTTP).
+
+    Validated 2026-05-02 on RTX 5090 + WSL2 Ubuntu 24.04 + CUDA 13.0:
+    50 tok/s output / 240 tok/s prefill at sustained 370-400 W.
+    """
+
+    def __init__(
+        self,
+        *,
+        model: str = "sakamakismile/Qwen3.6-27B-NVFP4",
+        max_model_len: int = 32768,
+        max_num_seqs: int = 64,
+        gpu_memory_utilization: float = 0.92,
+        enforce_eager: bool = False,
+        cuda_home: str = "/usr/local/cuda-13.0",
+        dtype: str = "auto",
+        hf_home: str | None = None,
+    ) -> None:
+        self._model_name = model
+        self._engine_kwargs = {
+            "model": model,
+            "max_model_len": max_model_len,
+            "max_num_seqs": max_num_seqs,
+            "gpu_memory_utilization": gpu_memory_utilization,
+            "enforce_eager": enforce_eager,
+            "dtype": dtype,
+        }
+        # Set env vars before vllm imports torch/cuda. The cuda_home
+        # path must be a real directory containing bin/nvcc; FlashInfer's
+        # NVFP4 JIT compile breaks without it on Blackwell.
+        if cuda_home and os.path.isdir(cuda_home):
+            os.environ.setdefault("CUDA_HOME", cuda_home)
+            os.environ["PATH"] = f"{cuda_home}/bin:{os.environ.get('PATH', '')}"
+        if hf_home:
+            os.environ.setdefault("HF_HOME", hf_home)
+        self._llm: Any = None  # lazy-init on first chat()
+        self._lock = asyncio.Lock()
+
+    @property
+    def backend_type(self) -> LLMBackendType:
+        return LLMBackendType.VLLM_INPROCESS
+
+    async def _ensure_engine(self) -> Any:
+        if self._llm is not None:
+            return self._llm
+        async with self._lock:
+            if self._llm is not None:
+                return self._llm
+            try:
+                # Heavy import — keep it lazy so the module loads on
+                # hosts without vLLM / GPU.
+                from vllm import LLM  # type: ignore[import-not-found]
+            except ImportError as exc:
+                raise LLMBackendError(
+                    "vllm is not installed. Run inside a venv with "
+                    "`pip install vllm` (Linux + CUDA-capable GPU only)."
+                ) from exc
+            try:
+                # vllm.LLM blocks while loading the model + warming up.
+                # Run it in a worker thread to keep the asyncio loop
+                # responsive (otherwise even health-pings stall).
+                self._llm = await asyncio.to_thread(LLM, **self._engine_kwargs)
+            except Exception as exc:
+                raise LLMBackendError(
+                    f"vLLM engine init failed: {type(exc).__name__}: {exc}"
+                ) from exc
+        return self._llm
+
+    async def chat(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+        format_json: bool = False,
+    ) -> ChatResponse:
+        del tools, format_json  # vLLM's chat method handles formatting natively
+        engine = await self._ensure_engine()
+        # The engine is bound to a single model loaded at init time.
+        # If the caller asks for a different model, fail loudly rather
+        # than silently dispatching to the wrong weights.
+        if model and model != self._model_name:
+            raise LLMBackendError(
+                f"VLLMInProcessBackend is loaded with {self._model_name!r}, "
+                f"caller requested {model!r}. Construct a new backend per model."
+            )
+        from vllm import SamplingParams  # type: ignore[import-not-found]
+
+        sampling = SamplingParams(temperature=temperature, top_p=top_p, max_tokens=2048)
+        outputs = await asyncio.to_thread(engine.chat, messages, sampling)
+        if not outputs:
+            raise LLMBackendError("vLLM returned empty output list")
+        text = outputs[0].outputs[0].text if outputs[0].outputs else ""
+        return ChatResponse(
+            content=text, model=self._model_name, raw={"vllm_output": str(outputs[0])}
+        )
+
+    async def chat_stream(
+        self,
+        model: str,
+        messages: list[dict[str, Any]],
+        *,
+        temperature: float = 0.7,
+        top_p: float = 0.9,
+    ) -> AsyncIterator[str]:
+        # Streaming is supported by vLLM but the in-process API
+        # delivers complete outputs. Async-iterator over the final
+        # text in chunks keeps the interface contract.
+        response = await self.chat(
+            model=model,
+            messages=messages,
+            temperature=temperature,
+            top_p=top_p,
+        )
+
+        async def _gen() -> AsyncIterator[str]:
+            yield response.content
+
+        return _gen()
+
+    async def embed(
+        self,
+        model: str,
+        text: str,
+    ) -> EmbedResponse:
+        del model, text
+        raise LLMBackendError(
+            "VLLMInProcessBackend does not implement embeddings yet. "
+            "Use a dedicated embedding backend (Ollama, OpenAI) for that."
+        )
+
+    async def is_available(self) -> bool:
+        # The backend is "available" once vLLM imports cleanly. We do
+        # NOT eagerly load the model here — that happens on first chat().
+        try:
+            import vllm  # type: ignore[import-not-found]  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+
+    async def list_models(self) -> list[str]:
+        return [self._model_name]
+
+    async def close(self) -> None:
+        # vLLM engine cleanup happens at process exit. Explicit shutdown
+        # would require holding a reference to the engine_core
+        # subprocess; the default GC path is sufficient for our usage.
+        self._llm = None
+
+
+__all__ = ["VLLMInProcessBackend"]

--- a/tests/test_channels/test_program_synthesis/phase2/test_config_loader.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_config_loader.py
@@ -70,7 +70,7 @@ class TestDefaultHeuristicsYaml:
         # ``model_path``.
         cfg = load_heuristics().phase2_config
         assert cfg.llm_base_url == "http://localhost:8000/v1"
-        assert cfg.llm_model_name == "Qwen/Qwen3.6-27B-FP8"
+        assert cfg.llm_model_name == "sakamakismile/Qwen3.6-27B-NVFP4"
         assert cfg.llm_fallback_model_name == "Qwen/Qwen3.6-27B"
         # llm.sampling.temperature_repair_cot / .temperature_repair_edit
         # populate the Phase2Config stage temperatures.
@@ -181,7 +181,7 @@ reserved_fixes:
 
 llm_prior:
   base_url: "http://localhost:8000/v1"
-  model_name: "Qwen/Qwen3.6-27B-FP8"
+  model_name: "sakamakismile/Qwen3.6-27B-NVFP4"
   inference: {}
   sampling:
     temperature_repair_cot: 0.3

--- a/tests/test_channels/test_program_synthesis/phase2/test_dual_prior.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_dual_prior.py
@@ -67,7 +67,7 @@ class _StubBackend(LLMBackend):
         return True
 
     async def list_models(self) -> list[str]:
-        return ["Qwen/Qwen3.6-27B-FP8"]
+        return ["sakamakismile/Qwen3.6-27B-NVFP4"]
 
     async def close(self) -> None:
         pass

--- a/tests/test_channels/test_program_synthesis/phase2/test_interactions_f3.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_interactions_f3.py
@@ -86,7 +86,7 @@ class _StubBackend(LLMBackend):
         return True
 
     async def list_models(self) -> list[str]:
-        return ["Qwen/Qwen3.6-27B-FP8"]
+        return ["sakamakismile/Qwen3.6-27B-NVFP4"]
 
     async def close(self) -> None:
         pass

--- a/tests/test_channels/test_program_synthesis/phase2/test_llm_prior.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_llm_prior.py
@@ -83,7 +83,7 @@ class _StubBackend(LLMBackend):
         return True
 
     async def list_models(self) -> list[str]:
-        return ["Qwen/Qwen3.6-27B-FP8"]
+        return ["sakamakismile/Qwen3.6-27B-NVFP4"]
 
     async def close(self) -> None:
         pass
@@ -348,6 +348,6 @@ class TestConfigValidation:
             DEFAULT_PHASE2_CONFIG,
         )
 
-        assert DEFAULT_PHASE2_CONFIG.llm_model_name == "Qwen/Qwen3.6-27B-FP8"
+        assert DEFAULT_PHASE2_CONFIG.llm_model_name == "sakamakismile/Qwen3.6-27B-NVFP4"
         assert DEFAULT_PHASE2_CONFIG.llm_fallback_model_name == "Qwen/Qwen3.6-27B"
         assert DEFAULT_PHASE2_CONFIG.llm_base_url == "http://localhost:8000/v1"

--- a/tests/test_channels/test_program_synthesis/phase2/test_llm_repair_two_stage.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_llm_repair_two_stage.py
@@ -86,7 +86,7 @@ class _StubBackend(LLMBackend):
         return True
 
     async def list_models(self) -> list[str]:
-        return ["Qwen/Qwen3.6-27B-FP8"]
+        return ["sakamakismile/Qwen3.6-27B-NVFP4"]
 
     async def close(self) -> None:
         pass

--- a/tests/test_channels/test_program_synthesis/synthesis/test_track_b_llm_prior_wiring.py
+++ b/tests/test_channels/test_program_synthesis/synthesis/test_track_b_llm_prior_wiring.py
@@ -26,7 +26,7 @@ class TestDualPriorStackConstruction:
         # Default vLLM endpoint + qwen3.6:27b. No actual call is made.
         mixer = _build_dual_prior_stack(
             base_url="http://localhost:8000/v1",
-            model_name="Qwen/Qwen3.6-27B-FP8",
+            model_name="sakamakismile/Qwen3.6-27B-NVFP4",
         )
         # Mixer wraps an LLMPriorClient + UniformSymbolicPrior; both
         # private but we can check it's the right class.
@@ -48,7 +48,7 @@ class TestPhase2EngineAcceptsDualPrior:
     def test_engine_built_with_dual_prior(self) -> None:
         mixer = _build_dual_prior_stack(
             base_url="http://localhost:8000/v1",
-            model_name="Qwen/Qwen3.6-27B-FP8",
+            model_name="sakamakismile/Qwen3.6-27B-NVFP4",
         )
         engine = _build_phase2_engine(dual_prior=mixer)
         # WiredPhase2Engine — exact class assertion via private attr.
@@ -64,7 +64,7 @@ class TestCLIFlags:
         args = _parse_args(["--output", "out.json"])
         assert args.llm_prior is False
         assert args.llm_base_url == "http://localhost:8000/v1"
-        assert args.llm_model == "Qwen/Qwen3.6-27B-FP8"
+        assert args.llm_model == "sakamakismile/Qwen3.6-27B-NVFP4"
 
     def test_llm_prior_flag(self) -> None:
         args = _parse_args(


### PR DESCRIPTION
## Summary

Sprint-12 codifies the runtime stack live-validated 2026-05-02 on **RTX 5090 + WSL2 Ubuntu 24.04 + CUDA 13.0**.

## What changed

### Production defaults updated
- **Model**: `sakamakismile/Qwen3.6-27B-NVFP4` (Blackwell-native FP4, 18.6 GB VRAM, 50 tok/s decode + 240 tok/s prefill at 370-400 W)
- **Engine**: `max_model_len=32768`, `max_num_seqs=64` (Mamba cache-block ceiling), `gpu_memory_utilization=0.92`, `enforce_eager=False` (CUDA graphs ~30× speedup vs eager on 5090)
- **CUDA**: Toolkit 13.0 at `/usr/local/cuda-13.0` — Blackwell SM_120 needs CUDA 12.8+ for FlashInfer NVFP4 JIT compile

### New: InProcess backend
- **`VLLMInProcessBackend`** (`src/cognithor/core/vllm_inprocess_backend.py`): full `LLMBackend` impl wrapping `vllm.LLM` directly, **no HTTP**. Lazy-imports vllm so the module loads cleanly on hosts without a GPU.
- **`build_inprocess_vllm_choice_fn`** (`arc_agi3/llm_agent.py`): synchronous factory for `LLMReasoningAgent`, includes Qwen3.6 thinking-mode parser (strips `<think>…</think>` before JSON extract).
- **`Phase2Config.llm_backend_kind`**: defaults to `\"inprocess\"` because WSL2 mirrored networking deadlocks vLLM's uvicorn TCP `accept()`.

### Bulk rename
Every `Qwen/Qwen3.6-27B-FP8` reference in source + docs + configs + 6 test files → `sakamakismile/Qwen3.6-27B-NVFP4`.

## Test plan
- [x] **1569 passed, 10 skipped** — no regressions
- [x] mypy + ruff clean
- [x] Live RTX 5090: vLLM loads in 36s from cache, NVFP4 GEMM via `FlashInferCutlassNvFp4LinearKernel`, **50 tok/s sustained** on real ARC-AGI-3 frames
- [x] In-process backend constructs cleanly without GPU (lazy import path)

## Hardware notes (operator-facing)
- vLLM **HTTP server unreachable in WSL2 mirrored mode** — uvicorn listens but `accept()` deadlocks. Plain Python `http.server` works on same port; vLLM/uvicorn × WSL2 interaction bug. Default to in-process backend until fixed upstream.
- VmmemWSL high RAM (~27 GB) is normal — HF mmap + Python multi-processing engine_core. Not a leak.
- **370 W sustained** on 575 W TGP is expected for memory-bound single-batch decoding. Batched inference would push 500+ W.

## Sprint-12 status
- Phase A (live ARC-AGI-3 game-loop validation): in-flight against bp35/ft09/lp85, will land as a follow-up PR with frozen scorecards.
- Phase B (this PR): production-default sync — Cognithor's runtime now reaches for the validated NVFP4/InProcess stack by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)