### PR TITLE
fix(pse): EpisodeRunner normalizes GameAction/GameState from pydantic int/str

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/runner.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/runner.py
@@ -118,8 +118,49 @@ class EpisodeRunner:
         env = arcade.make(self._game_id)
         if env is None:
             raise RuntimeError(f"arc_agi.Arcade.make({self._game_id!r}) returned None")
-        first_frame = env.reset()
+        first_frame = self._normalize_frame(env.reset())
         return arcade, env, first_frame
+
+    @staticmethod
+    def _normalize_frame(frame: Any) -> Any:
+        """Ensure ``frame.available_actions`` are GameAction enum members.
+
+        The pydantic-validated ``FrameData`` from arc_agi 0.9.x coerces
+        the enum to bare ints. Cognithor agents read ``action.name`` /
+        ``action.value`` / call ``action.set_data(...)`` — all attribute
+        accesses that fail on raw ints. We re-wrap each available action
+        as ``arcengine.GameAction.from_id(int)`` so the agent sees real
+        enum members again. Same for ``frame.state`` if it's a bare str.
+        """
+        try:
+            from arcengine import GameAction, GameState
+        except ImportError:
+            return frame  # arcengine missing — let downstream code fail naturally
+        actions = getattr(frame, "available_actions", None)
+        if actions is not None:
+            normalized = []
+            for a in actions:
+                if isinstance(a, int):
+                    normalized.append(GameAction.from_id(a))
+                else:
+                    normalized.append(a)
+            try:
+                frame.available_actions = normalized
+            except Exception:
+                # Pydantic frame may be frozen — try replace via model_copy.
+                if hasattr(frame, "model_copy"):
+                    frame = frame.model_copy(update={"available_actions": normalized})
+        state = getattr(frame, "state", None)
+        if isinstance(state, str):
+            import contextlib
+
+            try:
+                frame.state = GameState(state)
+            except Exception:
+                if hasattr(frame, "model_copy"):
+                    with contextlib.suppress(Exception):
+                        frame = frame.model_copy(update={"state": GameState(state)})
+        return frame
 
     def _loop(self, env: Any, first_frame: FrameDataProtocol) -> EpisodeResult:
         frames: list[FrameDataProtocol] = [first_frame]
@@ -134,7 +175,7 @@ class EpisodeRunner:
                 # ``(value, data)`` for click actions). Action6/Action7
                 # carry click coords via set_data() inside the agent.
                 payload = self._action_payload(action)
-                latest = env.step(*payload)
+                latest = self._normalize_frame(env.step(*payload))
                 frames.append(latest)
                 steps_taken += 1
         except Exception as exc:


### PR DESCRIPTION
## Summary

Real-SDK bug surfaced in Phase-A: `arc_agi` 0.9.x's pydantic `FrameData` strips the `GameAction` enum to `int`. Cognithor agents read `action.name` / `action.value` / call `set_data(...)` — all attribute accesses that fail on raw ints with the cryptic `"'int' object has no attribute 'name'"`.

This was the actual reason **every** `dsl_baseline` / `dsl_full` run in the first Phase-A pass crashed after 0 steps. `random_baseline` survived because it doesn't `.name`-access the chosen action.

## Fix

`EpisodeRunner._normalize_frame()` runs after every `reset` / `step` and re-wraps:

- `frame.available_actions: list[int]` → `list[GameAction]` via `arcengine.GameAction.from_id()`
- `frame.state: str` → `GameState` enum (sometimes; defensive)

Direct mutation first; pydantic `model_copy()` fallback for frozen instances; `arcengine` missing → return frame unchanged so downstream fails with a clear error message.

## Tests

- 250 arc_agi3 tests still green (stub frames already used proper enum-typed actions, so the fix doesn't break them).
- Phase-A re-run will exercise the live path on WSL2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)