### PR TITLE
feat(pse): Sprint-19 Hebel R — RESET-bonus when stalled+destructive

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/plan_scorer.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/plan_scorer.py
@@ -111,6 +111,40 @@ def score_plan(
     with_reasoning = sum(1 for s in plan if s.reasoning.strip())
     reasoning = with_reasoning / n
 
+    # Sprint-19 Hebel R — RESET-bonus when stalled + just-was-destructive.
+    # Run #28 stalled at level 0 for 64 steps with periodic destructive
+    # cascades; the LLM almost never picked RESET because the diversity
+    # / targetedness components don't reward it. R adds a small additive
+    # nudge applied AFTER the average is computed (so it doesn't change
+    # the baseline scale): when the agent has been at the current level
+    # for many frames AND the last action produced a high pixΔ AND
+    # ``RESET`` is actually available, plans that START with RESET get
+    # +0.30 added to the score (then clamped to 1.0). 0.30 is enough
+    # to flip a sane RESET candidate ahead of any plan that would
+    # otherwise win on a thin diversity margin.
+    reset_bonus = 0.0
+    if memory is not None and "RESET" in available_action_names and plan[0].action_name == "RESET":
+        try:
+            import numpy as _np
+
+            window = memory.window(80)
+            if len(window) >= 2:
+                current_level = window[0].levels_completed
+                steps_at = 0
+                for s in window:
+                    if s.levels_completed == current_level:
+                        steps_at += 1
+                    else:
+                        break
+                last_high_pix = False
+                a, b = window[0], window[1]
+                if a.grid.shape == b.grid.shape:
+                    last_high_pix = int(_np.sum(a.grid != b.grid)) > 500
+                if steps_at >= 15 and last_high_pix:
+                    reset_bonus = 0.30
+        except Exception:
+            pass
+
     # 6. Sprint-19 Hebel N — pixΔ-safety gate.
     #
     # Run #26c finding (motivation): the LLM queued plans whose first
@@ -161,9 +195,13 @@ def score_plan(
     # gates (plan with invalid actions, stuck-action repetition, or
     # destructive-action escalation is fundamentally broken).
     # Diversity, targetedness, reasoning are additive quality
-    # components averaged.
+    # components averaged. Sprint-19 Hebel R adds ``reset_bonus`` as
+    # a small post-hoc additive boost (0 unless triggered) and clamps
+    # the result back into [0, 1] — preserves existing scaling while
+    # giving stalled-and-destructive RESET plans a measurable edge.
     additive_avg = (diversity + targetedness + reasoning) / 3.0
-    return additive_avg * validity * anti_repetition * pix_delta_safety
+    base = additive_avg * validity * anti_repetition * pix_delta_safety
+    return min(1.0, base + reset_bonus)
 
 
 def pick_best_plan(

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_plan_scorer.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_plan_scorer.py
@@ -163,6 +163,100 @@ class TestScorePlanComponents:
         assert s_other == pytest.approx(s_baseline * 0.5, rel=1e-6)
 
 
+class TestResetBonus:
+    """Sprint-19 Hebel R — additive +0.30 RESET-bonus when the agent is
+    both stalled (≥15 steps at current level) and the last action was
+    destructive (pixΔ>500). Score clamped to [0, 1].
+    """
+
+    def test_reset_plan_gets_bonus_when_stalled_and_destructive(self) -> None:
+        m = EpisodeMemory()
+        # 16 prior frames at level 0 → "stalled" (≥15)
+        for _ in range(15):
+            m.append(
+                grid=np.zeros((64, 64), dtype=np.int8),
+                action_name="ACTION3",
+                levels_completed=0,
+            )
+        # The 16th frame is the destructive one — pixΔ=600 from
+        # this transition (10 rows × 60 cols = 600 cells flipped).
+        destructive = np.zeros((64, 64), dtype=np.int8)
+        destructive[:10, :60] = 4
+        m.append(grid=destructive, action_name="ACTION6", levels_completed=0)
+
+        actions = ("RESET", "ACTION3", "ACTION6")
+        plan_reset = [PlanStep("RESET", reasoning="restart")]
+        plan_other = [PlanStep("ACTION3", reasoning="explore")]
+        s_reset = score_plan(plan_reset, memory=m, available_action_names=actions)
+        s_other = score_plan(plan_other, memory=m, available_action_names=actions)
+        # The two plans have similar quality components, so the +0.30
+        # RESET-bonus must put plan_reset clearly ahead.
+        assert s_reset > s_other
+        assert s_reset - s_other >= 0.20
+
+    def test_no_bonus_when_reset_not_in_available(self) -> None:
+        m = EpisodeMemory()
+        for _ in range(15):
+            m.append(
+                grid=np.zeros((64, 64), dtype=np.int8),
+                action_name="ACTION3",
+                levels_completed=0,
+            )
+        destructive = np.zeros((64, 64), dtype=np.int8)
+        destructive[:10, :60] = 4
+        m.append(grid=destructive, action_name="ACTION6", levels_completed=0)
+
+        # RESET NOT in available_action_names → bonus never fires
+        # even if the plan claims to start with RESET.
+        actions = ("ACTION3", "ACTION6")
+        plan_reset = [PlanStep("RESET", reasoning="r")]
+        s_reset = score_plan(plan_reset, memory=m, available_action_names=actions)
+        # validity=0 (RESET not in actions) → score=0 regardless of bonus.
+        assert s_reset == 0.0
+
+    def test_no_bonus_when_not_stalled(self) -> None:
+        m = EpisodeMemory()
+        # Only 5 prior frames at level 0 → below the 15-step threshold.
+        for _ in range(5):
+            m.append(
+                grid=np.zeros((64, 64), dtype=np.int8),
+                action_name="ACTION3",
+                levels_completed=0,
+            )
+        destructive = np.zeros((64, 64), dtype=np.int8)
+        destructive[:10, :60] = 4
+        m.append(grid=destructive, action_name="ACTION6", levels_completed=0)
+
+        actions = ("RESET", "ACTION3", "ACTION6")
+        plan_reset = [PlanStep("RESET", reasoning="r")]
+        s_reset_with_memory = score_plan(plan_reset, memory=m, available_action_names=actions)
+        # Same plan but no memory at all (so the bonus path can't fire).
+        s_reset_no_memory = score_plan(plan_reset, available_action_names=actions)
+        # Bonus should NOT fire; the two scores match.
+        assert s_reset_with_memory == pytest.approx(s_reset_no_memory, rel=1e-6)
+
+    def test_no_bonus_when_last_pix_delta_low(self) -> None:
+        m = EpisodeMemory()
+        for _ in range(20):
+            m.append(
+                grid=np.zeros((64, 64), dtype=np.int8),
+                action_name="ACTION3",
+                levels_completed=0,
+            )
+        # Same grid → pixΔ=0 (below the 500 threshold).
+        m.append(
+            grid=np.zeros((64, 64), dtype=np.int8),
+            action_name="ACTION6",
+            levels_completed=0,
+        )
+
+        actions = ("RESET", "ACTION3", "ACTION6")
+        plan_reset = [PlanStep("RESET", reasoning="r")]
+        s_with_memory = score_plan(plan_reset, memory=m, available_action_names=actions)
+        s_no_memory = score_plan(plan_reset, available_action_names=actions)
+        assert s_with_memory == pytest.approx(s_no_memory, rel=1e-6)
+
+
 class TestPickBestPlan:
     def test_empty_list_returns_empty(self) -> None:
         assert pick_best_plan([]) == ([], "")


### PR DESCRIPTION
## Summary
- Run #28 stalled 64 steps at level 0 with periodic destructive cascades; LLM almost never picked RESET because existing scorer components don't reward it.
- **Hebel R** adds a post-hoc additive `+0.30` boost (clamped to 1.0) when the agent is **stalled** (≥15 frames at current level) **AND** **just-was-destructive** (last pixΔ>500) **AND** plan starts with `RESET` **AND** `RESET` is in `available_action_names`.

## Composition
```
base  = ((diversity + targetedness + reasoning) / 3)
      × validity × anti_repetition × pix_delta_safety
score = min(1.0, base + reset_bonus)
```
The `/3` divisor stays — Hebel R is a *post-hoc* additive nudge, not a 4th averaged component, so all existing test thresholds keep holding.

## Test plan
- [x] `pytest tests/test_channels/test_program_synthesis/arc_agi3/ -q` → **389 passed (+4 dedicated Hebel R coverage)**
- [x] `mypy --strict` plan_scorer.py → clean
- [x] `ruff check` + `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)