### PR TITLE
feat(pse): Sprint-12 PR-9 — salience-based ClickTargetSampler for click-target games

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
@@ -29,6 +29,9 @@ from cognithor.channels.program_synthesis.arc_agi3.agent import (
     CognithorPSEAgent,
     RandomActionAgent,
 )
+from cognithor.channels.program_synthesis.arc_agi3.click_target_sampler import (
+    ClickTargetSampler,
+)
 from cognithor.channels.program_synthesis.arc_agi3.dsl_action_decoder import (
     DSLActionDecoder,
 )
@@ -91,6 +94,7 @@ __all__ = [
     "ChangeDetector",
     "ChoiceFn",
     "ClampPolicy",
+    "ClickTargetSampler",
     "Cluster",
     "CognithorPSEAgent",
     "DSLActionDecoder",

--- a/src/cognithor/channels/program_synthesis/arc_agi3/click_target_sampler.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/click_target_sampler.py
@@ -1,0 +1,125 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 — salience-based click target sampler.
+
+For ARC-AGI-3 games where the goal is "click the target object" (rather
+than the LS20-style "click cluster to toggle colour"), the
+:func:`plan_click_solution` fast-path doesn't apply: there's no toggle
+pair to invert. Instead the agent has to *guess* a click coordinate
+each frame and observe the response.
+
+Picking coordinates by uniform random sampling wastes the frame budget
+on the background. The :class:`ClickTargetSampler` instead picks
+coordinates ranked by **salience**:
+
+* small connected components of non-background colours (likely "target"
+  objects rather than terrain)
+* unvisited coordinates (we don't re-click a position we already tried
+  in this episode)
+* coloured pixels over background (background is always the most
+  common colour; we never click pure background)
+
+The sampler maintains a per-grid plan that's recomputed when the grid
+changes meaningfully (different colour distribution). Each call to
+:meth:`next_click` pops one coordinate from the queue.
+
+This is intentionally pure-NumPy, env-independent, and side-effect-
+free — the agent feeds it a grid + observation history, it returns
+``(x, y)`` or ``None`` when no salient targets remain.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.arc_agi3.fast_grid_planner import (
+    find_clusters,
+)
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.arc_agi3.fast_grid_planner import (
+        Cluster,
+    )
+
+__all__ = ["ClickTargetSampler"]
+
+
+def _background_color(grid: np.ndarray[Any, Any]) -> int:
+    """The most common colour in ``grid`` is treated as background."""
+    colors, counts = np.unique(grid, return_counts=True)
+    return int(colors[int(np.argmax(counts))])
+
+
+def _rank_clusters(clusters: list[Cluster]) -> list[Cluster]:
+    """Rank clusters by salience: smallest first (likely "target" objects).
+
+    Ties broken by row, then column (deterministic).
+    """
+    return sorted(clusters, key=lambda c: (c.size, c.centroid[0], c.centroid[1]))
+
+
+class ClickTargetSampler:
+    """Salience-ranked click coordinate generator.
+
+    Per-instance state:
+
+    * ``visited`` — set of ``(x, y)`` tuples already emitted this episode.
+      Reset across level boundaries via :meth:`reset_for_new_level`.
+    * ``queue`` — current grid's salience-ranked click queue. Recomputed
+      whenever the grid's colour-distribution signature changes.
+    * ``signature`` — last grid's ``(shape, sorted unique colours)``
+      tuple. Cheap to compute, stable under translation but invalidates
+      when a new colour appears or the shape changes.
+    """
+
+    def __init__(self) -> None:
+        self._visited: set[tuple[int, int]] = set()
+        self._queue: list[tuple[int, int]] = []
+        self._signature: tuple[Any, ...] | None = None
+
+    @property
+    def visited(self) -> frozenset[tuple[int, int]]:
+        return frozenset(self._visited)
+
+    def next_click(self, grid: np.ndarray[Any, Any]) -> tuple[int, int] | None:
+        """Return the next salient click coordinate ``(x, y)`` or ``None``.
+
+        Coordinates returned in SDK click format: ``x = col``, ``y = row``.
+        Recomputes the queue when the grid's colour-distribution signature
+        changes; otherwise keeps popping from the existing queue.
+        """
+        signature = self._signature_of(grid)
+        if signature != self._signature:
+            self._queue = self._build_queue(grid)
+            self._signature = signature
+
+        while self._queue:
+            x, y = self._queue.pop(0)
+            if (x, y) in self._visited:
+                continue
+            self._visited.add((x, y))
+            return (x, y)
+
+        return None
+
+    def reset_for_new_level(self) -> None:
+        """Clear the visited set + queue on a level transition."""
+        self._visited.clear()
+        self._queue.clear()
+        self._signature = None
+
+    @staticmethod
+    def _signature_of(grid: np.ndarray[Any, Any]) -> tuple[Any, ...]:
+        return (grid.shape, tuple(sorted(np.unique(grid).tolist())))
+
+    @staticmethod
+    def _build_queue(grid: np.ndarray[Any, Any]) -> list[tuple[int, int]]:
+        bg = _background_color(grid)
+        non_bg_colors = [int(c) for c in np.unique(grid).tolist() if int(c) != bg]
+        all_clusters: list[Cluster] = []
+        for color in non_bg_colors:
+            all_clusters.extend(find_clusters(grid, color))
+        ranked = _rank_clusters(all_clusters)
+        # SDK convention: x = col, y = row.
+        return [(c, r) for r, c in (cl.centroid for cl in ranked)]

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_click_target_sampler.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_click_target_sampler.py
@@ -1,0 +1,91 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 — ClickTargetSampler tests."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.arc_agi3.click_target_sampler import (
+    ClickTargetSampler,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+class TestNextClick:
+    def test_pure_background_returns_none(self) -> None:
+        sampler = ClickTargetSampler()
+        grid = np.zeros((4, 4), dtype=np.int32)
+        assert sampler.next_click(grid) is None
+
+    def test_single_target_yields_centroid(self) -> None:
+        sampler = ClickTargetSampler()
+        grid = np.zeros((4, 4), dtype=np.int32)
+        grid[1, 2] = 5
+        click = sampler.next_click(grid)
+        # SDK: (x=col, y=row).
+        assert click == (2, 1)
+
+    def test_smaller_clusters_first(self) -> None:
+        # Big cluster of 1s + tiny cluster of 2s. The tiny one is picked
+        # first because it ranks higher on salience.
+        sampler = ClickTargetSampler()
+        grid = np.zeros((6, 6), dtype=np.int32)
+        grid[0:3, 0:3] = 1  # 9-pixel block
+        grid[5, 5] = 2  # 1-pixel target
+        click = sampler.next_click(grid)
+        assert click == (5, 5)
+
+    def test_visited_skipped_on_subsequent_calls(self) -> None:
+        sampler = ClickTargetSampler()
+        grid = np.zeros((4, 4), dtype=np.int32)
+        grid[0, 0] = 1
+        grid[3, 3] = 2
+        first = sampler.next_click(grid)
+        second = sampler.next_click(grid)
+        assert first != second
+        assert first is not None
+        assert second is not None
+
+    def test_exhausted_queue_returns_none(self) -> None:
+        sampler = ClickTargetSampler()
+        grid = np.zeros((3, 3), dtype=np.int32)
+        grid[0, 0] = 1
+        sampler.next_click(grid)  # picks (0, 0)
+        # Same signature → no rebuild. Queue is empty.
+        assert sampler.next_click(grid) is None
+
+
+class TestSignatureRebuild:
+    def test_new_colour_triggers_rebuild(self) -> None:
+        sampler = ClickTargetSampler()
+        grid_a = np.zeros((4, 4), dtype=np.int32)
+        grid_a[0, 0] = 1
+        sampler.next_click(grid_a)  # consumes (0, 0)
+
+        # Same shape, same colours → no rebuild → returns None
+        assert sampler.next_click(grid_a) is None
+
+        # Add a new colour → signature changes → rebuild → fresh queue
+        grid_b = grid_a.copy()
+        grid_b[2, 2] = 3
+        click = sampler.next_click(grid_b)
+        # Visited (0,0) is still in the visited set, so the new sample
+        # picks (2, 2) (the only unseen non-background pixel).
+        assert click == (2, 2)
+
+
+class TestResetForNewLevel:
+    def test_clears_visited_and_queue(self) -> None:
+        sampler = ClickTargetSampler()
+        grid = np.zeros((3, 3), dtype=np.int32)
+        grid[0, 0] = 1
+        sampler.next_click(grid)
+        assert sampler.visited == frozenset({(0, 0)})
+
+        sampler.reset_for_new_level()
+        assert sampler.visited == frozenset()
+        # After reset, same coordinate can be re-emitted.
+        click = sampler.next_click(grid)
+        assert click == (0, 0)


### PR DESCRIPTION
## Summary

ARC-AGI-3 has two distinct click-game families:

| Family | Mechanic | Sprint-12 handler |
|---|---|---|
| **Toggle** (LS20-style) | Click cluster → two colours swap | PR-3 (#292) + PR-8 (#294) |
| **Target** (ft09-style) | Click the right object → progress | This PR |

For target-games, random click sampling burns the 80-action budget on background pixels. We need a salience prior.

## What's new

`ClickTargetSampler`: pure-NumPy, env-independent, side-effect-free.

- `find_clusters()` across every non-background colour, ranked by size ascending (smallest = most likely "target")
- visited-set tracking prevents re-clicking the same coordinate inside an episode
- signature-keyed queue cache (shape + sorted unique colours) avoids re-computing every frame; rebuilds only when the colour distribution changes
- `reset_for_new_level()` clears state across level boundaries

The agent feeds a grid + asks for the next click; sampler returns `(x, y)` (SDK: `x=col`, `y=row`) or `None` when no salient targets remain.

## Scope

Wired into `__init__.py` package surface. **Not yet auto-wired** into `Sprint10DSLAgent` — that's a follow-up after the current wiring batch (PR-5/6/7) lands.

## Test plan

- [x] `pytest .../test_click_target_sampler.py` → 7/7 green
- [x] `pytest .../arc_agi3/` → 158/158 green
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)