### PR TITLE
fix(pse): Run #27 — broaden Hebel N + bump max_tokens 4096→6144

### DIFF
--- a/scripts/sprint12_phase_a_validation.py
+++ b/scripts/sprint12_phase_a_validation.py
@@ -355,16 +355,18 @@ def _make_llm_vision(game_id: str, results_dir: Path) -> tuple[Any, str | None]:
         choice_fn = build_inprocess_vllm_vision_planning_choice_fn(
             kv_cache_dtype="fp8",
             temperature=0.0,
-            # Sprint-19 Run #25 finding: max_tokens=2048 caused 76/80
-            # LLM calls to hit ``finish_reason="length"`` — the model
-            # was truncated mid-output before the closing JSON ``}``,
-            # so EVERY plan was unparseable and the upstream decoder
-            # silently fell back to its DSL policy. Bumped to 4096 so
-            # Qwen3.6 has room to finish its plan-JSON. Cost increase
-            # is modest because vLLM batches ``n=plan_candidates`` in
-            # parallel (shared prefill, parallel decode) — empirically
-            # ~1.3x wall-clock for n=3 at 4096 tokens.
-            max_tokens=4096,
+            # Sprint-19 Run #27 finding: 5/48 LLM calls again hit
+            # ``finish_reason="length"`` at the new 4096 budget — the
+            # Hebel M prompt additions (cluster summary + delta-window
+            # with explicit pixΔ trajectory + the longer numeric
+            # PLAN-PRINCIPLE rule) push input + reasoning past 4096.
+            # Bumped to 6144 to restore the slack lost to richer prompt
+            # content. vLLM batches ``n=plan_candidates`` in parallel,
+            # so the wall-clock cost grows roughly linearly with the
+            # *generated* part of the budget, not the cap itself —
+            # most plans still finish well under 4096 (Run #27: 1081–
+            # 4096, median ~2200).
+            max_tokens=6144,
             grid_scale=8,
             telemetry=telemetry,
             # Sprint-19 Hebel L: ask vLLM for 3 plan candidates per

--- a/src/cognithor/channels/program_synthesis/arc_agi3/plan_scorer.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/plan_scorer.py
@@ -111,26 +111,49 @@ def score_plan(
     with_reasoning = sum(1 for s in plan if s.reasoning.strip())
     reasoning = with_reasoning / n
 
-    # 6. Sprint-19 Hebel N — pixΔ-safety gate. Run #26c on bp35
-    # showed the LLM still queued plans whose first action had just
-    # produced pixΔ>500 (steps 37/40/41 each flipped 525-639 cells,
-    # then GAME_OVER at step 44). Hebel M makes the trajectory
-    # visible to the LLM in the prompt; Hebel N is the deterministic
-    # safety net for when the LLM ignores the warning. Multiplicative
-    # half-penalty (0.5) — strong enough to lose to any sane
-    # alternative candidate, but not a full zero so the gate degrades
-    # gracefully if ALL candidates inherit the same first-action.
+    # 6. Sprint-19 Hebel N — pixΔ-safety gate.
+    #
+    # Run #26c finding (motivation): the LLM queued plans whose first
+    # action repeated the destructive last action (pixΔ>500), then
+    # GAME_OVER. Initial Hebel N caught that single-action repeat case.
+    #
+    # Run #27 finding (broadening): with K=3 sampling + Hebel L active
+    # the LLM stopped repeating the *same* action — but it now rotates
+    # between ACTION3/4/6/7 each producing pixΔ ~525-636, ending in
+    # the same destructive cascade (528 → 525 → 525 → 525 → 636 →
+    # GAME_OVER at step 48). The single-action gate didn't fire
+    # because the action keeps changing.
+    #
+    # Broadened gate: TWO consecutive prior steps with pixΔ>500 means
+    # the agent is in the destructive-escalation regime regardless of
+    # action class — ANY plan-first-action gets the multiplicative
+    # 0.5× penalty. The prior single-action repeat case still applies
+    # as a separate trigger (relevant when only the last single step
+    # had pixΔ>500).
     pix_delta_safety = 1.0
     if memory is not None and len(memory) >= 2:
         try:
             import numpy as _np
 
-            recent = memory.window(2)
-            after, before = recent[0], recent[1]
-            if before.grid.shape == after.grid.shape:
-                last_pix_delta = int(_np.sum(before.grid != after.grid))
-                if last_pix_delta > 500 and plan[0].action_name == after.action_name:
-                    pix_delta_safety = 0.5
+            recent = memory.window(3)
+            last_after, last_before = recent[0], recent[1]
+            last_pix_delta = (
+                int(_np.sum(last_before.grid != last_after.grid))
+                if last_before.grid.shape == last_after.grid.shape
+                else 0
+            )
+            second_pix_delta = 0
+            if len(recent) >= 3:
+                second_after, second_before = recent[1], recent[2]
+                if second_before.grid.shape == second_after.grid.shape:
+                    second_pix_delta = int(_np.sum(second_before.grid != second_after.grid))
+
+            two_consecutive_high = last_pix_delta > 500 and second_pix_delta > 500
+            single_action_repeat = (
+                last_pix_delta > 500 and plan[0].action_name == last_after.action_name
+            )
+            if two_consecutive_high or single_action_repeat:
+                pix_delta_safety = 0.5
         except Exception:
             pass
 

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_plan_scorer.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_plan_scorer.py
@@ -131,6 +131,37 @@ class TestScorePlanComponents:
         # different colour so it can even win on pure quality.
         assert s_repeat >= s_pivot * 0.95
 
+    def test_pix_delta_safety_two_consecutive_high_penalises_any_first_action(self) -> None:
+        """Hebel N broadened (Run #27 finding): when the LAST TWO
+        recorded actions BOTH produced pixΔ>500 (destructive-escalation
+        regime), ANY plan-first-action gets the 0.5× penalty —
+        regardless of whether it matches the last action. This catches
+        the case the LLM K=3 candidates rotate ACTION3/4/6/7 to dodge
+        the single-action gate while still escalating.
+        """
+        m = EpisodeMemory()
+        zero = np.zeros((64, 64), dtype=np.int8)
+        big_a = np.full((64, 64), 4, dtype=np.int8)
+        big_b = np.full((64, 64), 7, dtype=np.int8)
+        # Two consecutive high-pixΔ transitions (~4096 cells each).
+        m.append(grid=zero, action_name="ACTION1", levels_completed=0)
+        m.append(grid=big_a, action_name="ACTION3", levels_completed=0)
+        m.append(grid=big_b, action_name="ACTION6", levels_completed=0)
+
+        # Plan first action is COMPLETELY DIFFERENT from the last
+        # action (ACTION6) — so the single-action repeat trigger does
+        # NOT fire. The two-consecutive trigger MUST still apply.
+        plan_other = [
+            PlanStep("ACTION7", data={"x": 5, "y": 5}, reasoning="r"),
+            PlanStep("ACTION3", reasoning="r"),
+        ]
+        actions = ("ACTION3", "ACTION6", "ACTION7")
+        s_other = score_plan(plan_other, memory=m, available_action_names=actions)
+        # Compare against the same plan scored without memory (gate
+        # inactive). The gate is the only multiplicative delta.
+        s_baseline = score_plan(plan_other, available_action_names=actions)
+        assert s_other == pytest.approx(s_baseline * 0.5, rel=1e-6)
+
 
 class TestPickBestPlan:
     def test_empty_list_returns_empty(self) -> None:


### PR DESCRIPTION
## Summary
Two follow-up fixes from Run #27 audit (post Hebel L+M+N stack on bp35).

**1. max_tokens regression (4096 → 6144)**
- Hebel M's prompt additions pushed 5/48 LLM calls back to `finish_reason=\"length\"` at the new 4096 budget.
- Run #27 actual output_tokens range: 1081–4096, median ~2200 — but long-tail reasoning needs headroom.
- vLLM's parallel `n=K` decoding makes the cost roughly linear in *generated* tokens, not the cap.

**2. Hebel N broadened to two-consecutive-high-pixΔ trigger**
- With K=3 + diversity score, the LLM stopped repeating the same action — but ROTATES between ACTION3/4/6/7 each producing pixΔ ~525-636, ending in the same destructive cascade (528 → 525 → 525 → 525 → 636 → GAME_OVER at step 48).
- The original single-action repeat trigger never fired because the action kept changing.
- New OR-trigger: when the last TWO recorded actions BOTH had pixΔ>500, ANY plan-first-action gets the 0.5× penalty (the agent is in destructive-escalation regime regardless of action class).
- Single-action trigger preserved as the second OR condition.

## Test plan
- [x] `pytest tests/test_channels/test_program_synthesis/arc_agi3/ -q` → 385 passed (+1 dedicated coverage for two-consecutive trigger)
- [x] `mypy --strict` plan_scorer.py → clean
- [x] `ruff check` + `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)