### PR TITLE
feat(pse): Sprint-12 — in-process EpisodeRunner for ad-hoc episodes

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
@@ -86,6 +86,11 @@ from cognithor.channels.program_synthesis.arc_agi3.protocol import (
     GameActionProtocol,
     GameStateProtocol,
 )
+from cognithor.channels.program_synthesis.arc_agi3.runner import (
+    EpisodeResult,
+    EpisodeRunner,
+    run_episode,
+)
 from cognithor.channels.program_synthesis.arc_agi3.scorecard import (
     GameResult,
     ScorecardSummary,
@@ -109,6 +114,8 @@ __all__ = [
     "CognithorPSEAgent",
     "DSLActionDecoder",
     "EpisodeMemory",
+    "EpisodeResult",
+    "EpisodeRunner",
     "EpisodeStep",
     "FrameAnalyzer",
     "FrameBridge",
@@ -141,6 +148,7 @@ __all__ = [
     "parse_scorecard",
     "plan_click_solution",
     "render_grid",
+    "run_episode",
     "simulate_combo",
     "simulate_toggle",
     "summarise",

--- a/src/cognithor/channels/program_synthesis/arc_agi3/runner.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/runner.py
@@ -1,0 +1,206 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 — in-process EpisodeRunner for the new arc_agi3 stack.
+
+The official ``arcprize/ARC-AGI-3-Agents`` harness drives the game
+loop itself when running benchmarks. For ad-hoc episodes (MCP tools,
+tests, debugging) we want an in-process runner that drives a
+:class:`CognithorPSEAgent` against a connected ``arc_agi.Arcade()``
+without the full harness.
+
+This module ships :class:`EpisodeRunner` — a thin loop:
+
+1. Lazy-import ``arc_agi`` (raises a clear error if not installed).
+2. Reset the env, hand the first frame to the agent.
+3. Repeat: call ``agent.choose_action(...)``, send the action back to
+   the env, store the result. Stop on WIN, GAME_OVER, or
+   ``max_steps``.
+4. Return :class:`EpisodeResult` with the headline numbers.
+
+``EpisodeRunner`` is intentionally narrow: it doesn't manage profiles
+or audit trails itself — those are the agent's concern (the new
+:class:`Sprint10DSLAgent` already wires both via PR-6/7). The runner
+just provides the event loop the harness would otherwise provide.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.arc_agi3.agent import CognithorPSEAgent
+    from cognithor.channels.program_synthesis.arc_agi3.protocol import (
+        FrameDataProtocol,
+    )
+
+__all__ = ["EpisodeResult", "EpisodeRunner", "run_episode"]
+
+log = get_logger(__name__)
+
+
+_INSTALL_HINT = (
+    "arc_agi (the ARC-AGI-3 SDK) is not installed. Install via:\n"
+    "  uv pip install arc-agi\n"
+    "or run inside a venv that already has it (e.g. the official\n"
+    "ARC-AGI-3-Agents harness venv with `uv sync` already done)."
+)
+
+
+@dataclass(frozen=True)
+class EpisodeResult:
+    """Headline numbers from a completed (or aborted) episode."""
+
+    game_id: str
+    levels_completed: int
+    win_levels: int
+    total_steps: int
+    final_state: str  # "WIN" / "GAME_OVER" / "TIMEOUT" / "ERROR"
+    won: bool
+    score: float  # levels_completed / win_levels (clamped to [0, 1])
+    error: str | None = None
+
+
+class EpisodeRunner:
+    """Drives one Cognithor agent through one game session in-process.
+
+    Usage::
+
+        from cognithor.channels.program_synthesis.arc_agi3 import (
+            Sprint10DSLAgent, EpisodeRunner
+        )
+        agent = Sprint10DSLAgent(fast_path_enabled=True)
+        runner = EpisodeRunner(agent=agent, game_id="ls20", max_steps=80)
+        result = runner.run()
+        print(f"score={result.score} levels={result.levels_completed}")
+    """
+
+    def __init__(
+        self,
+        *,
+        agent: CognithorPSEAgent,
+        game_id: str,
+        max_steps: int = 80,
+    ) -> None:
+        self._agent = agent
+        self._game_id = game_id
+        self._max_steps = max_steps
+
+    def run(self) -> EpisodeResult:
+        """Drive one episode end-to-end. Catches arcengine import +
+        connection errors and returns a populated :class:`EpisodeResult`
+        instead of raising.
+        """
+        try:
+            arcade, env, first_frame = self._connect()
+        except RuntimeError as exc:
+            log.error("episode_runner.connect_failed", game_id=self._game_id, error=str(exc))
+            return EpisodeResult(
+                game_id=self._game_id,
+                levels_completed=0,
+                win_levels=0,
+                total_steps=0,
+                final_state="ERROR",
+                won=False,
+                score=0.0,
+                error=str(exc),
+            )
+
+        return self._loop(env, first_frame)
+
+    def _connect(self) -> tuple[Any, Any, FrameDataProtocol]:
+        try:
+            import arc_agi  # type: ignore[import-untyped]
+        except ImportError as exc:
+            raise RuntimeError(_INSTALL_HINT) from exc
+        arcade = arc_agi.Arcade()
+        env = arcade.make(self._game_id)
+        if env is None:
+            raise RuntimeError(f"arc_agi.Arcade.make({self._game_id!r}) returned None")
+        first_frame = env.reset()
+        return arcade, env, first_frame
+
+    def _loop(self, env: Any, first_frame: FrameDataProtocol) -> EpisodeResult:
+        frames: list[FrameDataProtocol] = [first_frame]
+        latest = first_frame
+        steps_taken = 0
+        try:
+            while steps_taken < self._max_steps:
+                if self._agent.is_done(frames, latest):
+                    break
+                action = self._agent.choose_action(frames, latest)
+                # The arc_agi env.step accepts the GameAction value (or
+                # ``(value, data)`` for click actions). Action6/Action7
+                # carry click coords via set_data() inside the agent.
+                payload = self._action_payload(action)
+                latest = env.step(*payload)
+                frames.append(latest)
+                steps_taken += 1
+        except Exception as exc:
+            log.error("episode_runner.loop_error", game_id=self._game_id, error=str(exc))
+            return EpisodeResult(
+                game_id=self._game_id,
+                levels_completed=int(getattr(latest, "levels_completed", 0)),
+                win_levels=int(getattr(latest, "win_levels", 1)),
+                total_steps=steps_taken,
+                final_state="ERROR",
+                won=False,
+                score=0.0,
+                error=str(exc),
+            )
+
+        final_state = latest.state.name
+        levels_completed = int(latest.levels_completed)
+        win_levels = max(int(latest.win_levels), 1)
+        won = final_state == "WIN"
+        score = min(levels_completed / win_levels, 1.0)
+
+        # Hand the agent a chance to roll up its persistence (audit +
+        # profile) when the wiring exists. Sprint10DSLAgent has
+        # finalize_episode; the ABC doesn't, so we duck-check.
+        finalize = getattr(self._agent, "finalize_episode", None)
+        if callable(finalize):
+            try:
+                finalize(
+                    score=levels_completed,
+                    won=won,
+                    levels_solved=levels_completed,
+                    budget_ratio=steps_taken / self._max_steps if self._max_steps else 0.0,
+                )
+            except Exception as exc:  # pragma: no cover — defensive
+                log.warning("episode_runner.finalize_failed", error=str(exc))
+
+        return EpisodeResult(
+            game_id=self._game_id,
+            levels_completed=levels_completed,
+            win_levels=win_levels,
+            total_steps=steps_taken,
+            final_state=final_state,
+            won=won,
+            score=score,
+        )
+
+    @staticmethod
+    def _action_payload(action: Any) -> tuple[Any, ...]:
+        """Convert a Cognithor action object into ``env.step()`` args.
+
+        Simple actions (``RESET``, ``ACTION1``..``ACTION5``) take just
+        the value. Complex actions (``ACTION6``, ``ACTION7``) carry
+        ``(x, y)`` data the agent attached via ``set_data()``.
+        """
+        value = getattr(action, "value", action)
+        data = getattr(action, "_data", None)
+        if data:
+            return (value, {"data": dict(data)})
+        return (value,)
+
+
+def run_episode(
+    *,
+    agent: CognithorPSEAgent,
+    game_id: str,
+    max_steps: int = 80,
+) -> EpisodeResult:
+    """Convenience wrapper: ``EpisodeRunner(...).run()``."""
+    return EpisodeRunner(agent=agent, game_id=game_id, max_steps=max_steps).run()

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_runner.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_runner.py
@@ -1,0 +1,216 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 — EpisodeRunner tests (no real arc_agi import).
+
+Drives the runner against a stubbed env that mirrors the
+``arc_agi.Arcade()`` shape the runner expects. Validates the loop
+control + the EpisodeResult population.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import patch
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.arc_agi3.dsl_agent import Sprint10DSLAgent
+from cognithor.channels.program_synthesis.arc_agi3.runner import (
+    EpisodeResult,
+    EpisodeRunner,
+    run_episode,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+@dataclass
+class _StubGameState:
+    name: str = "NOT_FINISHED"
+
+
+@dataclass
+class _StubAction:
+    name: str
+    value: int
+    reasoning: str = ""
+    _data: dict[str, Any] = field(default_factory=dict)
+    _is_simple: bool = True
+
+    def is_simple(self) -> bool:
+        return self._is_simple
+
+    def is_complex(self) -> bool:
+        return not self._is_simple
+
+    def set_data(self, data: dict[str, Any]) -> None:
+        self._data = dict(data)
+
+
+@dataclass
+class _StubFrame:
+    game_id: str = "smoke"
+    state: _StubGameState = field(default_factory=_StubGameState)
+    levels_completed: int = 0
+    win_levels: int = 1
+    guid: str = ""
+    full_reset: bool = False
+    frame: list[Any] = field(default_factory=list)
+    available_actions: list[_StubAction] = field(default_factory=list)
+
+
+def _frame(grid: np.ndarray, state_name: str = "NOT_FINISHED", levels: int = 0) -> _StubFrame:
+    actions = [
+        _StubAction(name="RESET", value=0),
+        _StubAction(name="ACTION1", value=1),
+        _StubAction(name="ACTION2", value=2),
+    ]
+    return _StubFrame(
+        frame=[grid],
+        available_actions=actions,
+        state=_StubGameState(name=state_name),
+        levels_completed=levels,
+    )
+
+
+class _StubEnv:
+    """Stub env that emits a fixed sequence of frames."""
+
+    def __init__(self, frames: list[_StubFrame]) -> None:
+        self._frames = frames
+        self._idx = 0
+
+    def reset(self) -> _StubFrame:
+        self._idx = 0
+        return self._frames[0]
+
+    def step(self, *args: Any) -> _StubFrame:
+        self._idx = min(self._idx + 1, len(self._frames) - 1)
+        return self._frames[self._idx]
+
+
+class _StubArcade:
+    def __init__(self, env: _StubEnv) -> None:
+        self._env = env
+
+    def make(self, game_id: str) -> _StubEnv:
+        return self._env
+
+
+def _install_arc_agi_stub(env: _StubEnv) -> None:
+    """Inject a dummy ``arc_agi`` module into sys.modules so the runner's
+    lazy import succeeds against our stub Arcade."""
+    mod = types.ModuleType("arc_agi")
+    mod.Arcade = lambda: _StubArcade(env)  # type: ignore[attr-defined]
+    sys.modules["arc_agi"] = mod
+
+
+class TestEpisodeRunnerSuccess:
+    def test_runs_to_win(self) -> None:
+        # 4 frames, last one is WIN.
+        frames = [
+            _frame(np.zeros((2, 2), dtype=np.int8)),
+            _frame(np.array([[1, 0], [0, 0]], dtype=np.int8)),
+            _frame(np.array([[1, 1], [0, 0]], dtype=np.int8)),
+            _frame(np.ones((2, 2), dtype=np.int8), state_name="WIN", levels=1),
+        ]
+        env = _StubEnv(frames)
+        _install_arc_agi_stub(env)
+
+        agent = Sprint10DSLAgent()
+        result = run_episode(agent=agent, game_id="smoke", max_steps=10)
+
+        assert isinstance(result, EpisodeResult)
+        assert result.game_id == "smoke"
+        assert result.won is True
+        assert result.final_state == "WIN"
+        assert result.score == 1.0
+
+    def test_timeout_returns_partial_result(self) -> None:
+        # Frames never reach WIN. Runner stops at max_steps.
+        frames = [_frame(np.zeros((2, 2), dtype=np.int8)) for _ in range(20)]
+        env = _StubEnv(frames)
+        _install_arc_agi_stub(env)
+
+        agent = Sprint10DSLAgent()
+        result = run_episode(agent=agent, game_id="smoke", max_steps=5)
+        assert result.won is False
+        assert result.final_state == "NOT_FINISHED"
+        assert result.total_steps == 5
+
+    def test_finalize_episode_called(self) -> None:
+        frames = [
+            _frame(np.zeros((2, 2), dtype=np.int8)),
+            _frame(np.zeros((2, 2), dtype=np.int8), state_name="WIN", levels=1),
+        ]
+        env = _StubEnv(frames)
+        _install_arc_agi_stub(env)
+
+        # Use an agent with a recording fake finalize_episode.
+        called: list[dict[str, Any]] = []
+
+        class _RecordingAgent(Sprint10DSLAgent):
+            def finalize_episode(  # type: ignore[override]
+                self, *, score: int, won: bool, levels_solved: int, budget_ratio: float = 0.0
+            ) -> None:
+                called.append(
+                    {
+                        "score": score,
+                        "won": won,
+                        "levels_solved": levels_solved,
+                        "budget_ratio": budget_ratio,
+                    }
+                )
+
+        agent = _RecordingAgent()
+        run_episode(agent=agent, game_id="smoke", max_steps=10)
+        assert called
+        assert called[0]["won"] is True
+        assert called[0]["levels_solved"] == 1
+
+
+class TestEpisodeRunnerErrorPaths:
+    def test_missing_arc_agi_returns_error(self) -> None:
+        # Ensure arc_agi is NOT in sys.modules.
+        sys.modules.pop("arc_agi", None)
+        agent = Sprint10DSLAgent()
+        runner = EpisodeRunner(agent=agent, game_id="smoke", max_steps=10)
+
+        # Make ``import arc_agi`` raise even if pip installed it.
+        with patch.dict(sys.modules, {"arc_agi": None}):
+            result = runner.run()
+        assert result.final_state == "ERROR"
+        assert result.error is not None
+        assert "arc_agi" in result.error
+
+    def test_arcade_make_returns_none(self) -> None:
+        mod = types.ModuleType("arc_agi")
+
+        class _BadArcade:
+            def make(self, game_id: str) -> None:
+                return None
+
+        mod.Arcade = lambda: _BadArcade()  # type: ignore[attr-defined]
+        with patch.dict(sys.modules, {"arc_agi": mod}):
+            agent = Sprint10DSLAgent()
+            result = run_episode(agent=agent, game_id="bogus")
+        assert result.final_state == "ERROR"
+        assert "returned None" in (result.error or "")
+
+
+class TestActionPayload:
+    def test_simple_action_passes_value_only(self) -> None:
+        action = _StubAction(name="ACTION1", value=1)
+        payload = EpisodeRunner._action_payload(action)
+        assert payload == (1,)
+
+    def test_complex_action_passes_data(self) -> None:
+        action = _StubAction(name="ACTION6", value=6, _is_simple=False)
+        action.set_data({"x": 5, "y": 7})
+        payload = EpisodeRunner._action_payload(action)
+        assert payload[0] == 6
+        assert payload[1]["data"]["x"] == 5
+        assert payload[1]["data"]["y"] == 7


### PR DESCRIPTION
## Summary

For ad-hoc episodes (MCP tools, tests, debugging) we want a thin in-process runner that drives a `CognithorPSEAgent` against a connected `arc_agi.Arcade()` **without** the full official harness.

This PR ships `EpisodeRunner` — the missing piece for the MCP `arc_play` rewire (Step 9 of the Sprint-12 plan). The legacy MCP imports `cognithor.arc.agent` to drive episodes; once this lands, the new `arc_play` handler can import `EpisodeRunner` instead and drop the legacy dependency.

## What's new

- **`EpisodeResult`** dataclass — `game_id`, `levels_completed`, `win_levels`, `total_steps`, `final_state`, `won`, `score`, `error`.
- **`EpisodeRunner`** class:
  - Lazy-imports `arc_agi` (raises `RuntimeError` with install hint on miss).
  - Resets the env, drives the `choose_action` loop, captures all errors into `EpisodeResult.error`.
  - Auto-calls `finalize_episode()` on agents that support it (Sprint10DSLAgent does — wires up `audit_trail` + `game_profile`).
- **`run_episode()`** one-liner convenience wrapper.

## Stacking

Branched from current `main` (post-merges of #289–#294). Independent of all other open PRs.

## Test plan

- [x] `pytest .../test_runner.py` → 7/7 green
- [x] `pytest .../arc_agi3/` → 207/207 green
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy --strict` clean

Tests use `sys.modules` monkey-patching to inject a stub `arc_agi` so the success paths run without the real SDK installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)