### PR TITLE
feat(pse): Sprint-19 Hebel T — first-time-action exploration bonus

### DIFF
--- a/src/cognithor/channels/program_synthesis/arc_agi3/plan_scorer.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/plan_scorer.py
@@ -111,6 +111,28 @@ def score_plan(
     with_reasoning = sum(1 for s in plan if s.reasoning.strip())
     reasoning = with_reasoning / n
 
+    # Sprint-19 Hebel T — exploration bonus for first-time-action.
+    # Run #28's 64-step bp35 episode used ACTION3/4/6/7 ~equally but
+    # never RESET. Plans whose first action has NEVER been recorded in
+    # this episode's memory get a +0.20 post-hoc additive bonus, so
+    # candidate plans that explore an unused action class can beat
+    # equally-quality plans that re-use already-tried actions on a
+    # thin diversity margin. ``available_action_names`` validates that
+    # the action is actually offered (don't reward made-up actions).
+    exploration_bonus = 0.0
+    first_action = plan[0].action_name
+    if (
+        memory is not None
+        and len(memory) > 0
+        and (not available_action_names or first_action in available_action_names)
+    ):
+        try:
+            seen_actions = {s.action_name for s in memory.window(80)}
+            if first_action not in seen_actions:
+                exploration_bonus = 0.20
+        except Exception:
+            pass
+
     # 6. Sprint-19 Hebel N — pixΔ-safety gate.
     #
     # Run #26c finding (motivation): the LLM queued plans whose first
@@ -163,7 +185,10 @@ def score_plan(
     # Diversity, targetedness, reasoning are additive quality
     # components averaged.
     additive_avg = (diversity + targetedness + reasoning) / 3.0
-    return additive_avg * validity * anti_repetition * pix_delta_safety
+    base = additive_avg * validity * anti_repetition * pix_delta_safety
+    # Sprint-19 Hebel T: post-hoc additive exploration boost; clamp
+    # to [0, 1] so the bonus never inflates beyond a legal score.
+    return min(1.0, base + exploration_bonus)
 
 
 def pick_best_plan(

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_plan_scorer.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_plan_scorer.py
@@ -148,12 +148,14 @@ class TestScorePlanComponents:
         m.append(grid=big_a, action_name="ACTION3", levels_completed=0)
         m.append(grid=big_b, action_name="ACTION6", levels_completed=0)
 
-        # Plan first action is COMPLETELY DIFFERENT from the last
-        # action (ACTION6) — so the single-action repeat trigger does
-        # NOT fire. The two-consecutive trigger MUST still apply.
+        # Plan first action differs from the last action (ACTION6) so
+        # the single-action repeat trigger does NOT fire. ACTION3 is
+        # already in memory so Hebel T's exploration bonus also does
+        # NOT fire — leaving the two-consecutive trigger as the only
+        # multiplicative delta.
         plan_other = [
-            PlanStep("ACTION7", data={"x": 5, "y": 5}, reasoning="r"),
             PlanStep("ACTION3", reasoning="r"),
+            PlanStep("ACTION7", data={"x": 5, "y": 5}, reasoning="r"),
         ]
         actions = ("ACTION3", "ACTION6", "ACTION7")
         s_other = score_plan(plan_other, memory=m, available_action_names=actions)
@@ -161,6 +163,60 @@ class TestScorePlanComponents:
         # inactive). The gate is the only multiplicative delta.
         s_baseline = score_plan(plan_other, available_action_names=actions)
         assert s_other == pytest.approx(s_baseline * 0.5, rel=1e-6)
+
+
+class TestExplorationBonus:
+    """Sprint-19 Hebel T — +0.20 additive bonus on plans whose first
+    action has never appeared in memory.
+    """
+
+    def test_first_time_action_gets_bonus(self) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[1]]), action_name="ACTION3", levels_completed=0)
+        m.append(grid=_g([[1]]), action_name="ACTION3", levels_completed=0)
+        m.append(grid=_g([[1]]), action_name="ACTION6", levels_completed=0)
+
+        # Use non-click actions on both sides so the targetedness
+        # component is identical and only the exploration bonus
+        # differentiates the scores. Plans intentionally include one
+        # step without reasoning so the base score is well below 1.0
+        # (bonus visible after the post-hoc additive boost is applied
+        # before the clamp).
+        actions = ("ACTION1", "ACTION3", "ACTION6")
+        plan_unused = [
+            PlanStep("ACTION1", reasoning="explore"),
+            PlanStep("ACTION3"),  # no reasoning → drags the reasoning component down
+        ]
+        plan_reused = [
+            PlanStep("ACTION3", reasoning="re-try"),
+            PlanStep("ACTION1"),  # no reasoning → identical structural delta
+        ]
+        s_unused = score_plan(plan_unused, memory=m, available_action_names=actions)
+        s_reused = score_plan(plan_reused, memory=m, available_action_names=actions)
+        # Unused-action plan must beat the reused-action plan, and the
+        # gap should be roughly the +0.20 bonus.
+        assert s_unused > s_reused
+        assert s_unused - s_reused >= 0.15
+
+    def test_already_used_action_gets_no_bonus(self) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[1]]), action_name="ACTION3", levels_completed=0)
+
+        actions = ("ACTION3", "ACTION6")
+        plan = [PlanStep("ACTION3", reasoning="re-try")]
+        s_with = score_plan(plan, memory=m, available_action_names=actions)
+        s_without = score_plan(plan, available_action_names=actions)
+        # Memory contains the action → no bonus; same score either way.
+        assert s_with == pytest.approx(s_without, rel=1e-6)
+
+    def test_no_bonus_when_action_not_in_available(self) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[1]]), action_name="ACTION3", levels_completed=0)
+        # ACTION99 not in available_action_names → validity=0 → score=0.
+        # Bonus does not apply because validity gate kills it first.
+        plan = [PlanStep("ACTION99", reasoning="r")]
+        s = score_plan(plan, memory=m, available_action_names=("ACTION3", "ACTION6"))
+        assert s == 0.0
 
 
 class TestPickBestPlan:


### PR DESCRIPTION
## Summary
Run #28 used ACTION3/4/6/7 ~equally over 64 steps but never RESET or any other available action class. The diversity score rewards *within-plan* diversity, not *cross-episode* novelty.

**Hebel T**: +0.20 post-hoc additive boost on plans whose first action has never been recorded in this episode's memory window (and is in `available_action_names`).

```
base  = ((diversity + targetedness + reasoning) / 3)
      × validity × anti_repetition × pix_delta_safety
score = min(1.0, base + reset_bonus + exploration_bonus)
```

## Test plan
- [x] `pytest tests/test_channels/test_program_synthesis/arc_agi3/ -q` → **388 passed (+3 dedicated Hebel T coverage)**
- [x] `mypy --strict` plan_scorer.py → clean
- [x] `ruff check` + `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)