### PR TITLE
feat(pse): Sprint-22 Track B PR#2 — Regex/Pattern-DSL family

### DIFF
--- a/docs/channels/program_synthesis/benchmarks.md
+++ b/docs/channels/program_synthesis/benchmarks.md
@@ -64,7 +64,7 @@ pre-conditions for the success threshold above.
 
 | Metric | Value |
 |---|---|
-| Base primitives | **90** (56 base + 5 Phase-1.5 higher-order + 5 Sprint-8 object-level + 10 Sprint-10 + 14 Sprint-22 String-DSL) |
+| Base primitives | **104** (56 base + 5 Phase-1.5 higher-order + 5 Sprint-8 object-level + 10 Sprint-10 + 14 Sprint-22 String-DSL + 14 Sprint-22 Regex/Pattern-DSL) |
 | Predicate constructors | **13** (10 leaf + 3 combinators) |
 | Lambda constructors | **4** (`identity`, `recolor`, `shift`, `branch`) |
 | Higher-order primitives | **5** (`map_objects`, `filter_objects`, `align_to`, `sort_objects`, `branch`) |

--- a/docs/channels/program_synthesis/dsl_reference.md
+++ b/docs/channels/program_synthesis/dsl_reference.md
@@ -2,7 +2,7 @@
 
 _Auto-generated. PSE version `1.2.0`, DSL version `1.2.0`._
 
-**90 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
+**104 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
 
 Run `cognithor pse dsl describe <name>` for any primitive to see its full record (signature + cost + description + examples).
 
@@ -124,13 +124,27 @@ Run `cognithor pse dsl describe <name>` for any primitive to see its full record
 | Name | Signature | Cost | Description |
 |---|---|---|---|
 | `string_capitalize` | `(String) → String` | 1.00 | Return the string with the first char uppercased and rest lowercased. |
+| `string_collapse_spaces` | `(String) → String` | 1.00 | Replace any run of whitespace with a single space (no leading/trailing strip). |
+| `string_extract_email` | `(String) → String` | 1.00 | Return the first email-like token (\S+@\S+\.\S+) or '' if none. |
+| `string_extract_url` | `(String) → String` | 1.00 | Return the first http(s):// URL-like token, or '' if none. |
+| `string_first_digit_run` | `(String) → String` | 1.00 | Return the first contiguous run of digit characters, or '' if none. |
 | `string_first_word` | `(String) → String` | 1.00 | Return the first whitespace-delimited word, or '' for an empty input. |
 | `string_identity` | `(String) → String` | 0.00 | Return the string unchanged. Useful as a no-op leaf. |
 | `string_join_comma` | `(StringList) → String` | 1.00 | Join a list of strings with comma+space. |
 | `string_join_space` | `(StringList) → String` | 1.00 | Join a list of strings with single spaces. |
+| `string_keep_alphanumeric` | `(String) → String` | 1.00 | Return only the letters and digits of the string, in original order. |
+| `string_keep_digits` | `(String) → String` | 1.00 | Return only the digit characters of the string, in original order. |
+| `string_keep_letters` | `(String) → String` | 1.00 | Return only the alphabetic characters of the string, in original order. |
+| `string_last_digit_run` | `(String) → String` | 1.00 | Return the last contiguous run of digit characters, or '' if none. |
 | `string_last_word` | `(String) → String` | 1.00 | Return the last whitespace-delimited word, or '' for an empty input. |
 | `string_lower` | `(String) → String` | 1.00 | Return the string in all-lowercase. |
+| `string_remove_digits` | `(String) → String` | 1.00 | Return the string with every digit character removed. |
+| `string_remove_letters` | `(String) → String` | 1.00 | Return the string with every alphabetic character removed. |
+| `string_remove_punctuation` | `(String) → String` | 1.00 | Return the string with every non-alphanumeric, non-whitespace character removed. |
+| `string_remove_spaces` | `(String) → String` | 1.00 | Return the string with every whitespace character removed. |
 | `string_replace_dash_with_space` | `(String) → String` | 1.00 | Replace every '-' with a space. Common in slug → title transforms. |
+| `string_replace_space_with_dash` | `(String) → String` | 1.00 | Replace every space with a '-'. Title → slug. |
+| `string_replace_space_with_underscore` | `(String) → String` | 1.00 | Replace every space with a '_'. Title → snake_case. |
 | `string_replace_underscore_with_space` | `(String) → String` | 1.00 | Replace every '_' with a space. snake_case → words. |
 | `string_reverse` | `(String) → String` | 1.00 | Return the string with characters in reverse order. |
 | `string_strip` | `(String) → String` | 1.00 | Return the string with leading/trailing whitespace removed. |

--- a/src/cognithor/channels/program_synthesis/dsl/__init__.py
+++ b/src/cognithor/channels/program_synthesis/dsl/__init__.py
@@ -12,6 +12,11 @@ from __future__ import annotations
 # from being flagged as unused.
 from cognithor.channels.program_synthesis.dsl import primitives as primitives
 
+# Sprint-22 — Regex/Pattern-DSL family. Layered on top of the String family
+# with character-class filters, run extraction, pattern extraction (email /
+# URL), and slug rewrites.
+from cognithor.channels.program_synthesis.dsl import regex_primitives as regex_primitives
+
 # Sprint-22 — String-DSL family. Same import-side-effect pattern: pulling
 # the module triggers ``@primitive`` decoration on every string primitive,
 # which adds them to the singleton REGISTRY. Type filtering at search time
@@ -29,5 +34,6 @@ __all__ = [
     "ObjectSet",
     "Signature",
     "primitives",
+    "regex_primitives",
     "string_primitives",
 ]

--- a/src/cognithor/channels/program_synthesis/dsl/regex_primitives.py
+++ b/src/cognithor/channels/program_synthesis/dsl/regex_primitives.py
@@ -1,0 +1,283 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-22 — Regex/Pattern-DSL primitive family.
+
+PR#2 of Track B. Builds on the String-DSL groundwork in
+``string_primitives.py`` by adding pattern-matching, character-class
+filtering, and slug-style transforms — the operations FlashFill /
+ProgramFilter literature calls "extract", "filter", and "rewrite by
+character class". These cover most of the real-world data-cleaning
+gap that pure case/split/replace primitives leave open:
+
+* "Pull just the digits out of an order ID."
+* "Drop the punctuation."
+* "Find the first email in a free-text comment."
+
+Design constraints carried over from the grid + string families:
+
+* Pure functions — no IO, no globals, no random.
+* Total domains — empty / no-match returns ``""`` rather than
+  raising, so the executor sandbox keeps the candidate alive but
+  the verifier prunes it.
+* Deterministic — same inputs → same outputs.
+* Constants baked into the primitive name — there's no
+  parameterised ``regex(pattern)`` because that would explode the
+  search space. Instead each common need gets its own pre-baked
+  primitive (``string_keep_digits``, ``string_first_digit_run``,
+  …) — same trick the grid family uses for ``rotate90`` /
+  ``rotate180``.
+
+The 14 primitives below cover six axes:
+
+* **Character-class filter (keep)**: ``string_keep_digits``,
+  ``string_keep_letters``, ``string_keep_alphanumeric``.
+* **Character-class filter (remove)**: ``string_remove_digits``,
+  ``string_remove_letters``, ``string_remove_punctuation``,
+  ``string_remove_spaces``.
+* **Whitespace normalisation**: ``string_collapse_spaces``.
+* **Run extraction**: ``string_first_digit_run``,
+  ``string_last_digit_run``.
+* **Pattern extraction**: ``string_extract_email``,
+  ``string_extract_url``.
+* **Slug rewrites**: ``string_replace_space_with_dash``,
+  ``string_replace_space_with_underscore``.
+
+The email and URL regexes are intentionally simple — RFC-correct
+matching is not the goal; ``\\S+@\\S+\\.\\S+`` and ``https?://\\S+``
+are good enough for the FlashFill-style demo tasks the engine
+solves.
+"""
+
+from __future__ import annotations
+
+import re
+
+from cognithor.channels.program_synthesis.dsl.registry import primitive
+from cognithor.channels.program_synthesis.dsl.signatures import Signature
+
+_DIGITS_RUN = re.compile(r"\d+")
+_EMAIL = re.compile(r"\S+@\S+\.\S+")
+_URL = re.compile(r"https?://\S+")
+_PUNCT = re.compile(r"[^\w\s]", re.UNICODE)
+_SPACE_RUN = re.compile(r"\s+")
+
+
+# ---------------------------------------------------------------------------
+# Character-class filter — keep
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="string_keep_digits",
+    signature=Signature(("String",), "String"),
+    cost=1.0,
+    description="Return only the digit characters of the string, in original order.",
+)
+def string_keep_digits(s: str) -> str:
+    if not isinstance(s, str):
+        raise TypeError(f"string_keep_digits expected str, got {type(s).__name__}")
+    return "".join(ch for ch in s if ch.isdigit())
+
+
+@primitive(
+    name="string_keep_letters",
+    signature=Signature(("String",), "String"),
+    cost=1.0,
+    description="Return only the alphabetic characters of the string, in original order.",
+)
+def string_keep_letters(s: str) -> str:
+    if not isinstance(s, str):
+        raise TypeError(f"string_keep_letters expected str, got {type(s).__name__}")
+    return "".join(ch for ch in s if ch.isalpha())
+
+
+@primitive(
+    name="string_keep_alphanumeric",
+    signature=Signature(("String",), "String"),
+    cost=1.0,
+    description="Return only the letters and digits of the string, in original order.",
+)
+def string_keep_alphanumeric(s: str) -> str:
+    if not isinstance(s, str):
+        raise TypeError(f"string_keep_alphanumeric expected str, got {type(s).__name__}")
+    return "".join(ch for ch in s if ch.isalnum())
+
+
+# ---------------------------------------------------------------------------
+# Character-class filter — remove
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="string_remove_digits",
+    signature=Signature(("String",), "String"),
+    cost=1.0,
+    description="Return the string with every digit character removed.",
+)
+def string_remove_digits(s: str) -> str:
+    if not isinstance(s, str):
+        raise TypeError(f"string_remove_digits expected str, got {type(s).__name__}")
+    return "".join(ch for ch in s if not ch.isdigit())
+
+
+@primitive(
+    name="string_remove_letters",
+    signature=Signature(("String",), "String"),
+    cost=1.0,
+    description="Return the string with every alphabetic character removed.",
+)
+def string_remove_letters(s: str) -> str:
+    if not isinstance(s, str):
+        raise TypeError(f"string_remove_letters expected str, got {type(s).__name__}")
+    return "".join(ch for ch in s if not ch.isalpha())
+
+
+@primitive(
+    name="string_remove_punctuation",
+    signature=Signature(("String",), "String"),
+    cost=1.0,
+    description="Return the string with every non-alphanumeric, non-whitespace character removed.",
+)
+def string_remove_punctuation(s: str) -> str:
+    if not isinstance(s, str):
+        raise TypeError(f"string_remove_punctuation expected str, got {type(s).__name__}")
+    return _PUNCT.sub("", s)
+
+
+@primitive(
+    name="string_remove_spaces",
+    signature=Signature(("String",), "String"),
+    cost=1.0,
+    description="Return the string with every whitespace character removed.",
+)
+def string_remove_spaces(s: str) -> str:
+    if not isinstance(s, str):
+        raise TypeError(f"string_remove_spaces expected str, got {type(s).__name__}")
+    return "".join(ch for ch in s if not ch.isspace())
+
+
+# ---------------------------------------------------------------------------
+# Whitespace normalisation
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="string_collapse_spaces",
+    signature=Signature(("String",), "String"),
+    cost=1.0,
+    description="Replace any run of whitespace with a single space (no leading/trailing strip).",
+)
+def string_collapse_spaces(s: str) -> str:
+    if not isinstance(s, str):
+        raise TypeError(f"string_collapse_spaces expected str, got {type(s).__name__}")
+    return _SPACE_RUN.sub(" ", s)
+
+
+# ---------------------------------------------------------------------------
+# Run extraction (digits)
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="string_first_digit_run",
+    signature=Signature(("String",), "String"),
+    cost=1.0,
+    description="Return the first contiguous run of digit characters, or '' if none.",
+)
+def string_first_digit_run(s: str) -> str:
+    if not isinstance(s, str):
+        raise TypeError(f"string_first_digit_run expected str, got {type(s).__name__}")
+    match = _DIGITS_RUN.search(s)
+    return match.group(0) if match else ""
+
+
+@primitive(
+    name="string_last_digit_run",
+    signature=Signature(("String",), "String"),
+    cost=1.0,
+    description="Return the last contiguous run of digit characters, or '' if none.",
+)
+def string_last_digit_run(s: str) -> str:
+    if not isinstance(s, str):
+        raise TypeError(f"string_last_digit_run expected str, got {type(s).__name__}")
+    matches = _DIGITS_RUN.findall(s)
+    return matches[-1] if matches else ""
+
+
+# ---------------------------------------------------------------------------
+# Pattern extraction (free-text → first match or '')
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="string_extract_email",
+    signature=Signature(("String",), "String"),
+    cost=1.0,
+    description="Return the first email-like token (\\S+@\\S+\\.\\S+) or '' if none.",
+)
+def string_extract_email(s: str) -> str:
+    if not isinstance(s, str):
+        raise TypeError(f"string_extract_email expected str, got {type(s).__name__}")
+    match = _EMAIL.search(s)
+    return match.group(0) if match else ""
+
+
+@primitive(
+    name="string_extract_url",
+    signature=Signature(("String",), "String"),
+    cost=1.0,
+    description="Return the first http(s):// URL-like token, or '' if none.",
+)
+def string_extract_url(s: str) -> str:
+    if not isinstance(s, str):
+        raise TypeError(f"string_extract_url expected str, got {type(s).__name__}")
+    match = _URL.search(s)
+    return match.group(0) if match else ""
+
+
+# ---------------------------------------------------------------------------
+# Slug rewrites (space → separator)
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="string_replace_space_with_dash",
+    signature=Signature(("String",), "String"),
+    cost=1.0,
+    description="Replace every space with a '-'. Title → slug.",
+)
+def string_replace_space_with_dash(s: str) -> str:
+    if not isinstance(s, str):
+        raise TypeError(f"string_replace_space_with_dash expected str, got {type(s).__name__}")
+    return s.replace(" ", "-")
+
+
+@primitive(
+    name="string_replace_space_with_underscore",
+    signature=Signature(("String",), "String"),
+    cost=1.0,
+    description="Replace every space with a '_'. Title → snake_case.",
+)
+def string_replace_space_with_underscore(s: str) -> str:
+    if not isinstance(s, str):
+        raise TypeError(
+            f"string_replace_space_with_underscore expected str, got {type(s).__name__}"
+        )
+    return s.replace(" ", "_")
+
+
+__all__ = [
+    "string_collapse_spaces",
+    "string_extract_email",
+    "string_extract_url",
+    "string_first_digit_run",
+    "string_keep_alphanumeric",
+    "string_keep_digits",
+    "string_keep_letters",
+    "string_last_digit_run",
+    "string_remove_digits",
+    "string_remove_letters",
+    "string_remove_punctuation",
+    "string_remove_spaces",
+    "string_replace_space_with_dash",
+    "string_replace_space_with_underscore",
+]

--- a/tests/test_channels/test_program_synthesis/unit/test_regex_primitives.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_regex_primitives.py
@@ -1,0 +1,205 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-22 Track B PR#2 — Regex/Pattern-DSL family tests."""
+
+from __future__ import annotations
+
+from cognithor.channels.program_synthesis.core.types import (
+    Budget,
+    SynthesisStatus,
+    TaskSpec,
+)
+from cognithor.channels.program_synthesis.dsl import regex_primitives as rp
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+from cognithor.channels.program_synthesis.integration.pge_adapter import (
+    ProgramSynthesisChannel,
+    SynthesisRequest,
+)
+
+# ---------------------------------------------------------------------------
+# Pure-function unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestRegexPrimitivesPureKeep:
+    def test_keep_digits(self) -> None:
+        assert rp.string_keep_digits("abc123def456") == "123456"
+        assert rp.string_keep_digits("no-digits") == ""
+
+    def test_keep_letters(self) -> None:
+        assert rp.string_keep_letters("a1b2c3") == "abc"
+        assert rp.string_keep_letters("12345") == ""
+
+    def test_keep_alphanumeric(self) -> None:
+        assert rp.string_keep_alphanumeric("hello, world! 123") == "helloworld123"
+        assert rp.string_keep_alphanumeric("@@@!!!") == ""
+
+
+class TestRegexPrimitivesPureRemove:
+    def test_remove_digits(self) -> None:
+        assert rp.string_remove_digits("abc123def") == "abcdef"
+
+    def test_remove_letters(self) -> None:
+        assert rp.string_remove_letters("a1b2c3") == "123"
+
+    def test_remove_punctuation(self) -> None:
+        assert rp.string_remove_punctuation("hello, world!") == "hello world"
+        assert rp.string_remove_punctuation("a.b,c;d") == "abcd"
+
+    def test_remove_spaces(self) -> None:
+        assert rp.string_remove_spaces("a b c\td\ne") == "abcde"
+
+
+class TestRegexPrimitivesPureNormalise:
+    def test_collapse_spaces(self) -> None:
+        assert rp.string_collapse_spaces("a   b\t\tc") == "a b c"
+        assert rp.string_collapse_spaces("  trailing  ") == " trailing "
+
+
+class TestRegexPrimitivesPureRunExtract:
+    def test_first_digit_run(self) -> None:
+        assert rp.string_first_digit_run("abc123def456") == "123"
+        assert rp.string_first_digit_run("no-digits") == ""
+
+    def test_last_digit_run(self) -> None:
+        assert rp.string_last_digit_run("abc123def456") == "456"
+        assert rp.string_last_digit_run("no-digits") == ""
+
+
+class TestRegexPrimitivesPurePatternExtract:
+    def test_extract_email(self) -> None:
+        assert rp.string_extract_email("contact me at foo@example.com please") == "foo@example.com"
+        assert rp.string_extract_email("no email here") == ""
+
+    def test_extract_url(self) -> None:
+        assert rp.string_extract_url("see https://cognithor.ai for docs") == "https://cognithor.ai"
+        assert rp.string_extract_url("see http://x.io now") == "http://x.io"
+        assert rp.string_extract_url("no link here") == ""
+
+
+class TestRegexPrimitivesPureSlug:
+    def test_replace_space_with_dash(self) -> None:
+        assert rp.string_replace_space_with_dash("hello world foo") == "hello-world-foo"
+
+    def test_replace_space_with_underscore(self) -> None:
+        assert rp.string_replace_space_with_underscore("foo bar baz") == "foo_bar_baz"
+
+
+class TestRegexPrimitivesTypeChecking:
+    """Every primitive raises TypeError on non-str input so the executor
+    sandbox marks the candidate as failed and the search engine prunes
+    it instead of blowing up."""
+
+    def test_keep_digits_rejects_non_str(self) -> None:
+        import pytest
+
+        with pytest.raises(TypeError):
+            rp.string_keep_digits(123)  # type: ignore[arg-type]
+
+    def test_extract_email_rejects_non_str(self) -> None:
+        import pytest
+
+        with pytest.raises(TypeError):
+            rp.string_extract_email(["a@b.com"])  # type: ignore[arg-type]
+
+
+class TestRegexPrimitivesRegistration:
+    """All 14 regex primitives are registered with the singleton REGISTRY
+    on package import."""
+
+    def test_all_14_are_registered(self) -> None:
+        registered = {p.name for p in REGISTRY.all_primitives()}
+        expected = {
+            "string_keep_digits",
+            "string_keep_letters",
+            "string_keep_alphanumeric",
+            "string_remove_digits",
+            "string_remove_letters",
+            "string_remove_punctuation",
+            "string_remove_spaces",
+            "string_collapse_spaces",
+            "string_first_digit_run",
+            "string_last_digit_run",
+            "string_extract_email",
+            "string_extract_url",
+            "string_replace_space_with_dash",
+            "string_replace_space_with_underscore",
+        }
+        assert expected.issubset(registered)
+
+    def test_signatures_use_string_type_tag(self) -> None:
+        spec = REGISTRY.get("string_keep_digits")
+        assert spec.signature.inputs == ("String",)
+        assert spec.signature.output == "String"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end synthesis tests
+# ---------------------------------------------------------------------------
+
+
+def _synthesize(examples: tuple[tuple[str, str], ...]) -> object:
+    """Helper: run the channel against a small string-string spec."""
+    ch = ProgramSynthesisChannel(actor="regex-test")
+    spec = TaskSpec(examples=examples)
+    return ch.synthesize(
+        SynthesisRequest(
+            spec=spec,
+            budget=Budget(max_depth=3, wall_clock_seconds=5.0, cache_lookup=False),
+        )
+    )
+
+
+class TestRegexSynthesisEndToEnd:
+    """The engine synthesises real programs over the regex family."""
+
+    def test_synth_keep_digits(self) -> None:
+        result = _synthesize(
+            (
+                ("abc123", "123"),
+                ("x9y8z", "98"),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "string_keep_digits" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_remove_punctuation(self) -> None:
+        result = _synthesize(
+            (
+                ("hello, world!", "hello world"),
+                ("a.b,c", "abc"),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        # Either remove_punctuation or some equivalent — accept any program
+        # that produces the right output. Engine may pick a cheaper path.
+        assert result.program is not None  # type: ignore[attr-defined]
+
+    def test_synth_first_digit_run(self) -> None:
+        result = _synthesize(
+            (
+                ("order-123-abc-456", "123"),
+                ("x9y8", "9"),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "string_first_digit_run" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_replace_space_with_dash(self) -> None:
+        result = _synthesize(
+            (
+                ("hello world", "hello-world"),
+                ("foo bar baz", "foo-bar-baz"),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "string_replace_space_with_dash" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_extract_email(self) -> None:
+        result = _synthesize(
+            (
+                ("write me at foo@bar.com soon", "foo@bar.com"),
+                ("a@b.io is mine", "a@b.io"),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "string_extract_email" in str(result.program)  # type: ignore[attr-defined]

--- a/tests/test_channels/test_program_synthesis/unit/test_string_primitives.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_string_primitives.py
@@ -98,7 +98,7 @@ class TestStringPrimitivesRegistration:
     on package import."""
 
     def test_all_14_are_registered(self) -> None:
-        registered = {p.name for p in REGISTRY.all_primitives() if p.name.startswith("string_")}
+        registered = {p.name for p in REGISTRY.all_primitives()}
         expected = {
             "string_identity",
             "string_lower",
@@ -115,7 +115,7 @@ class TestStringPrimitivesRegistration:
             "string_last_word",
             "string_reverse",
         }
-        assert registered == expected
+        assert expected.issubset(registered)
 
     def test_signatures_use_string_type_tag(self) -> None:
         spec = REGISTRY.get("string_lower")
@@ -162,10 +162,14 @@ class TestStringSynthesisEndToEnd:
         assert "string_lower" in str(result.program)  # type: ignore[attr-defined]
 
     def test_synth_strip(self) -> None:
+        # Inputs have inner whitespace so ``string_remove_spaces`` would
+        # destroy it, plus digits/punct so ``string_keep_letters`` /
+        # ``string_remove_punctuation`` would also fail. Only
+        # ``string_strip`` survives.
         result = _synthesize(
             (
-                ("  foo  ", "foo"),
-                (" bar ", "bar"),
+                ("  hello-12 world  ", "hello-12 world"),
+                (" foo.45 bar ", "foo.45 bar"),
             )
         )
         assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

PR#2 of **Track B** (DSL-Coverage 3→10 push). Layered on top of PR#1's String-DSL groundwork — adds 14 pattern-matching, character-class filtering, and slug-rewrite primitives that close the FlashFill / ProgramFilter gap left by pure case/split/replace operations.

| Axis | After PR#1 | After this PR |
|---|---|---|
| **DSL-Coverage** | 6/10 (Grid + String) | 7/10 (Grid + String + Pattern) |
| Total registered primitives | 90 | **104** |

## What's in

**14 regex/pattern primitives** (`src/cognithor/channels/program_synthesis/dsl/regex_primitives.py`):

| Axis | Primitives |
|---|---|
| Char-class keep | `string_keep_digits`, `string_keep_letters`, `string_keep_alphanumeric` |
| Char-class remove | `string_remove_digits`, `string_remove_letters`, `string_remove_punctuation`, `string_remove_spaces` |
| Whitespace normalise | `string_collapse_spaces` |
| Run extract | `string_first_digit_run`, `string_last_digit_run` |
| Pattern extract | `string_extract_email`, `string_extract_url` |
| Slug rewrites | `string_replace_space_with_dash`, `string_replace_space_with_underscore` |

Constants stay baked into primitive names (no parameterised \`regex(pattern)\`) so the search space stays bounded — same trick the grid family uses for \`rotate90\` / \`rotate180\`.

## Cross-family fixes

The new family caused two issues in PR#1's test suite that this PR fixes:

1. **\`test_all_14_are_registered\`** — switched from \`set ==\` on the \`string_*\` prefix to \`expected.issubset(registered)\`. The regex family also uses \`string_\` prefix and would have leaked into the equality check.
2. **\`test_synth_strip\`** — got disambiguating inputs (inner whitespace + digits + punctuation) so neither \`string_keep_letters\` nor \`string_remove_spaces\` can satisfy the demos. Only \`string_strip\` survives.

## Tests (23 new, all green)

End-to-end synthesis on real demos:

```
keep_digits        success    string_keep_digits(InputRef(0))
first_digit_run    success    string_first_digit_run(InputRef(0))
replace_space_dash success    string_replace_space_with_dash(InputRef(0))
extract_email      success    string_extract_email(InputRef(0))
remove_punctuation success    (engine picks the cheapest equivalent)
```

## Local pre-flight

- [x] \`pytest tests/test_channels/test_program_synthesis/ tests/test_mcp/test_pse_tools.py\` → **1957 passed, 10 skipped**
- [x] \`ruff format --check\` clean
- [x] \`ruff check\` clean
- [x] \`mypy --strict regex_primitives.py\` clean

## Stack note

This branch carries PR#1's cherry-picked foundational commit (String-DSL family + generic input typing) so it stands alone — it doesn't structurally depend on PR#343's branch staying alive. When #343 lands first, the rebase here resolves to a no-op on the foundational files (identical text). If this lands first, #343 becomes a small subset.

## Track B roadmap

- ✅ **PR#1** (#343) — String-DSL + generic input typing (DSL-Coverage 3→6, Input-Typing 4→8)
- ✅ **PR#2 (this)** — Regex/Pattern-DSL family (DSL-Coverage 6→7)
- ⏭ PR#3 — Number/Math-DSL family (introduces Int input + output, DSL-Coverage 7→9)
- ⏭ PR#4 — List/Sequence-DSL family (DSL-Coverage 9→10, Input-Typing 8→10)

After all four families land, **DSL-Coverage** reaches 10/10 and **Input-Typing** reaches 10/10 — closing two of the remaining open-world readiness axes.