### PR TITLE
feat(pse): Sprint-20 Hebel V — few-shot win-demo store + auto-record

### DIFF
--- a/scripts/sprint12_phase_a_validation.py
+++ b/scripts/sprint12_phase_a_validation.py
@@ -410,6 +410,18 @@ def _make_llm_vision(game_id: str, results_dir: Path) -> tuple[Any, str | None]:
     except RuntimeError as exc:
         print(f"  [llm_vision] vLLM init failed ({exc}); falling back to dsl_full")
         return _make_dsl_full(game_id, results_dir)
+    # Sprint-20 Hebel V: wire the per-game win-demo store. Empty until
+    # an episode actually wins something on this game; once non-empty,
+    # subsequent runs prompt-inject the recorded action sequence as a
+    # few-shot demonstration of WHAT WINS the game.
+    from cognithor.channels.program_synthesis.arc_agi3.win_demos import WinDemoStore
+
+    win_demo_root = (
+        Path("/mnt/d/Jarvis/jarvis complete v20/cognithor_bench/win_demos")
+        if Path("/mnt/d").exists()
+        else Path("cognithor_bench/win_demos")
+    )
+    win_demo_store = WinDemoStore(win_demo_root)
     agent = PlanningLLMReasoningAgent(
         choice_fn=choice_fn,
         audit_trail=trail,
@@ -419,6 +431,7 @@ def _make_llm_vision(game_id: str, results_dir: Path) -> tuple[Any, str | None]:
         fast_path_enabled=False,
         plan_horizon=5,
         telemetry=telemetry,
+        win_demo_store=win_demo_store,
     )
     agent.__dict__["_phase_a_trail"] = trail
     agent.__dict__["_phase_a_audit_path"] = audit_path

--- a/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
@@ -210,6 +210,23 @@ class Sprint10DSLAgent(CognithorPSEAgent):
             self._last_levels_seen is not None
             and latest_frame.levels_completed > self._last_levels_seen
         ):
+            # Sprint-20 Hebel V: persist the trajectory that led to the
+            # level-up BEFORE clearing memory. Future episodes on this
+            # game can then prompt-inject the action sequence as a
+            # few-shot demonstration. ``_win_demo_store`` is set by
+            # PlanningLLMReasoningAgent; missing on the heuristic agent
+            # → no-op via getattr default.
+            store = getattr(self, "_win_demo_store", None)
+            if store is not None:
+                try:
+                    store.record_level_up(
+                        game_id=getattr(latest_frame, "game_id", "") or "unknown",
+                        from_level=self._last_levels_seen,
+                        to_level=latest_frame.levels_completed,
+                        memory=self._memory,
+                    )
+                except Exception:
+                    pass
             self._memory.clear()
             self._state_counter.clear()
             self._state_graph = type(self._state_graph)()  # fresh graph

--- a/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/dsl_agent.py
@@ -218,15 +218,15 @@ class Sprint10DSLAgent(CognithorPSEAgent):
             # → no-op via getattr default.
             store = getattr(self, "_win_demo_store", None)
             if store is not None:
-                try:
+                import contextlib
+
+                with contextlib.suppress(Exception):
                     store.record_level_up(
                         game_id=getattr(latest_frame, "game_id", "") or "unknown",
                         from_level=self._last_levels_seen,
                         to_level=latest_frame.levels_completed,
                         memory=self._memory,
                     )
-                except Exception:
-                    pass
             self._memory.clear()
             self._state_counter.clear()
             self._state_graph = type(self._state_graph)()  # fresh graph

--- a/src/cognithor/channels/program_synthesis/arc_agi3/llm_action_decoder.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/llm_action_decoder.py
@@ -127,6 +127,11 @@ class FrameContext:
     # (avg) at a glance. Empty string disables the corresponding
     # prompt section.
     action_pixel_history: str = ""
+    # Sprint-20 Hebel V (few-shot win-demo): rendered text block of a
+    # previously-recorded successful episode's action sequence for
+    # this game family. Empty string when no win demo is known yet —
+    # legacy prompts stay byte-identical until at least one win lands.
+    win_demo_block: str = ""
 
 
 # A callable that takes a :class:`FrameContext` and returns

--- a/src/cognithor/channels/program_synthesis/arc_agi3/planning_agent.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/planning_agent.py
@@ -295,6 +295,7 @@ _VISION_PLANNING_USER_TEMPLATE = (
     "{delta_window}\n"
     "\n"
     "{action_pixel_history_block}"
+    "{win_demo_block}"
     "Available actions: {actions}\n"
     "Recent action sequence: {history}\n"
     "{effects_line}"
@@ -452,11 +453,20 @@ def _build_vision_user_content(
             steps=steps_at, level=ctx.levels_completed
         )
 
+    # Sprint-20 Hebel V: render the few-shot win-demo block when a
+    # winning trajectory exists for this game family. Empty string
+    # → byte-identical legacy prompt.
+    win_demo_block = ""
+    win_demo_text = getattr(ctx, "win_demo_block", "")
+    if win_demo_text:
+        win_demo_block = win_demo_text.rstrip() + "\n\n"
+
     text = _VISION_PLANNING_USER_TEMPLATE.format(
         prev_image_note=prev_image_note,
         cluster_summary=cluster_summary,
         delta_window=delta_window,
         action_pixel_history_block=action_pixel_history_block,
+        win_demo_block=win_demo_block,
         actions=", ".join(ctx.available_action_names),
         history=ctx.history_summary,
         effects_line=effects_line,
@@ -594,11 +604,15 @@ def build_inprocess_vllm_vision_planning_choice_fn(
             stalled_warning = _STALLED_WARNING_TEMPLATE.format(
                 steps=steps_at, level=ctx.levels_completed
             )
+        # Sprint-20 Hebel V: read the decoder-populated win-demo block.
+        win_demo_text = getattr(ctx, "win_demo_block", "")
+        win_demo_block = win_demo_text.rstrip() + "\n\n" if win_demo_text else ""
         text_after_image = _VISION_PLANNING_USER_TEMPLATE.format(
             prev_image_note=prev_image_note,
             cluster_summary=cluster_summary,
             delta_window=delta_window,
             action_pixel_history_block=action_pixel_history_block,
+            win_demo_block=win_demo_block,
             actions=", ".join(ctx.available_action_names),
             history=ctx.history_summary,
             effects_line=(
@@ -688,6 +702,7 @@ class PlanningLLMReasoningAgent(Sprint10DSLAgent):
         history_steps: int = 8,
         plan_horizon: int = 5,
         goal_inferer: GoalInferer | None = None,
+        win_demo_store: Any = None,
         **parent_kwargs: Any,
     ) -> None:
         super().__init__(
@@ -713,6 +728,7 @@ class PlanningLLMReasoningAgent(Sprint10DSLAgent):
             ActionStreakDetector,
         )
 
+        self._win_demo_store = win_demo_store
         self._decoder = PlanningLLMActionDecoder(
             bridge=self._bridge,
             memory=self._memory,
@@ -723,6 +739,7 @@ class PlanningLLMReasoningAgent(Sprint10DSLAgent):
             goal_inferer=goal_inferer,
             state_counter=self._state_counter,
             action_streak_detector=ActionStreakDetector(),
+            win_demo_store=win_demo_store,
         )
 
     @property

--- a/src/cognithor/channels/program_synthesis/arc_agi3/planning_decoder.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/planning_decoder.py
@@ -119,6 +119,7 @@ class PlanningLLMActionDecoder(ActionDecoder):
         goal_inferer: GoalInferer | None = None,
         state_counter: Any = None,
         action_streak_detector: Any = None,
+        win_demo_store: Any = None,
     ) -> None:
         if plan_horizon < 1:
             raise ValueError(f"plan_horizon must be >= 1, got {plan_horizon}")
@@ -137,6 +138,11 @@ class PlanningLLMActionDecoder(ActionDecoder):
         # single-step decoder caught this; planning decoder didn't).
         self._state_counter = state_counter
         self._action_streak_detector = action_streak_detector
+        # Sprint-20 Hebel V: optional win-demo store. When wired, the
+        # decoder renders a previously-recorded winning trajectory into
+        # the prompt as a few-shot demonstration of WHAT WINS the game
+        # — Sprint-19 hebels only taught what loses.
+        self._win_demo_store = win_demo_store
         self._state = _PlanState()
 
     @property
@@ -334,6 +340,21 @@ class PlanningLLMActionDecoder(ActionDecoder):
                 )
 
                 ctx_kwargs["action_pixel_history"] = summarise_action_pixel_history(self._memory)
+            except Exception:
+                pass
+        if "win_demo_block" in existing and self._win_demo_store is not None:
+            # Sprint-20 Hebel V: render a previously-recorded winning
+            # trajectory for this game family if any exist. Renders to
+            # empty string when the store has no records — preserves
+            # byte-identical legacy prompts in the cold-start regime.
+            try:
+                from cognithor.channels.program_synthesis.arc_agi3.win_demos import (
+                    render_win_demo,
+                )
+
+                game_id = getattr(latest_frame, "game_id", "")
+                if game_id:
+                    ctx_kwargs["win_demo_block"] = render_win_demo(self._win_demo_store, game_id)
             except Exception:
                 pass
         ctx = FrameContext(**ctx_kwargs)

--- a/src/cognithor/channels/program_synthesis/arc_agi3/win_demos.py
+++ b/src/cognithor/channels/program_synthesis/arc_agi3/win_demos.py
@@ -1,0 +1,234 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-20 Hebel V — few-shot win-demo store + render.
+
+Sprint-19 capped at score 0/9: Hebel P's persisted reasoning showed
+the LLM understands every safety hebel but doesn't know what *wins*
+bp35. Sprint-20's Track A teaches the win condition by demonstration:
+when a prior episode achieved ``levels_completed > 0``, persist the
+``(grid, action_name, levels_completed)`` sequence around the level
+transition into a per-game JSONL. The vision prompt then injects a
+short "this exact (state, action) sequence completed level N before"
+block so the LLM has a positive example to anchor on.
+
+Bootstrap concern: until at least one episode wins ANYTHING, the demo
+store is empty and the prompt block stays absent — byte-identical
+legacy prompt. The store fills naturally once any agent (Cognithor
+or external) lands a level on a given game.
+
+Storage format (one JSON object per line)::
+
+    {"game_id": "bp35", "from_level": 0, "to_level": 1,
+     "captured_at": "2026-05-04T14:30:00Z",
+     "trajectory": [
+       {"action": "ACTION3", "grid_csv": "...", "pix_delta": 12},
+       {"action": "ACTION6", "grid_csv": "...", "pix_delta": 24,
+        "data": {"x": 12, "y": 8}},
+       ...
+     ]}
+
+``grid_csv`` is the post-action grid serialised as a comma-separated
+string of 64×64 int8 values (compact + grep-friendly + fast to parse;
+binary alternatives like .npy create per-step files which are harder
+to manage at scale).
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    import numpy as np
+    from numpy.typing import NDArray
+
+    from cognithor.channels.program_synthesis.arc_agi3.episode_memory import (
+        EpisodeMemory,
+    )
+
+    _Grid = NDArray[np.int8]
+
+
+__all__ = [
+    "WinDemoStore",
+    "decode_grid_csv",
+    "encode_grid_csv",
+    "render_win_demo",
+]
+
+
+def encode_grid_csv(grid: _Grid) -> str:
+    """Serialise an ``int8`` grid to a comma-separated string.
+
+    Format: ``"<rows>x<cols>,<v0,0>,<v0,1>,...,<vR-1,C-1>"``. Round-trips
+    through :func:`decode_grid_csv`.
+    """
+    rows, cols = grid.shape
+    cells = ",".join(str(int(c)) for c in grid.flatten())
+    return f"{rows}x{cols},{cells}"
+
+
+def decode_grid_csv(s: str) -> _Grid:
+    """Inverse of :func:`encode_grid_csv`."""
+    import numpy as np
+
+    shape_part, _, cells_part = s.partition(",")
+    rows_s, _, cols_s = shape_part.partition("x")
+    rows, cols = int(rows_s), int(cols_s)
+    flat = [int(v) for v in cells_part.split(",")]
+    if len(flat) != rows * cols:
+        raise ValueError(f"decode_grid_csv: expected {rows * cols} cells, got {len(flat)}")
+    arr: _Grid = np.array(flat, dtype=np.int8).reshape(rows, cols)
+    return arr
+
+
+class WinDemoStore:
+    """Per-game JSONL store of winning trajectories.
+
+    Each :meth:`record_level_up` call appends a single trajectory
+    record to ``<root>/<game_id>.jsonl``. :meth:`load_recent` returns
+    the most-recent ``max_records`` trajectories for a game.
+
+    Empty / missing files are not errors — :meth:`load_recent` returns
+    ``[]`` so the prompt builder simply renders no demo block.
+    """
+
+    def __init__(self, root: Path | str) -> None:
+        self.root = Path(root)
+        self.root.mkdir(parents=True, exist_ok=True)
+
+    def _path(self, game_id: str) -> Path:
+        # Hebel V: keep filenames safe — only the prefix matters for
+        # game-family lookup, but persist the full id so ad-hoc tooling
+        # can correlate against scorecards.
+        safe = "".join(c if c.isalnum() or c in "-_" else "_" for c in game_id)
+        return self.root / f"{safe}.jsonl"
+
+    def record_level_up(
+        self,
+        *,
+        game_id: str,
+        from_level: int,
+        to_level: int,
+        memory: EpisodeMemory,
+        max_steps_back: int = 8,
+    ) -> None:
+        """Append the trajectory leading to a level-up.
+
+        The most-recent ``max_steps_back`` memory entries are captured
+        with their grids + action names + per-step pixΔ. Caller should
+        invoke this from the agent's level-transition handler.
+        """
+        import numpy as np
+
+        if to_level <= from_level:
+            return  # not a level-up; ignore so callers can be lazy
+        window = memory.window(max_steps_back + 1)  # +1 to compute pixΔ for oldest
+        if len(window) < 2:
+            return
+        # window is most-recent first; flip to chronological for the
+        # demo (LLMs read trajectories left-to-right)
+        chrono = list(reversed(window))
+        traj: list[dict[str, Any]] = []
+        for i in range(1, len(chrono)):
+            after = chrono[i]
+            before = chrono[i - 1]
+            pix = (
+                int(np.sum(before.grid != after.grid))
+                if before.grid.shape == after.grid.shape
+                else -1
+            )
+            traj.append(
+                {
+                    "action": after.action_name,
+                    "grid_csv": encode_grid_csv(after.grid),
+                    "pix_delta": pix,
+                }
+            )
+        record = {
+            "game_id": game_id,
+            "from_level": from_level,
+            "to_level": to_level,
+            "captured_at": _dt.datetime.now(_dt.UTC).isoformat(),
+            "trajectory": traj,
+        }
+        with self._path(game_id).open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record) + "\n")
+
+    def load_recent(
+        self,
+        game_id: str,
+        *,
+        max_records: int = 1,
+    ) -> list[dict[str, Any]]:
+        """Return up to ``max_records`` most-recent winning trajectories.
+
+        Empty / missing files return ``[]``. Records are returned in
+        most-recent-first order.
+        """
+        path = self._path(game_id)
+        if not path.exists():
+            return []
+        try:
+            lines = path.read_text(encoding="utf-8").strip().splitlines()
+        except OSError:
+            return []
+        records: list[dict[str, Any]] = []
+        for line in reversed(lines):
+            if not line.strip():
+                continue
+            try:
+                records.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+            if len(records) >= max_records:
+                break
+        return records
+
+
+def render_win_demo(
+    store: WinDemoStore,
+    game_id: str,
+    *,
+    max_records: int = 1,
+    max_steps_per_record: int = 6,
+) -> str:
+    """Render the most-recent winning trajectory for a game as prompt text.
+
+    Format::
+
+        Past winning trajectory (level 0 → 1, captured 2026-05-04):
+          step 1: ACTION3 (pixΔ=12)
+          step 2: ACTION6 (pixΔ=24)
+          step 3: ACTION3 (pixΔ=8)
+          ... (level-up here)
+
+    Empty store → ``""`` (caller can use ``if win_demo:`` to gate the
+    block in the template). The exact grid contents are intentionally
+    NOT included — the LLM has the *current* grid as an image; the
+    demo's value is the action *sequence*, not the historical pixels.
+    """
+    records = store.load_recent(game_id, max_records=max_records)
+    if not records:
+        return ""
+    parts: list[str] = []
+    for rec in records:
+        from_level = rec.get("from_level", 0)
+        to_level = rec.get("to_level", 1)
+        captured = rec.get("captured_at", "")
+        captured_short = captured.split("T", 1)[0] if "T" in captured else captured
+        traj = rec.get("trajectory", [])[-max_steps_per_record:]
+        header = (
+            f"Past winning trajectory (level {from_level} → {to_level}"
+            + (f", captured {captured_short}" if captured_short else "")
+            + "):"
+        )
+        lines = [header]
+        for i, step in enumerate(traj, start=1):
+            act = step.get("action", "?")
+            pix = step.get("pix_delta", "?")
+            lines.append(f"  step {i}: {act} (pixΔ={pix})")
+        lines.append("  ... (level-up here)")
+        parts.append("\n".join(lines))
+    return "\n\n".join(parts)

--- a/tests/test_channels/test_program_synthesis/arc_agi3/test_win_demos.py
+++ b/tests/test_channels/test_program_synthesis/arc_agi3/test_win_demos.py
@@ -1,0 +1,203 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-20 Hebel V — win-demo store tests."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from cognithor.channels.program_synthesis.arc_agi3.episode_memory import EpisodeMemory
+from cognithor.channels.program_synthesis.arc_agi3.win_demos import (
+    WinDemoStore,
+    decode_grid_csv,
+    encode_grid_csv,
+    render_win_demo,
+)
+from cognithor.channels.program_synthesis.integration.capability_tokens import (  # noqa: F401
+    PSECapability as _PSECapability,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _g(rows: list[list[int]]) -> np.ndarray:
+    return np.array(rows, dtype=np.int8)
+
+
+class TestEncodeDecodeRoundtrip:
+    def test_small_grid(self) -> None:
+        g = _g([[0, 1, 2], [3, 4, 5]])
+        s = encode_grid_csv(g)
+        assert s.startswith("2x3,")
+        back = decode_grid_csv(s)
+        assert np.array_equal(g, back)
+
+    def test_64x64(self) -> None:
+        rng = np.random.default_rng(42)
+        g = rng.integers(0, 16, size=(64, 64), dtype=np.int8)
+        back = decode_grid_csv(encode_grid_csv(g))
+        assert np.array_equal(g, back)
+
+    def test_decode_rejects_wrong_cell_count(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError, match="expected"):
+            decode_grid_csv("3x3,0,1,2")  # claims 9 cells, has 3
+
+
+class TestWinDemoStore:
+    def test_empty_store_returns_no_records(self, tmp_path: Path) -> None:
+        store = WinDemoStore(tmp_path)
+        assert store.load_recent("bp35") == []
+
+    def test_record_level_up_appends_trajectory(self, tmp_path: Path) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[0]]), action_name="ACTION1", levels_completed=0)
+        m.append(grid=_g([[1]]), action_name="ACTION3", levels_completed=0)
+        m.append(grid=_g([[2]]), action_name="ACTION6", levels_completed=1)
+
+        store = WinDemoStore(tmp_path)
+        store.record_level_up(
+            game_id="bp35",
+            from_level=0,
+            to_level=1,
+            memory=m,
+        )
+        records = store.load_recent("bp35")
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["game_id"] == "bp35"
+        assert rec["from_level"] == 0
+        assert rec["to_level"] == 1
+        # trajectory has the 2 step pairs (3 frames → 2 transitions)
+        assert len(rec["trajectory"]) == 2
+        # in chronological order, last action is the level-up
+        assert rec["trajectory"][-1]["action"] == "ACTION6"
+
+    def test_record_level_up_skips_when_no_progress(self, tmp_path: Path) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[0]]), action_name="ACTION1", levels_completed=0)
+        m.append(grid=_g([[1]]), action_name="ACTION3", levels_completed=0)
+
+        store = WinDemoStore(tmp_path)
+        # to_level == from_level: not a level-up; ignore.
+        store.record_level_up(
+            game_id="bp35",
+            from_level=0,
+            to_level=0,
+            memory=m,
+        )
+        assert store.load_recent("bp35") == []
+
+    def test_record_level_up_skips_when_memory_too_short(self, tmp_path: Path) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[0]]), action_name="ACTION1", levels_completed=0)
+
+        store = WinDemoStore(tmp_path)
+        store.record_level_up(
+            game_id="bp35",
+            from_level=0,
+            to_level=1,
+            memory=m,
+        )
+        # Only one frame → no transition to capture.
+        assert store.load_recent("bp35") == []
+
+    def test_load_recent_returns_most_recent_first(self, tmp_path: Path) -> None:
+        m1 = EpisodeMemory()
+        m1.append(grid=_g([[0]]), action_name="ACTION1", levels_completed=0)
+        m1.append(grid=_g([[1]]), action_name="ACTION3", levels_completed=1)
+        m2 = EpisodeMemory()
+        m2.append(grid=_g([[5]]), action_name="ACTION4", levels_completed=0)
+        m2.append(grid=_g([[6]]), action_name="ACTION6", levels_completed=1)
+
+        store = WinDemoStore(tmp_path)
+        store.record_level_up(game_id="bp35", from_level=0, to_level=1, memory=m1)
+        store.record_level_up(game_id="bp35", from_level=0, to_level=1, memory=m2)
+
+        records = store.load_recent("bp35", max_records=2)
+        # Most recent first → m2's ACTION6 wins
+        assert records[0]["trajectory"][-1]["action"] == "ACTION6"
+        assert records[1]["trajectory"][-1]["action"] == "ACTION3"
+
+    def test_per_game_isolation(self, tmp_path: Path) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[0]]), action_name="ACTION1", levels_completed=0)
+        m.append(grid=_g([[1]]), action_name="ACTION3", levels_completed=1)
+
+        store = WinDemoStore(tmp_path)
+        store.record_level_up(game_id="bp35", from_level=0, to_level=1, memory=m)
+        # Different game gets its own file → empty.
+        assert store.load_recent("ft09") == []
+        assert len(store.load_recent("bp35")) == 1
+
+    def test_jsonl_format_one_record_per_line(self, tmp_path: Path) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[0]]), action_name="ACTION1", levels_completed=0)
+        m.append(grid=_g([[1]]), action_name="ACTION3", levels_completed=1)
+
+        store = WinDemoStore(tmp_path)
+        store.record_level_up(game_id="bp35", from_level=0, to_level=1, memory=m)
+        store.record_level_up(game_id="bp35", from_level=0, to_level=1, memory=m)
+        path = tmp_path / "bp35.jsonl"
+        lines = path.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 2
+        for line in lines:
+            json.loads(line)  # round-trips
+
+
+class TestRenderWinDemo:
+    def test_empty_store_returns_empty_string(self, tmp_path: Path) -> None:
+        store = WinDemoStore(tmp_path)
+        assert render_win_demo(store, "bp35") == ""
+
+    def test_renders_trajectory_with_header(self, tmp_path: Path) -> None:
+        m = EpisodeMemory()
+        m.append(grid=_g([[0]]), action_name="ACTION1", levels_completed=0)
+        m.append(grid=_g([[1]]), action_name="ACTION3", levels_completed=0)
+        m.append(grid=_g([[2]]), action_name="ACTION6", levels_completed=1)
+
+        store = WinDemoStore(tmp_path)
+        store.record_level_up(game_id="bp35", from_level=0, to_level=1, memory=m)
+        out = render_win_demo(store, "bp35")
+        assert "Past winning trajectory (level 0 → 1" in out
+        assert "ACTION3" in out
+        assert "ACTION6" in out
+        # Final marker telling the LLM where the win happened
+        assert "level-up here" in out
+
+    def test_does_not_leak_grid_csv_into_prompt(self, tmp_path: Path) -> None:
+        """The demo's value is the action sequence, NOT the historical
+        pixels — the LLM already has the current grid as an image.
+        Including raw cell-level CSV would bloat the prompt.
+        """
+        m = EpisodeMemory()
+        m.append(grid=_g([[0]]), action_name="ACTION1", levels_completed=0)
+        m.append(grid=_g([[1]]), action_name="ACTION3", levels_completed=1)
+
+        store = WinDemoStore(tmp_path)
+        store.record_level_up(game_id="bp35", from_level=0, to_level=1, memory=m)
+        out = render_win_demo(store, "bp35")
+        assert "grid_csv" not in out
+        assert "1x1," not in out  # the encoded shape header
+
+    def test_caps_steps_per_record(self, tmp_path: Path) -> None:
+        m = EpisodeMemory()
+        for i in range(20):
+            m.append(grid=_g([[i % 4]]), action_name=f"ACTION{i % 4}", levels_completed=0)
+        m.append(grid=_g([[7]]), action_name="ACTION6", levels_completed=1)
+
+        store = WinDemoStore(tmp_path)
+        store.record_level_up(
+            game_id="bp35",
+            from_level=0,
+            to_level=1,
+            memory=m,
+            max_steps_back=20,
+        )
+        out = render_win_demo(store, "bp35", max_steps_per_record=4)
+        # 4 step lines + header + footer = 6 lines
+        assert sum(1 for line in out.splitlines() if line.strip().startswith("step ")) == 4


### PR DESCRIPTION
## Summary
Sprint-19 ended at 0/9 with Hebel P's persisted reasoning showing the LLM understands every safety hebel but doesn't know what *wins* bp35. **Hebel V** teaches the win condition by demonstration.

- New module `cognithor.channels.program_synthesis.arc_agi3.win_demos`: `WinDemoStore` (per-game JSONL append-only), `encode_grid_csv` / `decode_grid_csv`, `render_win_demo`.
- `FrameContext.win_demo_block: str = ""` (new optional field).
- `PlanningLLMActionDecoder` gets `win_demo_store` kwarg; populates `ctx.win_demo_block` from the store on every planning call.
- `Sprint10DSLAgent.choose_action` **auto-records** to the store on level-transition (before memory clear). Any future win — on any game — backfills the store without extra wiring.
- `_VISION_PLANNING_USER_TEMPLATE` gains `{win_demo_block}` slot. Both render paths inject the block.
- `PlanningLLMReasoningAgent.__init__` forwards `win_demo_store`. Driver's `_make_llm_vision` instantiates `cognithor_bench/win_demos/` (works on Windows + WSL).

**Bootstrap**: store starts empty → byte-identical legacy prompts. After the first level-up on any game, that trajectory becomes the few-shot anchor for every subsequent episode of that game family.

## Test plan
- [x] `pytest tests/test_channels/test_program_synthesis/arc_agi3/ -q` → **423 passed (+14 dedicated win_demos coverage)**
- [x] `mypy --strict` on touched source files → clean
- [x] `ruff check` + `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)