### PR TITLE
feat(pse): Sprint-22 — JSONL cache persistence (Infrastruktur 9→10)

### DIFF
--- a/src/cognithor/channels/program_synthesis/integration/tactical_memory.py
+++ b/src/cognithor/channels/program_synthesis/integration/tactical_memory.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import hashlib
 import time
 from dataclasses import dataclass
-from typing import Protocol
+from typing import Any, Protocol
 
 from cognithor.channels.program_synthesis.core.types import (
     Budget,
@@ -114,10 +114,21 @@ class PSECache:
         *,
         dsl_version: str = DSL_VERSION,
         clock: _Clock = time,
+        persistence_path: str | None = None,
     ) -> None:
         self._dsl_version = dsl_version
         self._clock = clock
         self._entries: dict[str, CacheEntry] = {}
+        # Sprint-22: optional JSONL persistence so the cache survives
+        # process restarts. ``None`` keeps the legacy in-memory-only
+        # behaviour (every existing test stays byte-identical). When
+        # set, the cache loads existing entries on construction and
+        # appends every ``put`` to the JSONL. Stale entries (per
+        # ``_ttl_for``) are filtered at load time so a long-idle cache
+        # doesn't bloat memory with expired junk.
+        self._persistence_path = persistence_path
+        if persistence_path is not None:
+            self._load_from_disk()
 
     # -- Public API --------------------------------------------------
 
@@ -182,7 +193,7 @@ class PSECache:
             except Exception:
                 program_hash = None
         now = self._now()
-        self._entries[key] = CacheEntry(
+        entry = CacheEntry(
             spec_hash=spec.stable_hash(),
             dsl_version=self._dsl_version,
             program_source=program_source,
@@ -195,10 +206,25 @@ class PSECache:
             last_used_at=now,
             use_count=0,
         )
+        self._entries[key] = entry
+        if self._persistence_path is not None:
+            self._append_to_disk(key, entry)
 
     def clear(self) -> None:
         """Drop every entry."""
         self._entries.clear()
+        if self._persistence_path is not None:
+            # Truncate the JSONL too — calling clear() on an in-memory
+            # cache that's also persisted should not silently leave the
+            # next process to reload the wiped entries.
+            try:
+                from pathlib import Path
+
+                path = Path(self._persistence_path)
+                if path.exists():
+                    path.write_text("", encoding="utf-8")
+            except OSError:
+                pass
 
     def __len__(self) -> int:
         return len(self._entries)
@@ -212,6 +238,115 @@ class PSECache:
         # ``self._clock`` defaults to the ``time`` module; tests can
         # inject a fake whose ``.time()`` returns a fixed value.
         return float(self._clock.time())
+
+    # -- Persistence -------------------------------------------------
+
+    def _entry_to_jsonl(self, key: str, entry: CacheEntry) -> str:
+        """Serialise a (key, entry) pair as one JSONL line."""
+        import json
+
+        return json.dumps(
+            {
+                "key": key,
+                "spec_hash": entry.spec_hash,
+                "dsl_version": entry.dsl_version,
+                "program_source": entry.program_source,
+                "program_hash": entry.program_hash,
+                "status": entry.status.value,
+                "score": entry.score,
+                "confidence": entry.confidence,
+                "cost_seconds": entry.cost_seconds,
+                "created_at": entry.created_at,
+                "last_used_at": entry.last_used_at,
+                "use_count": entry.use_count,
+            }
+        )
+
+    def _entry_from_dict(self, data: dict[str, Any]) -> tuple[str, CacheEntry] | None:
+        """Reverse of :meth:`_entry_to_jsonl`. Returns ``None`` on schema
+        mismatch so a corrupt line doesn't break the whole cache load.
+        """
+        try:
+            key = str(data["key"])
+            entry = CacheEntry(
+                spec_hash=str(data["spec_hash"]),
+                dsl_version=str(data["dsl_version"]),
+                program_source=(
+                    str(data["program_source"]) if data.get("program_source") else None
+                ),
+                program_hash=str(data["program_hash"]) if data.get("program_hash") else None,
+                status=SynthesisStatus(str(data["status"])),
+                score=float(data["score"]),
+                confidence=float(data["confidence"]),
+                cost_seconds=float(data["cost_seconds"]),
+                created_at=float(data["created_at"]),
+                last_used_at=float(data["last_used_at"]),
+                use_count=int(data.get("use_count", 0)),
+            )
+        except (KeyError, ValueError, TypeError):
+            return None
+        return key, entry
+
+    def _append_to_disk(self, key: str, entry: CacheEntry) -> None:
+        """Append one entry to the JSONL. Best-effort — IO errors are
+        suppressed so the in-memory cache stays consistent even when
+        the disk is read-only.
+        """
+        if self._persistence_path is None:
+            return
+        try:
+            from pathlib import Path
+
+            path = Path(self._persistence_path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with path.open("a", encoding="utf-8") as fh:
+                fh.write(self._entry_to_jsonl(key, entry) + "\n")
+        except OSError:
+            pass
+
+    def _load_from_disk(self) -> None:
+        """Load entries from JSONL into ``self._entries``.
+
+        Filters out:
+        * Entries from a different ``dsl_version`` (silent invalidation
+          on DSL bump — same semantics as the live key derivation).
+        * Entries whose TTL has already elapsed.
+        * Lines that fail to parse (corrupt / partial writes).
+
+        Multiple JSONL lines with the same key keep only the LAST one
+        (chronological order — JSONL appends are time-ordered).
+        """
+        if self._persistence_path is None:
+            return
+        try:
+            import json
+            from pathlib import Path
+
+            path = Path(self._persistence_path)
+            if not path.exists():
+                return
+            now = self._now()
+            with path.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    parsed = self._entry_from_dict(data)
+                    if parsed is None:
+                        continue
+                    key, entry = parsed
+                    if entry.dsl_version != self._dsl_version:
+                        continue  # silent invalidation on DSL bump
+                    ttl = _ttl_for(entry.status)
+                    if ttl > 0 and now - entry.created_at > ttl:
+                        continue  # already expired
+                    self._entries[key] = entry  # later wins on dup
+        except OSError:
+            pass
 
 
 __all__ = [

--- a/src/cognithor/mcp/pse_tools.py
+++ b/src/cognithor/mcp/pse_tools.py
@@ -54,14 +54,39 @@ def _get_channel() -> ProgramSynthesisChannel:
     one instance per process (cache persistence + warm sandbox subprocess
     pool). Callers MUST treat the returned channel as read-only — concurrent
     callers serialise on the channel's internal locks.
+
+    Sprint-22: the cache is now JSONL-persistent at
+    ``~/.cognithor/pse_cache.jsonl`` so cross-session synthesise calls
+    benefit from prior runs. Persistence failures are non-fatal — the
+    channel falls back to the in-memory cache.
     """
     global _channel_singleton
     if _channel_singleton is None:
         from cognithor.channels.program_synthesis.integration.pge_adapter import (
             ProgramSynthesisChannel,
         )
+        from cognithor.channels.program_synthesis.integration.tactical_memory import (
+            PSECache,
+        )
 
-        _channel_singleton = ProgramSynthesisChannel(actor="mcp_tool@cognithor")
+        cache: PSECache | None = None
+        try:
+            from pathlib import Path
+
+            cache_path = Path.home() / ".cognithor" / "pse_cache.jsonl"
+            cache = PSECache(persistence_path=str(cache_path))
+            log.info(
+                "pse.cache_persistent",
+                path=str(cache_path),
+                entries=len(cache),
+            )
+        except Exception as exc:  # pragma: no cover — defensive
+            log.warning("pse.cache_persistence_disabled", error=str(exc))
+
+        _channel_singleton = ProgramSynthesisChannel(
+            actor="mcp_tool@cognithor",
+            cache=cache,
+        )
         log.info("pse.channel_initialised")
     return _channel_singleton
 

--- a/tests/test_channels/test_program_synthesis/unit/test_tactical_memory.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_tactical_memory.py
@@ -278,3 +278,93 @@ class TestCacheUtilities:
         cache = PSECache()
         assert (123 in cache) is False
         assert (None in cache) is False
+
+
+# ---------------------------------------------------------------------------
+# Sprint-22 — JSONL persistence
+# ---------------------------------------------------------------------------
+
+
+class TestCachePersistence:
+    """JSONL persistence: cache survives process restart, stale entries
+    get filtered at load, DSL-version bump silently invalidates everything.
+    """
+
+    def test_no_persistence_path_keeps_legacy_in_memory_only(self, tmp_path: object) -> None:
+        # Default constructor: no path → no JSONL written, no load.
+        cache = PSECache()
+        cache.put(_spec(), Budget(), _ok_result())
+        assert len(cache) == 1
+        # Re-construct → empty.
+        cache2 = PSECache()
+        assert len(cache2) == 0
+
+    def test_put_appends_to_jsonl_and_load_restores(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        path = tmp_path / "pse_cache.jsonl"
+        cache_a = PSECache(persistence_path=str(path))
+        cache_a.put(_spec(), Budget(), _ok_result())
+        # File should exist with one JSONL line.
+        assert path.exists()
+        assert path.read_text().strip().count("\n") == 0  # exactly one line, no extra
+        # Re-construct → should reload that one entry.
+        cache_b = PSECache(persistence_path=str(path))
+        assert len(cache_b) == 1
+        # And a fresh get returns a refreshed entry (proves the load
+        # actually populated _entries with the right key).
+        entry = cache_b.get(_spec(), Budget())
+        assert entry is not None
+        assert entry.status == SynthesisStatus.SUCCESS
+
+    def test_clear_truncates_jsonl(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        path = tmp_path / "pse_cache.jsonl"
+        cache = PSECache(persistence_path=str(path))
+        cache.put(_spec(), Budget(), _ok_result())
+        assert path.read_text().strip() != ""
+        cache.clear()
+        assert path.read_text() == ""
+        # And a fresh load also sees nothing.
+        cache_reload = PSECache(persistence_path=str(path))
+        assert len(cache_reload) == 0
+
+    def test_load_filters_expired_entries(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        path = tmp_path / "pse_cache.jsonl"
+        # Write the entry with a clock at t=0.
+        clock_old = _FakeClock(t=0.0)
+        cache_old = PSECache(persistence_path=str(path), clock=clock_old)
+        cache_old.put(_spec(), Budget(), _ok_result())
+        # SUCCESS entry's TTL is 30 days = 2_592_000s. Re-load with a
+        # clock at t=2_600_000 (older than TTL) → should be dropped.
+        clock_future = _FakeClock(t=2_600_000.0)
+        cache_reload = PSECache(persistence_path=str(path), clock=clock_future)
+        assert len(cache_reload) == 0
+
+    def test_load_filters_dsl_version_mismatch(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        path = tmp_path / "pse_cache.jsonl"
+        cache_v1 = PSECache(persistence_path=str(path), dsl_version="1.0.0")
+        cache_v1.put(_spec(), Budget(), _ok_result())
+        # New DSL version → silent invalidation.
+        cache_v2 = PSECache(persistence_path=str(path), dsl_version="2.0.0")
+        assert len(cache_v2) == 0
+
+    def test_load_skips_corrupt_lines(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        path = tmp_path / "pse_cache.jsonl"
+        # Write valid entry first via the cache so the schema matches.
+        cache_a = PSECache(persistence_path=str(path))
+        cache_a.put(_spec(), Budget(), _ok_result())
+        # Append corrupt + partial JSON to the JSONL.
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write("not valid json\n")
+            fh.write('{"key": "x"}\n')  # missing required fields
+            fh.write('{"key": "y", "spec_hash": "abc"}\n')  # also incomplete
+        # Re-load: should still have the original entry, ignore corrupt rows.
+        cache_b = PSECache(persistence_path=str(path))
+        assert len(cache_b) == 1
+
+    def test_duplicate_keys_keep_latest(self, tmp_path) -> None:  # type: ignore[no-untyped-def]
+        path = tmp_path / "pse_cache.jsonl"
+        cache_a = PSECache(persistence_path=str(path))
+        cache_a.put(_spec(), Budget(), _ok_result())
+        # Same key → JSONL gets a second line; later overwrites first.
+        cache_a.put(_spec(), Budget(), _ok_result())
+        cache_b = PSECache(persistence_path=str(path))
+        assert len(cache_b) == 1  # de-dup'd at load


### PR DESCRIPTION
## Summary
PSE Infrastruktur was rated 9/10 because the synthesis cache was in-memory-only — every process restart wiped accumulated results, zero cross-session benefit.

**This PR** adds opt-in JSONL persistence to `PSECache`:
- New `persistence_path` constructor kwarg → `__init__` loads from disk, `put` appends
- Load filters: TTL-stale dropped, DSL-version-mismatched silently invalidated, corrupt JSON lines skipped, duplicate keys keep latest
- `clear()` also truncates disk JSONL (no silent undo on next boot)
- Default `None` keeps legacy in-memory-only behaviour

## Production wiring
`mcp.pse_tools._get_channel` now instantiates the singleton with `persistence_path = ~/.cognithor/pse_cache.jsonl` so the MCP-tool path benefits automatically.

## Test plan
- [x] `pytest tests/test_channels/test_program_synthesis/unit/test_tactical_memory.py tests/test_mcp/test_pse_tools.py -q` → **47 passed (+7 dedicated persistence coverage)**
- [x] `mypy --strict` on tactical_memory.py → clean
- [x] `ruff check` + format check → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)