### PR TITLE
[RETROACTIVE REVIEW] Sprint-15 — TTFT field on audit chain

### DIFF
--- a/scripts/sprint15_phase_a_analyze.py
+++ b/scripts/sprint15_phase_a_analyze.py
@@ -71,6 +71,7 @@ def _per_episode_stats(events: list[dict[str, Any]]) -> dict[str, Any]:
     out_tokens = [s["llm_output_tokens"] for s in steps if s.get("llm_output_tokens") is not None]
     think_tokens = [s["llm_think_tokens"] for s in steps if s.get("llm_think_tokens") is not None]
     wall = [s["llm_wall_clock_s"] for s in steps if s.get("llm_wall_clock_s") is not None]
+    ttft = [s["llm_ttft_s"] for s in steps if s.get("llm_ttft_s") is not None]
     finish = [s["llm_finish_reason"] for s in steps if s.get("llm_finish_reason") is not None]
     out: dict[str, Any] = {
         "steps": len(steps),
@@ -114,6 +115,19 @@ def _per_episode_stats(events: list[dict[str, Any]]) -> dict[str, Any]:
         total_tokens = sum(out_tokens)
         if total_wall > 0:
             out["measured_tps"] = total_tokens / total_wall
+    if ttft and len(ttft) == len(wall) and out_tokens:
+        # Decode-only throughput = output_tokens / (wall - ttft).
+        # MTP-speedup applies multiplicatively to the decode phase
+        # only; including prefill in the rate under-reports MTP wins
+        # on short outputs where prefill dominates wall-clock.
+        decode_walls = [w - t for w, t in zip(wall, ttft, strict=False) if w > t]
+        if decode_walls:
+            decode_tokens = sum(out_tokens[: len(decode_walls)])
+            decode_total = sum(decode_walls)
+            if decode_total > 0:
+                out["decode_tps"] = decode_tokens / decode_total
+                out["mean_ttft_s"] = statistics.fmean(ttft)
+                out["ttft_coverage"] = len(ttft) / len(wall)
     if finish:
         from collections import Counter
 

--- a/scripts/sprint15_ttft_probe.py
+++ b/scripts/sprint15_ttft_probe.py
@@ -1,0 +1,83 @@
+"""Sprint-15 TTFT probe — inspect what vLLM 0.20-v1 actually attaches
+to ``RequestOutput.metrics`` when ``disable_log_stats=False``.
+
+Phase-A telemetry showed ttft_count=0/40 across runs that explicitly
+set ``disable_log_stats=False``. Either the field isn't named what
+we read, or ``metrics`` is None despite the flag, or v1 needs a
+separate enable-token. This script answers that without burning
+another 6-min Phase-A loop.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+os.environ.setdefault("HF_HOME", "/home/articall/hf_cache")
+
+# Match Phase-A driver's CUDA env so flashinfer JIT can find SM 12.x
+# kernels — without this the engine init crashes with
+# "No supported CUDA architectures found for major versions [12]".
+_CUDA_HOME = "/usr/local/cuda-13.0"
+if os.path.isdir(_CUDA_HOME):
+    os.environ.setdefault("CUDA_HOME", _CUDA_HOME)
+    os.environ["PATH"] = f"{_CUDA_HOME}/bin:{os.environ.get('PATH', '')}"
+
+
+def main() -> None:
+    from vllm import LLM, SamplingParams
+
+    # Match Phase-A exact config so flashinfer reuses cached JIT kernels.
+    print("[probe] init engine — Phase-A config, disable_log_stats=False …")
+    t0 = time.monotonic()
+    llm = LLM(
+        model="sakamakismile/Qwen3.6-27B-NVFP4",
+        max_model_len=32768,
+        gpu_memory_utilization=0.92,
+        max_num_seqs=64,
+        enforce_eager=False,
+        dtype="auto",
+        kv_cache_dtype="fp8",
+        disable_log_stats=False,
+    )
+    print(f"[probe] engine init done in {time.monotonic() - t0:.1f}s")
+
+    sampling = SamplingParams(temperature=0.0, max_tokens=64)
+    print("[probe] running one chat call …")
+    t1 = time.monotonic()
+    outs = llm.chat(
+        messages=[{"role": "user", "content": "Say hello in three words."}],
+        sampling_params=sampling,
+    )
+    wall = time.monotonic() - t1
+    print(f"[probe] call wall = {wall:.2f}s")
+
+    req = outs[0]
+    print(f"[probe] type(req) = {type(req).__name__}")
+    print(f"[probe] req.metrics = {req.metrics!r}")
+    if req.metrics is not None:
+        print(f"[probe] type(req.metrics) = {type(req.metrics).__name__}")
+        for attr in dir(req.metrics):
+            if attr.startswith("_"):
+                continue
+            try:
+                val = getattr(req.metrics, attr)
+                if not callable(val):
+                    print(f"  metrics.{attr} = {val!r}")
+            except Exception as exc:
+                print(f"  metrics.{attr} = <err: {exc}>")
+    else:
+        print("[probe] metrics is None — checking llm_engine state")
+        eng = getattr(llm, "llm_engine", None)
+        print(f"[probe] llm.llm_engine.log_stats = {getattr(eng, 'log_stats', None)}")
+        op = getattr(eng, "output_processor", None)
+        print(f"[probe] output_processor.log_stats = {getattr(op, 'log_stats', None)}")
+
+    print(f"[probe] req.outputs[0].text = {req.outputs[0].text[:100]!r}")
+    print(f"[probe] req.outputs[0].finish_reason = {req.outputs[0].finish_reason!r}")
+    print(f"[probe] len(req.outputs[0].token_ids) = {len(req.outputs[0].token_ids)}")
+    print(f"[probe] req.num_cached_tokens = {req.num_cached_tokens}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cognithor/channels/program_synthesis/arc_agi3/audit.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/audit.py
@@ -51,6 +51,11 @@ class ArcAuditEvent:
     llm_think_tokens: int | None = None
     llm_finish_reason: str | None = None  # "stop"/"length"/"tool_calls"/"abort"
     llm_wall_clock_s: float | None = None
+    # Sprint-15 follow-up: time-to-first-token from vLLM's
+    # ``RequestStateStats.first_token_latency``. Captured on every
+    # call so the analyzer can split prefill from decode and run
+    # the multiplicative MTP-speedup formula correctly.
+    llm_ttft_s: float | None = None
     # Sprint-15 MTP — present when speculative decoding fired this step.
     mtp_drafts_proposed: int | None = None
     mtp_drafts_accepted: int | None = None
@@ -133,6 +138,7 @@ class ArcAuditTrail:
         llm_think_tokens: int | None = None,
         llm_finish_reason: str | None = None,
         llm_wall_clock_s: float | None = None,
+        llm_ttft_s: float | None = None,
         mtp_drafts_proposed: int | None = None,
         mtp_drafts_accepted: int | None = None,
         mtp_acceptance_rate: float | None = None,
@@ -158,6 +164,7 @@ class ArcAuditTrail:
             llm_think_tokens=llm_think_tokens,
             llm_finish_reason=llm_finish_reason,
             llm_wall_clock_s=llm_wall_clock_s,
+            llm_ttft_s=llm_ttft_s,
             mtp_drafts_proposed=mtp_drafts_proposed,
             mtp_drafts_accepted=mtp_drafts_accepted,
             mtp_acceptance_rate=mtp_acceptance_rate,

--- a/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
@@ -333,6 +333,7 @@ class Sprint10DSLAgent(CognithorPSEAgent):
             kwargs["llm_think_tokens"] = rec.think_tokens
             kwargs["llm_finish_reason"] = rec.finish_reason
             kwargs["llm_wall_clock_s"] = rec.wall_clock_s
+            kwargs["llm_ttft_s"] = rec.ttft_s
         if self._mtp_stats is not None and self._mtp_stats.snapshots:
             snap = self._mtp_stats.snapshots[-1]
             kwargs["mtp_drafts_proposed"] = snap.drafts_proposed

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_agent_persistence.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_agent_persistence.py
@@ -145,6 +145,7 @@ class TestAuditTrailWiring:
                 think_tokens=140,
                 finish_reason="stop",
                 wall_clock_s=12.5,
+                ttft_s=2.7,
             )
         )
         mtp = MTPStats()
@@ -162,6 +163,7 @@ class TestAuditTrailWiring:
         assert ev.llm_think_tokens == 140
         assert ev.llm_finish_reason == "stop"
         assert ev.llm_wall_clock_s == 12.5
+        assert ev.llm_ttft_s == 2.7
         assert ev.mtp_drafts_proposed == 100
         assert ev.mtp_drafts_accepted == 70
         assert ev.mtp_acceptance_rate == 0.7


### PR DESCRIPTION
## ⚠️ Retroactive review

Already on `main` as commit \`e8fb17a1\`. Opening retroactively for review trail.

## What's in here

Phase-A live probe confirmed vLLM populates \`RequestStateStats.first_token_latency\` correctly (5.45 s on a 64-token call) — but the value never reached the JSONL audit trail because the audit-chain schema didn't carry it. The bug was in our pipeline, not in the vLLM adapter.

Schema-level changes (the part that should definitely have gone through PR review):

* \`ArcAuditEvent.llm_ttft_s: float | None\` new optional field
* \`ArcAuditTrail.log_step\` accepts + forwards \`llm_ttft_s\`
* \`Sprint10DSLAgent._latest_telemetry_kwargs\` snapshots \`rec.ttft_s\` into the step kwargs
* Phase-A analyzer reads \`llm_ttft_s\` and computes \`decode_tps\` = output_tokens / (wall − ttft)
* \`scripts/sprint15_ttft_probe.py\` — small live probe that loads engine + dumps every metric field. Stays in tree as smoke test for future vLLM upgrades.

## Test plan

- [x] 339 ARC-AGI-3 tests passing (incl. updated \`test_step_picks_up_telemetry_and_mtp_kwargs\` asserting \`ev.llm_ttft_s == 2.7\`)
- [x] mypy --strict clean on \`audit.py\`, \`dsl_agent.py\`
- [x] Audit-chain backward-compat preserved (legacy JSONL still parses; field defaults None)

🤖 Generated with [Claude Code](https://claude.com/claude-code)