### PR TITLE
feat(pse): Sprint-12 PR-3 — pure-NumPy fast-path planner for click-toggle games

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
@@ -41,6 +41,15 @@ from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
     StuckDetector,
     count_actions,
 )
+from cognithor.channels.program_synthesis.arc_agi3.fast_grid_planner import (
+    Cluster,
+    detect_toggle_pair,
+    find_clusters,
+    is_level_complete,
+    plan_click_solution,
+    simulate_combo,
+    simulate_toggle,
+)
 from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import (
     ClampPolicy,
     FrameBridge,
@@ -76,6 +85,7 @@ __all__ = [
     "ChangeDetector",
     "ChoiceFn",
     "ClampPolicy",
+    "Cluster",
     "CognithorPSEAgent",
     "DSLActionDecoder",
     "EpisodeMemory",
@@ -97,8 +107,14 @@ __all__ = [
     "build_vllm_choice_fn",
     "cognithor_agent_factory",
     "count_actions",
+    "detect_toggle_pair",
+    "find_clusters",
+    "is_level_complete",
     "parse_scorecard",
+    "plan_click_solution",
     "render_grid",
+    "simulate_combo",
+    "simulate_toggle",
     "summarise",
     "summarise_history",
 ]

--- a/src/cognithor/channels/program_synthesis/arc_agi3/fast_grid_planner.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/fast_grid_planner.py
@@ -1,0 +1,183 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 — pure-NumPy fast-path planner for click-toggle games.
+
+A planning-only adaptation of :mod:`cognithor.arc.fast_grid_solver`.
+The legacy module drove the ``arc_agi`` SDK directly (calling
+``env.step()`` between cluster-detection probes); for the new
+Sprint-11 game-agent stack we keep only the env-independent core:
+
+* :class:`Cluster` — connected pixel block with centroid/size
+* :func:`find_clusters` — 4-connectivity BFS
+* :func:`detect_toggle_pair` — pure-NumPy diff between before/after grids
+* :func:`simulate_toggle` / :func:`simulate_combo` — apply N toggles to a grid
+* :func:`is_level_complete` — "all source-color pixels eliminated"
+* :func:`plan_click_solution` — top-level: smallest subset of clusters that
+  clears the source colour. Returns the cluster indices to click, or
+  ``None`` when no solution found within ``max_combos``.
+
+The agent (e.g. :class:`Sprint10DSLAgent`) calls
+:func:`plan_click_solution` as a fast-path before falling through to
+the slower DSL search. Cluster index → SDK click coordinates is the
+agent's job (translate ``clusters[i].centroid`` to ACTION6 ``(x,y)``).
+
+This module is the cousin of :class:`NumpySolverBridge` (static
+ARC-AGI-1 grids) but for **interactive** click-toggle games. There is
+no overlap at the call-site.
+"""
+
+from __future__ import annotations
+
+import itertools
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+__all__ = [
+    "Cluster",
+    "detect_toggle_pair",
+    "find_clusters",
+    "is_level_complete",
+    "plan_click_solution",
+    "simulate_combo",
+    "simulate_toggle",
+]
+
+
+@dataclass(frozen=True)
+class Cluster:
+    """A connected pixel block of the same color."""
+
+    color: int
+    pixels: tuple[tuple[int, int], ...]
+
+    @property
+    def centroid(self) -> tuple[int, int]:
+        rows = [p[0] for p in self.pixels]
+        cols = [p[1] for p in self.pixels]
+        return int(np.mean(rows)), int(np.mean(cols))
+
+    @property
+    def size(self) -> int:
+        return len(self.pixels)
+
+
+def find_clusters(grid: np.ndarray[Any, Any], target_color: int) -> list[Cluster]:
+    """Return all 4-connected components of ``target_color`` in ``grid``."""
+    rows, cols = np.where(grid == target_color)
+    if len(rows) == 0:
+        return []
+
+    pixel_set = set(zip(rows.tolist(), cols.tolist(), strict=False))
+    visited: set[tuple[int, int]] = set()
+    clusters: list[Cluster] = []
+
+    for start in pixel_set:
+        if start in visited:
+            continue
+        component: list[tuple[int, int]] = []
+        queue = [start]
+        while queue:
+            px = queue.pop()
+            if px in visited or px not in pixel_set:
+                continue
+            visited.add(px)
+            component.append(px)
+            r, c = px
+            queue.extend([(r - 1, c), (r + 1, c), (r, c - 1), (r, c + 1)])
+        clusters.append(Cluster(color=target_color, pixels=tuple(component)))
+
+    return clusters
+
+
+def detect_toggle_pair(
+    grid_before: np.ndarray[Any, Any],
+    grid_after: np.ndarray[Any, Any],
+) -> tuple[int, int] | None:
+    """Return ``(source_color, target_color)`` of the dominant swap, or ``None``."""
+    diff_mask = grid_before != grid_after
+    if not diff_mask.any():
+        return None
+
+    before_colors = grid_before[diff_mask]
+    after_colors = grid_after[diff_mask]
+
+    pairs: dict[tuple[int, int], int] = {}
+    for b, a in zip(before_colors.tolist(), after_colors.tolist(), strict=False):
+        key = (int(b), int(a))
+        pairs[key] = pairs.get(key, 0) + 1
+
+    if not pairs:
+        return None
+
+    return max(pairs, key=lambda k: pairs[k])
+
+
+def simulate_toggle(
+    grid: np.ndarray[Any, Any],
+    cluster: Cluster,
+    source_color: int,
+    target_color: int,
+) -> np.ndarray[Any, Any]:
+    """Apply a single toggle to ``grid`` (out-of-place)."""
+    result = grid.copy()
+    for r, c in cluster.pixels:
+        if result[r, c] == source_color:
+            result[r, c] = target_color
+        elif result[r, c] == target_color:
+            result[r, c] = source_color
+    return result
+
+
+def simulate_combo(
+    grid: np.ndarray[Any, Any],
+    clusters: list[Cluster],
+    indices: tuple[int, ...],
+    source_color: int,
+    target_color: int,
+) -> np.ndarray[Any, Any]:
+    """Apply toggles for each ``clusters[i]`` (i in ``indices``) sequentially."""
+    result = grid.copy()
+    for idx in indices:
+        result = simulate_toggle(result, clusters[idx], source_color, target_color)
+    return result
+
+
+def is_level_complete(grid_after: np.ndarray[Any, Any], source_color: int) -> bool:
+    """Return True iff all ``source_color`` pixels are gone from ``grid_after``."""
+    return not (grid_after == source_color).any()
+
+
+def plan_click_solution(
+    grid: np.ndarray[Any, Any],
+    source_color: int,
+    target_color: int,
+    *,
+    max_combos: int = 100_000,
+) -> tuple[int, ...] | None:
+    """Find the smallest subset of ``source_color`` clusters that clears the level.
+
+    Returns a tuple of cluster indices (into ``find_clusters(grid, source_color)``)
+    that, when toggled, eliminate every ``source_color`` pixel. Returns ``None``
+    when no solution exists within ``max_combos`` simulations.
+
+    The caller is responsible for translating cluster indices to SDK click
+    actions (``ACTION6`` with ``(x=col, y=row)`` from each cluster's centroid).
+    """
+    clusters = find_clusters(grid, source_color)
+    if not clusters:
+        return None
+
+    n = len(clusters)
+    combos_tested = 0
+
+    for k in range(1, n + 1):
+        for combo in itertools.combinations(range(n), k):
+            if combos_tested >= max_combos:
+                return None
+            simulated = simulate_combo(grid, clusters, combo, source_color, target_color)
+            combos_tested += 1
+            if is_level_complete(simulated, source_color):
+                return combo
+
+    return None

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_fast_grid_planner.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_fast_grid_planner.py
@@ -1,0 +1,148 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 — fast_grid_planner tests."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.arc_agi3.fast_grid_planner import (
+    Cluster,
+    detect_toggle_pair,
+    find_clusters,
+    is_level_complete,
+    plan_click_solution,
+    simulate_combo,
+    simulate_toggle,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+class TestFindClusters:
+    def test_no_pixels_returns_empty(self) -> None:
+        grid = np.zeros((4, 4), dtype=np.int32)
+        assert find_clusters(grid, target_color=5) == []
+
+    def test_single_cluster(self) -> None:
+        grid = np.zeros((4, 4), dtype=np.int32)
+        grid[1, 1] = 7
+        grid[1, 2] = 7
+        grid[2, 1] = 7
+        clusters = find_clusters(grid, target_color=7)
+        assert len(clusters) == 1
+        assert clusters[0].color == 7
+        assert clusters[0].size == 3
+
+    def test_two_disconnected_clusters(self) -> None:
+        grid = np.zeros((5, 5), dtype=np.int32)
+        # Cluster A: top-left
+        grid[0, 0] = 3
+        grid[0, 1] = 3
+        # Cluster B: bottom-right (disconnected)
+        grid[4, 4] = 3
+        clusters = find_clusters(grid, target_color=3)
+        assert len(clusters) == 2
+        sizes = sorted(c.size for c in clusters)
+        assert sizes == [1, 2]
+
+    def test_diagonal_not_connected(self) -> None:
+        # 4-connectivity: diagonals are NOT connected.
+        grid = np.zeros((3, 3), dtype=np.int32)
+        grid[0, 0] = 9
+        grid[1, 1] = 9
+        clusters = find_clusters(grid, target_color=9)
+        assert len(clusters) == 2
+
+    def test_centroid_computation(self) -> None:
+        grid = np.zeros((4, 4), dtype=np.int32)
+        grid[1, 1] = 4
+        grid[1, 2] = 4
+        clusters = find_clusters(grid, target_color=4)
+        assert clusters[0].centroid == (1, 1)
+
+
+class TestDetectTogglePair:
+    def test_no_change_returns_none(self) -> None:
+        grid = np.array([[1, 2], [3, 4]], dtype=np.int32)
+        assert detect_toggle_pair(grid, grid.copy()) is None
+
+    def test_simple_toggle(self) -> None:
+        before = np.array([[1, 1], [1, 1]], dtype=np.int32)
+        after = np.array([[2, 2], [2, 2]], dtype=np.int32)
+        result = detect_toggle_pair(before, after)
+        assert result == (1, 2)
+
+    def test_dominant_pair_wins_on_ties(self) -> None:
+        # Three 1→2 swaps, one 3→4 swap → (1, 2) dominates.
+        before = np.array([[1, 1, 1, 3]], dtype=np.int32)
+        after = np.array([[2, 2, 2, 4]], dtype=np.int32)
+        result = detect_toggle_pair(before, after)
+        assert result == (1, 2)
+
+
+class TestSimulation:
+    def test_simulate_toggle_swaps_pixels(self) -> None:
+        grid = np.array([[1, 1], [0, 0]], dtype=np.int32)
+        cluster = Cluster(color=1, pixels=((0, 0), (0, 1)))
+        result = simulate_toggle(grid, cluster, source_color=1, target_color=2)
+        assert result[0, 0] == 2
+        assert result[0, 1] == 2
+        # Source untouched.
+        assert grid[0, 0] == 1
+
+    def test_simulate_combo_chains_toggles(self) -> None:
+        grid = np.array([[1, 0], [1, 0]], dtype=np.int32)
+        c0 = Cluster(color=1, pixels=((0, 0),))
+        c1 = Cluster(color=1, pixels=((1, 0),))
+        result = simulate_combo(grid, [c0, c1], (0, 1), source_color=1, target_color=9)
+        assert result[0, 0] == 9
+        assert result[1, 0] == 9
+
+    def test_is_level_complete(self) -> None:
+        grid = np.array([[2, 2], [2, 2]], dtype=np.int32)
+        assert is_level_complete(grid, source_color=1) is True
+        assert is_level_complete(grid, source_color=2) is False
+
+
+class TestPlanClickSolution:
+    def test_no_clusters_returns_none(self) -> None:
+        grid = np.zeros((3, 3), dtype=np.int32)
+        assert plan_click_solution(grid, source_color=5, target_color=6) is None
+
+    def test_single_cluster_solution(self) -> None:
+        # One blob of source colour → click it once.
+        grid = np.zeros((4, 4), dtype=np.int32)
+        grid[1, 1] = 1
+        grid[1, 2] = 1
+        result = plan_click_solution(grid, source_color=1, target_color=2)
+        assert result == (0,)
+
+    def test_two_independent_clusters_need_two_clicks(self) -> None:
+        grid = np.zeros((5, 5), dtype=np.int32)
+        grid[0, 0] = 1
+        grid[4, 4] = 1
+        result = plan_click_solution(grid, source_color=1, target_color=2)
+        assert result is not None
+        assert len(result) == 2
+
+    def test_max_combos_caps_search(self) -> None:
+        # Many small clusters but a tiny budget → returns None.
+        grid = np.zeros((6, 6), dtype=np.int32)
+        for i in range(6):
+            grid[i, i] = 1
+        result = plan_click_solution(grid, source_color=1, target_color=2, max_combos=2)
+        # Six singletons → we need all six toggled to win, but C(6,1)=6 alone
+        # exceeds the budget of 2 → None.
+        assert result is None
+
+    def test_smallest_subset_preferred(self) -> None:
+        # Three clusters; toggling any one alone clears that one only,
+        # so the only winning subset is all three.
+        grid = np.zeros((5, 5), dtype=np.int32)
+        grid[0, 0] = 1
+        grid[2, 2] = 1
+        grid[4, 4] = 1
+        result = plan_click_solution(grid, source_color=1, target_color=2)
+        assert result is not None
+        assert len(result) == 3


### PR DESCRIPTION
## Summary

Sprint-12 mega-merge PR-3: lifts the **env-independent core** of `cognithor.arc.fast_grid_solver` into a planning-only module the new Sprint-11 game agents can call as a fast-path before falling through to the slower DSL search.

The legacy `FastGridSolver` drove the `arc_agi` SDK directly. For the new stack we keep only the pure functions:

- `Cluster` — frozen dataclass with `centroid` / `size`
- `find_clusters` — 4-connectivity BFS
- `detect_toggle_pair` — pure-NumPy diff between before/after grids
- `simulate_toggle` / `simulate_combo` — out-of-place N-step simulation
- `is_level_complete` — "all source pixels eliminated"
- `plan_click_solution` — top-level: smallest cluster subset that clears the source colour. Returns indices into `find_clusters()`, or `None` on no-solution / `max_combos` exhaustion.

Cluster-index → SDK click translation is the agent's job (centroid → `ACTION6 (x=col, y=row)`). This module makes no SDK calls.

## Distinct from `NumpySolverBridge`

`NumpySolverBridge` (PSE core layer) is for static ARC-AGI-1 grids; this module is for **interactive** click-toggle games. Same NumPy-fast-path pattern, no call-site overlap.

## Stacking

Independent of #289 / #290 / #291 (no file overlap, only adds new module + extra `__init__.py` exports).

## Test plan

- [x] `pytest .../test_fast_grid_planner.py` → 16/16 green
- [x] `pytest .../arc_agi3/` → 121/121 green
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy --strict` clean (`np.ndarray[Any, Any]` per house style)

🤖 Generated with [Claude Code](https://claude.com/claude-code)