### PR TITLE
fix(pse): COGNITHOR_PSE_DEBUG_LLM env-flag for silent choice_fn exceptions

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/planning_decoder.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/planning_decoder.py
@@ -312,6 +312,22 @@ class PlanningLLMActionDecoder(ActionDecoder):
         try:
             plan, _top_reasoning = self._choice_fn(ctx)
         except Exception:
+            # Silent fallback hides genuine bugs in the LLM choice-fn —
+            # set ``COGNITHOR_PSE_DEBUG_LLM=1`` to surface the actual
+            # exception (full traceback to stderr) before returning the
+            # ``None`` that triggers the DSL fallback. Off by default to
+            # preserve the contract: production runs must keep playing.
+            import os as _os
+
+            if _os.environ.get("COGNITHOR_PSE_DEBUG_LLM"):
+                import sys as _sys
+                import traceback as _tb
+
+                print(
+                    "[pse-debug] choice_fn raised; falling back to DSL:",
+                    file=_sys.stderr,
+                )
+                _tb.print_exc(file=_sys.stderr)
             return None
         if not plan:
             return None


### PR DESCRIPTION
## Summary
- The PlanningLLMActionDecoder swallows all choice_fn exceptions silently and falls back to DSL — by design (production must keep playing) but cost is genuine bugs hide.
- Sprint-19 Run #26b had vLLM idle on GPU for 130s while every plan-call raised; the silent fallback made it look like vLLM was just slow.
- Adds env-gated traceback: ``COGNITHOR_PSE_DEBUG_LLM=1`` → full exception → stderr → fallback proceeds as before.
- Off by default. Production runs byte-identical.

## Test plan
- [x] `pytest tests/test_channels/test_program_synthesis/arc_agi3/test_planning_decoder.py -q` → 13 passed
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)