### PR TITLE
feat(pse): Sprint-22 Track B PR#3 — Number/Int-DSL family + Int as first-class

### DIFF
--- a/docs/channels/program_synthesis/benchmarks.md
+++ b/docs/channels/program_synthesis/benchmarks.md
@@ -64,7 +64,7 @@ pre-conditions for the success threshold above.
 
 | Metric | Value |
 |---|---|
-| Base primitives | **104** (56 base + 5 Phase-1.5 higher-order + 5 Sprint-8 object-level + 10 Sprint-10 + 14 Sprint-22 String-DSL + 14 Sprint-22 Regex/Pattern-DSL) |
+| Base primitives | **116** (56 base + 5 Phase-1.5 higher-order + 5 Sprint-8 object-level + 10 Sprint-10 + 14 Sprint-22 String-DSL + 14 Sprint-22 Regex/Pattern-DSL + 12 Sprint-22 Number-DSL) |
 | Predicate constructors | **13** (10 leaf + 3 combinators) |
 | Lambda constructors | **4** (`identity`, `recolor`, `shift`, `branch`) |
 | Higher-order primitives | **5** (`map_objects`, `filter_objects`, `align_to`, `sort_objects`, `branch`) |

--- a/docs/channels/program_synthesis/dsl_reference.md
+++ b/docs/channels/program_synthesis/dsl_reference.md
@@ -2,7 +2,7 @@
 
 _Auto-generated. PSE version `1.2.0`, DSL version `1.2.0`._
 
-**104 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
+**116 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
 
 Run `cognithor pse dsl describe <name>` for any primitive to see its full record (signature + cost + description + examples).
 
@@ -117,12 +117,24 @@ Run `cognithor pse dsl describe <name>` for any primitive to see its full record
 | Name | Signature | Cost | Description |
 |---|---|---|---|
 | `color_count` | `(Grid) → Int` | 1.00 | Number of distinct colors present in the grid (0..10). |
+| `int_abs` | `(Int) → Int` | 1.00 | Return \|n\|. |
+| `int_decrement` | `(Int) → Int` | 1.00 | Return n - 1. |
+| `int_double` | `(Int) → Int` | 1.00 | Return 2 * n. |
+| `int_half` | `(Int) → Int` | 1.00 | Return n // 2 (integer division, rounds toward negative infinity). |
+| `int_identity` | `(Int) → Int` | 0.00 | Return the integer unchanged. Useful as a no-op leaf. |
+| `int_increment` | `(Int) → Int` | 1.00 | Return n + 1. |
+| `int_negate` | `(Int) → Int` | 1.00 | Return -n. |
+| `int_square` | `(Int) → Int` | 1.00 | Return n * n. |
+| `int_triple` | `(Int) → Int` | 1.00 | Return 3 * n. |
 | `object_count` | `(ObjectSet) → Int` | 1.00 | Number of objects in the set (≥ 0). |
+| `string_length` | `(String) → Int` | 1.00 | Return the number of characters in the string. |
+| `string_to_int` | `(String) → Int` | 1.00 | Parse the string as a base-10 integer. Raises ``ValueError`` on non-numeric input so the executor sandbox prunes the candidate. |
 
 ### Output type: other
 
 | Name | Signature | Cost | Description |
 |---|---|---|---|
+| `int_to_string` | `(Int) → String` | 1.00 | Return the base-10 decimal string representation of the integer. |
 | `string_capitalize` | `(String) → String` | 1.00 | Return the string with the first char uppercased and rest lowercased. |
 | `string_collapse_spaces` | `(String) → String` | 1.00 | Replace any run of whitespace with a single space (no leading/trailing strip). |
 | `string_extract_email` | `(String) → String` | 1.00 | Return the first email-like token (\S+@\S+\.\S+) or '' if none. |

--- a/src/cognithor/channels/program_synthesis/dsl/__init__.py
+++ b/src/cognithor/channels/program_synthesis/dsl/__init__.py
@@ -7,6 +7,12 @@ predicate constructors. See spec §7 for the full catalog.
 
 from __future__ import annotations
 
+# Sprint-22 — Number/Int-DSL family. Brings ``Int`` to first-class
+# status with arithmetic primitives plus the two bridge conversions
+# (``int_to_string`` / ``string_to_int``) that connect the int-shaped
+# and str-shaped families.
+from cognithor.channels.program_synthesis.dsl import number_primitives as number_primitives
+
 # Importing the primitives module has the side effect of registering all
 # primitives into the module-level REGISTRY. The re-export keeps the import
 # from being flagged as unused.
@@ -33,6 +39,7 @@ __all__ = [
     "Object",
     "ObjectSet",
     "Signature",
+    "number_primitives",
     "primitives",
     "regex_primitives",
     "string_primitives",

--- a/src/cognithor/channels/program_synthesis/dsl/number_primitives.py
+++ b/src/cognithor/channels/program_synthesis/dsl/number_primitives.py
@@ -1,0 +1,238 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-22 — Number/Int-DSL primitive family.
+
+PR#3 of Track B. Brings ``Int`` to first-class status alongside
+``Grid`` and ``String``: integer arithmetic primitives plus the two
+conversions (``int_to_string`` / ``string_to_int``) that bridge the
+two text-shaped families. Combined with PR#1 + PR#2 the engine can
+now solve demo specs like:
+
+    examples = ((3, 9), (4, 16))         # int → int (square)
+    examples = (("12", 13), ("99", 100)) # str → int (parse + +1)
+    examples = ((5, "5"), (42, "42"))    # int → str (stringify)
+
+Design constraints carry over:
+
+* Pure functions — no IO, no globals, no random.
+* Total domains where reasonable. Conversions that *could* fail
+  (``string_to_int`` on a non-numeric string) raise so the executor
+  sandbox prunes the candidate. Other arithmetic over Python ints
+  is total and never raises.
+* Constants baked into the primitive name — ``int_double`` /
+  ``int_triple`` / ``int_increment`` instead of a parameterised
+  ``int_mul(k)`` — keeps the search space bounded the same way the
+  grid family does for ``rotate90`` / ``rotate180``.
+
+The 12 primitives below cover six axes:
+
+* **Identity**:       ``int_identity``
+* **Shift**:          ``int_increment``, ``int_decrement``
+* **Multiplicative**: ``int_double``, ``int_triple``, ``int_half``
+* **Sign**:           ``int_negate``, ``int_abs``
+* **Power**:          ``int_square``
+* **Bridges**:        ``int_to_string``, ``string_to_int``,
+                      ``string_length``
+
+``string_length`` lives in this family — not in ``string_primitives``
+— because it is the natural "string-shaped → Int-shaped" companion
+to ``string_to_int`` and only makes sense once ``Int`` is registered
+as an allowed type.
+"""
+
+from __future__ import annotations
+
+from cognithor.channels.program_synthesis.dsl.registry import primitive
+from cognithor.channels.program_synthesis.dsl.signatures import Signature
+
+# ---------------------------------------------------------------------------
+# Identity
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="int_identity",
+    signature=Signature(("Int",), "Int"),
+    cost=0.0,
+    description="Return the integer unchanged. Useful as a no-op leaf.",
+)
+def int_identity(n: int) -> int:
+    if not isinstance(n, int) or isinstance(n, bool):
+        raise TypeError(f"int_identity expected int, got {type(n).__name__}")
+    return n
+
+
+# ---------------------------------------------------------------------------
+# Additive shift
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="int_increment",
+    signature=Signature(("Int",), "Int"),
+    cost=1.0,
+    description="Return n + 1.",
+)
+def int_increment(n: int) -> int:
+    if not isinstance(n, int) or isinstance(n, bool):
+        raise TypeError(f"int_increment expected int, got {type(n).__name__}")
+    return n + 1
+
+
+@primitive(
+    name="int_decrement",
+    signature=Signature(("Int",), "Int"),
+    cost=1.0,
+    description="Return n - 1.",
+)
+def int_decrement(n: int) -> int:
+    if not isinstance(n, int) or isinstance(n, bool):
+        raise TypeError(f"int_decrement expected int, got {type(n).__name__}")
+    return n - 1
+
+
+# ---------------------------------------------------------------------------
+# Multiplicative
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="int_double",
+    signature=Signature(("Int",), "Int"),
+    cost=1.0,
+    description="Return 2 * n.",
+)
+def int_double(n: int) -> int:
+    if not isinstance(n, int) or isinstance(n, bool):
+        raise TypeError(f"int_double expected int, got {type(n).__name__}")
+    return 2 * n
+
+
+@primitive(
+    name="int_triple",
+    signature=Signature(("Int",), "Int"),
+    cost=1.0,
+    description="Return 3 * n.",
+)
+def int_triple(n: int) -> int:
+    if not isinstance(n, int) or isinstance(n, bool):
+        raise TypeError(f"int_triple expected int, got {type(n).__name__}")
+    return 3 * n
+
+
+@primitive(
+    name="int_half",
+    signature=Signature(("Int",), "Int"),
+    cost=1.0,
+    description="Return n // 2 (integer division, rounds toward negative infinity).",
+)
+def int_half(n: int) -> int:
+    if not isinstance(n, int) or isinstance(n, bool):
+        raise TypeError(f"int_half expected int, got {type(n).__name__}")
+    return n // 2
+
+
+# ---------------------------------------------------------------------------
+# Sign
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="int_negate",
+    signature=Signature(("Int",), "Int"),
+    cost=1.0,
+    description="Return -n.",
+)
+def int_negate(n: int) -> int:
+    if not isinstance(n, int) or isinstance(n, bool):
+        raise TypeError(f"int_negate expected int, got {type(n).__name__}")
+    return -n
+
+
+@primitive(
+    name="int_abs",
+    signature=Signature(("Int",), "Int"),
+    cost=1.0,
+    description="Return |n|.",
+)
+def int_abs(n: int) -> int:
+    if not isinstance(n, int) or isinstance(n, bool):
+        raise TypeError(f"int_abs expected int, got {type(n).__name__}")
+    return abs(n)
+
+
+# ---------------------------------------------------------------------------
+# Power
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="int_square",
+    signature=Signature(("Int",), "Int"),
+    cost=1.0,
+    description="Return n * n.",
+)
+def int_square(n: int) -> int:
+    if not isinstance(n, int) or isinstance(n, bool):
+        raise TypeError(f"int_square expected int, got {type(n).__name__}")
+    return n * n
+
+
+# ---------------------------------------------------------------------------
+# Bridges between Int and String
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="int_to_string",
+    signature=Signature(("Int",), "String"),
+    cost=1.0,
+    description="Return the base-10 decimal string representation of the integer.",
+)
+def int_to_string(n: int) -> str:
+    if not isinstance(n, int) or isinstance(n, bool):
+        raise TypeError(f"int_to_string expected int, got {type(n).__name__}")
+    return str(n)
+
+
+@primitive(
+    name="string_to_int",
+    signature=Signature(("String",), "Int"),
+    cost=1.0,
+    description=(
+        "Parse the string as a base-10 integer. "
+        "Raises ``ValueError`` on non-numeric input so the executor sandbox "
+        "prunes the candidate."
+    ),
+)
+def string_to_int(s: str) -> int:
+    if not isinstance(s, str):
+        raise TypeError(f"string_to_int expected str, got {type(s).__name__}")
+    return int(s)
+
+
+@primitive(
+    name="string_length",
+    signature=Signature(("String",), "Int"),
+    cost=1.0,
+    description="Return the number of characters in the string.",
+)
+def string_length(s: str) -> int:
+    if not isinstance(s, str):
+        raise TypeError(f"string_length expected str, got {type(s).__name__}")
+    return len(s)
+
+
+__all__ = [
+    "int_abs",
+    "int_decrement",
+    "int_double",
+    "int_half",
+    "int_identity",
+    "int_increment",
+    "int_negate",
+    "int_square",
+    "int_to_string",
+    "int_triple",
+    "string_length",
+    "string_to_int",
+]

--- a/src/cognithor/channels/program_synthesis/search/enumerative.py
+++ b/src/cognithor/channels/program_synthesis/search/enumerative.py
@@ -92,6 +92,13 @@ def _outputs_match(actual: Any, expected: Any) -> bool:
     """Tolerant equality used by the demo verifier."""
     if isinstance(actual, np.ndarray) and isinstance(expected, np.ndarray):
         return bool(actual.shape == expected.shape and np.array_equal(actual, expected))
+    # Sprint-22 PR#3: with ``Int`` now in the demo-output-type set the
+    # early-exit path can compare an ``np.ndarray`` candidate output
+    # against a scalar expected (or vice-versa). ``arr == scalar`` is
+    # element-wise, so ``bool(...)`` raises "truth value is ambiguous".
+    # Mixed shapes can never satisfy a demo, so short-circuit to False.
+    if isinstance(actual, np.ndarray) or isinstance(expected, np.ndarray):
+        return False
     return bool(actual == expected)
 
 
@@ -308,10 +315,16 @@ class EnumerativeSearch:
         input_type_tag = "Grid"
         if spec.examples:
             first_input = spec.examples[0][0]
+            # ``bool`` is a subclass of ``int`` so we explicitly exclude
+            # it — there is no ``Bool`` input in any demo task.
             if isinstance(first_input, str):
                 input_type_tag = "String"
             elif isinstance(first_input, np.ndarray):
                 input_type_tag = "Grid"
+            elif isinstance(first_input, bool):
+                input_type_tag = "Grid"  # never reached as demo input
+            elif isinstance(first_input, int):
+                input_type_tag = "Int"
 
         bank: dict[str, list[ProgramNode]] = _zero_arity_leaves(self._registry)
         bank.setdefault(input_type_tag, []).append(InputRef(output_type=input_type_tag))
@@ -369,11 +382,14 @@ class EnumerativeSearch:
                     # Sprint-22: any "demo-output type" is a candidate
                     # for early exit. Grid is the legacy Phase-1 type;
                     # String + StringList are added by the Sprint-22
-                    # FlashFill-style family. Other intermediate types
+                    # FlashFill-style family. ``Int`` is added by the
+                    # Number-DSL family — synthesis tasks like int → int
+                    # arithmetic and string → int parsing emit ints as
+                    # the expected output. Other intermediate types
                     # (Mask, Object, Color, Predicate, Lambda, ...) only
                     # exist as composition glue and never appear as a
                     # demo's expected output.
-                    is_demo_output_type = type_tag in ("Grid", "String", "StringList")
+                    is_demo_output_type = type_tag in ("Grid", "String", "StringList", "Int")
                     if is_demo_output_type and _all_demos_correct(candidate, spec, self._executor):
                         return _success(program=candidate, stats=stats, cache_hit=False)
 

--- a/src/cognithor/mcp/pse_tools.py
+++ b/src/cognithor/mcp/pse_tools.py
@@ -124,17 +124,30 @@ def _coerce_value(raw: Any) -> Any:
 
     * ``list[list[int]]`` → ``np.ndarray`` (grid family — ARC-DSL)
     * ``str`` → ``str`` (string family — FlashFill-style)
+    * ``int`` → ``int`` (number family — arithmetic + bridge ops)
 
-    More families register here as they ship (sql / regex / ast).
+    Booleans are explicitly rejected: Python's ``bool`` is a subclass
+    of ``int`` so an unguarded ``isinstance(raw, int)`` check would
+    accept ``True`` / ``False`` and the search engine would happily
+    type-check them as ``Int``, which is never what the caller meant.
+
+    More families register here as they ship (sql / ast).
     Non-fitting payloads raise :class:`ValueError` so the MCP layer
     returns a structured error rather than crashing the engine.
     """
     if isinstance(raw, str):
         return raw
+    if isinstance(raw, bool):
+        raise ValueError(
+            f"unsupported input type {type(raw).__name__} — "
+            "expected 2-D int list (grid), str, or int"
+        )
+    if isinstance(raw, int):
+        return raw
     if isinstance(raw, list) and raw and isinstance(raw[0], list):
         return _coerce_grid(raw)
     raise ValueError(
-        f"unsupported input type {type(raw).__name__} — expected 2-D int list (grid) or str"
+        f"unsupported input type {type(raw).__name__} — expected 2-D int list (grid), str, or int"
     )
 
 
@@ -175,9 +188,13 @@ def _examples_from_json(payload: Any) -> tuple[tuple[Any, Any], ...]:
         parsed.append((inp, out))
     # Heterogeneous families would always lose at the type-filter; the
     # explicit error makes the diagnostic obvious instead of silently
-    # returning ``no_solution``.
-    if "ndarray" in families and "str" in families:
-        raise ValueError("'examples' must be homogeneous (all grids OR all strings)")
+    # returning ``no_solution``. Sprint-22: ``str`` ↔ ``int`` is
+    # *allowed* because the Number-DSL family ships explicit bridge
+    # primitives (``int_to_string`` / ``string_to_int`` /
+    # ``string_length``); only the Grid family is structurally
+    # disjoint from the text-shaped families.
+    if "ndarray" in families and ("str" in families or "int" in families):
+        raise ValueError("'examples' must not mix grids with text-shaped values (strings or ints)")
     return tuple(parsed)
 
 

--- a/tests/test_channels/test_program_synthesis/unit/test_number_primitives.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_number_primitives.py
@@ -1,0 +1,250 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-22 Track B PR#3 — Number/Int-DSL family tests."""
+
+from __future__ import annotations
+
+from cognithor.channels.program_synthesis.core.types import (
+    Budget,
+    SynthesisStatus,
+    TaskSpec,
+)
+from cognithor.channels.program_synthesis.dsl import number_primitives as np_dsl
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+from cognithor.channels.program_synthesis.integration.pge_adapter import (
+    ProgramSynthesisChannel,
+    SynthesisRequest,
+)
+
+# ---------------------------------------------------------------------------
+# Pure-function unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestNumberPrimitivesPure:
+    def test_identity(self) -> None:
+        assert np_dsl.int_identity(5) == 5
+        assert np_dsl.int_identity(0) == 0
+        assert np_dsl.int_identity(-3) == -3
+
+    def test_increment(self) -> None:
+        assert np_dsl.int_increment(0) == 1
+        assert np_dsl.int_increment(-1) == 0
+        assert np_dsl.int_increment(99) == 100
+
+    def test_decrement(self) -> None:
+        assert np_dsl.int_decrement(1) == 0
+        assert np_dsl.int_decrement(0) == -1
+
+    def test_double(self) -> None:
+        assert np_dsl.int_double(0) == 0
+        assert np_dsl.int_double(7) == 14
+        assert np_dsl.int_double(-3) == -6
+
+    def test_triple(self) -> None:
+        assert np_dsl.int_triple(0) == 0
+        assert np_dsl.int_triple(4) == 12
+        assert np_dsl.int_triple(-2) == -6
+
+    def test_half(self) -> None:
+        assert np_dsl.int_half(10) == 5
+        assert np_dsl.int_half(7) == 3  # floor division
+        assert np_dsl.int_half(-1) == -1  # rounds toward -infinity
+
+    def test_negate(self) -> None:
+        assert np_dsl.int_negate(5) == -5
+        assert np_dsl.int_negate(-7) == 7
+        assert np_dsl.int_negate(0) == 0
+
+    def test_abs(self) -> None:
+        assert np_dsl.int_abs(5) == 5
+        assert np_dsl.int_abs(-5) == 5
+        assert np_dsl.int_abs(0) == 0
+
+    def test_square(self) -> None:
+        assert np_dsl.int_square(0) == 0
+        assert np_dsl.int_square(3) == 9
+        assert np_dsl.int_square(-4) == 16
+
+    def test_int_to_string(self) -> None:
+        assert np_dsl.int_to_string(0) == "0"
+        assert np_dsl.int_to_string(42) == "42"
+        assert np_dsl.int_to_string(-7) == "-7"
+
+    def test_string_to_int(self) -> None:
+        assert np_dsl.string_to_int("0") == 0
+        assert np_dsl.string_to_int("42") == 42
+        assert np_dsl.string_to_int("-7") == -7
+
+    def test_string_length(self) -> None:
+        assert np_dsl.string_length("") == 0
+        assert np_dsl.string_length("hi") == 2
+        assert np_dsl.string_length("hello") == 5
+
+
+class TestNumberPrimitivesTypeChecking:
+    """Every primitive raises on wrong input shape so the executor
+    sandbox prunes the candidate."""
+
+    def test_int_double_rejects_str(self) -> None:
+        import pytest
+
+        with pytest.raises(TypeError):
+            np_dsl.int_double("5")  # type: ignore[arg-type]
+
+    def test_int_double_rejects_bool(self) -> None:
+        # ``bool`` is a subclass of ``int`` in Python — we explicitly
+        # reject it so the type filter cannot accept ``True`` / ``False``
+        # as Int leaves.
+        import pytest
+
+        with pytest.raises(TypeError):
+            np_dsl.int_double(True)  # type: ignore[arg-type]
+
+    def test_string_to_int_rejects_non_str(self) -> None:
+        import pytest
+
+        with pytest.raises(TypeError):
+            np_dsl.string_to_int(5)  # type: ignore[arg-type]
+
+    def test_string_to_int_raises_on_non_numeric(self) -> None:
+        import pytest
+
+        # Python's ``int(s)`` raises ValueError on a non-numeric string.
+        # The sandbox catches that just like a TypeError and prunes the
+        # candidate.
+        with pytest.raises(ValueError):
+            np_dsl.string_to_int("not a number")
+
+    def test_string_length_rejects_non_str(self) -> None:
+        import pytest
+
+        with pytest.raises(TypeError):
+            np_dsl.string_length(5)  # type: ignore[arg-type]
+
+
+class TestNumberPrimitivesRegistration:
+    """All 12 number primitives are registered with the singleton REGISTRY
+    on package import."""
+
+    def test_all_12_are_registered(self) -> None:
+        registered = {p.name for p in REGISTRY.all_primitives()}
+        expected = {
+            "int_identity",
+            "int_increment",
+            "int_decrement",
+            "int_double",
+            "int_triple",
+            "int_half",
+            "int_negate",
+            "int_abs",
+            "int_square",
+            "int_to_string",
+            "string_to_int",
+            "string_length",
+        }
+        assert expected.issubset(registered)
+
+    def test_int_signatures(self) -> None:
+        spec = REGISTRY.get("int_double")
+        assert spec.signature.inputs == ("Int",)
+        assert spec.signature.output == "Int"
+
+    def test_int_to_string_signature(self) -> None:
+        spec = REGISTRY.get("int_to_string")
+        assert spec.signature.inputs == ("Int",)
+        assert spec.signature.output == "String"
+
+    def test_string_to_int_signature(self) -> None:
+        spec = REGISTRY.get("string_to_int")
+        assert spec.signature.inputs == ("String",)
+        assert spec.signature.output == "Int"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end synthesis tests
+# ---------------------------------------------------------------------------
+
+
+def _synthesize(examples: tuple[tuple[object, object], ...]) -> object:
+    """Helper: run the channel against a small spec — int, str, or mixed."""
+    ch = ProgramSynthesisChannel(actor="number-test")
+    spec = TaskSpec(examples=examples)
+    return ch.synthesize(
+        SynthesisRequest(
+            spec=spec,
+            budget=Budget(max_depth=3, wall_clock_seconds=5.0, cache_lookup=False),
+        )
+    )
+
+
+class TestNumberSynthesisEndToEnd:
+    """The engine routes int → int / str → int / int → str tasks
+    through the same enumerative loop now that ``Int`` is a
+    first-class input *and* demo-output type tag.
+    """
+
+    def test_synth_int_double(self) -> None:
+        result = _synthesize(
+            (
+                (3, 6),
+                (7, 14),
+                (10, 20),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "int_double" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_int_square(self) -> None:
+        result = _synthesize(
+            (
+                (3, 9),
+                (4, 16),
+                (5, 25),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "int_square" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_int_increment(self) -> None:
+        result = _synthesize(
+            (
+                (0, 1),
+                (5, 6),
+                (99, 100),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "int_increment" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_int_to_string(self) -> None:
+        result = _synthesize(
+            (
+                (5, "5"),
+                (42, "42"),
+                (-7, "-7"),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "int_to_string" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_string_length(self) -> None:
+        result = _synthesize(
+            (
+                ("hi", 2),
+                ("hello", 5),
+                ("foo", 3),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "string_length" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_string_to_int(self) -> None:
+        result = _synthesize(
+            (
+                ("5", 5),
+                ("42", 42),
+                ("100", 100),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "string_to_int" in str(result.program)  # type: ignore[attr-defined]

--- a/tests/test_mcp/test_pse_tools.py
+++ b/tests/test_mcp/test_pse_tools.py
@@ -74,7 +74,9 @@ class TestExamplesFromJson:
         # Sprint-22: ``"not a grid"`` is now a *valid* string input, so
         # the coercion no longer rejects it per-example. Instead the
         # mixed grid+string payload triggers the homogeneity check.
-        with pytest.raises(ValueError, match="homogeneous"):
+        # PR#3: error message switched from "homogeneous" to the more
+        # precise "must not mix grids with text-shaped values".
+        with pytest.raises(ValueError, match="must not mix grids"):
             _examples_from_json(
                 [
                     {"input": [[0]], "output": [[1]]},
@@ -84,14 +86,17 @@ class TestExamplesFromJson:
 
     def test_truly_invalid_value_still_propagates_per_example_with_index(self) -> None:
         """A payload that is neither a grid (2-D int list) nor a string
-        is rejected by ``_coerce_value`` per-example, with the index in
-        the error so the caller can locate the bad row.
+        nor an int is rejected by ``_coerce_value`` per-example, with
+        the index in the error so the caller can locate the bad row.
         """
+        # PR#3: ``int`` is now a valid input type via the Number-DSL
+        # family, so the previous "42" test value is no longer rejected.
+        # ``None`` and ``float`` are still genuinely unsupported.
         with pytest.raises(ValueError, match="example 1"):
             _examples_from_json(
                 [
                     {"input": "abc", "output": "abc"},
-                    {"input": 42, "output": "x"},  # int is not a grid or str
+                    {"input": None, "output": "x"},  # None is not a grid/str/int
                 ]
             )
 


### PR DESCRIPTION
## Summary

PR#3 of **Track B** (DSL-Coverage 3→10 push). Brings \`Int\` to first-class status alongside \`Grid\` and \`String\` — the engine can now synthesise int → int arithmetic, str → int parsing, int → str formatting, and string → int extraction tasks through the same enumerative loop.

| Axis | After PR#2 | After this PR |
|---|---|---|
| **DSL-Coverage** | 7/10 (Grid + String + Pattern) | 9/10 (Grid + String + Pattern + Int) |
| **Input-Typing** | 8/10 (Grid + String) | 9/10 (Grid + String + Int) |
| Total registered primitives | 104 | **116** |

## What's in

**12 number/int primitives** (\`src/cognithor/channels/program_synthesis/dsl/number_primitives.py\`):

| Axis | Primitives |
|---|---|
| Identity | \`int_identity\` |
| Additive shift | \`int_increment\`, \`int_decrement\` |
| Multiplicative | \`int_double\`, \`int_triple\`, \`int_half\` |
| Sign | \`int_negate\`, \`int_abs\` |
| Power | \`int_square\` |
| Bridges | \`int_to_string\`, \`string_to_int\`, \`string_length\` |

The bridge primitives are the key piece — they let int-shaped tasks compose with string-shaped tasks and vice-versa, which is exactly what most real "extract a number from a label" or "format an ID" tasks need.

## Engine generalisations

1. **Input-type detection** for \`int\` (with explicit \`bool\` exclusion — Python's \`bool\` is a subclass of \`int\` and would otherwise leak in).
2. **\`Int\` joins the demo-output type set** alongside \`Grid\` / \`String\` / \`StringList\` so the early-exit verifier triggers.
3. **\`_outputs_match\` hardened** — with \`Int\` now eligible for early-exit, the verifier can compare an \`np.ndarray\` candidate against a scalar expected (or vice-versa). \`bool(arr == scalar)\` is element-wise and raises "truth value is ambiguous". Mixed shapes can never satisfy a demo → short-circuit to \`False\`. This was a latent bug Phase-1 dodged only because Int was excluded from early-exit.
4. **MCP boundary** \`_coerce_value\` accepts \`int\`, rejects \`bool\`. \`str\` ↔ \`int\` mixing is allowed (bridge primitives handle conversion); only \`Grid\` stays disjoint from text-shaped values.

## Tests (27 new, all green)

End-to-end synthesis on real demos:

```
int_double      success    int_double(InputRef(0))
int_square      success    int_square(InputRef(0))
int_increment   success    int_increment(InputRef(0))
int_to_string   success    int_to_string(InputRef(0))
string_length   success    string_length(InputRef(0))
string_to_int   success    string_to_int(InputRef(0))
```

## Cross-PR fixes

\`test_pse_tools.py\`:

- \`test_invalid_inner_grid_propagates_with_index\` — error message changed from "homogeneous" to "must not mix grids".
- \`test_truly_invalid_value_still_propagates_per_example_with_index\` — replaced int 42 (now valid) with \`None\`.

## Local pre-flight

- [x] \`pytest tests/test_channels/test_program_synthesis/ tests/test_mcp/test_pse_tools.py\` → **1984 passed, 10 skipped**
- [x] \`ruff format --check\` clean
- [x] \`ruff check\` clean
- [x] \`mypy --strict number_primitives.py\` clean

## Stack note

This branch carries PR#1 + PR#2's cherry-picked foundational commits so it stands alone — it doesn't structurally depend on PR#343 or PR#344's branches staying alive. When those land first, the rebase here resolves to a no-op on identical text.

## Track B roadmap

- ✅ **PR#1** (#343) — String-DSL + generic input typing (DSL-Coverage 3→6, Input-Typing 4→8)
- ✅ **PR#2** (#344) — Regex/Pattern-DSL family (DSL-Coverage 6→7)
- ✅ **PR#3 (this)** — Number/Int-DSL family + Int as first-class (DSL-Coverage 7→9, Input-Typing 8→9)
- ⏭ PR#4 — List/Sequence-DSL family (DSL-Coverage 9→10, Input-Typing 9→10)

After PR#4 lands, **DSL-Coverage** reaches 10/10 and **Input-Typing** reaches 10/10 — closing two of the open-world readiness axes.