### PR TITLE
feat(pse): Sprint-12 PR-5+11 — wire FrameAnalyzer + level-transition resets

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
@@ -25,7 +25,7 @@ GAME_OVER policies (e.g. retry loops).
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
@@ -49,6 +49,9 @@ from cognithor.channels.program_synthesis.arc_agi3.state_graph import (
 if TYPE_CHECKING:
     from cognithor.channels.program_synthesis.arc_agi3.action_decoder import (
         ActionDecoder,
+    )
+    from cognithor.channels.program_synthesis.arc_agi3.frame_analyzer import (
+        FrameAnalyzer,
     )
     from cognithor.channels.program_synthesis.arc_agi3.protocol import (
         FrameDataProtocol,
@@ -74,6 +77,7 @@ class Sprint10DSLAgent(CognithorPSEAgent):
         stuck_detector: StuckDetector | None = None,
         state_counter: StateActionCounter | None = None,
         state_graph: StateGraphNavigator | None = None,
+        frame_analyzer: FrameAnalyzer | None = None,
     ) -> None:
         self._bridge = bridge if bridge is not None else FrameBridge()
         self._memory = memory if memory is not None else EpisodeMemory()
@@ -94,8 +98,19 @@ class Sprint10DSLAgent(CognithorPSEAgent):
         self._pending_levels: int | None = None
         # Cache the previous-frame grid so we can detect no-op transitions
         # and feed the StateGraphNavigator with full (from, action, to) tuples.
-        self._prev_grid: np.ndarray | None = None
+        self._prev_grid: np.ndarray[Any, Any] | None = None
         self._prev_state_hash: str | None = None
+        # Sprint-12 PR-11: track levels_completed so we can detect a
+        # level-transition and reset per-level state (memory, state-keyed
+        # counts, state-graph) without losing the cross-level audit trail
+        # or game-profile aggregates.
+        self._last_levels_seen: int | None = None
+        # Sprint-12 PR-5: per-action movement-signature tracker. When a
+        # FrameAnalyzer is wired in, choose_action feeds it each
+        # observation so it can build a model of "ACTION3 → moves down"
+        # over time. Action effects survive level boundaries; positions
+        # don't.
+        self._frame_analyzer = frame_analyzer
 
     @property
     def memory(self) -> EpisodeMemory:
@@ -129,6 +144,32 @@ class Sprint10DSLAgent(CognithorPSEAgent):
         # harness logs and retries one frame later if this happens.
         current_grid = self._bridge.extract_grid(latest_frame)
         current_hash = hash_state(current_grid)
+
+        # Step 1a — feed the FrameAnalyzer (if wired) so the per-action
+        # movement-signature model stays current. The action tag is the
+        # PREVIOUS action (the one whose result we are now observing),
+        # which matches FrameAnalyzer's semantics.
+        if self._frame_analyzer is not None:
+            self._frame_analyzer.analyze(current_grid, action=self._pending_action_name)
+
+        # Step 1b — detect a level transition. When ``levels_completed``
+        # increased since the last call, reset the per-level state
+        # (EpisodeMemory + StateActionCounter + StateGraph). The
+        # FrameAnalyzer's reset_for_new_level() preserves learned action
+        # effects but clears position tracking. Audit trail + GameProfile
+        # are deliberately NOT reset — they aggregate across levels.
+        if (
+            self._last_levels_seen is not None
+            and latest_frame.levels_completed > self._last_levels_seen
+        ):
+            self._memory.clear()
+            self._state_counter.clear()
+            self._state_graph = type(self._state_graph)()  # fresh graph
+            if self._frame_analyzer is not None:
+                self._frame_analyzer.reset_for_new_level()
+            self._pending_action_name = None
+            self._prev_grid = None
+            self._prev_state_hash = None
 
         # Step 2 — record the previous step in the memory if we
         # already chose an action. The grid we pair with the
@@ -170,7 +211,13 @@ class Sprint10DSLAgent(CognithorPSEAgent):
         self._pending_levels = latest_frame.levels_completed
         self._prev_grid = current_grid
         self._prev_state_hash = current_hash
+        self._last_levels_seen = latest_frame.levels_completed
         return chosen
+
+    @property
+    def frame_analyzer(self) -> FrameAnalyzer | None:
+        """Read-only access to the wired FrameAnalyzer (or None)."""
+        return self._frame_analyzer
 
 
 __all__ = ["Sprint10DSLAgent"]

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_agent_level_transition.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_agent_level_transition.py
@@ -1,0 +1,150 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 PR-5+11 — FrameAnalyzer wiring + level-transition resets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.arc_agi3.dsl_agent import Sprint10DSLAgent
+from cognithor.channels.program_synthesis.arc_agi3.frame_analyzer import (
+    FrameAnalyzer,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+@dataclass
+class _StubGameState:
+    name: str = "NOT_FINISHED"
+
+
+@dataclass
+class _StubAction:
+    name: str
+    value: int
+    reasoning: str = ""
+    _data: dict[str, Any] = field(default_factory=dict)
+    _is_simple: bool = True
+
+    def is_simple(self) -> bool:
+        return self._is_simple
+
+    def is_complex(self) -> bool:
+        return not self._is_simple
+
+    def set_data(self, data: dict[str, Any]) -> None:
+        self._data = dict(data)
+
+
+@dataclass
+class _StubFrame:
+    game_id: str = "smoke"
+    state: _StubGameState = field(default_factory=_StubGameState)
+    levels_completed: int = 0
+    win_levels: int = 1
+    guid: str = ""
+    full_reset: bool = False
+    frame: list[Any] = field(default_factory=list)
+    available_actions: list[_StubAction] = field(default_factory=list)
+
+
+def _frame(grid: np.ndarray, levels_completed: int = 0) -> _StubFrame:
+    actions = [
+        _StubAction(name="RESET", value=0),
+        _StubAction(name="ACTION1", value=1),
+        _StubAction(name="ACTION2", value=2),
+    ]
+    return _StubFrame(
+        frame=[grid],
+        available_actions=actions,
+        levels_completed=levels_completed,
+    )
+
+
+class TestFrameAnalyzerWiring:
+    def test_analyzer_optional(self) -> None:
+        agent = Sprint10DSLAgent()  # no analyzer
+        assert agent.frame_analyzer is None
+
+    def test_analyzer_receives_frames(self) -> None:
+        fa = FrameAnalyzer()
+        agent = Sprint10DSLAgent(frame_analyzer=fa)
+        # Frame 1: grid full of 1s.
+        f1 = _frame(np.array([[1, 1], [1, 1]], dtype=np.int8))
+        agent.choose_action([f1], f1)
+        # Frame 2: those flipped to 2 → analyzer sees the change tagged
+        # with the action chosen on frame 1.
+        f2 = _frame(np.array([[2, 2], [2, 2]], dtype=np.int8))
+        agent.choose_action([f2], f2)
+        # Analyzer recorded one observation tagged with f1's chosen action.
+        summary = fa.get_action_summary()
+        assert summary  # non-empty
+        # The recorded action-name should be one the agent actually picked.
+        recorded_actions = set(summary.keys())
+        assert recorded_actions <= {"RESET", "ACTION1", "ACTION2"}
+
+
+class TestLevelTransitionReset:
+    def test_no_transition_no_reset(self) -> None:
+        agent = Sprint10DSLAgent()
+        for _ in range(3):
+            f = _frame(np.array([[1, 0], [0, 1]], dtype=np.int8), levels_completed=0)
+            agent.choose_action([f], f)
+        # 3 calls, all same level → 2 memory entries (first call doesn't
+        # record because pending_action_name is None then).
+        assert len(agent.memory) == 2
+
+    def test_level_increment_clears_memory(self) -> None:
+        agent = Sprint10DSLAgent()
+        # Build up some level-0 memory.
+        for _ in range(3):
+            f = _frame(np.array([[1, 0], [0, 1]], dtype=np.int8), levels_completed=0)
+            agent.choose_action([f], f)
+        assert len(agent.memory) == 2
+
+        # Level 1 — same shape, but levels_completed went up. Memory cleared.
+        f = _frame(np.array([[2, 2], [2, 2]], dtype=np.int8), levels_completed=1)
+        agent.choose_action([f], f)
+        # After the transition the memory was cleared, then this call
+        # didn't append (pending_action_name was reset to None). So len == 0.
+        assert len(agent.memory) == 0
+
+    def test_level_increment_clears_state_counter(self) -> None:
+        agent = Sprint10DSLAgent()
+        for _ in range(3):
+            f = _frame(np.array([[1, 0]], dtype=np.int8), levels_completed=0)
+            agent.choose_action([f], f)
+        # Counter has at least one entry.
+        first_state_hash = next(iter(agent.state_counter._counts.keys()))
+        assert agent.state_counter.count(first_state_hash, "ACTION1") >= 0
+
+        # Level transition — counter cleared.
+        f = _frame(np.array([[1, 0]], dtype=np.int8), levels_completed=1)
+        agent.choose_action([f], f)
+        # The counter dict was cleared, then the new state's increment
+        # was added. So only the new state has any count.
+        assert len(agent.state_counter._counts) == 1
+
+    def test_frame_analyzer_keeps_action_effects_across_levels(self) -> None:
+        fa = FrameAnalyzer()
+        agent = Sprint10DSLAgent(frame_analyzer=fa)
+
+        # Level 0: train an action effect.
+        f1 = _frame(np.array([[1, 1], [1, 1]], dtype=np.int8), levels_completed=0)
+        agent.choose_action([f1], f1)
+        f2 = _frame(np.array([[2, 2], [2, 2]], dtype=np.int8), levels_completed=0)
+        agent.choose_action([f2], f2)
+        before_summary = fa.get_action_summary()
+        assert before_summary
+
+        # Level 1 — analyzer reset_for_new_level was called BUT
+        # action_effects were preserved.
+        f3 = _frame(np.array([[3, 3]], dtype=np.int8), levels_completed=1)
+        agent.choose_action([f3], f3)
+        after_summary = fa.get_action_summary()
+        # Effects from level 0 still present.
+        assert set(after_summary.keys()) >= set(before_summary.keys())


### PR DESCRIPTION
## Summary

Combines two related agent-side wirings (both touch the same `choose_action` code path):

### PR-5 — FrameAnalyzer wiring

- `Sprint10DSLAgent.__init__` accepts optional `frame_analyzer` (default `None`, opt-in).
- On every `choose_action` call, the agent feeds the current grid + the previous action's name to `FrameAnalyzer.analyze()` so the per-action movement-signature model stays current.
- New `frame_analyzer` property for read-only inspection.

### PR-11 — Level-transition resets

- `Sprint10DSLAgent` tracks `levels_completed` across calls.
- When the count **increments** (level boundary), the agent resets per-level state:
  - `EpisodeMemory.clear()`
  - `StateActionCounter.clear()`
  - fresh `StateGraphNavigator`
  - pending-action + prev-grid trackers zeroed
- If a `FrameAnalyzer` is wired in, `reset_for_new_level()` is called — **preserves learned action effects** but clears position tracking.
- Audit trail + GameProfile are **not** reset (cross-level by design).

## Stacking

Branched from `main` post-#293 merge (which gave us `FrameAnalyzer`). Independent of every other open PR.

## Test plan

- [x] `pytest .../test_agent_level_transition.py` → 6/6 green
- [x] `pytest .../arc_agi3/` → 193/193 green
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)