### PR TITLE
feat(pse): Sprint-12 PR-2 — persistent observation log + GameProfile

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
@@ -29,6 +29,10 @@ from cognithor.channels.program_synthesis.arc_agi3.agent import (
     CognithorPSEAgent,
     RandomActionAgent,
 )
+from cognithor.channels.program_synthesis.arc_agi3.audit import (
+    ArcAuditEvent,
+    ArcAuditTrail,
+)
 from cognithor.channels.program_synthesis.arc_agi3.dsl_action_decoder import (
     DSLActionDecoder,
 )
@@ -44,6 +48,10 @@ from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
 from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import (
     ClampPolicy,
     FrameBridge,
+)
+from cognithor.channels.program_synthesis.arc_agi3.game_profile import (
+    GameProfile,
+    StrategyMetrics,
 )
 from cognithor.channels.program_synthesis.arc_agi3.harness_shim import (
     cognithor_agent_factory,
@@ -73,6 +81,8 @@ from cognithor.channels.program_synthesis.arc_agi3.scorecard import (
 
 __all__ = [
     "ActionDecoder",
+    "ArcAuditEvent",
+    "ArcAuditTrail",
     "ChangeDetector",
     "ChoiceFn",
     "ClampPolicy",
@@ -85,6 +95,7 @@ __all__ = [
     "FrameContext",
     "FrameDataProtocol",
     "GameActionProtocol",
+    "GameProfile",
     "GameResult",
     "GameStateProtocol",
     "LLMActionDecoder",
@@ -92,6 +103,7 @@ __all__ = [
     "RandomActionAgent",
     "ScorecardSummary",
     "Sprint10DSLAgent",
+    "StrategyMetrics",
     "StuckDetector",
     "UniformActionDecoder",
     "build_vllm_choice_fn",

--- a/src/cognithor/channels/program_synthesis/arc_agi3/audit.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/audit.py
@@ -1,0 +1,155 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 — ARC-AGI-3 Audit Trail (lifted from cognithor.arc.audit).
+
+Append-only chain of audit events (game_start, step, level_complete,
+game_end, error) with a SHA-256 hash chain for tamper detection. Every
+event includes its predecessor's hash, so any post-hoc edit to a logged
+event is detectable via :meth:`verify_integrity`.
+
+Drop-in usable from :class:`Sprint10DSLAgent` to record episode
+provenance — useful for replay debugging and for cross-episode
+analytics in :class:`GameProfileStore`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from typing import Any
+
+__all__ = ["ArcAuditEvent", "ArcAuditTrail"]
+
+
+@dataclass
+class ArcAuditEvent:
+    """A single auditable event in an ARC game session."""
+
+    timestamp: float
+    event_type: str  # "game_start", "step", "level_complete", "game_end", "error"
+    game_id: str
+    level: int
+    step: int
+    action: str | None = None
+    game_state: str | None = None
+    pixels_changed: int | None = None
+    score: float | None = None
+    error: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+def _event_to_json(event: ArcAuditEvent) -> str:
+    """Serialize an event to a canonical JSON string (sorted keys)."""
+    return json.dumps(asdict(event), sort_keys=True, ensure_ascii=False)
+
+
+class ArcAuditTrail:
+    """Append-only audit trail with a SHA-256 hash chain for tamper detection."""
+
+    def __init__(self, game_id: str, agent_version: str = "cognithor-arc-v1") -> None:
+        self.game_id = game_id
+        self.agent_version = agent_version
+        self.events: list[ArcAuditEvent] = []
+        self._hashes: list[str] = []
+        self._previous_hash: str | None = None
+
+        # run_id: first 16 chars of SHA-256(game_id:timestamp:version:uuid)
+        seed = f"{game_id}:{time.time()}:{agent_version}:{uuid.uuid4().hex}"
+        self.run_id = hashlib.sha256(seed.encode()).hexdigest()[:16]
+
+    # ------------------------------------------------------------------
+    # Core append method
+    # ------------------------------------------------------------------
+
+    def log_event(self, event: ArcAuditEvent) -> str:
+        """Append *event* to the trail, compute its chain hash, and return it."""
+        event_json = _event_to_json(event)
+        prev = self._previous_hash if self._previous_hash is not None else "GENESIS"
+        chain_input = f"{prev}:{event_json}"
+        new_hash = hashlib.sha256(chain_input.encode()).hexdigest()
+
+        self.events.append(event)
+        self._hashes.append(new_hash)
+        self._previous_hash = new_hash
+        return new_hash
+
+    # ------------------------------------------------------------------
+    # Convenience wrappers
+    # ------------------------------------------------------------------
+
+    def log_game_start(self) -> str:
+        """Log a game_start event and return its chain hash."""
+        event = ArcAuditEvent(
+            timestamp=time.time(),
+            event_type="game_start",
+            game_id=self.game_id,
+            level=0,
+            step=0,
+            metadata={"agent_version": self.agent_version, "run_id": self.run_id},
+        )
+        return self.log_event(event)
+
+    def log_game_end(self, final_score: float) -> str:
+        """Log a game_end event with the final score and return its chain hash."""
+        event = ArcAuditEvent(
+            timestamp=time.time(),
+            event_type="game_end",
+            game_id=self.game_id,
+            level=0,
+            step=0,
+            score=final_score,
+        )
+        return self.log_event(event)
+
+    def log_step(
+        self,
+        level: int,
+        step: int,
+        action: str,
+        game_state: str,
+        pixels_changed: int,
+    ) -> str:
+        """Log a single agent step and return its chain hash."""
+        event = ArcAuditEvent(
+            timestamp=time.time(),
+            event_type="step",
+            game_id=self.game_id,
+            level=level,
+            step=step,
+            action=action,
+            game_state=game_state,
+            pixels_changed=pixels_changed,
+        )
+        return self.log_event(event)
+
+    # ------------------------------------------------------------------
+    # Export
+    # ------------------------------------------------------------------
+
+    def export_jsonl(self, filepath: str) -> None:
+        """Write all events as JSONL (one JSON object per line)."""
+        with open(filepath, "w", encoding="utf-8") as fh:
+            for event in self.events:
+                fh.write(_event_to_json(event) + "\n")
+
+    # ------------------------------------------------------------------
+    # Integrity verification
+    # ------------------------------------------------------------------
+
+    def verify_integrity(self) -> bool:
+        """Replay the hash chain from scratch and confirm it matches stored hashes."""
+        if not self.events:
+            return True
+
+        prev = "GENESIS"
+        for event, stored_hash in zip(self.events, self._hashes, strict=False):
+            event_json = _event_to_json(event)
+            chain_input = f"{prev}:{event_json}"
+            expected = hashlib.sha256(chain_input.encode()).hexdigest()
+            if expected != stored_hash:
+                return False
+            prev = stored_hash
+
+        return True

--- a/src/cognithor/channels/program_synthesis/arc_agi3/game_profile.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/game_profile.py
@@ -1,0 +1,197 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 — GameProfile (lifted from cognithor.arc.game_profile).
+
+Persistent per-game mechanic profile with cross-episode learning
+metrics. Each game-id gets a JSON file at
+``~/.cognithor/arc/game_profiles/<id>.json`` that accumulates
+``total_runs``, ``best_score``, per-strategy ``win_rate``, and analysis
+results (``click_zones``, ``movement_effects``, ``win_condition``).
+
+The new Sprint-11 ``Sprint10DSLAgent``'s ``EpisodeMemory`` is volatile
+(in-memory, capacity 16). ``GameProfile`` is the **persistent**
+counterpart — what was learned this run carries to the next.
+
+Drop-in import; the disk format is unchanged from ``cognithor.arc``,
+so an existing ``~/.cognithor/arc/game_profiles/`` populated by the
+legacy stack is forward-compatible.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from cognithor.utils.logging import get_logger
+
+__all__ = ["GameProfile", "StrategyMetrics"]
+
+log = get_logger(__name__)
+
+_DEFAULT_BASE_DIR = Path.home() / ".cognithor" / "arc"
+
+
+@dataclass
+class StrategyMetrics:
+    """Tracks success metrics for a single solver strategy."""
+
+    attempts: int = 0
+    wins: int = 0
+    total_levels_solved: int = 0
+    avg_steps_to_win: float = 0.0
+    avg_budget_ratio: float = 0.0
+
+    @property
+    def win_rate(self) -> float:
+        if self.attempts == 0:
+            return 0.0
+        return self.wins / self.attempts
+
+
+@dataclass
+class GameProfile:
+    """Persistent per-game mechanic profile."""
+
+    game_id: str
+    game_type: Literal["click", "keyboard", "mixed"]
+    available_actions: list[int]
+
+    # Analysis results
+    click_zones: list[tuple[int, int]]
+    target_colors: list[int]
+    movement_effects: dict[int, str]
+    win_condition: str
+    vision_description: str
+    vision_strategy: str
+
+    # Learning metrics
+    strategy_metrics: dict[str, StrategyMetrics]
+    total_runs: int = 0
+    best_score: int = 0
+
+    # Meta
+    analyzed_at: str = ""
+    profile_version: int = 1
+    has_toggles: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        d = {
+            "game_id": self.game_id,
+            "game_type": self.game_type,
+            "available_actions": self.available_actions,
+            "click_zones": [list(z) for z in self.click_zones],
+            "target_colors": self.target_colors,
+            "movement_effects": {str(k): v for k, v in self.movement_effects.items()},
+            "win_condition": self.win_condition,
+            "vision_description": self.vision_description,
+            "vision_strategy": self.vision_strategy,
+            "strategy_metrics": {name: asdict(m) for name, m in self.strategy_metrics.items()},
+            "total_runs": self.total_runs,
+            "best_score": self.best_score,
+            "analyzed_at": self.analyzed_at,
+            "profile_version": self.profile_version,
+            "has_toggles": self.has_toggles,
+        }
+        return d
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> GameProfile:
+        metrics = {}
+        for name, m in d.get("strategy_metrics", {}).items():
+            metrics[name] = StrategyMetrics(**m)
+        movement = {int(k): v for k, v in d.get("movement_effects", {}).items()}
+        click_zones = [tuple(z) for z in d.get("click_zones", [])]
+        return cls(
+            game_id=d["game_id"],
+            game_type=d["game_type"],
+            available_actions=d.get("available_actions", []),
+            click_zones=click_zones,
+            target_colors=d.get("target_colors", []),
+            movement_effects=movement,
+            win_condition=d.get("win_condition", "unknown"),
+            vision_description=d.get("vision_description", ""),
+            vision_strategy=d.get("vision_strategy", ""),
+            strategy_metrics=metrics,
+            total_runs=d.get("total_runs", 0),
+            best_score=d.get("best_score", 0),
+            analyzed_at=d.get("analyzed_at", ""),
+            profile_version=d.get("profile_version", 1),
+            has_toggles=d.get("has_toggles", False),
+        )
+
+    def save(self, base_dir: Path | None = None) -> None:
+        base = base_dir or _DEFAULT_BASE_DIR
+        profile_dir = base / "game_profiles"
+        profile_dir.mkdir(parents=True, exist_ok=True)
+        path = profile_dir / f"{self.game_id}.json"
+        path.write_text(json.dumps(self.to_dict(), indent=2), encoding="utf-8")
+        log.info("arc.profile_saved", game_id=self.game_id, path=str(path))
+
+    @classmethod
+    def load(cls, game_id: str, base_dir: Path | None = None) -> GameProfile | None:
+        base = base_dir or _DEFAULT_BASE_DIR
+        path = base / "game_profiles" / f"{game_id}.json"
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            return cls.from_dict(data)
+        except (json.JSONDecodeError, KeyError, TypeError) as exc:
+            log.warning("arc.profile_load_failed", game_id=game_id, error=str(exc))
+            return None
+
+    def update_metrics(
+        self,
+        strategy_name: str,
+        *,
+        won: bool,
+        levels_solved: int,
+        steps: int,
+        budget_ratio: float,
+    ) -> None:
+        if strategy_name not in self.strategy_metrics:
+            self.strategy_metrics[strategy_name] = StrategyMetrics()
+        m = self.strategy_metrics[strategy_name]
+        m.attempts += 1
+        m.total_levels_solved += levels_solved
+        if won:
+            m.wins += 1
+            if m.wins == 1:
+                m.avg_steps_to_win = float(steps)
+                m.avg_budget_ratio = budget_ratio
+            else:
+                n = m.wins
+                m.avg_steps_to_win = m.avg_steps_to_win * (n - 1) / n + steps / n
+                m.avg_budget_ratio = m.avg_budget_ratio * (n - 1) / n + budget_ratio / n
+
+    def update_run(self, score: int) -> None:
+        self.total_runs += 1
+        if score > self.best_score:
+            self.best_score = score
+
+    def ranked_strategies(self) -> list[str]:
+        if not self.strategy_metrics:
+            return []
+
+        def score(name: str) -> float:
+            m = self.strategy_metrics[name]
+            if m.attempts == 0:
+                return 1.0  # exploration bonus
+            return m.win_rate
+
+        return sorted(self.strategy_metrics.keys(), key=score, reverse=True)
+
+    def default_strategies(self) -> list[tuple[str, float]]:
+        if self.game_type == "click":
+            if self.has_toggles:
+                return [("cluster_click", 0.6), ("sequence_click", 0.3), ("targeted_click", 0.1)]
+            return [("sequence_click", 0.6), ("cluster_click", 0.3), ("targeted_click", 0.1)]
+        if self.game_type == "keyboard":
+            return [("keyboard_explore", 0.5), ("keyboard_sequence", 0.3), ("hybrid", 0.2)]
+        return [("hybrid", 0.5), ("targeted_click", 0.3), ("keyboard_explore", 0.2)]
+
+    @classmethod
+    def exists(cls, game_id: str, base_dir: Path | None = None) -> bool:
+        base = base_dir or _DEFAULT_BASE_DIR
+        return (base / "game_profiles" / f"{game_id}.json").exists()

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_audit.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_audit.py
@@ -1,0 +1,120 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 — ArcAuditTrail tests."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import TYPE_CHECKING
+
+from cognithor.channels.program_synthesis.arc_agi3.audit import (
+    ArcAuditEvent,
+    ArcAuditTrail,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class TestArcAuditTrailBasics:
+    def test_run_id_is_16_hex_chars(self) -> None:
+        trail = ArcAuditTrail(game_id="ls20")
+        assert len(trail.run_id) == 16
+        # hex
+        int(trail.run_id, 16)
+
+    def test_distinct_runs_get_distinct_ids(self) -> None:
+        a = ArcAuditTrail(game_id="ls20")
+        b = ArcAuditTrail(game_id="ls20")
+        assert a.run_id != b.run_id
+
+    def test_log_event_returns_hash(self) -> None:
+        trail = ArcAuditTrail(game_id="ls20")
+        h = trail.log_game_start()
+        # SHA-256 hex = 64 chars
+        assert len(h) == 64
+        int(h, 16)
+
+    def test_chain_links_events(self) -> None:
+        trail = ArcAuditTrail(game_id="ls20")
+        trail.log_game_start()
+        h2 = trail.log_step(
+            level=0, step=1, action="ACTION1", game_state="NOT_FINISHED", pixels_changed=0
+        )
+        h3 = trail.log_step(
+            level=0, step=2, action="ACTION2", game_state="NOT_FINISHED", pixels_changed=4
+        )
+        assert h2 != h3
+        assert len(trail.events) == 3
+
+
+class TestIntegrity:
+    def test_clean_chain_verifies(self) -> None:
+        trail = ArcAuditTrail(game_id="ls20")
+        trail.log_game_start()
+        trail.log_step(
+            level=0, step=1, action="ACTION1", game_state="NOT_FINISHED", pixels_changed=0
+        )
+        trail.log_step(
+            level=0, step=2, action="ACTION2", game_state="NOT_FINISHED", pixels_changed=4
+        )
+        trail.log_game_end(final_score=0.5)
+        assert trail.verify_integrity() is True
+
+    def test_tamper_detected(self) -> None:
+        trail = ArcAuditTrail(game_id="ls20")
+        trail.log_game_start()
+        trail.log_step(
+            level=0, step=1, action="ACTION1", game_state="NOT_FINISHED", pixels_changed=0
+        )
+        trail.events[1].action = "TAMPERED"
+        assert trail.verify_integrity() is False
+
+    def test_empty_trail_verifies(self) -> None:
+        trail = ArcAuditTrail(game_id="ls20")
+        assert trail.verify_integrity() is True
+
+
+class TestExport:
+    def test_export_jsonl_roundtrip(self, tmp_path: Path) -> None:
+        trail = ArcAuditTrail(game_id="ls20")
+        trail.log_game_start()
+        trail.log_step(
+            level=0, step=1, action="ACTION1", game_state="NOT_FINISHED", pixels_changed=0
+        )
+        path = tmp_path / "audit.jsonl"
+        trail.export_jsonl(str(path))
+        lines = path.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 2
+        first = json.loads(lines[0])
+        assert first["event_type"] == "game_start"
+        assert first["game_id"] == "ls20"
+
+
+class TestEventDataclass:
+    def test_event_has_required_fields(self) -> None:
+        event = ArcAuditEvent(
+            timestamp=time.time(),
+            event_type="step",
+            game_id="ls20",
+            level=0,
+            step=1,
+            action="ACTION1",
+        )
+        assert event.event_type == "step"
+        assert event.action == "ACTION1"
+
+    def test_optional_fields_default_none(self) -> None:
+        event = ArcAuditEvent(
+            timestamp=0.0,
+            event_type="game_start",
+            game_id="ls20",
+            level=0,
+            step=0,
+        )
+        assert event.error is None
+        assert event.score is None
+        assert event.metadata is None

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_game_profile.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_game_profile.py
@@ -1,0 +1,147 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 — GameProfile persistence tests."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cognithor.channels.program_synthesis.arc_agi3.game_profile import (
+    GameProfile,
+    StrategyMetrics,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_profile(game_id: str = "ls20") -> GameProfile:
+    return GameProfile(
+        game_id=game_id,
+        game_type="keyboard",
+        available_actions=[0, 1, 2, 3, 4],
+        click_zones=[],
+        target_colors=[10, 11],
+        movement_effects={1: "up", 2: "down", 3: "left", 4: "right"},
+        win_condition="reach_door",
+        vision_description="LockSmith level",
+        vision_strategy="rotate key, navigate to door",
+        strategy_metrics={},
+    )
+
+
+class TestStrategyMetrics:
+    def test_win_rate_zero_attempts(self) -> None:
+        m = StrategyMetrics()
+        assert m.win_rate == 0.0
+
+    def test_win_rate_basic(self) -> None:
+        m = StrategyMetrics(attempts=10, wins=4)
+        assert m.win_rate == 0.4
+
+    def test_default_zero_fields(self) -> None:
+        m = StrategyMetrics()
+        assert m.attempts == 0
+        assert m.wins == 0
+
+
+class TestGameProfileBasics:
+    def test_construct(self) -> None:
+        p = _make_profile()
+        assert p.game_id == "ls20"
+        assert p.game_type == "keyboard"
+        assert p.movement_effects[1] == "up"
+
+    def test_to_dict_then_from_dict(self) -> None:
+        p = _make_profile()
+        p.update_run(score=3)
+        p.update_metrics("hybrid", won=True, levels_solved=2, steps=20, budget_ratio=0.5)
+        round_tripped = GameProfile.from_dict(p.to_dict())
+        assert round_tripped.game_id == p.game_id
+        assert round_tripped.total_runs == 1
+        assert round_tripped.best_score == 3
+        assert "hybrid" in round_tripped.strategy_metrics
+        assert round_tripped.strategy_metrics["hybrid"].wins == 1
+
+
+class TestPersistence:
+    def test_save_and_load(self, tmp_path: Path) -> None:
+        p = _make_profile()
+        p.update_run(score=5)
+        p.save(base_dir=tmp_path)
+
+        # Profile file should exist.
+        assert (tmp_path / "game_profiles" / "ls20.json").exists()
+
+        loaded = GameProfile.load("ls20", base_dir=tmp_path)
+        assert loaded is not None
+        assert loaded.game_id == "ls20"
+        assert loaded.best_score == 5
+
+    def test_load_missing_returns_none(self, tmp_path: Path) -> None:
+        loaded = GameProfile.load("nonexistent", base_dir=tmp_path)
+        assert loaded is None
+
+    def test_exists(self, tmp_path: Path) -> None:
+        assert GameProfile.exists("ls20", base_dir=tmp_path) is False
+        p = _make_profile()
+        p.save(base_dir=tmp_path)
+        assert GameProfile.exists("ls20", base_dir=tmp_path) is True
+
+
+class TestMetricsUpdate:
+    def test_update_run_increments(self) -> None:
+        p = _make_profile()
+        p.update_run(score=2)
+        p.update_run(score=5)
+        p.update_run(score=3)
+        assert p.total_runs == 3
+        assert p.best_score == 5
+
+    def test_update_metrics_creates_entry(self) -> None:
+        p = _make_profile()
+        p.update_metrics("cluster_click", won=True, levels_solved=2, steps=15, budget_ratio=0.3)
+        assert "cluster_click" in p.strategy_metrics
+        assert p.strategy_metrics["cluster_click"].attempts == 1
+        assert p.strategy_metrics["cluster_click"].wins == 1
+        assert p.strategy_metrics["cluster_click"].avg_steps_to_win == 15.0
+
+    def test_avg_steps_running_average(self) -> None:
+        p = _make_profile()
+        p.update_metrics("a", won=True, levels_solved=1, steps=10, budget_ratio=0.5)
+        p.update_metrics("a", won=True, levels_solved=1, steps=20, budget_ratio=0.5)
+        # (10 + 20) / 2 = 15
+        assert abs(p.strategy_metrics["a"].avg_steps_to_win - 15.0) < 1e-9
+
+    def test_ranked_strategies_orders_by_win_rate(self) -> None:
+        p = _make_profile()
+        p.update_metrics("low_winner", won=False, levels_solved=0, steps=10, budget_ratio=0.5)
+        p.update_metrics("low_winner", won=False, levels_solved=0, steps=10, budget_ratio=0.5)
+        p.update_metrics("high_winner", won=True, levels_solved=2, steps=20, budget_ratio=0.5)
+        ranked = p.ranked_strategies()
+        # high_winner has 1.0 win rate, low_winner has 0.0
+        assert ranked[0] == "high_winner"
+
+
+class TestDefaultStrategies:
+    def test_click_with_toggles(self) -> None:
+        p = _make_profile()
+        p.game_type = "click"
+        p.has_toggles = True
+        defaults = p.default_strategies()
+        assert defaults[0][0] == "cluster_click"
+
+    def test_click_without_toggles(self) -> None:
+        p = _make_profile()
+        p.game_type = "click"
+        p.has_toggles = False
+        defaults = p.default_strategies()
+        assert defaults[0][0] == "sequence_click"
+
+    def test_keyboard_game(self) -> None:
+        p = _make_profile()
+        p.game_type = "keyboard"
+        defaults = p.default_strategies()
+        assert defaults[0][0] == "keyboard_explore"


### PR DESCRIPTION
## Summary

Sprint-12 mega-merge PR-2: lifts the two highest-value persistence primitives from the legacy `cognithor.arc/` toolset into the new Sprint-11 `program_synthesis/arc_agi3/` stack.

- **`ArcAuditEvent` / `ArcAuditTrail`** — append-only event log (`game_start`, `step`, `level_complete`, `game_end`, `error`) with a SHA-256 hash chain. `verify_integrity()` detects post-hoc tampering. Replay-ready JSONL export.
- **`GameProfile` / `StrategyMetrics`** — persistent per-game mechanic profile at `~/.cognithor/arc/game_profiles/<id>.json`. Cross-episode learning metrics (per-strategy win rate, best score, total runs, click zones, movement effects, win condition). Forward-compatible with the legacy disk format.

These complement the volatile `EpisodeMemory` (Wave-3) by giving the agent a memory that survives process restarts.

## Scope

- New: `audit.py`, `game_profile.py`, `test_audit.py`, `test_game_profile.py`.
- Wires both into the package surface via `__init__.py`.
- Does **not** yet plumb either into `Sprint10DSLAgent` / `LLMReasoningAgent` — that is PR-3+.

## Stacking

Independent of PRs #289 / #290 (no file overlap). Can land before or after them.

## Test plan

- [x] `pytest tests/test_channels/test_program_synthesis/arc_agi3/test_audit.py tests/test_channels/test_program_synthesis/arc_agi3/test_game_profile.py` → 25/25 green
- [x] `pytest tests/test_channels/test_program_synthesis/arc_agi3/` → 130/130 green
- [x] `ruff check` clean on all 5 changed files
- [x] `ruff format --check` clean on all 5 changed files
- [x] `mypy --strict` clean on `audit.py` + `game_profile.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)