### PR TITLE
feat(pse): Sprint-19 Hebel O — stalled-progress warning in vision prompt

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/llm_action_decoder.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/llm_action_decoder.py
@@ -113,6 +113,13 @@ class FrameContext:
     # prompts stay byte-identical.
     cluster_summary: str = ""
     delta_window_summary: str = ""
+    # Sprint-19 Hebel O (stalled-progress signal): how many consecutive
+    # recent memory entries have the same ``levels_completed`` as the
+    # current frame. Computed by the decoder from memory; lets the
+    # prompt builder inject a "you've been stuck for N steps" warning
+    # when the agent is failing for too long. ``0`` means "no stall
+    # observed yet" so legacy prompt builders stay byte-identical.
+    steps_at_current_level: int = 0
 
 
 # A callable that takes a :class:`FrameContext` and returns

--- a/src/cognithor/channels/program_synthesis/arc_agi3/planning_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/planning_agent.py
@@ -298,7 +298,9 @@ _VISION_PLANNING_USER_TEMPLATE = (
     "Recent action sequence: {history}\n"
     "{effects_line}"
     "{goal_line}"
-    "Progress: {levels}/{win_levels} levels.\n\n"
+    "Progress: {levels}/{win_levels} levels.\n"
+    "{stalled_warning}"
+    "\n"
     "PLAN-PRINCIPLE:\n"
     "- If the same action has been picked many times without level "
     "progress, the strategy is wrong — pick something else.\n"
@@ -314,6 +316,32 @@ _VISION_PLANNING_USER_TEMPLATE = (
     "exploration over exploitation.\n\n"
     "Plan the next 3-5 actions and respond as JSON with the "
     '{{"reasoning": "...", "plan": [...]}} schema.'
+)
+
+
+# Sprint-19 Hebel O — stalled-progress threshold. After this many
+# consecutive frames at the same ``levels_completed`` (and
+# ``levels_completed == 0``), the prompt builder injects an explicit
+# "you are losing" warning. Run #28 went 64 steps at level 0 without
+# any signal of failure being shown to the LLM.
+#
+# Set to 15 because :class:`EpisodeMemory` defaults to capacity 16 —
+# the decoder's consecutive-same-level counter walks memory backwards
+# and therefore caps at the buffer size. 15 means "essentially the
+# entire memory window has been at the current level", which is a
+# strong-enough signal without being over-sensitive on the very first
+# fresh-game frames where memory is also small.
+_STALLED_THRESHOLD = 15
+
+_STALLED_WARNING_TEMPLATE = (
+    "STALLED-PROGRESS WARNING: {steps} consecutive steps elapsed at "
+    "level {level} — your current strategy is not advancing the win "
+    "counter. Empirically, agents that keep picking high-pixΔ actions "
+    "after this many fruitless steps run out of episode budget and "
+    "GAME_OVER. Pivot fundamentally: try the action types you have NOT "
+    "used yet, prefer minimal-change exploration (small pixΔ) over "
+    "another big move, or RESET if it is in the available actions and "
+    "you cannot infer a path forward.\n"
 )
 
 
@@ -391,6 +419,13 @@ def _build_vision_user_content(
         if getattr(ctx, "goal_summary", "")
         else ""
     )
+    stalled_warning = ""
+    steps_at = getattr(ctx, "steps_at_current_level", 0)
+    if steps_at >= _STALLED_THRESHOLD and ctx.levels_completed == 0:
+        stalled_warning = _STALLED_WARNING_TEMPLATE.format(
+            steps=steps_at, level=ctx.levels_completed
+        )
+
     text = _VISION_PLANNING_USER_TEMPLATE.format(
         prev_image_note=prev_image_note,
         cluster_summary=cluster_summary,
@@ -401,6 +436,7 @@ def _build_vision_user_content(
         goal_line=goal_line,
         levels=ctx.levels_completed,
         win_levels=ctx.win_levels,
+        stalled_warning=stalled_warning,
     )
     return [*images, {"type": "text", "text": text}]
 
@@ -513,6 +549,12 @@ def build_inprocess_vllm_vision_planning_choice_fn(
             )
         cluster_summary = getattr(ctx, "cluster_summary", "") or "(not annotated)"
         delta_window = getattr(ctx, "delta_window_summary", "") or "(no completed transitions yet)"
+        steps_at = getattr(ctx, "steps_at_current_level", 0)
+        stalled_warning = ""
+        if steps_at >= _STALLED_THRESHOLD and ctx.levels_completed == 0:
+            stalled_warning = _STALLED_WARNING_TEMPLATE.format(
+                steps=steps_at, level=ctx.levels_completed
+            )
         text_after_image = _VISION_PLANNING_USER_TEMPLATE.format(
             prev_image_note=prev_image_note,
             cluster_summary=cluster_summary,
@@ -531,6 +573,7 @@ def build_inprocess_vllm_vision_planning_choice_fn(
             ),
             levels=ctx.levels_completed,
             win_levels=ctx.win_levels,
+            stalled_warning=stalled_warning,
         )
         messages = [
             {"role": "system", "content": _build_planning_system_prompt(ctx)},

--- a/src/cognithor/channels/program_synthesis/arc_agi3/planning_decoder.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/planning_decoder.py
@@ -307,6 +307,27 @@ class PlanningLLMActionDecoder(ActionDecoder):
                 )
             except Exception:
                 pass
+        if "steps_at_current_level" in existing:
+            # Sprint-19 Hebel O: count how many consecutive recent memory
+            # entries share the current ``levels_completed``. The vision
+            # prompt template reads this to decide whether to inject a
+            # stalled-progress warning. Walk memory.window() from most
+            # recent backwards while the level matches.
+            try:
+                current_level = latest_frame.levels_completed
+                steps_at = 0
+                # Use a generous window — bp35 has 9 levels with episodes
+                # capped at 80 steps, so a stall of >50 steps is the
+                # whole episode. Walking 80 entries is microsecond-cheap
+                # so we don't bother capping.
+                for step_entry in self._memory.window(80):
+                    if step_entry.levels_completed == current_level:
+                        steps_at += 1
+                    else:
+                        break
+                ctx_kwargs["steps_at_current_level"] = steps_at
+            except Exception:
+                pass
         ctx = FrameContext(**ctx_kwargs)
 
         try:

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_planning_decoder.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_planning_decoder.py
@@ -135,6 +135,152 @@ class TestPlanningDecoder:
         chosen, _ = decoder.pick_action([f], f, f.available_actions)
         assert len(calls) == 2
 
+    def test_populates_steps_at_current_level(self) -> None:
+        """Sprint-19 Hebel O: decoder must count consecutive recent
+        memory entries with the same ``levels_completed`` and pass the
+        count via ``FrameContext.steps_at_current_level`` so the prompt
+        builder can decide whether to inject the stalled-progress
+        warning. Builds a memory of 25 frames at level 0, then verifies
+        the choice-fn sees ``steps_at_current_level == 25``.
+        """
+        captured: list[int] = []
+
+        def _planner(ctx: Any) -> tuple[list[PlanStep], str]:
+            captured.append(getattr(ctx, "steps_at_current_level", -1))
+            return [PlanStep("ACTION1")], ""
+
+        memory = EpisodeMemory()
+        # 25 prior frames all at level 0; memory capacity is 16 so the
+        # counter caps at the buffer size, which is the working
+        # assumption for the prompt-side stalled-progress threshold.
+        for _ in range(25):
+            memory.append(
+                grid=np.zeros((2, 2), dtype=np.int8),
+                action_name="ACTION1",
+                levels_completed=0,
+            )
+
+        decoder = PlanningLLMActionDecoder(
+            bridge=FrameBridge(),
+            memory=memory,
+            choice_fn=_planner,
+        )
+        f = _frame(np.zeros((2, 2), dtype=np.int8))
+        decoder.pick_action([f], f, f.available_actions)
+        assert captured == [16]
+
+    def test_steps_at_current_level_does_not_inject_warning_when_below_threshold(
+        self,
+    ) -> None:
+        """Hebel O: ``_VISION_PLANNING_USER_TEMPLATE`` has a
+        ``{stalled_warning}`` slot. When ``steps_at_current_level`` is
+        below the threshold OR ``levels_completed > 0``, the slot stays
+        empty so legacy prompts are byte-identical.
+        """
+        from cognithor.channels.program_synthesis.arc_agi3.planning_agent import (
+            _STALLED_THRESHOLD,
+        )
+
+        # Build a plausible context with a sub-threshold count.
+        memory = EpisodeMemory()
+        for _ in range(_STALLED_THRESHOLD - 1):
+            memory.append(
+                grid=np.zeros((2, 2), dtype=np.int8),
+                action_name="ACTION1",
+                levels_completed=0,
+            )
+
+        captured_text: list[str] = []
+
+        def _planner(ctx: Any) -> tuple[list[PlanStep], str]:
+            from cognithor.channels.program_synthesis.arc_agi3.planning_agent import (
+                _build_vision_user_content,
+            )
+
+            content = _build_vision_user_content(ctx, memory=memory)
+            text = next(item["text"] for item in content if item.get("type") == "text")
+            captured_text.append(text)
+            return [PlanStep("ACTION1")], ""
+
+        decoder = PlanningLLMActionDecoder(
+            bridge=FrameBridge(),
+            memory=memory,
+            choice_fn=_planner,
+        )
+        f = _frame(np.zeros((2, 2), dtype=np.int8))
+        decoder.pick_action([f], f, f.available_actions)
+        assert "STALLED-PROGRESS WARNING" not in captured_text[0]
+
+    def test_steps_at_current_level_injects_warning_when_above_threshold(self) -> None:
+        """Hebel O: when memory is full of same-level entries beyond
+        the threshold AND ``levels_completed == 0``, the warning is
+        rendered into the user prompt.
+        """
+        memory = EpisodeMemory()
+        for _ in range(20):  # ≥ _STALLED_THRESHOLD; capacity is 16 so caps there
+            memory.append(
+                grid=np.zeros((2, 2), dtype=np.int8),
+                action_name="ACTION1",
+                levels_completed=0,
+            )
+
+        captured_text: list[str] = []
+
+        def _planner(ctx: Any) -> tuple[list[PlanStep], str]:
+            from cognithor.channels.program_synthesis.arc_agi3.planning_agent import (
+                _build_vision_user_content,
+            )
+
+            content = _build_vision_user_content(ctx, memory=memory)
+            text = next(item["text"] for item in content if item.get("type") == "text")
+            captured_text.append(text)
+            return [PlanStep("ACTION1")], ""
+
+        decoder = PlanningLLMActionDecoder(
+            bridge=FrameBridge(),
+            memory=memory,
+            choice_fn=_planner,
+        )
+        f = _frame(np.zeros((2, 2), dtype=np.int8))
+        decoder.pick_action([f], f, f.available_actions)
+        assert "STALLED-PROGRESS WARNING" in captured_text[0]
+        # The warning quotes the actual count.
+        assert "16 consecutive steps" in captured_text[0]
+
+    def test_steps_at_current_level_resets_on_level_change(self) -> None:
+        """Sprint-19 Hebel O: the consecutive-same-level counter must
+        STOP at the last level transition. Memory of 5 frames at level 0
+        then 3 frames at level 1 → counter is 3, not 8.
+        """
+        captured: list[int] = []
+
+        def _planner(ctx: Any) -> tuple[list[PlanStep], str]:
+            captured.append(getattr(ctx, "steps_at_current_level", -1))
+            return [PlanStep("ACTION1")], ""
+
+        memory = EpisodeMemory()
+        for _ in range(5):
+            memory.append(
+                grid=np.zeros((2, 2), dtype=np.int8),
+                action_name="ACTION1",
+                levels_completed=0,
+            )
+        for _ in range(3):
+            memory.append(
+                grid=np.zeros((2, 2), dtype=np.int8),
+                action_name="ACTION1",
+                levels_completed=1,
+            )
+
+        decoder = PlanningLLMActionDecoder(
+            bridge=FrameBridge(),
+            memory=memory,
+            choice_fn=_planner,
+        )
+        f = _frame(np.zeros((2, 2), dtype=np.int8), levels=1)
+        decoder.pick_action([f], f, f.available_actions)
+        assert captured == [3]
+
     def test_invalidates_plan_on_level_change(self) -> None:
         calls: list[int] = []
 


### PR DESCRIPTION
## Summary
- Run #28 went 64 steps at `level=0` before GAME_OVER, but the LLM had no explicit signal it had been failing for that long. `Progress: 0/9 levels` was the only static cue.
- **Hebel O** plumbs `FrameContext.steps_at_current_level` from the planning decoder (counts consecutive recent memory entries with the same `levels_completed`, resets on level change) and renders an explicit `STALLED-PROGRESS WARNING` block into the vision-planning prompt template once a threshold is crossed.
- Threshold = **15** because `EpisodeMemory` defaults to capacity 16, so the counter caps there. 15 = "essentially the entire memory window is at this level".

## Behaviour
- `steps_at_current_level >= 15` AND `levels_completed == 0` → warning text injected; otherwise empty slot, byte-identical legacy prompt.
- Decoder gracefully no-ops when `FrameContext.steps_at_current_level` is absent (older builds).

## Test plan
- [x] `pytest tests/test_channels/test_program_synthesis/arc_agi3/ -q` → **389 passed (+4)**
  - `test_populates_steps_at_current_level` — counter fills from memory
  - `test_steps_at_current_level_resets_on_level_change` — counter restarts on transition
  - `test_steps_at_current_level_does_not_inject_warning_when_below_threshold`
  - `test_steps_at_current_level_injects_warning_when_above_threshold`
- [x] `mypy --strict` on the 3 touched source files → clean
- [x] `ruff check` + `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)