### PR TITLE
feat(pse): Sprint-15 — LLM call telemetry (evidence for tuning)

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
@@ -88,6 +88,14 @@ from cognithor.channels.program_synthesis.arc_agi3.llm_agent import (
     build_inprocess_vllm_choice_fn,
     build_vllm_choice_fn,
 )
+from cognithor.channels.program_synthesis.arc_agi3.llm_telemetry import (
+    LLMCallRecord,
+    LLMTelemetry,
+    estimate_token_count,
+    extract_think_tokens,
+    wrap_planning_choice_fn,
+    wrap_text_choice_fn,
+)
 from cognithor.channels.program_synthesis.arc_agi3.planning_agent import (
     PlanningLLMReasoningAgent,
     build_inprocess_vllm_planning_choice_fn,
@@ -154,7 +162,9 @@ __all__ = [
     "GameStateProtocol",
     "GoalInferer",
     "LLMActionDecoder",
+    "LLMCallRecord",
     "LLMReasoningAgent",
+    "LLMTelemetry",
     "MovementInfo",
     "PlanStep",
     "PlanningLLMActionDecoder",
@@ -176,6 +186,8 @@ __all__ = [
     "cognithor_agent_factory",
     "count_actions",
     "detect_toggle_pair",
+    "estimate_token_count",
+    "extract_think_tokens",
     "find_clusters",
     "infer_goal_summary",
     "is_level_complete",
@@ -191,4 +203,6 @@ __all__ = [
     "simulate_toggle",
     "summarise",
     "summarise_history",
+    "wrap_planning_choice_fn",
+    "wrap_text_choice_fn",
 ]

--- a/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/__init__.py
@@ -93,6 +93,7 @@ from cognithor.channels.program_synthesis.arc_agi3.llm_telemetry import (
     LLMTelemetry,
     estimate_token_count,
     extract_think_tokens,
+    record_vllm_request_output,
     wrap_planning_choice_fn,
     wrap_text_choice_fn,
 )
@@ -194,6 +195,7 @@ __all__ = [
     "parse_plan_response",
     "parse_scorecard",
     "plan_click_solution",
+    "record_vllm_request_output",
     "render_grid",
     "render_grid_data_uri",
     "render_grid_image",

--- a/src/cognithor/channels/program_synthesis/arc_agi3/llm_telemetry.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/llm_telemetry.py
@@ -1,0 +1,292 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-15 — LLM call telemetry for evidence-based tuning.
+
+Phase-A blind-spot: every Qwen3.6 inference takes 30-40s and we have
+no idea whether the time goes into prefill (input tokens), decode
+(output tokens), or wasted ``<think>`` ramble that hits ``max_tokens``
+and gets truncated. Without that data, every tuning decision (raise
+``max_model_len``? raise ``max_tokens``? add KV-FP8?) is a guess.
+
+This module ships :class:`LLMTelemetry`, a per-episode aggregator
+that records for each LLM call:
+
+* ``input_tokens`` — tokens fed to the model (prompt size).
+* ``output_tokens`` — tokens emitted including any ``<think>`` block.
+* ``think_tokens`` — tokens consumed by Qwen3.6's ``<think>...
+  </think>`` block, if present (so we can split reasoning from final
+  answer cost).
+* ``finish_reason`` — ``"stop"`` (model done), ``"length"`` (hit
+  ``max_tokens``), or ``"abort"`` (engine error).
+* ``wall_clock_s`` — end-to-end choice-fn duration.
+
+Two integration paths:
+
+1. ``wrap_text_choice_fn(fn)`` — decorator for the single-step
+   choice-fn signature ``(ctx) -> (action_name, reasoning)``.
+2. ``wrap_planning_choice_fn(fn)`` — decorator for the planning
+   signature ``(ctx) -> (list[PlanStep], reasoning)``.
+
+Both decorators preserve the original return value and add a
+side-effect: append a :class:`LLMCallRecord` to the wrapped
+:class:`LLMTelemetry`. Use :meth:`summary` to print or persist the
+aggregated stats at episode end.
+
+The telemetry is **non-invasive** — without wrapping, the existing
+choice-fns behave exactly as before.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from cognithor.channels.program_synthesis.arc_agi3.llm_action_decoder import (
+        FrameContext,
+    )
+
+__all__ = [
+    "LLMCallRecord",
+    "LLMTelemetry",
+    "estimate_token_count",
+    "extract_think_tokens",
+    "wrap_planning_choice_fn",
+    "wrap_text_choice_fn",
+]
+
+
+@dataclass(frozen=True)
+class LLMCallRecord:
+    """One LLM call's measurements."""
+
+    call_index: int
+    input_tokens: int
+    output_tokens: int
+    think_tokens: int
+    finish_reason: str
+    wall_clock_s: float
+
+    @property
+    def post_think_tokens(self) -> int:
+        """Output tokens that were NOT inside the ``<think>`` block."""
+        return max(0, self.output_tokens - self.think_tokens)
+
+
+@dataclass
+class LLMTelemetry:
+    """Per-episode aggregator for LLM call records.
+
+    Pass an instance to :func:`wrap_text_choice_fn` or
+    :func:`wrap_planning_choice_fn` and the wrapped fn will append
+    one :class:`LLMCallRecord` per call.
+
+    The aggregator is intentionally trivial — no dependencies, no
+    persistence; the caller decides when to dump it (typically at
+    ``EpisodeRunner`` finalisation alongside the audit-trail JSONL).
+    """
+
+    records: list[LLMCallRecord] = field(default_factory=list)
+
+    def __len__(self) -> int:
+        return len(self.records)
+
+    def summary(self) -> dict[str, Any]:
+        """Aggregate stats useful for tuning decisions.
+
+        Reports:
+        * ``calls`` — total LLM calls
+        * ``finish_reason_dist`` — ``{"stop": N1, "length": N2, ...}``
+          (Claude-style truncation diagnostic)
+        * ``input_tokens_{avg,max,total}``
+        * ``output_tokens_{avg,max,total}``
+        * ``think_tokens_{avg,max,total}``
+        * ``wall_clock_s_{avg,max,total}``
+        * ``length_truncation_rate`` — fraction of calls hitting
+          ``max_tokens``; if > 0.10 you should raise the cap.
+        """
+        n = len(self.records)
+        if n == 0:
+            return {"calls": 0}
+
+        from collections import Counter
+
+        finish_dist = dict(Counter(r.finish_reason for r in self.records))
+        in_t = [r.input_tokens for r in self.records]
+        out_t = [r.output_tokens for r in self.records]
+        think_t = [r.think_tokens for r in self.records]
+        wall = [r.wall_clock_s for r in self.records]
+        return {
+            "calls": n,
+            "finish_reason_dist": finish_dist,
+            "length_truncation_rate": finish_dist.get("length", 0) / n,
+            "input_tokens_avg": sum(in_t) / n,
+            "input_tokens_max": max(in_t),
+            "input_tokens_total": sum(in_t),
+            "output_tokens_avg": sum(out_t) / n,
+            "output_tokens_max": max(out_t),
+            "output_tokens_total": sum(out_t),
+            "think_tokens_avg": sum(think_t) / n,
+            "think_tokens_max": max(think_t),
+            "think_tokens_total": sum(think_t),
+            "wall_clock_s_avg": sum(wall) / n,
+            "wall_clock_s_max": max(wall),
+            "wall_clock_s_total": sum(wall),
+        }
+
+
+# --------------------------------------------------------------------------
+# Token-estimation helpers
+# --------------------------------------------------------------------------
+
+
+def estimate_token_count(text: str) -> int:
+    """Rough token count from character length.
+
+    Uses the ~4-chars-per-token English approximation (close enough
+    for telemetry; for hard sizing use a real tokenizer). Returns 0
+    for empty input.
+    """
+    if not text:
+        return 0
+    return max(1, len(text) // 4)
+
+
+def extract_think_tokens(text: str) -> int:
+    """Return the estimated token count inside ``<think>...</think>``.
+
+    Qwen3.6 wraps its reasoning trace in ``<think>...</think>{json}``;
+    this helper isolates the reasoning portion so the summary can
+    distinguish "model thought a lot" from "model produced a long
+    answer". Returns 0 if no think block is present.
+    """
+    if "</think>" not in text:
+        return 0
+    head, _, _ = text.partition("</think>")
+    # Strip leading "<think>" if present.
+    if "<think>" in head:
+        head = head.split("<think>", 1)[1]
+    return estimate_token_count(head)
+
+
+# --------------------------------------------------------------------------
+# Decorators
+# --------------------------------------------------------------------------
+
+
+def _record_call(
+    telemetry: LLMTelemetry,
+    *,
+    input_text: str,
+    output_text: str,
+    finish_reason: str,
+    wall_clock_s: float,
+) -> None:
+    record = LLMCallRecord(
+        call_index=len(telemetry.records),
+        input_tokens=estimate_token_count(input_text),
+        output_tokens=estimate_token_count(output_text),
+        think_tokens=extract_think_tokens(output_text),
+        finish_reason=finish_reason,
+        wall_clock_s=wall_clock_s,
+    )
+    telemetry.records.append(record)
+
+
+def _ctx_to_input_text(ctx: FrameContext) -> str:
+    """Approximate the prompt's character length from the context."""
+    parts: list[str] = [
+        ctx.history_summary,
+        " ".join(ctx.available_action_names),
+    ]
+    parts.append(getattr(ctx, "action_effects_summary", ""))
+    parts.append(getattr(ctx, "goal_summary", ""))
+    parts.append(getattr(ctx, "game_id", ""))
+    # The grid contributes the bulk of the prompt; approximate as
+    # one token per cell (rough — vision input would actually be
+    # much smaller, but this errs on the safe side for diagnostics).
+    if hasattr(ctx, "grid") and ctx.grid is not None:
+        parts.append("X" * (4 * ctx.grid.size))
+    return "\n".join(parts)
+
+
+def wrap_text_choice_fn(
+    fn: Callable[[FrameContext], tuple[str, str]],
+    telemetry: LLMTelemetry,
+) -> Callable[[FrameContext], tuple[str, str]]:
+    """Decorator for single-step text choice-fns.
+
+    The wrapped fn returns the same ``(action_name, reasoning)`` tuple
+    but also appends a :class:`LLMCallRecord` to ``telemetry`` per
+    call. The reasoning string is treated as the *output text* for
+    token estimation (which gives a small underestimate — it doesn't
+    include any stripped ``<think>`` block — but the decorator can't
+    see the raw model output through the choice-fn boundary).
+    """
+
+    def _wrapped(ctx: FrameContext) -> tuple[str, str]:
+        t0 = time.monotonic()
+        finish_reason = "stop"
+        try:
+            action_name, reasoning = fn(ctx)
+        except Exception:
+            finish_reason = "abort"
+            _record_call(
+                telemetry,
+                input_text=_ctx_to_input_text(ctx),
+                output_text="",
+                finish_reason=finish_reason,
+                wall_clock_s=time.monotonic() - t0,
+            )
+            raise
+        _record_call(
+            telemetry,
+            input_text=_ctx_to_input_text(ctx),
+            output_text=reasoning,
+            finish_reason=finish_reason,
+            wall_clock_s=time.monotonic() - t0,
+        )
+        return action_name, reasoning
+
+    return _wrapped
+
+
+def wrap_planning_choice_fn(
+    fn: Callable[[FrameContext], tuple[Any, str]],
+    telemetry: LLMTelemetry,
+) -> Callable[[FrameContext], tuple[Any, str]]:
+    """Decorator for multi-step planning choice-fns.
+
+    Same telemetry semantics as :func:`wrap_text_choice_fn`. The
+    "output text" is the top-level reasoning; the plan-step list is
+    not directly token-measured (its length is bounded and predictable
+    given ``plan_horizon``).
+    """
+
+    def _wrapped(ctx: FrameContext) -> tuple[Any, str]:
+        t0 = time.monotonic()
+        finish_reason = "stop"
+        try:
+            plan, reasoning = fn(ctx)
+        except Exception:
+            finish_reason = "abort"
+            _record_call(
+                telemetry,
+                input_text=_ctx_to_input_text(ctx),
+                output_text="",
+                finish_reason=finish_reason,
+                wall_clock_s=time.monotonic() - t0,
+            )
+            raise
+        _record_call(
+            telemetry,
+            input_text=_ctx_to_input_text(ctx),
+            output_text=reasoning,
+            finish_reason=finish_reason,
+            wall_clock_s=time.monotonic() - t0,
+        )
+        return plan, reasoning
+
+    return _wrapped

--- a/src/cognithor/channels/program_synthesis/arc_agi3/llm_telemetry.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/llm_telemetry.py
@@ -53,6 +53,7 @@ __all__ = [
     "LLMTelemetry",
     "estimate_token_count",
     "extract_think_tokens",
+    "record_vllm_request_output",
     "wrap_planning_choice_fn",
     "wrap_text_choice_fn",
 ]
@@ -210,6 +211,64 @@ def _ctx_to_input_text(ctx: FrameContext) -> str:
     if hasattr(ctx, "grid") and ctx.grid is not None:
         parts.append("X" * (4 * ctx.grid.size))
     return "\n".join(parts)
+
+
+def record_vllm_request_output(
+    telemetry: LLMTelemetry,
+    request_output: Any,
+    *,
+    wall_clock_s: float,
+    input_text_for_estimate: str = "",
+) -> None:
+    """Record a real vLLM ``RequestOutput`` into the telemetry.
+
+    Use this from inside an in-process choice-fn (where you have the
+    actual ``llm.chat(...)`` return value) to capture vLLM's
+    authoritative numbers:
+
+    * ``request_output.prompt_token_ids`` length → exact ``input_tokens``
+    * ``request_output.outputs[0].token_ids`` length → exact
+      ``output_tokens``
+    * ``request_output.outputs[0].finish_reason`` → exact reason
+      (``stop`` / ``length`` / ``tool_calls`` / ``abort``)
+
+    The ``input_text_for_estimate`` fallback is used when
+    ``prompt_token_ids`` isn't accessible (some vLLM versions hide it).
+    """
+    out = None
+    finish_reason = "stop"
+    output_text = ""
+    output_tokens = 0
+    try:
+        if request_output.outputs:
+            out = request_output.outputs[0]
+            output_text = getattr(out, "text", "") or ""
+            output_tokens = len(getattr(out, "token_ids", []) or [])
+            finish_reason = getattr(out, "finish_reason", "stop") or "stop"
+    except Exception:
+        finish_reason = "abort"
+
+    input_tokens = 0
+    try:
+        prompt_ids = getattr(request_output, "prompt_token_ids", None)
+        if prompt_ids:
+            input_tokens = len(prompt_ids)
+    except Exception:
+        pass
+    if input_tokens == 0:
+        input_tokens = estimate_token_count(input_text_for_estimate)
+    if output_tokens == 0:
+        output_tokens = estimate_token_count(output_text)
+
+    record = LLMCallRecord(
+        call_index=len(telemetry.records),
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        think_tokens=extract_think_tokens(output_text),
+        finish_reason=str(finish_reason),
+        wall_clock_s=wall_clock_s,
+    )
+    telemetry.records.append(record)
 
 
 def wrap_text_choice_fn(

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_llm_telemetry.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_llm_telemetry.py
@@ -1,0 +1,148 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-15 — LLM telemetry tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+
+from cognithor.channels.program_synthesis.arc_agi3.llm_action_decoder import (
+    FrameContext,
+)
+from cognithor.channels.program_synthesis.arc_agi3.llm_telemetry import (
+    LLMTelemetry,
+    estimate_token_count,
+    extract_think_tokens,
+    wrap_planning_choice_fn,
+    wrap_text_choice_fn,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+
+def _ctx() -> FrameContext:
+    return FrameContext(
+        grid=np.zeros((4, 4), dtype=np.int8),
+        available_action_names=["RESET", "ACTION1", "ACTION2"],
+        history_summary="(no actions yet)",
+        levels_completed=0,
+        win_levels=1,
+    )
+
+
+class TestTokenEstimate:
+    def test_zero_for_empty(self) -> None:
+        assert estimate_token_count("") == 0
+
+    def test_grows_with_length(self) -> None:
+        assert estimate_token_count("abcd") < estimate_token_count("abcd" * 10)
+
+    def test_minimum_one_for_nonempty(self) -> None:
+        assert estimate_token_count("a") == 1
+
+
+class TestThinkExtraction:
+    def test_zero_without_think_block(self) -> None:
+        assert extract_think_tokens('{"action": "RESET"}') == 0
+
+    def test_counts_think_content(self) -> None:
+        # The "think" block is "Long reasoning here" → ~5 tokens estimate.
+        text = "<think>" + ("Long reasoning here. " * 5) + "</think>{json}"
+        assert extract_think_tokens(text) > 5
+
+    def test_counts_only_inside_block(self) -> None:
+        a = "<think>x</think>after"
+        b = "<think>x" + "y" * 200 + "</think>after"
+        assert extract_think_tokens(b) > extract_think_tokens(a)
+
+
+class TestTextWrapper:
+    def test_records_one_call(self) -> None:
+        tele = LLMTelemetry()
+
+        def _stub(ctx: FrameContext) -> tuple[str, str]:
+            return "ACTION1", "stub reasoning"
+
+        wrapped = wrap_text_choice_fn(_stub, tele)
+        out = wrapped(_ctx())
+        assert out == ("ACTION1", "stub reasoning")
+        assert len(tele) == 1
+        rec = tele.records[0]
+        assert rec.finish_reason == "stop"
+        assert rec.input_tokens > 0
+        assert rec.output_tokens > 0
+        assert rec.wall_clock_s >= 0.0
+
+    def test_records_abort_on_exception(self) -> None:
+        tele = LLMTelemetry()
+
+        def _bad(ctx: FrameContext) -> tuple[str, str]:
+            raise RuntimeError("boom")
+
+        wrapped = wrap_text_choice_fn(_bad, tele)
+        with pytest.raises(RuntimeError):
+            wrapped(_ctx())
+        assert len(tele) == 1
+        assert tele.records[0].finish_reason == "abort"
+        assert tele.records[0].output_tokens == 0
+
+
+class TestPlanningWrapper:
+    def test_records_planning_call(self) -> None:
+        tele = LLMTelemetry()
+
+        def _stub(ctx: FrameContext) -> tuple[Any, str]:
+            return ([{"action": "ACTION1"}], "two-step plan")
+
+        wrapped = wrap_planning_choice_fn(_stub, tele)
+        plan, reasoning = wrapped(_ctx())
+        assert plan == [{"action": "ACTION1"}]
+        assert reasoning == "two-step plan"
+        assert len(tele) == 1
+
+
+class TestSummary:
+    def test_empty_summary(self) -> None:
+        s = LLMTelemetry().summary()
+        assert s == {"calls": 0}
+
+    def test_aggregates_multiple_calls(self) -> None:
+        tele = LLMTelemetry()
+
+        def _stub(ctx: FrameContext) -> tuple[str, str]:
+            return "X", "y" * 100
+
+        wrapped = wrap_text_choice_fn(_stub, tele)
+        for _ in range(3):
+            wrapped(_ctx())
+        s = tele.summary()
+        assert s["calls"] == 3
+        assert s["finish_reason_dist"] == {"stop": 3}
+        assert s["length_truncation_rate"] == 0.0
+        assert s["input_tokens_total"] > 0
+        assert s["output_tokens_avg"] > 0
+
+    def test_truncation_rate_picks_up_aborts(self) -> None:
+        # Mix one abort with two normal calls → finish_reason_dist
+        # tracks both, length_truncation_rate stays 0 (abort != length).
+        tele = LLMTelemetry()
+        good_count = [0]
+
+        def _flaky(ctx: FrameContext) -> tuple[str, str]:
+            if good_count[0] < 2:
+                good_count[0] += 1
+                return "ACTION1", "ok"
+            raise RuntimeError("late failure")
+
+        wrapped = wrap_text_choice_fn(_flaky, tele)
+        wrapped(_ctx())
+        wrapped(_ctx())
+        with pytest.raises(RuntimeError):
+            wrapped(_ctx())
+        s = tele.summary()
+        assert s["calls"] == 3
+        assert s["finish_reason_dist"]["abort"] == 1
+        assert s["finish_reason_dist"]["stop"] == 2

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_llm_telemetry.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_llm_telemetry.py
@@ -15,6 +15,7 @@ from cognithor.channels.program_synthesis.arc_agi3.llm_telemetry import (
     LLMTelemetry,
     estimate_token_count,
     extract_think_tokens,
+    record_vllm_request_output,
     wrap_planning_choice_fn,
     wrap_text_choice_fn,
 )
@@ -102,6 +103,45 @@ class TestPlanningWrapper:
         assert plan == [{"action": "ACTION1"}]
         assert reasoning == "two-step plan"
         assert len(tele) == 1
+
+
+class TestVllmRequestOutput:
+    def test_records_real_finish_reason(self) -> None:
+        # Mock a vLLM RequestOutput-shaped object.
+        class _Out:
+            text = "<think>some reasoning</think>{json}"
+            token_ids = list(range(120))
+            finish_reason = "length"
+
+        class _Req:
+            prompt_token_ids = list(range(450))
+            outputs = [_Out()]
+
+        tele = LLMTelemetry()
+        record_vllm_request_output(tele, _Req(), wall_clock_s=12.5)
+        rec = tele.records[0]
+        assert rec.finish_reason == "length"
+        assert rec.input_tokens == 450
+        assert rec.output_tokens == 120
+        assert rec.think_tokens > 0
+        assert rec.wall_clock_s == 12.5
+
+    def test_handles_tool_calls_finish_reason(self) -> None:
+        class _Out:
+            text = '{"action": "call_tool"}'
+            token_ids = [1, 2, 3]
+            finish_reason = "tool_calls"
+
+        class _Req:
+            prompt_token_ids = [0] * 200
+            outputs = [_Out()]
+
+        tele = LLMTelemetry()
+        record_vllm_request_output(tele, _Req(), wall_clock_s=1.0)
+        s = tele.summary()
+        assert s["finish_reason_dist"]["tool_calls"] == 1
+        # tool_calls is NOT length → truncation rate stays 0.
+        assert s["length_truncation_rate"] == 0.0
 
 
 class TestSummary:


### PR DESCRIPTION
## Summary

Per Anthropic Claude's tuning analysis: \"Schau in deinen Logs nach finish_reason. Wenn du dort gehäuft length siehst (statt stop), läufst du ins Limit.\" — but our in-process vLLM path has **no per-call telemetry**. This PR ships it as a non-invasive decorator pattern.

## What's new

`LLMTelemetry` aggregator + two decorators (`wrap_text_choice_fn`, `wrap_planning_choice_fn`) that record per LLM call:

- input_tokens (estimated from FrameContext)
- output_tokens (estimated from reasoning text)
- think_tokens (Qwen3.6's `<think>...</think>` portion)
- finish_reason (`stop` / `abort` — extend to `length` once vLLM RequestOutput.finished is threaded through)
- wall_clock_s

`LLMTelemetry.summary()` reports aggregates including `length_truncation_rate` (Claude's diagnostic metric — if > 0.10, raise `max_tokens` or `max_model_len`).

## Why

Without this, every \"raise context to 49K?\" / \"more max_tokens?\" decision is blind. Phase-3 driver will wrap its choice-fn and dump the summary alongside the audit JSONL.

## Non-invasive

Without wrapping, all existing choice-fns behave exactly as before. Drop-in opt-in.

## Test plan

- [x] 12 new tests (token estimation, think extraction, text/planning wrappers, abort recording, summary aggregation)
- [x] 303/303 passing
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] `mypy --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)