### PR TITLE
feat(pse): Sprint-19 Hebel N — plan_scorer pixΔ-safety gate

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/plan_scorer.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/plan_scorer.py
@@ -111,12 +111,36 @@ def score_plan(
     with_reasoning = sum(1 for s in plan if s.reasoning.strip())
     reasoning = with_reasoning / n
 
-    # Validity + anti_repetition are multiplicative gates (plan with
-    # invalid actions or stuck-action repetition is fundamentally
-    # broken). Diversity, targetedness, reasoning are additive
-    # quality components averaged.
+    # 6. Sprint-19 Hebel N — pixΔ-safety gate. Run #26c on bp35
+    # showed the LLM still queued plans whose first action had just
+    # produced pixΔ>500 (steps 37/40/41 each flipped 525-639 cells,
+    # then GAME_OVER at step 44). Hebel M makes the trajectory
+    # visible to the LLM in the prompt; Hebel N is the deterministic
+    # safety net for when the LLM ignores the warning. Multiplicative
+    # half-penalty (0.5) — strong enough to lose to any sane
+    # alternative candidate, but not a full zero so the gate degrades
+    # gracefully if ALL candidates inherit the same first-action.
+    pix_delta_safety = 1.0
+    if memory is not None and len(memory) >= 2:
+        try:
+            import numpy as _np
+
+            recent = memory.window(2)
+            after, before = recent[0], recent[1]
+            if before.grid.shape == after.grid.shape:
+                last_pix_delta = int(_np.sum(before.grid != after.grid))
+                if last_pix_delta > 500 and plan[0].action_name == after.action_name:
+                    pix_delta_safety = 0.5
+        except Exception:
+            pass
+
+    # Validity + anti_repetition + pix_delta_safety are multiplicative
+    # gates (plan with invalid actions, stuck-action repetition, or
+    # destructive-action escalation is fundamentally broken).
+    # Diversity, targetedness, reasoning are additive quality
+    # components averaged.
     additive_avg = (diversity + targetedness + reasoning) / 3.0
-    return additive_avg * validity * anti_repetition
+    return additive_avg * validity * anti_repetition * pix_delta_safety
 
 
 def pick_best_plan(

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_plan_scorer.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_plan_scorer.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from cognithor.channels.program_synthesis.arc_agi3.episode_memory import EpisodeMemory
 from cognithor.channels.program_synthesis.arc_agi3.plan_scorer import (
@@ -79,6 +80,56 @@ class TestScorePlanComponents:
             available_action_names=("ACTION3", "ACTION6"),
         )
         assert s_diff > s_same
+
+    def test_pix_delta_safety_penalises_repeat_after_high_delta(self) -> None:
+        """Hebel N: if the LAST action produced pixΔ>500 AND the plan's
+        first action repeats it, the plan is multiplicatively penalised
+        (0.5×). A plan that picks a different first-action wins.
+        """
+        # Build memory: one tame ACTION3 step, then one ACTION7 that
+        # flipped the entire 64×64 grid (pixΔ ~= 4096).
+        m = EpisodeMemory()
+        before = np.zeros((64, 64), dtype=np.int8)
+        m.append(grid=before, action_name="ACTION3", levels_completed=0)
+        after = np.full((64, 64), 4, dtype=np.int8)
+        m.append(grid=after, action_name="ACTION7", levels_completed=0)
+
+        # Plan A repeats the destructive action; Plan B picks something else.
+        plan_repeat = [
+            PlanStep("ACTION7", data={"x": 10, "y": 10}, reasoning="r"),
+            PlanStep("ACTION3", reasoning="r"),
+        ]
+        plan_pivot = [
+            PlanStep("ACTION3", reasoning="r"),
+            PlanStep("ACTION7", data={"x": 10, "y": 10}, reasoning="r"),
+        ]
+        actions = ("ACTION3", "ACTION7")
+        s_repeat = score_plan(plan_repeat, memory=m, available_action_names=actions)
+        s_pivot = score_plan(plan_pivot, memory=m, available_action_names=actions)
+        # Pivot must beat repeat. Same component composition modulo
+        # the pix-delta gate (0.5× for repeat, 1.0× for pivot).
+        assert s_pivot > s_repeat
+        # Pivot must be roughly twice the repeat (since the only delta
+        # is the multiplicative gate).
+        assert s_repeat == pytest.approx(s_pivot * 0.5, rel=1e-6)
+
+    def test_pix_delta_safety_no_penalty_when_last_delta_low(self) -> None:
+        """Hebel N: if the last action produced a SMALL pixΔ, the gate
+        is inactive — repeat is fine.
+        """
+        m = EpisodeMemory()
+        m.append(grid=_g([[0]]), action_name="ACTION3", levels_completed=0)
+        # Same grid → pixΔ=0, well below the 500-cell threshold.
+        m.append(grid=_g([[0]]), action_name="ACTION7", levels_completed=0)
+
+        plan_repeat = [PlanStep("ACTION7", data={"x": 1, "y": 1}, reasoning="r")]
+        plan_pivot = [PlanStep("ACTION3", reasoning="r")]
+        actions = ("ACTION3", "ACTION7")
+        s_repeat = score_plan(plan_repeat, memory=m, available_action_names=actions)
+        s_pivot = score_plan(plan_pivot, memory=m, available_action_names=actions)
+        # Both should be in the same ballpark; the repeat is targeted +
+        # different colour so it can even win on pure quality.
+        assert s_repeat >= s_pivot * 0.95
 
 
 class TestPickBestPlan:


### PR DESCRIPTION
## Summary
- Deterministic complement to Hebel M (#325). Hebel M makes the recent pixΔ trajectory visible in the LLM's prompt and adds a concrete numeric rule; Hebel N is the safety net when the LLM ignores that rule.
- New 6th component in ``score_plan``: ``pix_delta_safety``. Active when memory ≥2 entries AND the last recorded action produced ``pixΔ > 500`` cells. If the plan's first action repeats that destructive last action, the plan is multiplied by 0.5 — strong enough to lose to any sane alternative, but not a full zero so the scorer degrades gracefully.
- Independent of Hebel M (#325) — both can land in any order; final state is `additive_avg × validity × anti_repetition × pix_delta_safety`.

## Test plan
- [x] `pytest tests/test_channels/test_program_synthesis/arc_agi3/ -q` → 382 passed (+2 dedicated Hebel N coverage)
- [x] `mypy --strict` on plan_scorer.py → clean
- [x] `ruff check` + `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)