### PR TITLE
feat(pse): Sprint-19 Hebel S — per-action pixΔ histogram in vision prompt

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/llm_action_decoder.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/llm_action_decoder.py
@@ -113,6 +113,13 @@ class FrameContext:
     # prompts stay byte-identical.
     cluster_summary: str = ""
     delta_window_summary: str = ""
+    # Sprint-19 Hebel S (per-action pixΔ histogram): one line per
+    # action seen in the episode showing avg / max pixΔ + count, with
+    # DANGER / CAUTION suffixes matching Hebel M's risk vocabulary.
+    # Lets the LLM reason about per-action risk (max) and impact
+    # (avg) at a glance. Empty string disables the corresponding
+    # prompt section.
+    action_pixel_history: str = ""
 
 
 # A callable that takes a :class:`FrameContext` and returns

--- a/src/cognithor/channels/program_synthesis/arc_agi3/planning_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/planning_agent.py
@@ -294,6 +294,7 @@ _VISION_PLANNING_USER_TEMPLATE = (
     "Trajectory (most-recent first, what each action did):\n"
     "{delta_window}\n"
     "\n"
+    "{action_pixel_history_block}"
     "Available actions: {actions}\n"
     "Recent action sequence: {history}\n"
     "{effects_line}"
@@ -391,10 +392,34 @@ def _build_vision_user_content(
         if getattr(ctx, "goal_summary", "")
         else ""
     )
+    # Sprint-19 Hebel S: per-action pixΔ histogram. The legacy helper
+    # is called with explicit memory; render the block inline so this
+    # path stays self-contained for tests that don't go through the
+    # decoder.
+    action_pixel_history_block = ""
+    if memory is not None:
+        try:
+            from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
+                EpisodeMemory as _EM,
+            )
+            from cognithor.channels.program_synthesis.arc_agi3.state_renderer import (
+                summarise_action_pixel_history,
+            )
+
+            if isinstance(memory, _EM):
+                hist = summarise_action_pixel_history(memory)
+                if hist and "no action history" not in hist:
+                    action_pixel_history_block = (
+                        "Per-action pixΔ history (this episode):\n" + hist + "\n\n"
+                    )
+        except Exception:
+            pass
+
     text = _VISION_PLANNING_USER_TEMPLATE.format(
         prev_image_note=prev_image_note,
         cluster_summary=cluster_summary,
         delta_window=delta_window,
+        action_pixel_history_block=action_pixel_history_block,
         actions=", ".join(ctx.available_action_names),
         history=ctx.history_summary,
         effects_line=effects_line,
@@ -513,10 +538,20 @@ def build_inprocess_vllm_vision_planning_choice_fn(
             )
         cluster_summary = getattr(ctx, "cluster_summary", "") or "(not annotated)"
         delta_window = getattr(ctx, "delta_window_summary", "") or "(no completed transitions yet)"
+        # Sprint-19 Hebel S: render the per-action pixΔ block from the
+        # decoder-populated ``ctx.action_pixel_history`` field. Empty
+        # string disables the block (legacy prompt byte-identical).
+        action_pixel_history = getattr(ctx, "action_pixel_history", "")
+        action_pixel_history_block = ""
+        if action_pixel_history and "no action history" not in action_pixel_history:
+            action_pixel_history_block = (
+                "Per-action pixΔ history (this episode):\n" + action_pixel_history + "\n\n"
+            )
         text_after_image = _VISION_PLANNING_USER_TEMPLATE.format(
             prev_image_note=prev_image_note,
             cluster_summary=cluster_summary,
             delta_window=delta_window,
+            action_pixel_history_block=action_pixel_history_block,
             actions=", ".join(ctx.available_action_names),
             history=ctx.history_summary,
             effects_line=(

--- a/src/cognithor/channels/program_synthesis/arc_agi3/planning_decoder.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/planning_decoder.py
@@ -307,6 +307,18 @@ class PlanningLLMActionDecoder(ActionDecoder):
                 )
             except Exception:
                 pass
+        if "action_pixel_history" in existing:
+            # Sprint-19 Hebel S: per-action pixΔ histogram (avg / max /
+            # n with DANGER / CAUTION suffixes) so the vision prompt
+            # can show the LLM the risk profile of each action class.
+            try:
+                from cognithor.channels.program_synthesis.arc_agi3.state_renderer import (
+                    summarise_action_pixel_history,
+                )
+
+                ctx_kwargs["action_pixel_history"] = summarise_action_pixel_history(self._memory)
+            except Exception:
+                pass
         ctx = FrameContext(**ctx_kwargs)
 
         try:

--- a/src/cognithor/channels/program_synthesis/arc_agi3/state_renderer.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/state_renderer.py
@@ -218,8 +218,70 @@ def render_state_changes_in_window(
     return "\n".join(parts)
 
 
+def summarise_action_pixel_history(
+    memory: EpisodeMemory,
+    *,
+    max_window: int = 80,
+) -> str:
+    """Per-action pixΔ statistics over the recent memory window.
+
+    Format::
+
+        ACTION3: avg pixΔ=42, max=120, n=8
+        ACTION6: avg pixΔ=380, max=1220, n=24 (DANGER: max>1000)
+        ACTION7: avg pixΔ=156, max=636, n=10 (CAUTION: max>500)
+
+    Sprint-19 Hebel S: gives the LLM a single per-action summary of
+    "what each action has historically done in this episode" so it
+    can reason about action *risk* (max pixΔ) and *typical impact*
+    (avg pixΔ) without re-reading the entire trajectory. Empty
+    memory or single-step memory yields ``"(no action history yet)"``.
+
+    The DANGER / CAUTION suffixes match Hebel M's prompt vocabulary
+    (>1000 = single-spike danger zone, >500 = consecutive-trigger
+    danger zone) so the LLM sees a consistent risk vocabulary across
+    trajectory + per-action signals.
+    """
+    from collections import defaultdict
+
+    import numpy as np
+
+    window = memory.window(max_window)
+    if len(window) < 2:
+        return "(no action history yet)"
+
+    per_action: dict[str, list[int]] = defaultdict(list)
+    # window is most-recent first; pairs are (window[i], window[i+1])
+    # where window[i] is the AFTER and window[i+1] is the BEFORE state
+    # of action ``window[i].action_name``.
+    for i in range(len(window) - 1):
+        after = window[i]
+        before = window[i + 1]
+        if before.grid.shape == after.grid.shape:
+            pix = int(np.sum(before.grid != after.grid))
+            per_action[after.action_name].append(pix)
+
+    if not per_action:
+        return "(no action history yet)"
+
+    rows: list[tuple[int, str]] = []
+    for name, pixs in per_action.items():
+        n = len(pixs)
+        avg = sum(pixs) / n
+        mx = max(pixs)
+        suffix = ""
+        if mx > 1000:
+            suffix = " (DANGER: max>1000)"
+        elif mx > 500:
+            suffix = " (CAUTION: max>500)"
+        rows.append((n, f"{name}: avg pixΔ={avg:.0f}, max={mx}, n={n}{suffix}"))
+    rows.sort(reverse=True)
+    return "\n".join(r[1] for r in rows)
+
+
 __all__ = [
     "render_cluster_summary",
     "render_delta_summary",
     "render_state_changes_in_window",
+    "summarise_action_pixel_history",
 ]

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_state_renderer.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_state_renderer.py
@@ -11,6 +11,7 @@ from cognithor.channels.program_synthesis.arc_agi3.state_renderer import (
     render_cluster_summary,
     render_delta_summary,
     render_state_changes_in_window,
+    summarise_action_pixel_history,
 )
 from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
     PSECapability as _PSECapability,
@@ -193,3 +194,56 @@ class TestRenderStateChangesInWindow:
             m.append(grid=grid, action_name=f"ACTION{i % 4}", levels_completed=0)
         out = render_state_changes_in_window(m, max_steps=3)
         assert len(out.splitlines()) == 3
+
+
+class TestSummariseActionPixelHistory:
+    """Sprint-19 Hebel S — per-action pixΔ stats over the recent window."""
+
+    def test_empty_memory_returns_marker(self) -> None:
+        assert summarise_action_pixel_history(EpisodeMemory()) == "(no action history yet)"
+
+    def test_single_step_no_pair_yet(self) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[1]]), action_name="ACTION3", levels_completed=0)
+        assert summarise_action_pixel_history(m) == "(no action history yet)"
+
+    def test_renders_avg_max_n_per_action(self) -> None:
+        m = EpisodeMemory()
+        # ACTION3 → pixΔ=1, ACTION3 → pixΔ=1, ACTION6 → pixΔ=1
+        m.append(grid=_g([[0, 0]]), action_name="ACTION1", levels_completed=0)
+        m.append(grid=_g([[1, 0]]), action_name="ACTION3", levels_completed=0)
+        m.append(grid=_g([[1, 1]]), action_name="ACTION3", levels_completed=0)
+        m.append(grid=_g([[2, 1]]), action_name="ACTION6", levels_completed=0)
+        out = summarise_action_pixel_history(m)
+        assert "ACTION3:" in out
+        assert "ACTION6:" in out
+        assert "n=2" in out  # ACTION3 occurred twice
+
+    def test_appends_danger_suffix_above_1000(self) -> None:
+        m = EpisodeMemory()
+        small = np.zeros((64, 64), dtype=np.int8)
+        big = np.full((64, 64), 4, dtype=np.int8)  # ~4096-cell flip
+        m.append(grid=small, action_name="ACTION1", levels_completed=0)
+        m.append(grid=big, action_name="ACTION6", levels_completed=0)
+        out = summarise_action_pixel_history(m)
+        assert "DANGER: max>1000" in out
+
+    def test_appends_caution_suffix_between_500_and_1000(self) -> None:
+        m = EpisodeMemory()
+        before = np.zeros((64, 64), dtype=np.int8)
+        after = np.zeros((64, 64), dtype=np.int8)
+        # 600 cells flipped (10 rows × 60 cols)
+        after[:10, :60] = 4
+        m.append(grid=before, action_name="ACTION1", levels_completed=0)
+        m.append(grid=after, action_name="ACTION6", levels_completed=0)
+        out = summarise_action_pixel_history(m)
+        assert "CAUTION: max>500" in out
+        assert "DANGER" not in out
+
+    def test_no_suffix_when_max_below_500(self) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[0, 0]]), action_name="ACTION1", levels_completed=0)
+        m.append(grid=_g([[1, 0]]), action_name="ACTION3", levels_completed=0)
+        out = summarise_action_pixel_history(m)
+        assert "DANGER" not in out
+        assert "CAUTION" not in out


### PR DESCRIPTION
## Summary
Run #28 had 24 ACTION6 calls (pixΔ 1-1220) but the LLM saw **no per-action risk signal** in the prompt. Trajectory window shows only the last 5 pairs; cluster summary is point-in-time.

**Hebel S** ships a single per-action summary block:

```
Per-action pixΔ history (this episode):
ACTION6: avg pixΔ=380, max=1220, n=24 (DANGER: max>1000)
ACTION3: avg pixΔ=42, max=120, n=8
ACTION7: avg pixΔ=156, max=636, n=10 (CAUTION: max>500)
```

DANGER (>1000) and CAUTION (>500) suffixes match Hebel M's risk vocabulary so the LLM sees a consistent vocabulary across trajectory + per-action signals.

## Plumbing
- `state_renderer.summarise_action_pixel_history` (new)
- `FrameContext.action_pixel_history: str = ""` (new field)
- `planning_decoder._consult_llm` populates from memory window
- `_VISION_PLANNING_USER_TEMPLATE` gains `{action_pixel_history_block}` slot (empty default → byte-identical legacy prompt)
- Both render paths (legacy `_build_vision_user_content` + production `_sync_choice`) inject the block

## Test plan
- [x] `pytest tests/test_channels/test_program_synthesis/arc_agi3/ -q` → **391 passed (+6)**
- [x] `mypy --strict` on 4 touched source files → clean
- [x] `ruff check` + `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)