### PR TITLE
feat(pse): Sprint-12 PR-4 — FrameAnalyzer (per-action movement signatures)

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
@@ -41,6 +41,10 @@ from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
     StuckDetector,
     count_actions,
 )
+from cognithor.channels.program_synthesis.arc_agi3.frame_analyzer import (
+    FrameAnalyzer,
+    MovementInfo,
+)
 from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import (
     ClampPolicy,
     FrameBridge,
@@ -80,6 +84,7 @@ __all__ = [
     "DSLActionDecoder",
     "EpisodeMemory",
     "EpisodeStep",
+    "FrameAnalyzer",
     "FrameBridge",
     "FrameChange",
     "FrameContext",
@@ -89,6 +94,7 @@ __all__ = [
     "GameStateProtocol",
     "LLMActionDecoder",
     "LLMReasoningAgent",
+    "MovementInfo",
     "RandomActionAgent",
     "ScorecardSummary",
     "Sprint10DSLAgent",

--- a/src/cognithor/channels/program_synthesis/arc_agi3/frame_analyzer.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/frame_analyzer.py
@@ -1,0 +1,191 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 — FrameAnalyzer (lifted from cognithor.arc.frame_analyzer).
+
+Learns per-action movement signatures from successive frames so the
+agent can build a model of what each ACTIONx button actually does.
+This is critical for keyboard-controlled games where ARC-AGI-3 does
+not announce which action is "up", "down", "left", "right" — the
+agent has to discover that mapping from observed pixel motion.
+
+Usage::
+
+    fa = FrameAnalyzer()
+    fa.analyze(grid_t0, action=None)        # bootstrap
+    fa.analyze(grid_t1, action="ACTION3")   # records "ACTION3 → down"
+    summary = fa.get_action_summary()
+    # → {"ACTION3": {"avg_pixels": 2, "avg_direction_row": +1, "count": 1, ...}}
+
+The Wave-3 :class:`EpisodeMemory`/:class:`ChangeDetector` already
+counts pixel-changes; FrameAnalyzer is the structured cousin that
+also remembers direction + region, so an LLM-driven decoder can be
+told "ACTION3 has historically moved your sprite downward" instead of
+just "ACTION3 changed 2 pixels".
+
+Stateless across game-switches; carries learned action effects across
+levels of the same game (the operator calls
+:meth:`reset_for_new_level` on level transitions).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+__all__ = ["FrameAnalyzer", "MovementInfo"]
+
+
+@dataclass
+class MovementInfo:
+    """One observed movement: which action caused which pixel-region delta."""
+
+    action: str
+    pixels_changed: int
+    min_row: int
+    max_row: int
+    min_col: int
+    max_col: int
+    direction_row: int = 0  # negative = up, positive = down
+    direction_col: int = 0  # negative = left, positive = right
+
+
+class FrameAnalyzer:
+    """Tracks objects + learns per-action movement signatures across frames."""
+
+    def __init__(self) -> None:
+        self._prev_grid: np.ndarray[Any, Any] | None = None
+        self._prev_movement: MovementInfo | None = None
+        self._action_effects: dict[str, list[MovementInfo]] = {}
+        self._static_mask: np.ndarray[Any, Any] | None = None
+        self._visited_positions: set[tuple[int, int]] = set()
+        self._frame_count: int = 0
+
+    def analyze(
+        self,
+        grid: np.ndarray[Any, Any],
+        action: str | None = None,
+    ) -> MovementInfo | None:
+        """Analyze ``grid`` against the previous frame, optionally tagging the
+        observed change with ``action``. Returns the :class:`MovementInfo` if
+        a change was detected, ``None`` if the grid was identical to the
+        previous one (or this is the first frame).
+        """
+        if grid.ndim == 3:
+            grid = grid[0]
+
+        self._frame_count += 1
+        movement: MovementInfo | None = None
+
+        if self._prev_grid is not None:
+            diff = grid != self._prev_grid
+            n_changed = int(np.sum(diff))
+
+            if n_changed > 0:
+                rows = np.where(diff.any(axis=1))[0]
+                cols = np.where(diff.any(axis=0))[0]
+
+                center_row = int(np.mean(rows))
+                center_col = int(np.mean(cols))
+
+                prev_center_row = 0
+                prev_center_col = 0
+                if self._prev_movement is not None:
+                    prev_center_row = (
+                        self._prev_movement.min_row + self._prev_movement.max_row
+                    ) // 2
+                    prev_center_col = (
+                        self._prev_movement.min_col + self._prev_movement.max_col
+                    ) // 2
+
+                movement = MovementInfo(
+                    action=action or "unknown",
+                    pixels_changed=n_changed,
+                    min_row=int(rows[0]),
+                    max_row=int(rows[-1]),
+                    min_col=int(cols[0]),
+                    max_col=int(cols[-1]),
+                    direction_row=(
+                        center_row - prev_center_row if self._prev_movement is not None else 0
+                    ),
+                    direction_col=(
+                        center_col - prev_center_col if self._prev_movement is not None else 0
+                    ),
+                )
+
+                if action:
+                    self._action_effects.setdefault(action, []).append(movement)
+
+                self._visited_positions.add((center_row, center_col))
+                self._prev_movement = movement
+
+            if self._static_mask is None:
+                self._static_mask = ~diff
+            else:
+                self._static_mask &= ~diff
+
+        self._prev_grid = grid.copy()
+        return movement
+
+    def get_action_summary(self) -> dict[str, dict[str, float]]:
+        """Return ``{action: {avg_pixels, avg_direction_row, avg_direction_col, count}}``."""
+        summary: dict[str, dict[str, float]] = {}
+        for action, movements in self._action_effects.items():
+            if not movements:
+                continue
+            n = len(movements)
+            summary[action] = {
+                "avg_pixels": sum(m.pixels_changed for m in movements) / n,
+                "avg_direction_row": sum(m.direction_row for m in movements) / n,
+                "avg_direction_col": sum(m.direction_col for m in movements) / n,
+                "count": float(n),
+            }
+        return summary
+
+    def suggest_action(self, available_actions: list[Any]) -> Any | None:
+        """Round-robin exploration with a bias toward directional actions.
+
+        * Untested actions get top priority.
+        * Among tested ones, prefer the least-used (balanced exploration).
+        * Tie-break by stronger directional signal (high abs row+col delta).
+        """
+        if not available_actions:
+            return None
+
+        ranked: list[tuple[Any, float, int]] = []
+        for a in available_actions:
+            key = a.name if hasattr(a, "name") else str(a)
+            effects = self._action_effects.get(key, [])
+            if not effects:
+                # Untested → highest priority.
+                return a
+
+            recent = effects[-10:]
+            avg_dir = (
+                sum(abs(m.direction_row) for m in recent)
+                + sum(abs(m.direction_col) for m in recent)
+            ) / len(recent)
+            ranked.append((a, avg_dir, len(effects)))
+
+        ranked.sort(key=lambda t: (t[2], -t[1]))
+        return ranked[0][0] if ranked else None
+
+    def reset_for_new_level(self) -> None:
+        """Drop position tracking but **keep** learned action effects.
+
+        Useful on level boundaries: the new level's geometry is fresh, but
+        what each action does (up/down/left/right) is unchanged.
+        """
+        self._prev_grid = None
+        self._prev_movement = None
+        self._static_mask = None
+        self._visited_positions.clear()
+        self._frame_count = 0
+
+    @property
+    def frame_count(self) -> int:
+        return self._frame_count
+
+    @property
+    def visited_positions(self) -> frozenset[tuple[int, int]]:
+        return frozenset(self._visited_positions)

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_frame_analyzer.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_frame_analyzer.py
@@ -1,0 +1,132 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 — FrameAnalyzer tests."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.arc_agi3.frame_analyzer import (
+    FrameAnalyzer,
+    MovementInfo,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+def _grid(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int32)
+
+
+class TestAnalyzeBasics:
+    def test_first_frame_returns_none(self) -> None:
+        fa = FrameAnalyzer()
+        assert fa.analyze(_grid([[0, 0], [0, 0]])) is None
+        assert fa.frame_count == 1
+
+    def test_no_change_returns_none(self) -> None:
+        fa = FrameAnalyzer()
+        g = _grid([[1, 0], [0, 1]])
+        fa.analyze(g)
+        assert fa.analyze(g) is None
+
+    def test_movement_detected(self) -> None:
+        fa = FrameAnalyzer()
+        fa.analyze(_grid([[1, 0], [0, 0]]))
+        movement = fa.analyze(_grid([[0, 1], [0, 0]]), action="ACTION3")
+        assert movement is not None
+        assert movement.action == "ACTION3"
+        assert movement.pixels_changed == 2  # Two cells changed.
+
+
+class TestActionEffects:
+    def test_action_effect_recorded(self) -> None:
+        fa = FrameAnalyzer()
+        fa.analyze(_grid([[1, 0], [0, 0]]))
+        fa.analyze(_grid([[0, 0], [1, 0]]), action="DOWN")
+        summary = fa.get_action_summary()
+        assert "DOWN" in summary
+        assert summary["DOWN"]["count"] == 1.0
+
+    def test_summary_averages_over_multiple_calls(self) -> None:
+        fa = FrameAnalyzer()
+        # Three same-shape frames with two DOWN-tagged transitions.
+        fa.analyze(_grid([[1, 0, 0], [0, 0, 0], [0, 0, 0]]))
+        fa.analyze(_grid([[0, 0, 0], [1, 0, 0], [0, 0, 0]]), action="DOWN")
+        fa.analyze(_grid([[0, 0, 0], [0, 0, 0], [1, 0, 0]]), action="DOWN")
+        summary = fa.get_action_summary()
+        assert summary["DOWN"]["count"] == 2.0
+
+    def test_unspecified_action_marked_unknown(self) -> None:
+        fa = FrameAnalyzer()
+        fa.analyze(_grid([[1, 0], [0, 0]]))
+        movement = fa.analyze(_grid([[0, 1], [0, 0]]))
+        assert movement is not None
+        assert movement.action == "unknown"
+        # Unspecified action is NOT recorded in action_effects.
+        assert fa.get_action_summary() == {}
+
+
+class TestSuggestAction:
+    def test_no_history_no_actions(self) -> None:
+        fa = FrameAnalyzer()
+        assert fa.suggest_action([]) is None
+
+    def test_untested_action_wins(self) -> None:
+        class _A:
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+        fa = FrameAnalyzer()
+        # Train one action.
+        fa.analyze(_grid([[1, 0]]))
+        fa.analyze(_grid([[0, 1]]), action="ACTION_TESTED")
+        actions = [_A("ACTION_TESTED"), _A("ACTION_NEW")]
+        suggested = fa.suggest_action(actions)
+        # ACTION_NEW has zero history → highest priority.
+        assert suggested.name == "ACTION_NEW"
+
+    def test_least_used_wins_among_tested(self) -> None:
+        class _A:
+            def __init__(self, name: str) -> None:
+                self.name = name
+
+        fa = FrameAnalyzer()
+        fa.analyze(_grid([[1, 0]]))
+        # Use ACTION_A twice, ACTION_B once.
+        fa.analyze(_grid([[0, 1]]), action="ACTION_A")
+        fa.analyze(_grid([[1, 0]]), action="ACTION_A")
+        fa.analyze(_grid([[0, 1]]), action="ACTION_B")
+        actions = [_A("ACTION_A"), _A("ACTION_B")]
+        suggested = fa.suggest_action(actions)
+        assert suggested.name == "ACTION_B"
+
+
+class TestResetForNewLevel:
+    def test_clears_position_keeps_effects(self) -> None:
+        fa = FrameAnalyzer()
+        fa.analyze(_grid([[1, 0]]))
+        fa.analyze(_grid([[0, 1]]), action="DOWN")
+        assert fa.get_action_summary()  # non-empty
+
+        fa.reset_for_new_level()
+        # Effects survive.
+        assert "DOWN" in fa.get_action_summary()
+        # Position tracking is cleared.
+        assert fa.frame_count == 0
+        assert fa.visited_positions == frozenset()
+
+
+class TestMovementInfoDataclass:
+    def test_construct_minimal(self) -> None:
+        m = MovementInfo(
+            action="ACTION1",
+            pixels_changed=4,
+            min_row=0,
+            max_row=2,
+            min_col=0,
+            max_col=2,
+        )
+        assert m.action == "ACTION1"
+        assert m.direction_row == 0
+        assert m.direction_col == 0


### PR DESCRIPTION
## Summary

Sprint-12 mega-merge PR-4: lifts `cognithor.arc.frame_analyzer` into the new `program_synthesis/arc_agi3/` stack. Tracks per-action movement deltas across successive frames so an agent can build a model of what each `ACTIONx` button actually does.

This is critical for **keyboard-controlled games** where ARC-AGI-3 does **not** announce which action is up / down / left / right — the agent has to discover that mapping from observed pixel motion.

## What's new

- **`MovementInfo`** dataclass — action, pixels_changed, region bounds, direction deltas.
- **`FrameAnalyzer.analyze()`** — diffs against the previous frame, tags the change with the action that produced it, accumulates per-action statistics.
- **`get_action_summary()`** — `{action: {avg_pixels, avg_direction_row, avg_direction_col, count}}`.
- **`suggest_action()`** — round-robin exploration with directional bias.
- **`reset_for_new_level()`** — drops position tracking but **keeps** learned action effects (transfer across level boundaries).

## How it differs from `EpisodeMemory` / `ChangeDetector`

Wave-3's `ChangeDetector` only counts pixel deltas. `FrameAnalyzer` is the structured cousin that also remembers **direction + region**, so an `LLMReasoningAgent` can quote *"ACTION3 has historically moved your sprite downward"* into the next prompt instead of just *"ACTION3 changed 2 pixels"*.

## Stacking

Independent of #289 / #290 / #291 / #292 (no file overlap, only adds new module + extra `__init__.py` exports).

## Test plan

- [x] `pytest .../test_frame_analyzer.py` → 11/11 green
- [x] `pytest .../arc_agi3/` → 116/116 green
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)