### PR TITLE
feat(integration): Sprint-22 Track A.2 — PSE tools as GREEN in Gatekeeper

### DIFF
--- a/src/cognithor/core/gatekeeper.py
+++ b/src/cognithor/core/gatekeeper.py
@@ -667,6 +667,15 @@ class Gatekeeper:
             # ARC-AGI-3 (read-only)
             "arc_status",
             "arc_replay",
+            # Sprint-22 Track A.2: Program Synthesis Engine.
+            # Pure-Python deterministic search over a typed DSL with a
+            # subprocess sandbox + capability tokens — no filesystem,
+            # network, or shell side effects. Cache + verifier are
+            # sealed inside the channel. All three calls are safe to
+            # auto-execute without user-confirm friction.
+            "pse_synthesize",
+            "pse_is_synthesizable",
+            "pse_status",
             # ATL (read-only)
             "atl_status",
             "atl_journal",

--- a/tests/test_core/test_gatekeeper.py
+++ b/tests/test_core/test_gatekeeper.py
@@ -138,6 +138,10 @@ class TestRiskClassification:
             "screenshot_desktop",
             "vault_list",
             "vault_search",
+            # Sprint-22 Track A.2: PSE tools (deterministic, sandboxed)
+            "pse_synthesize",
+            "pse_is_synthesizable",
+            "pse_status",
         ],
     )
     def test_green_tools_comprehensive(


### PR DESCRIPTION
## Summary
Track A (PR #337) registered the 3 PSE MCP tools but didn't add them to the Gatekeeper GREEN-list. Per `_classify_risk`'s `unknown tools default to ORANGE` policy, every PSE invocation would trigger user-confirm friction.

PSE engine properties: deterministic, sandboxed (subprocess + capability tokens K4), no FS/network/shell side-effects, cache + verifier sealed inside the channel, audit-trail integrated. → unambiguously safe to auto-execute.

This PR adds `pse_synthesize` / `pse_is_synthesizable` / `pse_status` to the GREEN-list.

## Test plan
- [x] 3 new entries in `test_green_tools_comprehensive` parametrize → **81 gatekeeper tests passing (+3)**
- [x] `ruff check` + `ruff format --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)