### PR TITLE
feat(mcp): rewire arc_play/arc_replay onto the new program_synthesis stack

### DIFF
--- a/src/cognithor/mcp/arc_tools.py
+++ b/src/cognithor/mcp/arc_tools.py
@@ -30,7 +30,13 @@ _active_sessions: dict[str, dict[str, Any]] = {}
 
 
 async def handle_arc_play(**kwargs: Any) -> str:
-    """Start or resume an ARC-AGI-3 game session."""
+    """Start or resume an ARC-AGI-3 game session.
+
+    Sprint-12: rewired to the new ``program_synthesis.arc_agi3`` stack
+    via :class:`EpisodeRunner`. ``use_llm=True`` selects
+    :class:`LLMReasoningAgent` (vLLM/qwen3.6:27b in-process); ``use_llm=False``
+    selects :class:`Sprint10DSLAgent` (heuristic, no LLM dependency).
+    """
     game_id: str = kwargs.get("game_id", "").strip()
     if not game_id:
         return "Error: 'game_id' is required."
@@ -39,12 +45,19 @@ async def handle_arc_play(**kwargs: Any) -> str:
     if isinstance(use_llm, str):
         use_llm = use_llm.lower() not in ("false", "0", "no")
 
-    max_steps: int = int(kwargs.get("max_steps", 500))
+    max_steps: int = int(kwargs.get("max_steps", 80))
 
     try:
-        from cognithor.arc.agent import CognithorArcAgent
+        from cognithor.channels.program_synthesis.arc_agi3 import (
+            ArcAuditTrail,
+            EpisodeRunner,
+            GameProfile,
+            LLMReasoningAgent,
+            Sprint10DSLAgent,
+            build_inprocess_vllm_choice_fn,
+        )
     except ImportError as exc:
-        return f"Error: ARC-AGI-3 module not available ({exc}). Install jarvis[arc] dependencies."
+        return f"Error: PSE arc_agi3 module not available ({exc})."
 
     log.info("arc_play.start", game_id=game_id, use_llm=use_llm, max_steps=max_steps)
 
@@ -53,12 +66,64 @@ async def handle_arc_play(**kwargs: Any) -> str:
     loop = asyncio.get_running_loop()
 
     def _run() -> dict[str, Any]:
-        agent = CognithorArcAgent(
+        # Cross-episode profile + per-run audit trail.
+        profile = GameProfile.load(game_id) or GameProfile(
             game_id=game_id,
-            use_llm_planner=use_llm,
-            max_steps_per_level=max_steps,
+            game_type="mixed",
+            available_actions=[],
+            click_zones=[],
+            target_colors=[],
+            movement_effects={},
+            win_condition="",
+            vision_description="",
+            vision_strategy="",
+            strategy_metrics={},
         )
-        return agent.run()
+        trail = ArcAuditTrail(game_id=game_id)
+
+        if use_llm:
+            try:
+                choice_fn = build_inprocess_vllm_choice_fn()
+            except RuntimeError as exc:
+                log.warning("arc_play.vllm_unavailable", error=str(exc))
+                # vLLM not available → fall through to DSL agent.
+                use_llm_local = False
+            else:
+                use_llm_local = True
+        else:
+            use_llm_local = False
+
+        if use_llm_local:
+            agent = LLMReasoningAgent(  # type: ignore[call-arg]
+                choice_fn=choice_fn,
+                audit_trail=trail,
+                game_profile=profile,
+                strategy_name="llm_reasoning",
+                fast_path_enabled=True,
+            )
+        else:
+            agent = Sprint10DSLAgent(
+                audit_trail=trail,
+                game_profile=profile,
+                strategy_name="dsl_full",
+                fast_path_enabled=True,
+            )
+
+        result = EpisodeRunner(agent=agent, game_id=game_id, max_steps=max_steps).run()
+        # Persist the updated profile so the next run inherits the metrics.
+        try:
+            profile.save()
+        except Exception as save_exc:  # pragma: no cover — defensive
+            log.warning("arc_play.profile_save_failed", error=str(save_exc))
+
+        return {
+            "score": result.score,
+            "levels_completed": result.levels_completed,
+            "total_steps": result.total_steps,
+            "final_state": result.final_state,
+            "won": result.won,
+            "error": result.error,
+        }
 
     try:
         result: dict[str, Any] = await loop.run_in_executor(None, _run)
@@ -103,7 +168,16 @@ async def handle_arc_status(**kwargs: Any) -> str:
 
 
 async def handle_arc_replay(**kwargs: Any) -> str:
-    """Replay a completed ARC game session from its audit trail."""
+    """Replay a completed ARC game session from its audit trail JSONL.
+
+    Sprint-12: reads the JSONL exported by the new
+    :class:`ArcAuditTrail.export_jsonl`. By default looks for
+    ``~/.cognithor/arc/audits/<game_id>.jsonl``; override via
+    ``audit_path``.
+    """
+    import json
+    from pathlib import Path
+
     game_id: str = kwargs.get("game_id", "").strip()
     if not game_id:
         return "Error: 'game_id' is required."
@@ -112,28 +186,41 @@ async def handle_arc_replay(**kwargs: Any) -> str:
     if isinstance(verbose, str):
         verbose = verbose.lower() in ("true", "1", "yes")
 
-    try:
-        from cognithor.arc.audit import ArcAuditTrail
-    except ImportError as exc:
-        return f"Error: ARC audit module not available ({exc})."
+    audit_path_arg = kwargs.get("audit_path")
+    if audit_path_arg:
+        audit_path = Path(str(audit_path_arg))
+    else:
+        audit_path = Path.home() / ".cognithor" / "arc" / "audits" / f"{game_id}.jsonl"
+
+    if not audit_path.exists():
+        return (
+            f"No audit trail found for game_id='{game_id}' at {audit_path}. "
+            f"Pass 'audit_path' to override."
+        )
 
     try:
-        trail = ArcAuditTrail(game_id)
-        events = trail.load_events()
+        events = [
+            json.loads(line)
+            for line in audit_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
     except Exception as exc:
-        return f"Error: Could not load audit trail for '{game_id}': {exc}"
+        return f"Error: Could not parse audit trail for '{game_id}': {exc}"
 
     if not events:
-        return f"No audit trail found for game_id='{game_id}'."
+        return f"Audit trail for '{game_id}' is empty."
 
     total = len(events)
     summary_lines = [
-        f"Replay of '{game_id}': {total} recorded event(s).",
+        f"Replay of '{game_id}': {total} recorded event(s) from {audit_path}.",
     ]
 
     if verbose:
-        for i, evt in enumerate(events[:20]):  # cap at 20 for output safety
-            summary_lines.append(f"  [{i + 1:>4}] {evt}")
+        for i, evt in enumerate(events[:20]):
+            summary_lines.append(
+                f"  [{i + 1:>4}] {evt.get('event_type', '?')} "
+                f"step={evt.get('step', '?')} action={evt.get('action', '-')}"
+            )
         if total > 20:
             summary_lines.append(f"  ... ({total - 20} more events)")
 

--- a/tests/test_mcp/test_arc_tools.py
+++ b/tests/test_mcp/test_arc_tools.py
@@ -1,0 +1,122 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 — MCP arc_tools rewire tests.
+
+Verifies that ``handle_arc_play`` and ``handle_arc_replay`` use the
+new ``program_synthesis.arc_agi3`` stack (EpisodeRunner + ArcAuditTrail
+JSONL) instead of the legacy ``cognithor.arc.agent`` / ``cognithor.arc.audit``
+imports.
+
+The tests don't drive a real arc_agi harness — they exercise the
+input-validation + error paths and the JSONL-replay format.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import TYPE_CHECKING, Any
+from unittest.mock import patch
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from cognithor.mcp.arc_tools import (
+    handle_arc_play,
+    handle_arc_replay,
+    handle_arc_status,
+)
+
+
+class TestArcPlayValidation:
+    @pytest.mark.asyncio
+    async def test_missing_game_id(self) -> None:
+        result = await handle_arc_play()
+        assert "game_id" in result
+        assert "required" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_game_id(self) -> None:
+        result = await handle_arc_play(game_id="")
+        assert "required" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_arc_agi_missing_returns_graceful_error(self) -> None:
+        # Block arc_agi import so EpisodeRunner._connect raises.
+        with patch.dict(sys.modules, {"arc_agi": None}):
+            result = await handle_arc_play(game_id="smoke", use_llm=False, max_steps=3)
+        # Either the runner returns an ERROR result or the function
+        # surfaces it as a string. Either way the response is non-empty
+        # and references the game_id.
+        assert "smoke" in result.lower() or "error" in result.lower()
+
+
+class TestArcReplayJsonl:
+    @pytest.mark.asyncio
+    async def test_missing_game_id(self) -> None:
+        result = await handle_arc_replay()
+        assert "required" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_no_audit_file_returns_clear_message(self, tmp_path: Path) -> None:
+        bogus = tmp_path / "does_not_exist.jsonl"
+        result = await handle_arc_replay(game_id="ghost", audit_path=str(bogus))
+        assert "No audit trail" in result or "not found" in result.lower()
+
+    @pytest.mark.asyncio
+    async def test_reads_jsonl_format(self, tmp_path: Path) -> None:
+        path = tmp_path / "audit.jsonl"
+        events: list[dict[str, Any]] = [
+            {
+                "event_type": "game_start",
+                "game_id": "smoke",
+                "step": 0,
+                "action": None,
+            },
+            {
+                "event_type": "step",
+                "game_id": "smoke",
+                "step": 1,
+                "action": "ACTION1",
+            },
+            {
+                "event_type": "game_end",
+                "game_id": "smoke",
+                "step": 2,
+                "action": None,
+                "score": 1.0,
+            },
+        ]
+        path.write_text(
+            "\n".join(json.dumps(e) for e in events),
+            encoding="utf-8",
+        )
+
+        result = await handle_arc_replay(game_id="smoke", audit_path=str(path))
+        assert "3 recorded event" in result
+        assert "smoke" in result
+
+    @pytest.mark.asyncio
+    async def test_verbose_lists_events(self, tmp_path: Path) -> None:
+        path = tmp_path / "audit.jsonl"
+        path.write_text(
+            json.dumps({"event_type": "step", "step": 1, "action": "ACTION1"}) + "\n",
+            encoding="utf-8",
+        )
+        result = await handle_arc_replay(game_id="smoke", audit_path=str(path), verbose=True)
+        assert "ACTION1" in result
+        assert "step=1" in result
+
+
+class TestArcStatusUnchanged:
+    """The status handler doesn't depend on any agent stack — quick sanity check."""
+
+    @pytest.mark.asyncio
+    async def test_no_active_sessions(self) -> None:
+        # Clear any session state from prior tests.
+        from cognithor.mcp.arc_tools import _active_sessions
+
+        _active_sessions.clear()
+        result = await handle_arc_status()
+        assert "No active" in result


### PR DESCRIPTION
## Summary

Sprint-12 closing PR — removes the legacy `cognithor.arc.agent` and `cognithor.arc.audit` runtime imports from MCP `arc_tools`. The MCP layer now drives the new Sprint-11 / Sprint-12 stack via `EpisodeRunner` (#302).

## What's new

### `handle_arc_play`

- Imports `EpisodeRunner`, `Sprint10DSLAgent`, `LLMReasoningAgent`, `ArcAuditTrail`, `GameProfile`, `build_inprocess_vllm_choice_fn` from `program_synthesis.arc_agi3`.
- `use_llm=True` drives `LLMReasoningAgent` over in-process vLLM (qwen3.6:27b NVFP4); on vLLM unavailable, falls back to `Sprint10DSLAgent` rather than crashing.
- Both agent paths auto-wire `audit_trail` + `game_profile`, so every run produces a SHA-256-chained JSONL audit and updates the persistent profile.
- `max_steps` default lowered from 500 → 80 to match ARC-AGI-3's upstream `MAX_ACTIONS` cap.

### `handle_arc_replay`

- Reads JSONL exported by `ArcAuditTrail.export_jsonl()`.
- Default location `~/.cognithor/arc/audits/<game_id>.jsonl`; overridable via `audit_path` kwarg.
- `verbose=True` shows `event_type + step + action` per line.

## Test plan

- [x] `pytest tests/test_mcp/test_arc_tools.py` → 8/8 green (input validation, arc_agi-missing graceful error, JSONL read + verbose, status no-active-sessions)
- [x] `ruff check` clean
- [x] `ruff format --check` clean

## Net effect

The MCP runtime path no longer imports `cognithor.arc/*`. Sprint-12 mega-merge is now fully closed at the MCP boundary. Legacy `cognithor.arc/` can be deprecated/deleted in a follow-up cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)