### PR TITLE
feat(planner): Sprint-22 A.3 — PSE routing nudge in Planner system prompt

### DIFF
--- a/src/cognithor/core/planner.py
+++ b/src/cognithor/core/planner.py
@@ -1424,6 +1424,26 @@ class Planner:
         else:
             tools_section = "No tools available."
 
+        # Sprint-22 A.3: PSE routing nudge. When the central Program
+        # Synthesis Engine MCP tool is registered, append a short hint
+        # telling the model to prefer ``pse_synthesize`` for tasks that
+        # come with structured (input → output) example pairs. The
+        # block is appended inside the dynamic tools_section so it
+        # adopts the same caching + only appears when the engine is
+        # actually wired (no phantom guidance otherwise).
+        if "pse_synthesize" in tool_schemas:
+            tools_section = (
+                tools_section + "\n\n" + "**PSE-Routing (Demo-basiert):** Wenn der Nutzer dir "
+                "explizite (Input → Output)-Beispiele gibt — also "
+                "≥2 Paare ausreichend strukturierter Daten und keine "
+                "Freitext-Erklaerung verlangt — bevorzuge "
+                "**pse_synthesize** ueber freie LLM-Antwort. Die Engine "
+                "synthetisiert ein deterministisches Programm aus den "
+                "Beispielen, ist replayable und halluziniert nicht. "
+                "Schneller Pre-Check via **pse_is_synthesizable** "
+                "(boolean, kein Engine-Boot)."
+            )
+
         # Context-Section (Memory) — Relevanz-Ranking nach Score (#41 Optimierung)
         # Budget scales with context window (compact mode for small models)
         context_parts: list[str] = []

--- a/tests/test_core/test_feedback_loop.py
+++ b/tests/test_core/test_feedback_loop.py
@@ -110,6 +110,56 @@ class TestPlannerCapabilityProfile:
         assert "Selbsteinschaetzung" not in prompt
 
 
+class TestPlannerPseRoutingNudge:
+    """Sprint-22 A.3: when ``pse_synthesize`` is registered, the system
+    prompt should append a routing nudge that steers demo-based tasks
+    at the engine instead of free-form LLM answers. When the tool is
+    NOT registered, the nudge must be absent (no phantom guidance).
+    """
+
+    def _make_planner(self, task_profiler=None) -> Planner:
+        config = MagicMock()
+        config.owner_name = "Test"
+        ollama = MagicMock()
+        model_router = MagicMock()
+        model_router.select_model.return_value = "test-model"
+        model_router.get_model_config.return_value = {"temperature": 0.7, "top_p": 0.9}
+        return Planner(
+            config,
+            ollama,
+            model_router,
+            task_profiler=task_profiler,
+        )
+
+    def test_pse_routing_nudge_present_when_tool_registered(self):
+        planner = self._make_planner()
+        wm = WorkingMemory(session_id="test")
+        prompt = planner._build_system_prompt(
+            working_memory=wm,
+            tool_schemas={
+                "pse_synthesize": {"description": "synthesize a program"},
+                "read_file": {"description": "read a file"},
+            },
+        )
+        assert "PSE-Routing" in prompt
+        assert "pse_synthesize" in prompt
+        assert "pse_is_synthesizable" in prompt
+
+    def test_pse_routing_nudge_absent_when_tool_not_registered(self):
+        planner = self._make_planner()
+        wm = WorkingMemory(session_id="test")
+        prompt = planner._build_system_prompt(
+            working_memory=wm,
+            tool_schemas={
+                "read_file": {"description": "read a file"},
+                "write_file": {"description": "write a file"},
+            },
+        )
+        assert "PSE-Routing" not in prompt
+        # And the rest of the prompt is intact (sanity check).
+        assert "read_file" in prompt
+
+
 # ── Reflector Tests ──────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary
Track A registered the PSE engine as MCP tools, A.2 marked them GREEN in the Gatekeeper — but the Planner had no concrete steer toward `pse_synthesize` over free-form LLM answers when the user gives demo-style examples. The LLM saw the tool listed but rarely picked it.

**A.3** closes the loop with a conditional system-prompt block in `Planner._build_system_prompt`: when `pse_synthesize` is in `tool_schemas` (engine wired AND gatekeeper hasn't disabled it), append a 5-line nudge:
- prefer `pse_synthesize` for ≥2 input/output demo pairs
- note: deterministic, replayable, hallucination-free
- use `pse_is_synthesizable` as cheap pre-check

Conditional plumbing matters — no phantom guidance when PSE is uninstalled.

## Test plan
- [x] `pytest tests/test_core/test_feedback_loop.py -v` → **12 passed (+2)**
- [x] `ruff check` + format check → clean

## Sprint-22 Cognithor-Runtime-Integration: 5/10 → 10/10
After this lands: Tools registered ✓, Gatekeeper GREEN ✓, Planner auto-routes ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)