### PR TITLE
feat(pse): Sprint-19 Hebel P — raw LLM reasoning in audit JSONL

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/audit.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/audit.py
@@ -60,6 +60,13 @@ class ArcAuditEvent:
     mtp_drafts_proposed: int | None = None
     mtp_drafts_accepted: int | None = None
     mtp_acceptance_rate: float | None = None
+    # Sprint-19 Hebel P — raw LLM reasoning persisted with the step.
+    # Lets post-mortem analysis read what the model was thinking when
+    # it picked a destructive plan-step. Truncated to 4000 chars by
+    # the producer to keep audit JSONL parse-friendly. ``None`` means
+    # "no LLM call drove this step" (DSL fallback) or "the choice-fn
+    # didn't surface a reasoning string".
+    llm_reasoning: str | None = None
 
 
 def _event_to_json(event: ArcAuditEvent) -> str:
@@ -142,6 +149,7 @@ class ArcAuditTrail:
         mtp_drafts_proposed: int | None = None,
         mtp_drafts_accepted: int | None = None,
         mtp_acceptance_rate: float | None = None,
+        llm_reasoning: str | None = None,
     ) -> str:
         """Log a single agent step and return its chain hash.
 
@@ -149,7 +157,19 @@ class ArcAuditTrail:
         same hash-chained event so per-step token counts + speculative-
         decoding stats are tamper-evident alongside the action history.
         All defaults ``None`` preserve backwards compatibility.
+
+        Sprint-19 Hebel P: ``llm_reasoning`` carries the model's
+        top-level reasoning string (truncated to 4000 chars by the
+        producer) so post-mortem analysis can read what the LLM was
+        thinking when it picked the action — without re-running the
+        episode.
         """
+        # Hebel P safety: if the producer forgot to truncate, do it
+        # here. Audit JSONL parsers choke on arbitrarily-long fields,
+        # and 4000 chars is plenty for one reasoning sentence + plan
+        # step rationales.
+        if llm_reasoning is not None and len(llm_reasoning) > 4000:
+            llm_reasoning = llm_reasoning[:4000]
         event = ArcAuditEvent(
             timestamp=time.time(),
             event_type="step",
@@ -168,6 +188,7 @@ class ArcAuditTrail:
             mtp_drafts_proposed=mtp_drafts_proposed,
             mtp_drafts_accepted=mtp_drafts_accepted,
             mtp_acceptance_rate=mtp_acceptance_rate,
+            llm_reasoning=llm_reasoning,
         )
         return self.log_event(event)
 

--- a/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
@@ -334,6 +334,11 @@ class Sprint10DSLAgent(CognithorPSEAgent):
             kwargs["llm_finish_reason"] = rec.finish_reason
             kwargs["llm_wall_clock_s"] = rec.wall_clock_s
             kwargs["llm_ttft_s"] = rec.ttft_s
+            # Sprint-19 Hebel P: forward the model's top-level
+            # reasoning when the telemetry-wrapped choice-fn captured
+            # it. ``None`` is the legacy default and stays JSONL-clean.
+            if getattr(rec, "reasoning", None) is not None:
+                kwargs["llm_reasoning"] = rec.reasoning
         if self._mtp_stats is not None and self._mtp_stats.snapshots:
             snap = self._mtp_stats.snapshots[-1]
             kwargs["mtp_drafts_proposed"] = snap.drafts_proposed

--- a/src/cognithor/channels/program_synthesis/arc_agi3/llm_telemetry.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/llm_telemetry.py
@@ -81,6 +81,12 @@ class LLMCallRecord:
     # vLLM, HTTP backend) — analyzers must tolerate the gap rather
     # than reject the record.
     ttft_s: float | None = None
+    # Sprint-19 Hebel P — top-level reasoning string the model
+    # produced for this call. Truncated to ≤4000 chars at record
+    # construction so audit JSONL stays parse-friendly. ``None`` when
+    # the producer didn't surface a reasoning string (e.g. legacy
+    # decoder paths or a parse-failed plan).
+    reasoning: str | None = None
 
     @property
     def post_think_tokens(self) -> int:
@@ -349,6 +355,35 @@ def record_vllm_request_output(
     except Exception:
         pass
 
+    # Sprint-19 Hebel P: best-effort reasoning capture. If the output
+    # is the JSON-with-think-block format the planning factories use,
+    # extract the top-level "reasoning" field; otherwise pass the raw
+    # post-think text. Failures fall back to ``None`` so a malformed
+    # response doesn't tank the telemetry record.
+    reasoning_text: str | None = None
+    try:
+        body = output_text
+        if "</think>" in body:
+            body = body.split("</think>", 1)[1].strip()
+        # Try strict JSON first (planning paths emit a single object).
+        start = body.find("{")
+        end = body.rfind("}")
+        if start >= 0 and end > start:
+            import json as _json
+
+            parsed = _json.loads(body[start : end + 1])
+            reasoning_field = parsed.get("reasoning")
+            if isinstance(reasoning_field, str) and reasoning_field.strip():
+                reasoning_text = reasoning_field.strip()
+        # Fallback to the raw post-think body when JSON parse failed
+        # or didn't carry a reasoning key — still a useful trace.
+        if reasoning_text is None and body.strip():
+            reasoning_text = body.strip()
+        if reasoning_text is not None and len(reasoning_text) > 4000:
+            reasoning_text = reasoning_text[:4000]
+    except Exception:
+        reasoning_text = None
+
     record = LLMCallRecord(
         call_index=len(telemetry.records),
         input_tokens=input_tokens,
@@ -357,6 +392,7 @@ def record_vllm_request_output(
         finish_reason=str(finish_reason),
         wall_clock_s=wall_clock_s,
         ttft_s=ttft_s,
+        reasoning=reasoning_text,
     )
     telemetry.records.append(record)
 

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_audit.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_audit.py
@@ -208,3 +208,57 @@ class TestHashlineSeal:
         out_path = tmp_path / "audit.jsonl"
         result = trail.export_jsonl(str(out_path))  # default seal_into_hashline=False
         assert result is None
+
+
+class TestHebelPReasoningPersistence:
+    def test_log_step_accepts_and_persists_reasoning(self, tmp_path: Path) -> None:
+        """Hebel P: ``log_step(..., llm_reasoning="...")`` round-trips
+        the reasoning text into the exported JSONL row.
+        """
+        trail = ArcAuditTrail(game_id="bp35")
+        trail.log_game_start()
+        trail.log_step(
+            level=0,
+            step=1,
+            action="ACTION3",
+            game_state="NOT_FINISHED",
+            pixels_changed=12,
+            llm_reasoning="explore right corridor",
+        )
+        out_path = tmp_path / "audit.jsonl"
+        trail.export_jsonl(str(out_path))
+        rows = [json.loads(line) for line in out_path.read_text().splitlines()]
+        step_row = next(r for r in rows if r["event_type"] == "step")
+        assert step_row["llm_reasoning"] == "explore right corridor"
+
+    def test_log_step_truncates_oversize_reasoning(self) -> None:
+        """Hebel P: producer-side oversize strings get capped at 4000
+        chars before joining the audit chain.
+        """
+        trail = ArcAuditTrail(game_id="bp35")
+        long_text = "y" * 5000
+        trail.log_step(
+            level=0,
+            step=1,
+            action="ACTION3",
+            game_state="NOT_FINISHED",
+            pixels_changed=12,
+            llm_reasoning=long_text,
+        )
+        event = trail.events[-1]
+        assert event.llm_reasoning is not None
+        assert len(event.llm_reasoning) == 4000
+
+    def test_log_step_reasoning_defaults_to_none(self) -> None:
+        """Hebel P: when no kwarg is passed, the field stays ``None`` —
+        legacy callers don't see a behavioural change.
+        """
+        trail = ArcAuditTrail(game_id="bp35")
+        trail.log_step(
+            level=0,
+            step=1,
+            action="ACTION3",
+            game_state="NOT_FINISHED",
+            pixels_changed=12,
+        )
+        assert trail.events[-1].llm_reasoning is None

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_llm_telemetry.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_llm_telemetry.py
@@ -190,6 +190,71 @@ class TestVllmRequestOutput:
         assert "ttft_s_avg" in s
         assert s["ttft_coverage"] == 1.0
 
+    def test_extracts_reasoning_from_planning_json(self) -> None:
+        """Hebel P: if the output text is the JSON-with-think-block
+        format the planning factory uses, the recorder extracts the
+        top-level ``reasoning`` field and stores it on the record.
+        """
+
+        class _Out:
+            text = (
+                "<think>weighing options</think>"
+                '{"reasoning": "explore right corridor first", '
+                '"plan": [{"action": "ACTION3", "data": null}]}'
+            )
+            token_ids = [0] * 50
+            finish_reason = "stop"
+
+        class _Req:
+            prompt_token_ids = [0] * 100
+            outputs = [_Out()]
+
+        tele = LLMTelemetry()
+        record_vllm_request_output(tele, _Req(), wall_clock_s=1.0)
+        rec = tele.records[0]
+        assert rec.reasoning == "explore right corridor first"
+
+    def test_reasoning_truncated_at_4000_chars(self) -> None:
+        """Hebel P: oversized reasoning fields are truncated to 4000
+        chars at record-construction time so audit JSONL stays
+        parse-friendly.
+        """
+        long_reason = "x" * 5000
+
+        class _Out:
+            text = f'{{"reasoning": "{long_reason}", "plan": []}}'
+            token_ids = [0] * 50
+            finish_reason = "stop"
+
+        class _Req:
+            prompt_token_ids = [0] * 100
+            outputs = [_Out()]
+
+        tele = LLMTelemetry()
+        record_vllm_request_output(tele, _Req(), wall_clock_s=1.0)
+        rec = tele.records[0]
+        assert rec.reasoning is not None
+        assert len(rec.reasoning) == 4000
+
+    def test_reasoning_falls_back_to_post_think_body_when_no_json(self) -> None:
+        """Hebel P: when output isn't strict JSON, the recorder still
+        captures the post-think body as the reasoning trace.
+        """
+
+        class _Out:
+            text = "<think>reasoning trace</think>final answer is X"
+            token_ids = [0] * 20
+            finish_reason = "stop"
+
+        class _Req:
+            prompt_token_ids = [0] * 50
+            outputs = [_Out()]
+
+        tele = LLMTelemetry()
+        record_vllm_request_output(tele, _Req(), wall_clock_s=1.0)
+        rec = tele.records[0]
+        assert rec.reasoning == "final answer is X"
+
     def test_ttft_none_when_metrics_missing(self) -> None:
         # Backward-compat: legacy request objects without ``metrics``
         # don't crash the recorder; TTFT stays None and decode rate is


### PR DESCRIPTION
## Summary
- Run #28 went 64 steps without level progress; audit had **no record** of what the model was thinking when it picked any of the destructive plans. Post-mortem could only see action+pixΔ.
- **Hebel P** plumbs the LLM's top-level reasoning string through every layer (`LLMCallRecord.reasoning` → `dsl_agent._latest_telemetry_kwargs` → `ArcAuditTrail.log_step(llm_reasoning=...)` → `ArcAuditEvent.llm_reasoning` → JSONL).
- Truncation at 4000 chars on both producer (telemetry) and consumer (audit) side. Defaults to `None`; legacy callers + JSONL parsers byte-identical.

## What gets captured
- Strict JSON path: planning factory's `<think>…</think>{"reasoning":"...", "plan":[...]}` → extracts the `reasoning` field.
- Fallback: post-`</think>` body → captured as-is so non-JSON responses still leave a trace.
- Failures → `None` (telemetry is a side-channel; never fail the run).

## Test plan
- [x] `pytest tests/test_channels/test_program_synthesis/arc_agi3/ -q` → **391 passed (+6)**
  - `test_extracts_reasoning_from_planning_json`
  - `test_reasoning_truncated_at_4000_chars`
  - `test_reasoning_falls_back_to_post_think_body_when_no_json`
  - `test_log_step_accepts_and_persists_reasoning`
  - `test_log_step_truncates_oversize_reasoning`
  - `test_log_step_reasoning_defaults_to_none`
- [x] `mypy --strict` on audit.py + llm_telemetry.py → clean
- [x] `ruff check` + `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)