### PR TITLE
feat(pse): Sprint-12 PR-13 — wire ClickTargetSampler into Sprint10DSLAgent

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
@@ -55,6 +55,9 @@ if TYPE_CHECKING:
         ActionDecoder,
     )
     from cognithor.channels.program_synthesis.arc_agi3.audit import ArcAuditTrail
+    from cognithor.channels.program_synthesis.arc_agi3.click_target_sampler import (
+        ClickTargetSampler,
+    )
     from cognithor.channels.program_synthesis.arc_agi3.frame_analyzer import (
         FrameAnalyzer,
     )
@@ -88,6 +91,7 @@ class Sprint10DSLAgent(CognithorPSEAgent):
         strategy_name: str = "sprint10_dsl",
         frame_analyzer: FrameAnalyzer | None = None,
         fast_path_enabled: bool = False,
+        click_target_sampler: ClickTargetSampler | None = None,
     ) -> None:
         self._bridge = bridge if bridge is not None else FrameBridge()
         self._memory = memory if memory is not None else EpisodeMemory()
@@ -133,6 +137,13 @@ class Sprint10DSLAgent(CognithorPSEAgent):
         # search when the most recent transition reveals a toggle pair.
         self._fast_path_enabled = fast_path_enabled
         self._click_cache: ClickPlanCache | None = ClickPlanCache() if fast_path_enabled else None
+        # Sprint-12 PR-13: salience-ranked click-target sampler. When
+        # ACTION6 is available and the toggle fast-path can't fire (no
+        # toggle pair observed), this picks a click coordinate from the
+        # smallest non-background object instead of a uniform-random one.
+        # Reset on level transition so visited-set doesn't leak across
+        # levels.
+        self._click_target_sampler = click_target_sampler
 
     @property
     def memory(self) -> EpisodeMemory:
@@ -194,6 +205,8 @@ class Sprint10DSLAgent(CognithorPSEAgent):
             self._state_graph = type(self._state_graph)()  # fresh graph
             if self._frame_analyzer is not None:
                 self._frame_analyzer.reset_for_new_level()
+            if self._click_target_sampler is not None:
+                self._click_target_sampler.reset_for_new_level()
             self._pending_action_name = None
             self._prev_grid = None
             self._prev_state_hash = None
@@ -232,17 +245,23 @@ class Sprint10DSLAgent(CognithorPSEAgent):
                 if self._prev_state_hash == current_hash:
                     self._state_counter.mark_dead(self._prev_state_hash, self._pending_action_name)
 
-        # Step 3a — try the fast-path planner if enabled. The planner
-        # only fires when ACTION6 is available AND we've seen a clean
-        # toggle pair in the last two frames AND the planner finds a
-        # winning click sequence. On a miss it returns None and we fall
-        # through to the regular DSL decoder unchanged.
+        # Step 3a — try the toggle-fast-path planner if enabled. The
+        # planner only fires when ACTION6 is available AND we've seen a
+        # clean toggle pair in the last two frames AND the planner finds
+        # a winning click sequence. On a miss it returns None.
         chosen: GameActionProtocol | None = None
         if self._click_cache is not None:
             chosen = self._try_fast_path(latest_frame, current_grid, current_hash)
 
-        # Step 3b — delegate to the DSL decoder when the fast-path
-        # didn't fire.
+        # Step 3b — try the salience-based click sampler. Fires only when
+        # the toggle fast-path didn't, ACTION6 is available, and the
+        # sampler has a non-empty queue. Useful for "click target"
+        # games where there's no toggle pair to detect.
+        if chosen is None and self._click_target_sampler is not None:
+            chosen = self._try_click_target(latest_frame, current_grid)
+
+        # Step 3c — delegate to the DSL decoder when no click sampler
+        # fired.
         if chosen is None:
             chosen = self._decoder.decode(frames, latest_frame)
 
@@ -353,6 +372,35 @@ class Sprint10DSLAgent(CognithorPSEAgent):
             f"Sprint10DSLAgent fast-path: plan_click_solution "
             f"({source_color}->{target_color}) → click ({x},{y})"
         )
+        return click_action
+
+    def _try_click_target(
+        self,
+        latest_frame: FrameDataProtocol,
+        current_grid: np.ndarray[Any, Any],
+    ) -> GameActionProtocol | None:
+        """Salience-based click target sampling.
+
+        For "click target" games (no toggle pair, just "click the right
+        object"). Returns ACTION6 with the next salient ``(x, y)`` from
+        :class:`ClickTargetSampler`, or ``None`` when ACTION6 isn't
+        available or the sampler queue is empty.
+        """
+        if self._click_target_sampler is None:
+            return None
+        click_action: GameActionProtocol | None = None
+        for action in latest_frame.available_actions:
+            if action.name == "ACTION6":
+                click_action = action
+                break
+        if click_action is None:
+            return None
+        click_xy = self._click_target_sampler.next_click(current_grid)
+        if click_xy is None:
+            return None
+        x, y = click_xy
+        click_action.set_data({"x": int(x), "y": int(y)})
+        click_action.reasoning = f"Sprint10DSLAgent click-target sampler → click ({x},{y})"
         return click_action
 
 

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_agent_click_target.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_agent_click_target.py
@@ -1,0 +1,149 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-12 PR-13 — ClickTargetSampler wiring in Sprint10DSLAgent."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.arc_agi3.click_target_sampler import (
+    ClickTargetSampler,
+)
+from cognithor.channels.program_synthesis.arc_agi3.dsl_agent import Sprint10DSLAgent
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+@dataclass
+class _StubGameState:
+    name: str = "NOT_FINISHED"
+
+
+@dataclass
+class _StubAction:
+    name: str
+    value: int
+    reasoning: str = ""
+    _data: dict[str, Any] = field(default_factory=dict)
+    _is_simple: bool = True
+
+    def is_simple(self) -> bool:
+        return self._is_simple
+
+    def is_complex(self) -> bool:
+        return not self._is_simple
+
+    def set_data(self, data: dict[str, Any]) -> None:
+        self._data = dict(data)
+
+
+@dataclass
+class _StubFrame:
+    game_id: str = "smoke"
+    state: _StubGameState = field(default_factory=_StubGameState)
+    levels_completed: int = 0
+    win_levels: int = 1
+    guid: str = ""
+    full_reset: bool = False
+    frame: list[Any] = field(default_factory=list)
+    available_actions: list[_StubAction] = field(default_factory=list)
+
+
+def _frame(grid: np.ndarray, *, with_click: bool = True, levels: int = 0) -> _StubFrame:
+    actions = [
+        _StubAction(name="RESET", value=0),
+        _StubAction(name="ACTION1", value=1),
+        _StubAction(name="ACTION2", value=2),
+    ]
+    if with_click:
+        actions.append(_StubAction(name="ACTION6", value=6, _is_simple=False))
+    return _StubFrame(frame=[grid], available_actions=actions, levels_completed=levels)
+
+
+class TestClickTargetSamplerWiring:
+    def test_sampler_optional(self) -> None:
+        agent = Sprint10DSLAgent()
+        # No sampler wired → no crash, no click emitted.
+        f = _frame(np.zeros((3, 3), dtype=np.int8))
+        chosen = agent.choose_action([f], f)
+        assert chosen.name in {"RESET", "ACTION1", "ACTION2", "ACTION6"}
+
+    def test_sampler_emits_action6_when_target_present(self) -> None:
+        sampler = ClickTargetSampler()
+        agent = Sprint10DSLAgent(click_target_sampler=sampler)
+        # Grid has one salient target at (1, 2) → sampler will return (2, 1).
+        grid = np.zeros((4, 4), dtype=np.int8)
+        grid[1, 2] = 5
+        f = _frame(grid)
+        chosen = agent.choose_action([f], f)
+        assert chosen.name == "ACTION6"
+        assert "click-target" in chosen.reasoning
+
+    def test_sampler_skipped_when_no_action6(self) -> None:
+        sampler = ClickTargetSampler()
+        agent = Sprint10DSLAgent(click_target_sampler=sampler)
+        # No ACTION6 in available list → fall through to DSL decoder.
+        grid = np.zeros((4, 4), dtype=np.int8)
+        grid[1, 2] = 5
+        f = _frame(grid, with_click=False)
+        chosen = agent.choose_action([f], f)
+        assert chosen.name in {"RESET", "ACTION1", "ACTION2"}
+
+    def test_sampler_skipped_when_pure_background(self) -> None:
+        sampler = ClickTargetSampler()
+        agent = Sprint10DSLAgent(click_target_sampler=sampler)
+        # All-zero grid → no targets → sampler returns None → DSL decoder.
+        f = _frame(np.zeros((3, 3), dtype=np.int8))
+        chosen = agent.choose_action([f], f)
+        assert chosen.name != "ACTION6"
+
+    def test_fast_path_takes_priority_over_sampler(self) -> None:
+        """Toggle fast-path fires first; sampler only kicks in on miss.
+
+        The toggle detector needs 2 grids in memory, so we need at least
+        3 ``choose_action`` calls before fast-path can fire (the agent
+        appends pending_action_name's grid only on call N+1).
+        """
+        sampler = ClickTargetSampler()
+        agent = Sprint10DSLAgent(
+            fast_path_enabled=True,
+            click_target_sampler=sampler,
+        )
+
+        # Frame 1: seed the agent (memory still empty after this call).
+        g1 = np.zeros((5, 5), dtype=np.int8)
+        agent.choose_action([_frame(g1)], _frame(g1))
+
+        # Frame 2: 6 cells of 1 (memory now has 1 entry).
+        g2 = np.zeros((5, 5), dtype=np.int8)
+        g2[0:2, 0:3] = 1
+        agent.choose_action([_frame(g2)], _frame(g2))
+
+        # Frame 3: those 6 flipped to 2 + a small fresh 1-cluster the
+        # planner can target. Memory now has 2 entries → toggle pair
+        # (1, 2) detected → fast-path fires.
+        g3 = np.zeros((5, 5), dtype=np.int8)
+        g3[0:2, 0:3] = 2
+        g3[2, 3:5] = 1
+        chosen = agent.choose_action([_frame(g3)], _frame(g3))
+        assert chosen.name == "ACTION6"
+        assert "fast-path" in chosen.reasoning  # NOT click-target
+
+    def test_sampler_resets_on_level_transition(self) -> None:
+        sampler = ClickTargetSampler()
+        agent = Sprint10DSLAgent(click_target_sampler=sampler)
+        # Level 0: emit one click.
+        g0 = np.zeros((3, 3), dtype=np.int8)
+        g0[1, 1] = 5
+        agent.choose_action([_frame(g0, levels=0)], _frame(g0, levels=0))
+        assert (1, 1) in sampler.visited
+
+        # Level 1: visited set must be cleared.
+        g1 = np.zeros((3, 3), dtype=np.int8)
+        g1[2, 2] = 5
+        agent.choose_action([_frame(g1, levels=1)], _frame(g1, levels=1))
+        # After the level-1 click, only the level-1 coordinate is visited.
+        assert sampler.visited == frozenset({(2, 2)})


### PR DESCRIPTION
## Summary

Activates the Sprint-12 PR-9 (#295) salience-ranked click sampler **inside** the running agent, complementing the toggle fast-path (PR-8 / #294).

## Action selection priority

1. **Toggle fast-path** (`plan_click_solution`) — fires when ACTION6 available + toggle pair observed in the last two frames.
2. **`ClickTargetSampler`** — fires when ACTION6 is available but the toggle fast-path missed (no toggle pair). Picks the salience-ranked centroid.
3. **`DSLActionDecoder`** — fallback for non-click games or pure-background grids.

This closes the click-game coverage:

| Family | Mechanic | Handler |
|---|---|---|
| Toggle (LS20-style) | Click cluster → two colours swap | PR-8 planner |
| Target (ft09-style) | Click the right object → progress | **PR-13 sampler (this PR)** |
| Keyboard | Arrow / button presses | DSL decoder |

## What's new

- `Sprint10DSLAgent.__init__` accepts optional `click_target_sampler` (default `None`, opt-in).
- New `_try_click_target` private method.
- Level-transition resets `ClickTargetSampler.reset_for_new_level()` alongside the other per-level state (memory, state-counter, graph).

## Stacking

Branched from `main` post-#297 (audit/profile wiring merged). Independent of #303 (MCP rewire — touches different module).

## Test plan

- [x] `pytest .../test_agent_click_target.py` → 6/6 green
- [x] `pytest .../arc_agi3/` → 250/250 green
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)