### PR TITLE
feat(pse): Sprint-12 PR-8 — wire plan_click_solution() as Sprint10DSLAgent fast-path

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
@@ -25,7 +25,7 @@ GAME_OVER policies (e.g. retry loops).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -36,6 +36,10 @@ from cognithor.channels.program_synthesis.arc_agi3.dsl_action_decoder import (
 from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
     EpisodeMemory,
     StuckDetector,
+)
+from cognithor.channels.program_synthesis.arc_agi3.fast_path import (
+    ClickPlanCache,
+    detect_toggle_pair_from_memory,
 )
 from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import FrameBridge
 from cognithor.channels.program_synthesis.arc_agi3.state_action_counts import (
@@ -74,6 +78,7 @@ class Sprint10DSLAgent(CognithorPSEAgent):
         stuck_detector: StuckDetector | None = None,
         state_counter: StateActionCounter | None = None,
         state_graph: StateGraphNavigator | None = None,
+        fast_path_enabled: bool = False,
     ) -> None:
         self._bridge = bridge if bridge is not None else FrameBridge()
         self._memory = memory if memory is not None else EpisodeMemory()
@@ -94,8 +99,13 @@ class Sprint10DSLAgent(CognithorPSEAgent):
         self._pending_levels: int | None = None
         # Cache the previous-frame grid so we can detect no-op transitions
         # and feed the StateGraphNavigator with full (from, action, to) tuples.
-        self._prev_grid: np.ndarray | None = None
+        self._prev_grid: np.ndarray[Any, Any] | None = None
         self._prev_state_hash: str | None = None
+        # Sprint-12 PR-8: pure-NumPy click-toggle fast-path. Disabled by
+        # default; enable via constructor flag to short-circuit the DSL
+        # search when the most recent transition reveals a toggle pair.
+        self._fast_path_enabled = fast_path_enabled
+        self._click_cache: ClickPlanCache | None = ClickPlanCache() if fast_path_enabled else None
 
     @property
     def memory(self) -> EpisodeMemory:
@@ -141,8 +151,14 @@ class Sprint10DSLAgent(CognithorPSEAgent):
                 action_name=self._pending_action_name,
                 levels_completed=latest_frame.levels_completed,
             )
-            # State-graph: record the (from, action, to) edge.
-            if self._prev_grid is not None and self._prev_state_hash is not None:
+            # State-graph: record the (from, action, to) edge. Skip when
+            # the grid shape changed (e.g. across a level boundary) — the
+            # graph only models intra-level transitions.
+            if (
+                self._prev_grid is not None
+                and self._prev_state_hash is not None
+                and self._prev_grid.shape == current_grid.shape
+            ):
                 pixels_changed = int(np.sum(self._prev_grid != current_grid))
                 self._state_graph.add_transition(
                     from_grid=self._prev_grid,
@@ -158,8 +174,19 @@ class Sprint10DSLAgent(CognithorPSEAgent):
                 if self._prev_state_hash == current_hash:
                     self._state_counter.mark_dead(self._prev_state_hash, self._pending_action_name)
 
-        # Step 3 — delegate to the DSL decoder.
-        chosen = self._decoder.decode(frames, latest_frame)
+        # Step 3a — try the fast-path planner if enabled. The planner
+        # only fires when ACTION6 is available AND we've seen a clean
+        # toggle pair in the last two frames AND the planner finds a
+        # winning click sequence. On a miss it returns None and we fall
+        # through to the regular DSL decoder unchanged.
+        chosen: GameActionProtocol | None = None
+        if self._click_cache is not None:
+            chosen = self._try_fast_path(latest_frame, current_grid, current_hash)
+
+        # Step 3b — delegate to the DSL decoder when the fast-path
+        # didn't fire.
+        if chosen is None:
+            chosen = self._decoder.decode(frames, latest_frame)
 
         # Step 4 — bookkeeping: increment the (current_state, chosen) count
         # so the next decode skips it if alternatives exist.
@@ -171,6 +198,50 @@ class Sprint10DSLAgent(CognithorPSEAgent):
         self._prev_grid = current_grid
         self._prev_state_hash = current_hash
         return chosen
+
+    def _try_fast_path(
+        self,
+        latest_frame: FrameDataProtocol,
+        current_grid: np.ndarray[Any, Any],
+        current_hash: str,
+    ) -> GameActionProtocol | None:
+        """Click-toggle fast-path. Returns ACTION6 with click coordinates
+        when a winning plan exists, ``None`` otherwise.
+
+        Side-effect-free on miss; the cache is keyed by ``(state_hash,
+        source, target)`` so repeated calls on the same state don't
+        re-run the NumPy search.
+        """
+        if self._click_cache is None:
+            return None
+        # ACTION6 must be available for clicks.
+        click_action: GameActionProtocol | None = None
+        for action in latest_frame.available_actions:
+            if action.name == "ACTION6":
+                click_action = action
+                break
+        if click_action is None:
+            return None
+        # Need a toggle pair signal from the last two grids.
+        toggle = detect_toggle_pair_from_memory(self._memory)
+        if toggle is None:
+            return None
+        source_color, target_color = toggle
+        click_xy = self._click_cache.next_click(
+            state_hash=current_hash,
+            grid=current_grid,
+            source_color=source_color,
+            target_color=target_color,
+        )
+        if click_xy is None:
+            return None
+        x, y = click_xy
+        click_action.set_data({"x": int(x), "y": int(y)})
+        click_action.reasoning = (
+            f"Sprint10DSLAgent fast-path: plan_click_solution "
+            f"({source_color}->{target_color}) → click ({x},{y})"
+        )
+        return click_action
 
 
 __all__ = ["Sprint10DSLAgent"]

--- a/src/cognithor/channels/program_synthesis/arc_agi3/fast_path.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/fast_path.py
@@ -1,0 +1,132 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 — fast-path planner integration helpers.
+
+The :class:`Sprint10DSLAgent` (Wave-4) drives a least-tried search over
+DSL primitives. For click-toggle games (the LS20-style "click pixel,
+swap a→b" mechanic) the legacy :func:`plan_click_solution` finds the
+winning click sequence in pure NumPy, far faster than the agent can
+discover it via single-step DSL search.
+
+This module is the glue:
+
+* :func:`detect_toggle_pair_from_memory` — look at the last two grids
+  in :class:`EpisodeMemory` and infer the dominant ``(source, target)``
+  swap, or ``None`` when the most recent transition wasn't a clean
+  toggle.
+* :class:`ClickPlanCache` — runs :func:`plan_click_solution` once per
+  ``(state_hash, toggle_pair)`` pair, caches the resulting cluster
+  centroids, and pops them one-by-one each subsequent call. The agent
+  emits one click per frame; the cache survives across frames so the
+  expensive search isn't re-run on every step.
+
+The whole thing is opt-in via :class:`Sprint10DSLAgent`'s
+``fast_path_enabled`` flag — disabled by default so existing
+behaviour is preserved.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from cognithor.channels.program_synthesis.arc_agi3.fast_grid_planner import (
+    detect_toggle_pair,
+    find_clusters,
+    plan_click_solution,
+)
+
+if TYPE_CHECKING:
+    import numpy as np
+
+    from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
+        EpisodeMemory,
+    )
+
+__all__ = [
+    "ClickPlanCache",
+    "detect_toggle_pair_from_memory",
+]
+
+
+def detect_toggle_pair_from_memory(memory: EpisodeMemory) -> tuple[int, int] | None:
+    """Infer the most recent ``(source, target)`` toggle from the last two grids.
+
+    Returns ``None`` when the memory has fewer than two snapshots or the
+    most recent transition wasn't a clean two-colour swap.
+    """
+    if len(memory) < 2:
+        return None
+    window = memory.window(2)
+    if len(window) < 2:
+        return None
+    # window is most-recent first.
+    g_after = window[0].grid
+    g_before = window[1].grid
+    if g_before.shape != g_after.shape:
+        return None
+    return detect_toggle_pair(g_before, g_after)
+
+
+class ClickPlanCache:
+    """Per-state click-plan cache for the fast-path.
+
+    Keyed by ``(state_hash, source_color, target_color)``. The first call
+    runs :func:`plan_click_solution` and stores the resulting list of
+    cluster centroids in ``(x=col, y=row)`` form (the SDK's coordinate
+    convention for ``ACTION6``). Subsequent calls pop centroids one at
+    a time so the agent can emit one click per frame.
+
+    On a cache miss with no available solution the cache stores the
+    sentinel "no solution" so :func:`plan_click_solution` is not re-run.
+    """
+
+    _NO_SOLUTION: list[tuple[int, int]] = []  # singleton sentinel
+
+    def __init__(self, *, max_combos: int = 100_000) -> None:
+        self._max_combos = max_combos
+        self._cache: dict[tuple[str, int, int], list[tuple[int, int]]] = {}
+
+    def next_click(
+        self,
+        *,
+        state_hash: str,
+        grid: np.ndarray[Any, Any],
+        source_color: int,
+        target_color: int,
+    ) -> tuple[int, int] | None:
+        """Return the next ``(x, y)`` click, or ``None`` when no plan exists.
+
+        On the first call for a given ``(state_hash, source, target)`` the
+        plan is computed and cached. Each subsequent call pops the next
+        click from the queue. Once the queue is exhausted, returns ``None``.
+        """
+        key = (state_hash, source_color, target_color)
+        plan = self._cache.get(key)
+        if plan is None:
+            plan = self._compute_plan(grid, source_color, target_color)
+            self._cache[key] = plan
+        if not plan:
+            return None
+        return plan.pop(0)
+
+    def _compute_plan(
+        self,
+        grid: np.ndarray[Any, Any],
+        source_color: int,
+        target_color: int,
+    ) -> list[tuple[int, int]]:
+        clusters = find_clusters(grid, source_color)
+        if not clusters:
+            return list(self._NO_SOLUTION)
+        indices = plan_click_solution(
+            grid,
+            source_color,
+            target_color,
+            max_combos=self._max_combos,
+        )
+        if indices is None:
+            return list(self._NO_SOLUTION)
+        # Cluster centroids → SDK click format (x=col, y=row).
+        return [(c, r) for r, c in (clusters[i].centroid for i in indices)]
+
+    def clear(self) -> None:
+        self._cache.clear()

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_fast_path.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_fast_path.py
@@ -1,0 +1,220 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 PR-8 — fast_path glue + Sprint10DSLAgent fast-path wiring."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.arc_agi3.dsl_agent import Sprint10DSLAgent
+from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
+    EpisodeMemory,
+)
+from cognithor.channels.program_synthesis.arc_agi3.fast_path import (
+    ClickPlanCache,
+    detect_toggle_pair_from_memory,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+# ---------------------------------------------------------------------------
+# Stub harness types — same shape as test_llm_agent.py + test_dsl_agent.py
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _StubGameState:
+    name: str = "NOT_FINISHED"
+
+
+@dataclass
+class _StubAction:
+    name: str
+    value: int
+    reasoning: str = ""
+    _data: dict[str, Any] = field(default_factory=dict)
+    _is_simple: bool = True
+
+    def is_simple(self) -> bool:
+        return self._is_simple
+
+    def is_complex(self) -> bool:
+        return not self._is_simple
+
+    def set_data(self, data: dict[str, Any]) -> None:
+        self._data = dict(data)
+
+
+@dataclass
+class _StubFrame:
+    game_id: str = "ls20"
+    state: _StubGameState = field(default_factory=_StubGameState)
+    levels_completed: int = 0
+    win_levels: int = 1
+    guid: str = ""
+    full_reset: bool = False
+    frame: list[Any] = field(default_factory=list)
+    available_actions: list[_StubAction] = field(default_factory=list)
+
+
+def _frame(grid: np.ndarray, *, with_click: bool = True) -> _StubFrame:
+    actions = [
+        _StubAction(name="RESET", value=0),
+        _StubAction(name="ACTION1", value=1),
+        _StubAction(name="ACTION2", value=2),
+    ]
+    if with_click:
+        actions.append(_StubAction(name="ACTION6", value=6, _is_simple=False))
+    return _StubFrame(frame=[grid], available_actions=actions)
+
+
+# ---------------------------------------------------------------------------
+# detect_toggle_pair_from_memory
+# ---------------------------------------------------------------------------
+
+
+class TestDetectTogglePairFromMemory:
+    def test_empty_memory_returns_none(self) -> None:
+        assert detect_toggle_pair_from_memory(EpisodeMemory()) is None
+
+    def test_single_step_returns_none(self) -> None:
+        m = EpisodeMemory()
+        m.append(grid=np.zeros((2, 2), dtype=np.int8), action_name="A", levels_completed=0)
+        assert detect_toggle_pair_from_memory(m) is None
+
+    def test_clean_swap_detected(self) -> None:
+        m = EpisodeMemory()
+        m.append(
+            grid=np.array([[1, 1], [1, 1]], dtype=np.int8),
+            action_name="ACTION6",
+            levels_completed=0,
+        )
+        m.append(
+            grid=np.array([[2, 2], [2, 2]], dtype=np.int8),
+            action_name="ACTION6",
+            levels_completed=0,
+        )
+        result = detect_toggle_pair_from_memory(m)
+        assert result == (1, 2)
+
+    def test_no_change_returns_none(self) -> None:
+        m = EpisodeMemory()
+        g = np.array([[1, 0], [0, 1]], dtype=np.int8)
+        m.append(grid=g, action_name="A", levels_completed=0)
+        m.append(grid=g.copy(), action_name="A", levels_completed=0)
+        assert detect_toggle_pair_from_memory(m) is None
+
+
+# ---------------------------------------------------------------------------
+# ClickPlanCache
+# ---------------------------------------------------------------------------
+
+
+class TestClickPlanCache:
+    def test_first_call_computes_plan(self) -> None:
+        cache = ClickPlanCache()
+        grid = np.zeros((4, 4), dtype=np.int8)
+        grid[1, 1] = 1
+        grid[1, 2] = 1
+        click = cache.next_click(state_hash="hash1", grid=grid, source_color=1, target_color=2)
+        assert click is not None
+        # SDK convention: (x=col, y=row) → centroid (1, 1) → x=1, y=1.
+        assert click == (1, 1)
+
+    def test_second_call_pops_next(self) -> None:
+        cache = ClickPlanCache()
+        grid = np.zeros((5, 5), dtype=np.int8)
+        grid[0, 0] = 1
+        grid[4, 4] = 1
+        first = cache.next_click(state_hash="hash2", grid=grid, source_color=1, target_color=2)
+        second = cache.next_click(state_hash="hash2", grid=grid, source_color=1, target_color=2)
+        third = cache.next_click(state_hash="hash2", grid=grid, source_color=1, target_color=2)
+        assert first is not None
+        assert second is not None
+        # Two clusters → two clicks → third call returns None.
+        assert third is None
+        assert first != second
+
+    def test_no_solution_returns_none(self) -> None:
+        cache = ClickPlanCache()
+        grid = np.zeros((3, 3), dtype=np.int8)  # No source pixels.
+        click = cache.next_click(state_hash="hash3", grid=grid, source_color=5, target_color=6)
+        assert click is None
+
+    def test_cache_does_not_recompute(self) -> None:
+        cache = ClickPlanCache()
+        grid = np.zeros((3, 3), dtype=np.int8)
+        grid[1, 1] = 1
+        cache.next_click(state_hash="hash4", grid=grid, source_color=1, target_color=2)
+        # Same state hash → cached plan, doesn't matter that grid changed.
+        empty_grid = np.zeros((3, 3), dtype=np.int8)
+        # Cache hit: would compute None on the empty grid, but cache holds
+        # the original plan (already popped to []) so returns None.
+        click = cache.next_click(
+            state_hash="hash4", grid=empty_grid, source_color=1, target_color=2
+        )
+        # Plan was 1 click long, already popped → None.
+        assert click is None
+
+
+# ---------------------------------------------------------------------------
+# Sprint10DSLAgent fast-path integration
+# ---------------------------------------------------------------------------
+
+
+class TestAgentFastPath:
+    def test_disabled_by_default(self) -> None:
+        agent = Sprint10DSLAgent()
+        assert agent._click_cache is None
+
+    def test_enabled_creates_cache(self) -> None:
+        agent = Sprint10DSLAgent(fast_path_enabled=True)
+        assert agent._click_cache is not None
+
+    def test_fast_path_skipped_when_no_action6(self) -> None:
+        agent = Sprint10DSLAgent(fast_path_enabled=True)
+        grid = np.zeros((4, 4), dtype=np.int8)
+        grid[1, 1] = 1
+        # First frame — ACTION6 missing.
+        frame = _frame(grid, with_click=False)
+        chosen = agent.choose_action([frame], frame)
+        # No click action available → fall through to DSL decoder.
+        assert chosen.name in {"ACTION1", "ACTION2"}
+
+    def test_fast_path_skipped_when_no_toggle_pair_observed(self) -> None:
+        # On the very first frame the memory is empty → no toggle pair
+        # → fast-path skipped → DSL decoder picks something simple.
+        agent = Sprint10DSLAgent(fast_path_enabled=True)
+        grid = np.zeros((4, 4), dtype=np.int8)
+        grid[1, 1] = 1
+        frame = _frame(grid)
+        chosen = agent.choose_action([frame], frame)
+        # First call: empty memory → fast-path bails → DSL decoder.
+        assert chosen.name != "ACTION6" or "fast-path" not in chosen.reasoning
+
+    def test_fast_path_fires_after_toggle_observed(self) -> None:
+        """End-to-end: feed three same-shape grids. Frames 2→3 show a
+        dominant 1→2 swap with a fresh 1-cluster appearing; the
+        fast-path should detect the toggle and emit ACTION6."""
+        agent = Sprint10DSLAgent(fast_path_enabled=True)
+
+        # Frame 1: any non-trivial start — needed to seed memory.
+        g1 = np.zeros((5, 5), dtype=np.int8)
+        agent.choose_action([_frame(g1)], _frame(g1))
+
+        # Frame 2: 6 cells of colour 1 (block in top-left).
+        g2 = np.zeros((5, 5), dtype=np.int8)
+        g2[0:2, 0:3] = 1
+        agent.choose_action([_frame(g2)], _frame(g2))
+
+        # Frame 3: those 6 cells flipped to 2 (dominant swap = 1→2),
+        # plus a small fresh 1-cluster the planner can target.
+        g3 = np.zeros((5, 5), dtype=np.int8)
+        g3[0:2, 0:3] = 2
+        g3[2, 3:5] = 1
+        chosen = agent.choose_action([_frame(g3)], _frame(g3))
+        assert chosen.name == "ACTION6"
+        assert "fast-path" in chosen.reasoning


### PR DESCRIPTION
## Summary

Sprint-12 wiring PR-8 — activates the Sprint-12 PR-3 (#292) click-toggle planner inside the running `Sprint10DSLAgent`. When enabled, after the most recent two frames in `EpisodeMemory` reveal a clean colour-swap, the agent calls `plan_click_solution()` and emits `ACTION6` with the cluster's centroid coordinates instead of falling through to the slow DSL search.

## What's new

**New module `fast_path.py`:**
- `detect_toggle_pair_from_memory()` — pull the dominant `(source, target)` swap from the last two grids in memory
- `ClickPlanCache` — keyed by `(state_hash, source, target)`. First call runs `plan_click_solution()`; subsequent calls pop centroids one-at-a-time so the agent emits one click per frame.

**`Sprint10DSLAgent` change:**
- New `fast_path_enabled` constructor flag (default `False` — opt-in to preserve baseline behaviour).
- When `True`, `_try_fast_path()` runs **before** the DSL decoder. On a miss it returns `None` and the decoder runs unchanged. On a hit it emits `ACTION6` with `set_data({x, y})` and a `"fast-path"` reasoning marker.

**Side-fix:** state-graph `add_transition` now skips when grid shape changed (e.g. across a level boundary) — was previously crashing on shape-mismatched `np.sum`.

## Stacking

Branched from current `main` (post-merge of #289/#290/#292). Independent of #291 / #293 (still in-flight).

## Test plan

- [x] `pytest .../test_fast_path.py` → 13/13 green (toggle detection + plan cache + agent integration)
- [x] `pytest .../arc_agi3/` → 164/164 green (no regression)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)