### PR TITLE
feat(pse): Sprint-12 PR-12 — feed FrameAnalyzer summary into LLMActionDecoder prompt

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/llm_action_decoder.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/llm_action_decoder.py
@@ -38,6 +38,9 @@ if TYPE_CHECKING:
     from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
         EpisodeMemory,
     )
+    from cognithor.channels.program_synthesis.arc_agi3.frame_analyzer import (
+        FrameAnalyzer,
+    )
     from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import FrameBridge
     from cognithor.channels.program_synthesis.arc_agi3.protocol import (
         FrameDataProtocol,
@@ -56,6 +59,11 @@ class FrameContext:
     callable returns ``(action_name, reasoning)``; the decoder
     matches the name against ``available_actions`` and returns the
     matching action.
+
+    ``action_effects_summary`` is an optional one-line description of
+    what each action has historically done (Sprint-12 PR-12 — fed by
+    a wired :class:`FrameAnalyzer`). Empty string when no analyser is
+    wired or no observations have been recorded yet.
     """
 
     grid: _Grid
@@ -63,6 +71,7 @@ class FrameContext:
     history_summary: str
     levels_completed: int
     win_levels: int
+    action_effects_summary: str = ""
 
 
 # A callable that takes a :class:`FrameContext` and returns
@@ -82,6 +91,31 @@ def render_grid(grid: _Grid) -> str:
     if grid.ndim != 2:
         raise ValueError(f"render_grid: expected 2-D grid, got {grid.ndim}-D")
     return "\n".join(" ".join(str(int(c)) for c in row) for row in grid)
+
+
+def summarise_action_effects(analyzer: FrameAnalyzer, *, max_actions: int = 6) -> str:
+    """Compact one-line summary of FrameAnalyzer's per-action effect model.
+
+    Format: ``"ACTION1: row+1, col+0 (n=4); ACTION3: row+0, col-1 (n=2); ..."``.
+    Empty observations yield ``"(no action effects observed yet)"``.
+
+    The Sprint-12 :class:`Sprint10DSLAgent` feeds a wired :class:`FrameAnalyzer`
+    each frame; this helper formats its accumulated knowledge into a string the
+    LLM can read in the next prompt. Knowing "ACTION3 has historically moved
+    your sprite down" is critical for keyboard-controlled games where the
+    upstream API doesn't announce what each ``ACTIONx`` does.
+    """
+    summary = analyzer.get_action_summary()
+    if not summary:
+        return "(no action effects observed yet)"
+    items = sorted(summary.items(), key=lambda kv: -kv[1]["count"])[:max_actions]
+    parts: list[str] = []
+    for name, stats in items:
+        row = stats["avg_direction_row"]
+        col = stats["avg_direction_col"]
+        n = int(stats["count"])
+        parts.append(f"{name}: row{row:+.0f}, col{col:+.0f} (n={n})")
+    return "; ".join(parts)
 
 
 def summarise_history(memory: EpisodeMemory, max_steps: int = 8) -> str:
@@ -132,12 +166,16 @@ class LLMActionDecoder(ActionDecoder):
         choice_fn: ChoiceFn,
         fallback: ActionDecoder | None = None,
         history_steps: int = 8,
+        frame_analyzer: FrameAnalyzer | None = None,
     ) -> None:
         self._bridge = bridge
         self._memory = memory
         self._choice_fn = choice_fn
         self._fallback = fallback if fallback is not None else DSLActionDecoder(memory=memory)
         self._history_steps = history_steps
+        # Sprint-12 PR-12: optional FrameAnalyzer for per-action movement
+        # signatures fed into the LLM prompt. Default None preserves baseline.
+        self._frame_analyzer = frame_analyzer
 
     def pick_action(
         self,
@@ -153,12 +191,18 @@ class LLMActionDecoder(ActionDecoder):
                 f" [LLM bridge failed: {type(exc).__name__}]",
             )[0:0] or self._fallback.pick_action(frames, latest_frame, available_actions)
 
+        action_effects_summary = (
+            summarise_action_effects(self._frame_analyzer)
+            if self._frame_analyzer is not None
+            else ""
+        )
         ctx = FrameContext(
             grid=grid,
             available_action_names=[a.name for a in available_actions],
             history_summary=summarise_history(self._memory, self._history_steps),
             levels_completed=latest_frame.levels_completed,
             win_levels=latest_frame.win_levels,
+            action_effects_summary=action_effects_summary,
         )
 
         # Call the LLM (or stub). Failures fall back to the DSL decoder.
@@ -192,5 +236,6 @@ __all__ = [
     "FrameContext",
     "LLMActionDecoder",
     "render_grid",
+    "summarise_action_effects",
     "summarise_history",
 ]

--- a/src/cognithor/channels/program_synthesis/arc_agi3/llm_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/llm_agent.py
@@ -54,14 +54,23 @@ Do not output anything outside the JSON block."""
 
 
 def _build_user_prompt(ctx: FrameContext) -> str:
-    return (
-        f"Current grid ({ctx.grid.shape[0]}x{ctx.grid.shape[1]}):\n"
-        f"{render_grid(ctx.grid)}\n\n"
-        f"Available actions: {', '.join(ctx.available_action_names)}\n"
-        f"Recent history: {ctx.history_summary}\n"
-        f"Progress: {ctx.levels_completed}/{ctx.win_levels} levels\n\n"
-        f"Pick one action and respond as JSON."
+    parts = [
+        f"Current grid ({ctx.grid.shape[0]}x{ctx.grid.shape[1]}):",
+        render_grid(ctx.grid),
+        "",
+        f"Available actions: {', '.join(ctx.available_action_names)}",
+        f"Recent history: {ctx.history_summary}",
+    ]
+    if ctx.action_effects_summary:
+        parts.append(f"Learned action effects: {ctx.action_effects_summary}")
+    parts.extend(
+        [
+            f"Progress: {ctx.levels_completed}/{ctx.win_levels} levels",
+            "",
+            "Pick one action and respond as JSON.",
+        ]
     )
+    return "\n".join(parts)
 
 
 def build_vllm_choice_fn(
@@ -158,7 +167,7 @@ def build_inprocess_vllm_choice_fn(
         if "llm" in _engine_state:
             return _engine_state["llm"], _engine_state["sampling"]
         try:
-            from vllm import LLM, SamplingParams  # type: ignore[import-not-found]
+            from vllm import LLM, SamplingParams
         except ImportError as exc:
             raise RuntimeError(
                 "vllm is not installed. Run `pip install vllm` inside a "

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_llm_action_effects.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_llm_action_effects.py
@@ -1,0 +1,172 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 PR-12 — LLM prompt enrichment with FrameAnalyzer summary.
+
+The :class:`LLMActionDecoder` now accepts an optional
+:class:`FrameAnalyzer`. When wired, every prompt sent to the LLM
+includes a one-line summary of the per-action movement signatures
+the analyser has learned so far — a critical signal for keyboard-
+controlled games where the upstream API doesn't announce what each
+``ACTIONx`` does.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
+    EpisodeMemory,
+)
+from cognithor.channels.program_synthesis.arc_agi3.frame_analyzer import (
+    FrameAnalyzer,
+)
+from cognithor.channels.program_synthesis.arc_agi3.frame_bridge import FrameBridge
+from cognithor.channels.program_synthesis.arc_agi3.llm_action_decoder import (
+    FrameContext,
+    LLMActionDecoder,
+    summarise_action_effects,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+@dataclass
+class _StubGameState:
+    name: str = "NOT_FINISHED"
+
+
+@dataclass
+class _StubAction:
+    name: str
+    value: int
+    reasoning: str = ""
+    _data: dict[str, Any] = field(default_factory=dict)
+    _is_simple: bool = True
+
+    def is_simple(self) -> bool:
+        return self._is_simple
+
+    def is_complex(self) -> bool:
+        return not self._is_simple
+
+    def set_data(self, data: dict[str, Any]) -> None:
+        self._data = dict(data)
+
+
+@dataclass
+class _StubFrame:
+    game_id: str = "smoke"
+    state: _StubGameState = field(default_factory=_StubGameState)
+    levels_completed: int = 0
+    win_levels: int = 1
+    guid: str = ""
+    full_reset: bool = False
+    frame: list[Any] = field(default_factory=list)
+    available_actions: list[_StubAction] = field(default_factory=list)
+
+
+def _frame(grid: np.ndarray) -> _StubFrame:
+    actions = [
+        _StubAction(name="RESET", value=0),
+        _StubAction(name="ACTION1", value=1),
+        _StubAction(name="ACTION2", value=2),
+        _StubAction(name="ACTION3", value=3),
+    ]
+    return _StubFrame(frame=[grid], available_actions=actions)
+
+
+class TestSummariseActionEffects:
+    def test_empty_analyzer_returns_placeholder(self) -> None:
+        fa = FrameAnalyzer()
+        out = summarise_action_effects(fa)
+        assert "no action effects" in out
+
+    def test_summary_contains_action_names(self) -> None:
+        fa = FrameAnalyzer()
+        # Train the analyzer on a clear "DOWN" pattern.
+        fa.analyze(np.array([[1, 0], [0, 0]], dtype=np.int8))
+        fa.analyze(np.array([[0, 0], [1, 0]], dtype=np.int8), action="DOWN")
+        out = summarise_action_effects(fa)
+        assert "DOWN" in out
+        assert "n=" in out
+
+    def test_summary_caps_at_max_actions(self) -> None:
+        fa = FrameAnalyzer()
+        # Inject 10 distinct actions.
+        prev = np.zeros((4, 4), dtype=np.int8)
+        fa.analyze(prev)
+        for i in range(10):
+            new = prev.copy()
+            new[i % 4, i % 4] = (i % 7) + 1
+            fa.analyze(new, action=f"ACT{i}")
+            prev = new
+        out = summarise_action_effects(fa, max_actions=3)
+        # Only 3 actions in the summary string.
+        assert out.count(";") == 2  # 3 items separated by 2 semicolons
+
+
+class TestFrameContextActionEffects:
+    def test_default_is_empty(self) -> None:
+        ctx = FrameContext(
+            grid=np.zeros((2, 2), dtype=np.int8),
+            available_action_names=["ACTION1"],
+            history_summary="",
+            levels_completed=0,
+            win_levels=1,
+        )
+        assert ctx.action_effects_summary == ""
+
+    def test_explicit_value_persists(self) -> None:
+        ctx = FrameContext(
+            grid=np.zeros((2, 2), dtype=np.int8),
+            available_action_names=["ACTION1"],
+            history_summary="",
+            levels_completed=0,
+            win_levels=1,
+            action_effects_summary="ACTION1: row+1, col+0 (n=2)",
+        )
+        assert "row+1" in ctx.action_effects_summary
+
+
+class TestLLMActionDecoderWithAnalyzer:
+    def test_no_analyzer_summary_empty(self) -> None:
+        captured: list[FrameContext] = []
+
+        def _capture(ctx: FrameContext) -> tuple[str, str]:
+            captured.append(ctx)
+            return "ACTION1", "stub"
+
+        decoder = LLMActionDecoder(
+            bridge=FrameBridge(),
+            memory=EpisodeMemory(),
+            choice_fn=_capture,
+        )
+        f = _frame(np.array([[1, 0]], dtype=np.int8))
+        decoder.decode([f], f)
+        assert captured[0].action_effects_summary == ""
+
+    def test_with_analyzer_summary_populated(self) -> None:
+        fa = FrameAnalyzer()
+        # Pre-train the analyzer.
+        fa.analyze(np.array([[1, 0]], dtype=np.int8))
+        fa.analyze(np.array([[0, 1]], dtype=np.int8), action="RIGHT")
+
+        captured: list[FrameContext] = []
+
+        def _capture(ctx: FrameContext) -> tuple[str, str]:
+            captured.append(ctx)
+            return "ACTION1", "stub"
+
+        decoder = LLMActionDecoder(
+            bridge=FrameBridge(),
+            memory=EpisodeMemory(),
+            choice_fn=_capture,
+            frame_analyzer=fa,
+        )
+        f = _frame(np.array([[1, 0]], dtype=np.int8))
+        decoder.decode([f], f)
+        assert captured[0].action_effects_summary  # non-empty
+        assert "RIGHT" in captured[0].action_effects_summary


### PR DESCRIPTION
## Summary

Closes the loop on `FrameAnalyzer` (#293). Previously the analyser recorded per-action movement signatures but the `LLMReasoningAgent` never saw them. Now the LLM reads them.

## What's new

- `FrameContext.action_effects_summary: str = \"\"` — new opt-in field.
- `summarise_action_effects(analyzer, *, max_actions=6)` helper formats `FrameAnalyzer` output as a one-line string:
  ```
  ACTION1: row+1, col+0 (n=4); ACTION3: row+0, col-1 (n=2); ...
  ```
- `LLMActionDecoder` accepts optional `frame_analyzer` and populates `ctx.action_effects_summary` on every `decode`.
- `_build_user_prompt` renders the summary as a `\"Learned action effects:\"` line in the LLM prompt when non-empty.

## Why this matters

Keyboard-controlled ARC-AGI-3 games don't announce `ACTION→direction` mappings. Previously the LLM had to discover them blind. Now once the agent has acted a few times, the LLM sees:

```
Learned action effects: ACTION3: row+1, col+0 (n=5); ACTION1: row-1, col+0 (n=3)
```

…which is the action→direction model the LLM can quote into its decision.

## Side-fix

Removed unused `# type: ignore[import-not-found]` on the `vllm` import in `llm_agent.py` (mypy --strict flagged it as `unused-ignore`).

## Stacking

Branched from `main` post-#293. Independent of all other open PRs.

## Test plan

- [x] `pytest .../test_llm_action_effects.py` → 7/7 green
- [x] `pytest .../arc_agi3/` → 194/194 green
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)