### PR TITLE
feat(pse): Sprint-22 Track B PR#4 — List/Sequence-DSL family + IntList type

### DIFF
--- a/docs/channels/program_synthesis/benchmarks.md
+++ b/docs/channels/program_synthesis/benchmarks.md
@@ -64,7 +64,7 @@ pre-conditions for the success threshold above.
 
 | Metric | Value |
 |---|---|
-| Base primitives | **116** (56 base + 5 Phase-1.5 higher-order + 5 Sprint-8 object-level + 10 Sprint-10 + 14 Sprint-22 String-DSL + 14 Sprint-22 Regex/Pattern-DSL + 12 Sprint-22 Number-DSL) |
+| Base primitives | **130** (56 base + 5 Phase-1.5 higher-order + 5 Sprint-8 object-level + 10 Sprint-10 + 14 Sprint-22 String-DSL + 14 Sprint-22 Regex/Pattern-DSL + 12 Sprint-22 Number-DSL + 14 Sprint-22 List-DSL) |
 | Predicate constructors | **13** (10 leaf + 3 combinators) |
 | Lambda constructors | **4** (`identity`, `recolor`, `shift`, `branch`) |
 | Higher-order primitives | **5** (`map_objects`, `filter_objects`, `align_to`, `sort_objects`, `branch`) |

--- a/docs/channels/program_synthesis/dsl_reference.md
+++ b/docs/channels/program_synthesis/dsl_reference.md
@@ -2,7 +2,7 @@
 
 _Auto-generated. PSE version `1.2.0`, DSL version `1.2.0`._
 
-**116 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
+**130 primitives** registered, plus 13 predicate constructors and the closed Lambda / AlignMode / SortKey enums.
 
 Run `cognithor pse dsl describe <name>` for any primitive to see its full record (signature + cost + description + examples).
 
@@ -123,17 +123,26 @@ Run `cognithor pse dsl describe <name>` for any primitive to see its full record
 | `int_half` | `(Int) → Int` | 1.00 | Return n // 2 (integer division, rounds toward negative infinity). |
 | `int_identity` | `(Int) → Int` | 0.00 | Return the integer unchanged. Useful as a no-op leaf. |
 | `int_increment` | `(Int) → Int` | 1.00 | Return n + 1. |
+| `int_list_first` | `(IntList) → Int` | 1.00 | Return the first integer; raises on empty list. |
+| `int_list_length` | `(IntList) → Int` | 1.00 | Return the number of elements in the int list. |
+| `int_list_max` | `(IntList) → Int` | 1.00 | Return the maximum integer; raises on empty list. |
+| `int_list_min` | `(IntList) → Int` | 1.00 | Return the minimum integer; raises on empty list. |
+| `int_list_sum` | `(IntList) → Int` | 1.00 | Return the sum of the integers; 0 for an empty list. |
 | `int_negate` | `(Int) → Int` | 1.00 | Return -n. |
 | `int_square` | `(Int) → Int` | 1.00 | Return n * n. |
 | `int_triple` | `(Int) → Int` | 1.00 | Return 3 * n. |
 | `object_count` | `(ObjectSet) → Int` | 1.00 | Number of objects in the set (≥ 0). |
 | `string_length` | `(String) → Int` | 1.00 | Return the number of characters in the string. |
+| `string_list_count_nonempty` | `(StringList) → Int` | 1.00 | Return the number of elements that are not the empty string. |
+| `string_list_length` | `(StringList) → Int` | 1.00 | Return the number of elements in the list. |
 | `string_to_int` | `(String) → Int` | 1.00 | Parse the string as a base-10 integer. Raises ``ValueError`` on non-numeric input so the executor sandbox prunes the candidate. |
 
 ### Output type: other
 
 | Name | Signature | Cost | Description |
 |---|---|---|---|
+| `int_list_reverse` | `(IntList) → IntList` | 1.00 | Return the list of ints in reverse order. |
+| `int_list_sort` | `(IntList) → IntList` | 1.00 | Return the list of ints sorted ascending. |
 | `int_to_string` | `(Int) → String` | 1.00 | Return the base-10 decimal string representation of the integer. |
 | `string_capitalize` | `(String) → String` | 1.00 | Return the string with the first char uppercased and rest lowercased. |
 | `string_collapse_spaces` | `(String) → String` | 1.00 | Replace any run of whitespace with a single space (no leading/trailing strip). |
@@ -149,6 +158,8 @@ Run `cognithor pse dsl describe <name>` for any primitive to see its full record
 | `string_keep_letters` | `(String) → String` | 1.00 | Return only the alphabetic characters of the string, in original order. |
 | `string_last_digit_run` | `(String) → String` | 1.00 | Return the last contiguous run of digit characters, or '' if none. |
 | `string_last_word` | `(String) → String` | 1.00 | Return the last whitespace-delimited word, or '' for an empty input. |
+| `string_list_first` | `(StringList) → String` | 1.00 | Return the first element, or '' for an empty list. |
+| `string_list_last` | `(StringList) → String` | 1.00 | Return the last element, or '' for an empty list. |
 | `string_lower` | `(String) → String` | 1.00 | Return the string in all-lowercase. |
 | `string_remove_digits` | `(String) → String` | 1.00 | Return the string with every digit character removed. |
 | `string_remove_letters` | `(String) → String` | 1.00 | Return the string with every alphabetic character removed. |
@@ -161,6 +172,9 @@ Run `cognithor pse dsl describe <name>` for any primitive to see its full record
 | `string_reverse` | `(String) → String` | 1.00 | Return the string with characters in reverse order. |
 | `string_strip` | `(String) → String` | 1.00 | Return the string with leading/trailing whitespace removed. |
 | `string_upper` | `(String) → String` | 1.00 | Return the string in all-uppercase. |
+| `string_list_reverse` | `(StringList) → StringList` | 1.00 | Return the list with elements in reverse order. |
+| `string_list_sort` | `(StringList) → StringList` | 1.00 | Return the list sorted lexicographically (Python default str ordering). |
+| `string_list_unique` | `(StringList) → StringList` | 1.00 | Deduplicate the list, preserving first-seen order. |
 | `string_split_comma` | `(String) → StringList` | 1.00 | Split on commas. Empty fields kept (use string_strip on parts to clean). |
 | `string_split_space` | `(String) → StringList` | 1.00 | Split on any whitespace run; collapse consecutive separators. |
 

--- a/src/cognithor/channels/program_synthesis/dsl/__init__.py
+++ b/src/cognithor/channels/program_synthesis/dsl/__init__.py
@@ -7,6 +7,10 @@ predicate constructors. See spec §7 for the full catalog.
 
 from __future__ import annotations
 
+# Sprint-22 — List/Sequence-DSL family. Reductions, reorderings, and
+# bridges over both ``StringList`` (PR#1) and the new ``IntList`` type.
+from cognithor.channels.program_synthesis.dsl import list_primitives as list_primitives
+
 # Sprint-22 — Number/Int-DSL family. Brings ``Int`` to first-class
 # status with arithmetic primitives plus the two bridge conversions
 # (``int_to_string`` / ``string_to_int``) that connect the int-shaped
@@ -39,6 +43,7 @@ __all__ = [
     "Object",
     "ObjectSet",
     "Signature",
+    "list_primitives",
     "number_primitives",
     "primitives",
     "regex_primitives",

--- a/src/cognithor/channels/program_synthesis/dsl/list_primitives.py
+++ b/src/cognithor/channels/program_synthesis/dsl/list_primitives.py
@@ -1,0 +1,270 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-22 — List/Sequence-DSL primitive family.
+
+PR#4 of Track B and the final piece of the Open-World DSL push.
+Adds reductions, reorderings, and bridges over both ``StringList``
+(introduced in PR#1) and the new ``IntList`` type, so the engine
+can solve demo specs like:
+
+    examples = ((["c", "a", "b"], ["a", "b", "c"]),  # str-list sort
+                (["x", "y"],      ["x", "y"]))
+
+    examples = (([1, 2, 3], 6),                     # int-list sum
+                ([10, 20], 30))
+
+    examples = (([5, 1, 9], 9),                     # int-list max
+                ([3, 7, 4], 7))
+
+Design constraints carry over:
+
+* Pure functions — no IO, no globals, no random.
+* Total domains where reasonable. Reductions over an empty list
+  raise (``max(empty)`` / ``min(empty)`` are undefined) so the
+  executor sandbox prunes the candidate.
+* JSON-serialisable signature strings — ``IntList`` and
+  ``StringList`` are both registered in :data:`ALLOWED_TYPES`.
+
+The 14 primitives below cover four axes:
+
+* **String-list reorder**:    ``string_list_reverse``,
+                              ``string_list_unique``,
+                              ``string_list_sort``
+* **String-list reduce**:     ``string_list_first``,
+                              ``string_list_last``,
+                              ``string_list_length``,
+                              ``string_list_count_nonempty``
+* **Int-list reorder**:       ``int_list_reverse``,
+                              ``int_list_sort``
+* **Int-list reduce**:        ``int_list_first``,
+                              ``int_list_sum``,
+                              ``int_list_max``,
+                              ``int_list_min``,
+                              ``int_list_length``
+
+Reductions to ``Int`` (length / sum / max / min) are the bridges
+that connect this family back to the Number-DSL family from PR#3 —
+e.g. ``int_increment(int_list_max(...))`` is now a reachable
+program.
+"""
+
+from __future__ import annotations
+
+from cognithor.channels.program_synthesis.dsl.registry import primitive
+from cognithor.channels.program_synthesis.dsl.signatures import Signature
+
+# ---------------------------------------------------------------------------
+# StringList — reorder
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="string_list_reverse",
+    signature=Signature(("StringList",), "StringList"),
+    cost=1.0,
+    description="Return the list with elements in reverse order.",
+)
+def string_list_reverse(parts: list[str]) -> list[str]:
+    if not isinstance(parts, list):
+        raise TypeError(f"string_list_reverse expected list, got {type(parts).__name__}")
+    return list(reversed(parts))
+
+
+@primitive(
+    name="string_list_unique",
+    signature=Signature(("StringList",), "StringList"),
+    cost=1.0,
+    description="Deduplicate the list, preserving first-seen order.",
+)
+def string_list_unique(parts: list[str]) -> list[str]:
+    if not isinstance(parts, list):
+        raise TypeError(f"string_list_unique expected list, got {type(parts).__name__}")
+    seen: set[str] = set()
+    out: list[str] = []
+    for p in parts:
+        if p not in seen:
+            seen.add(p)
+            out.append(p)
+    return out
+
+
+@primitive(
+    name="string_list_sort",
+    signature=Signature(("StringList",), "StringList"),
+    cost=1.0,
+    description="Return the list sorted lexicographically (Python default str ordering).",
+)
+def string_list_sort(parts: list[str]) -> list[str]:
+    if not isinstance(parts, list):
+        raise TypeError(f"string_list_sort expected list, got {type(parts).__name__}")
+    return sorted(parts)
+
+
+# ---------------------------------------------------------------------------
+# StringList — reduce
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="string_list_first",
+    signature=Signature(("StringList",), "String"),
+    cost=1.0,
+    description="Return the first element, or '' for an empty list.",
+)
+def string_list_first(parts: list[str]) -> str:
+    if not isinstance(parts, list):
+        raise TypeError(f"string_list_first expected list, got {type(parts).__name__}")
+    return parts[0] if parts else ""
+
+
+@primitive(
+    name="string_list_last",
+    signature=Signature(("StringList",), "String"),
+    cost=1.0,
+    description="Return the last element, or '' for an empty list.",
+)
+def string_list_last(parts: list[str]) -> str:
+    if not isinstance(parts, list):
+        raise TypeError(f"string_list_last expected list, got {type(parts).__name__}")
+    return parts[-1] if parts else ""
+
+
+@primitive(
+    name="string_list_length",
+    signature=Signature(("StringList",), "Int"),
+    cost=1.0,
+    description="Return the number of elements in the list.",
+)
+def string_list_length(parts: list[str]) -> int:
+    if not isinstance(parts, list):
+        raise TypeError(f"string_list_length expected list, got {type(parts).__name__}")
+    return len(parts)
+
+
+@primitive(
+    name="string_list_count_nonempty",
+    signature=Signature(("StringList",), "Int"),
+    cost=1.0,
+    description="Return the number of elements that are not the empty string.",
+)
+def string_list_count_nonempty(parts: list[str]) -> int:
+    if not isinstance(parts, list):
+        raise TypeError(f"string_list_count_nonempty expected list, got {type(parts).__name__}")
+    return sum(1 for p in parts if p)
+
+
+# ---------------------------------------------------------------------------
+# IntList — reorder
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="int_list_reverse",
+    signature=Signature(("IntList",), "IntList"),
+    cost=1.0,
+    description="Return the list of ints in reverse order.",
+)
+def int_list_reverse(values: list[int]) -> list[int]:
+    if not isinstance(values, list):
+        raise TypeError(f"int_list_reverse expected list, got {type(values).__name__}")
+    return list(reversed(values))
+
+
+@primitive(
+    name="int_list_sort",
+    signature=Signature(("IntList",), "IntList"),
+    cost=1.0,
+    description="Return the list of ints sorted ascending.",
+)
+def int_list_sort(values: list[int]) -> list[int]:
+    if not isinstance(values, list):
+        raise TypeError(f"int_list_sort expected list, got {type(values).__name__}")
+    return sorted(values)
+
+
+# ---------------------------------------------------------------------------
+# IntList — reduce
+# ---------------------------------------------------------------------------
+
+
+@primitive(
+    name="int_list_first",
+    signature=Signature(("IntList",), "Int"),
+    cost=1.0,
+    description="Return the first integer; raises on empty list.",
+)
+def int_list_first(values: list[int]) -> int:
+    if not isinstance(values, list):
+        raise TypeError(f"int_list_first expected list, got {type(values).__name__}")
+    if not values:
+        raise ValueError("int_list_first: empty list")
+    return int(values[0])
+
+
+@primitive(
+    name="int_list_sum",
+    signature=Signature(("IntList",), "Int"),
+    cost=1.0,
+    description="Return the sum of the integers; 0 for an empty list.",
+)
+def int_list_sum(values: list[int]) -> int:
+    if not isinstance(values, list):
+        raise TypeError(f"int_list_sum expected list, got {type(values).__name__}")
+    return sum(int(v) for v in values)
+
+
+@primitive(
+    name="int_list_max",
+    signature=Signature(("IntList",), "Int"),
+    cost=1.0,
+    description="Return the maximum integer; raises on empty list.",
+)
+def int_list_max(values: list[int]) -> int:
+    if not isinstance(values, list):
+        raise TypeError(f"int_list_max expected list, got {type(values).__name__}")
+    if not values:
+        raise ValueError("int_list_max: empty list")
+    return int(max(values))
+
+
+@primitive(
+    name="int_list_min",
+    signature=Signature(("IntList",), "Int"),
+    cost=1.0,
+    description="Return the minimum integer; raises on empty list.",
+)
+def int_list_min(values: list[int]) -> int:
+    if not isinstance(values, list):
+        raise TypeError(f"int_list_min expected list, got {type(values).__name__}")
+    if not values:
+        raise ValueError("int_list_min: empty list")
+    return int(min(values))
+
+
+@primitive(
+    name="int_list_length",
+    signature=Signature(("IntList",), "Int"),
+    cost=1.0,
+    description="Return the number of elements in the int list.",
+)
+def int_list_length(values: list[int]) -> int:
+    if not isinstance(values, list):
+        raise TypeError(f"int_list_length expected list, got {type(values).__name__}")
+    return len(values)
+
+
+__all__ = [
+    "int_list_first",
+    "int_list_length",
+    "int_list_max",
+    "int_list_min",
+    "int_list_reverse",
+    "int_list_sort",
+    "int_list_sum",
+    "string_list_count_nonempty",
+    "string_list_first",
+    "string_list_last",
+    "string_list_length",
+    "string_list_reverse",
+    "string_list_sort",
+    "string_list_unique",
+]

--- a/src/cognithor/channels/program_synthesis/dsl/signatures.py
+++ b/src/cognithor/channels/program_synthesis/dsl/signatures.py
@@ -34,6 +34,13 @@ ALLOWED_TYPES: frozenset[str] = frozenset(
         # rejects all type-mismatched compositions).
         "String",
         "StringList",
+        # Sprint-22 PR#4 — List/Sequence-DSL family. ``IntList`` is the
+        # carrier for list-of-int synthesis tasks (sum / max / min /
+        # length / sort / reverse). It is structurally disjoint from
+        # ``StringList`` so the type-filter cleanly routes a list-of-
+        # ints input through the int-list primitives without a Python
+        # ``isinstance(int, str)`` accident.
+        "IntList",
     }
 )
 

--- a/src/cognithor/channels/program_synthesis/search/enumerative.py
+++ b/src/cognithor/channels/program_synthesis/search/enumerative.py
@@ -325,6 +325,17 @@ class EnumerativeSearch:
                 input_type_tag = "Grid"  # never reached as demo input
             elif isinstance(first_input, int):
                 input_type_tag = "Int"
+            elif isinstance(first_input, list) and first_input:
+                # Sprint-22 PR#4: list inputs are StringList or IntList
+                # depending on element type. Empty lists are ambiguous
+                # and stay tagged Grid (the default), which means no
+                # primitive will match — caller should send at least
+                # one populated example.
+                head = first_input[0]
+                if isinstance(head, str):
+                    input_type_tag = "StringList"
+                elif isinstance(head, int) and not isinstance(head, bool):
+                    input_type_tag = "IntList"
 
         bank: dict[str, list[ProgramNode]] = _zero_arity_leaves(self._registry)
         bank.setdefault(input_type_tag, []).append(InputRef(output_type=input_type_tag))
@@ -385,11 +396,19 @@ class EnumerativeSearch:
                     # FlashFill-style family. ``Int`` is added by the
                     # Number-DSL family — synthesis tasks like int → int
                     # arithmetic and string → int parsing emit ints as
-                    # the expected output. Other intermediate types
+                    # the expected output. ``IntList`` is added by the
+                    # List-DSL family for tasks that produce a sorted /
+                    # reversed list of ints. Other intermediate types
                     # (Mask, Object, Color, Predicate, Lambda, ...) only
                     # exist as composition glue and never appear as a
                     # demo's expected output.
-                    is_demo_output_type = type_tag in ("Grid", "String", "StringList", "Int")
+                    is_demo_output_type = type_tag in (
+                        "Grid",
+                        "String",
+                        "StringList",
+                        "Int",
+                        "IntList",
+                    )
                     if is_demo_output_type and _all_demos_correct(candidate, spec, self._executor):
                         return _success(program=candidate, stats=stats, cache_hit=False)
 

--- a/src/cognithor/mcp/pse_tools.py
+++ b/src/cognithor/mcp/pse_tools.py
@@ -125,13 +125,19 @@ def _coerce_value(raw: Any) -> Any:
     * ``list[list[int]]`` → ``np.ndarray`` (grid family — ARC-DSL)
     * ``str`` → ``str`` (string family — FlashFill-style)
     * ``int`` → ``int`` (number family — arithmetic + bridge ops)
+    * ``list[str]`` → ``list[str]`` (string-list family — split / join)
+    * ``list[int]`` → ``list[int]`` (int-list family — sum / max / sort)
 
     Booleans are explicitly rejected: Python's ``bool`` is a subclass
     of ``int`` so an unguarded ``isinstance(raw, int)`` check would
     accept ``True`` / ``False`` and the search engine would happily
     type-check them as ``Int``, which is never what the caller meant.
 
-    More families register here as they ship (sql / ast).
+    Empty lists are rejected per-example because the type tag (str-
+    list vs int-list) cannot be inferred — the homogeneity check
+    would then have to guess. Callers should send at least one
+    populated demo so the type is unambiguous.
+
     Non-fitting payloads raise :class:`ValueError` so the MCP layer
     returns a structured error rather than crashing the engine.
     """
@@ -140,14 +146,30 @@ def _coerce_value(raw: Any) -> Any:
     if isinstance(raw, bool):
         raise ValueError(
             f"unsupported input type {type(raw).__name__} — "
-            "expected 2-D int list (grid), str, or int"
+            "expected 2-D int list (grid), str, int, list[str], or list[int]"
         )
     if isinstance(raw, int):
         return raw
-    if isinstance(raw, list) and raw and isinstance(raw[0], list):
-        return _coerce_grid(raw)
+    if isinstance(raw, list):
+        if not raw:
+            raise ValueError(
+                "empty list rejected — type (StringList vs IntList) "
+                "cannot be inferred from an empty payload"
+            )
+        head = raw[0]
+        if isinstance(head, list):
+            return _coerce_grid(raw)
+        if isinstance(head, str):
+            if not all(isinstance(v, str) for v in raw):
+                raise ValueError("string list must contain only str elements")
+            return raw
+        if isinstance(head, int) and not isinstance(head, bool):
+            if not all(isinstance(v, int) and not isinstance(v, bool) for v in raw):
+                raise ValueError("int list must contain only non-bool int elements")
+            return raw
     raise ValueError(
-        f"unsupported input type {type(raw).__name__} — expected 2-D int list (grid), str, or int"
+        f"unsupported input type {type(raw).__name__} — "
+        "expected 2-D int list (grid), str, int, list[str], or list[int]"
     )
 
 
@@ -188,13 +210,15 @@ def _examples_from_json(payload: Any) -> tuple[tuple[Any, Any], ...]:
         parsed.append((inp, out))
     # Heterogeneous families would always lose at the type-filter; the
     # explicit error makes the diagnostic obvious instead of silently
-    # returning ``no_solution``. Sprint-22: ``str`` ↔ ``int`` is
-    # *allowed* because the Number-DSL family ships explicit bridge
-    # primitives (``int_to_string`` / ``string_to_int`` /
-    # ``string_length``); only the Grid family is structurally
-    # disjoint from the text-shaped families.
-    if "ndarray" in families and ("str" in families or "int" in families):
-        raise ValueError("'examples' must not mix grids with text-shaped values (strings or ints)")
+    # returning ``no_solution``. Sprint-22: ``str`` / ``int`` / ``list``
+    # mix freely because the families ship explicit bridge primitives
+    # (``int_to_string`` / ``string_to_int`` / ``string_length`` /
+    # ``string_list_length`` / ``int_list_sum``); only the Grid
+    # family is structurally disjoint from the text-shaped families.
+    if "ndarray" in families and len(families - {"ndarray"}) > 0:
+        raise ValueError(
+            "'examples' must not mix grids with text-shaped values (strings, ints, or lists)"
+        )
     return tuple(parsed)
 
 

--- a/tests/test_channels/test_program_synthesis/unit/test_list_primitives.py
+++ b/tests/test_channels/test_program_synthesis/unit/test_list_primitives.py
@@ -1,0 +1,279 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-22 Track B PR#4 — List/Sequence-DSL family tests."""
+
+from __future__ import annotations
+
+from cognithor.channels.program_synthesis.core.types import (
+    Budget,
+    SynthesisStatus,
+    TaskSpec,
+)
+from cognithor.channels.program_synthesis.dsl import list_primitives as lp
+from cognithor.channels.program_synthesis.dsl.registry import REGISTRY
+from cognithor.channels.program_synthesis.dsl.signatures import ALLOWED_TYPES
+from cognithor.channels.program_synthesis.integration.pge_adapter import (
+    ProgramSynthesisChannel,
+    SynthesisRequest,
+)
+
+# ---------------------------------------------------------------------------
+# Pure-function unit tests — StringList
+# ---------------------------------------------------------------------------
+
+
+class TestStringListPrimitivesPure:
+    def test_reverse(self) -> None:
+        assert lp.string_list_reverse(["a", "b", "c"]) == ["c", "b", "a"]
+        assert lp.string_list_reverse([]) == []
+
+    def test_unique(self) -> None:
+        assert lp.string_list_unique(["a", "b", "a", "c", "b"]) == ["a", "b", "c"]
+        assert lp.string_list_unique([]) == []
+
+    def test_sort(self) -> None:
+        assert lp.string_list_sort(["c", "a", "b"]) == ["a", "b", "c"]
+        assert lp.string_list_sort([]) == []
+
+    def test_first(self) -> None:
+        assert lp.string_list_first(["a", "b"]) == "a"
+        assert lp.string_list_first([]) == ""
+
+    def test_last(self) -> None:
+        assert lp.string_list_last(["a", "b", "c"]) == "c"
+        assert lp.string_list_last([]) == ""
+
+    def test_length(self) -> None:
+        assert lp.string_list_length([]) == 0
+        assert lp.string_list_length(["a", "b", "c"]) == 3
+
+    def test_count_nonempty(self) -> None:
+        assert lp.string_list_count_nonempty(["a", "", "b", ""]) == 2
+        assert lp.string_list_count_nonempty([]) == 0
+
+
+# ---------------------------------------------------------------------------
+# Pure-function unit tests — IntList
+# ---------------------------------------------------------------------------
+
+
+class TestIntListPrimitivesPure:
+    def test_reverse(self) -> None:
+        assert lp.int_list_reverse([1, 2, 3]) == [3, 2, 1]
+        assert lp.int_list_reverse([]) == []
+
+    def test_sort(self) -> None:
+        assert lp.int_list_sort([3, 1, 2]) == [1, 2, 3]
+        assert lp.int_list_sort([]) == []
+
+    def test_first(self) -> None:
+        assert lp.int_list_first([5, 9, 1]) == 5
+
+    def test_first_raises_on_empty(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError):
+            lp.int_list_first([])
+
+    def test_sum(self) -> None:
+        assert lp.int_list_sum([1, 2, 3]) == 6
+        assert lp.int_list_sum([]) == 0  # empty sum is 0
+        assert lp.int_list_sum([-1, 1]) == 0
+
+    def test_max(self) -> None:
+        assert lp.int_list_max([5, 1, 9]) == 9
+        assert lp.int_list_max([-3, -1, -7]) == -1
+
+    def test_max_raises_on_empty(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError):
+            lp.int_list_max([])
+
+    def test_min(self) -> None:
+        assert lp.int_list_min([5, 1, 9]) == 1
+        assert lp.int_list_min([-3, -1, -7]) == -7
+
+    def test_min_raises_on_empty(self) -> None:
+        import pytest
+
+        with pytest.raises(ValueError):
+            lp.int_list_min([])
+
+    def test_length(self) -> None:
+        assert lp.int_list_length([]) == 0
+        assert lp.int_list_length([7]) == 1
+        assert lp.int_list_length([1, 2, 3, 4, 5]) == 5
+
+
+# ---------------------------------------------------------------------------
+# Type-checking
+# ---------------------------------------------------------------------------
+
+
+class TestListPrimitivesTypeChecking:
+    def test_string_list_reverse_rejects_non_list(self) -> None:
+        import pytest
+
+        with pytest.raises(TypeError):
+            lp.string_list_reverse("abc")  # type: ignore[arg-type]
+
+    def test_int_list_sum_rejects_non_list(self) -> None:
+        import pytest
+
+        with pytest.raises(TypeError):
+            lp.int_list_sum(5)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+class TestListPrimitivesRegistration:
+    def test_intlist_in_allowed_types(self) -> None:
+        assert "IntList" in ALLOWED_TYPES
+
+    def test_all_14_are_registered(self) -> None:
+        registered = {p.name for p in REGISTRY.all_primitives()}
+        expected = {
+            "string_list_reverse",
+            "string_list_unique",
+            "string_list_sort",
+            "string_list_first",
+            "string_list_last",
+            "string_list_length",
+            "string_list_count_nonempty",
+            "int_list_reverse",
+            "int_list_sort",
+            "int_list_first",
+            "int_list_sum",
+            "int_list_max",
+            "int_list_min",
+            "int_list_length",
+        }
+        assert expected.issubset(registered)
+
+    def test_string_list_signatures(self) -> None:
+        spec = REGISTRY.get("string_list_first")
+        assert spec.signature.inputs == ("StringList",)
+        assert spec.signature.output == "String"
+
+    def test_int_list_signatures(self) -> None:
+        spec = REGISTRY.get("int_list_max")
+        assert spec.signature.inputs == ("IntList",)
+        assert spec.signature.output == "Int"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end synthesis tests
+# ---------------------------------------------------------------------------
+
+
+def _synthesize(examples: tuple[tuple[object, object], ...]) -> object:
+    ch = ProgramSynthesisChannel(actor="list-test")
+    spec = TaskSpec(examples=examples)
+    return ch.synthesize(
+        SynthesisRequest(
+            spec=spec,
+            budget=Budget(max_depth=3, wall_clock_seconds=5.0, cache_lookup=False),
+        )
+    )
+
+
+class TestStringListSynthesisEndToEnd:
+    def test_synth_reverse(self) -> None:
+        result = _synthesize(
+            (
+                (["a", "b", "c"], ["c", "b", "a"]),
+                (["x", "y"], ["y", "x"]),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "string_list_reverse" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_sort(self) -> None:
+        result = _synthesize(
+            (
+                (["c", "a", "b"], ["a", "b", "c"]),
+                (["d", "b", "c", "a"], ["a", "b", "c", "d"]),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "string_list_sort" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_first(self) -> None:
+        result = _synthesize(
+            (
+                (["alpha", "beta", "gamma"], "alpha"),
+                (["foo", "bar"], "foo"),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "string_list_first" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_length(self) -> None:
+        result = _synthesize(
+            (
+                (["a", "b"], 2),
+                (["x", "y", "z"], 3),
+                (["one"], 1),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "string_list_length" in str(result.program)  # type: ignore[attr-defined]
+
+
+class TestIntListSynthesisEndToEnd:
+    def test_synth_sum(self) -> None:
+        result = _synthesize(
+            (
+                ([1, 2, 3], 6),
+                ([10, 20, 30], 60),
+                ([5, 5], 10),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "int_list_sum" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_max(self) -> None:
+        result = _synthesize(
+            (
+                ([5, 1, 9], 9),
+                ([3, 7, 4], 7),
+                ([-1, -5, -2], -1),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "int_list_max" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_min(self) -> None:
+        result = _synthesize(
+            (
+                ([5, 1, 9], 1),
+                ([3, 7, 4], 3),
+                ([-1, -5, -2], -5),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "int_list_min" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_length(self) -> None:
+        result = _synthesize(
+            (
+                ([1, 2], 2),
+                ([7, 8, 9], 3),
+                ([42], 1),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "int_list_length" in str(result.program)  # type: ignore[attr-defined]
+
+    def test_synth_sort(self) -> None:
+        result = _synthesize(
+            (
+                ([3, 1, 2], [1, 2, 3]),
+                ([5, 9, 1], [1, 5, 9]),
+            )
+        )
+        assert result.status == SynthesisStatus.SUCCESS  # type: ignore[attr-defined]
+        assert "int_list_sort" in str(result.program)  # type: ignore[attr-defined]


### PR DESCRIPTION
## Summary

PR#4 of **Track B** and the **final** piece of the Open-World DSL push. Adds 14 reductions, reorderings, and bridges over both \`StringList\` (introduced in PR#1) and the new \`IntList\` type — **closing DSL-Coverage and Input-Typing axes at 10/10**.

| Axis | After PR#3 | After this PR |
|---|---|---|
| **DSL-Coverage** | 9/10 | **10/10** |
| **Input-Typing** | 9/10 | **10/10** |
| Total registered primitives | 116 | **130** |

## What's in

**14 list/sequence primitives** (\`src/cognithor/channels/program_synthesis/dsl/list_primitives.py\`):

| Axis | Primitives |
|---|---|
| String-list reorder | \`string_list_reverse\`, \`string_list_unique\`, \`string_list_sort\` |
| String-list reduce | \`string_list_first\`, \`string_list_last\`, \`string_list_length\`, \`string_list_count_nonempty\` |
| Int-list reorder | \`int_list_reverse\`, \`int_list_sort\` |
| Int-list reduce | \`int_list_first\`, \`int_list_sum\`, \`int_list_max\`, \`int_list_min\`, \`int_list_length\` |

Reductions to \`Int\` are the bridges that connect this family back to the Number-DSL family from PR#3 — programs like \`int_increment(int_list_max(...))\` are now reachable.

## Engine generalisations

1. **\`IntList\` added to \`ALLOWED_TYPES\`** alongside \`StringList\`.
2. **Input-type detection** for \`list[str]\` → StringList and \`list[int]\` → IntList (with the same explicit \`bool\` exclusion the Number-DSL applies).
3. **\`IntList\` joins the demo-output type set** so list-producing programs can early-exit.
4. **MCP \`_coerce_value\`** accepts \`list[str]\` and \`list[int]\`; homogeneity check now allows free mixing of str / int / list (bridge primitives connect them) and only rejects Grid + text-shaped mixing.

## Tests (32 new, all green)

End-to-end synthesis on real demos:

```
StringList:
  reverse  success    string_list_reverse(InputRef(0))
  sort     success    string_list_sort(InputRef(0))
  first    success    string_list_first(InputRef(0))
  length   success    string_list_length(InputRef(0))

IntList:
  sum      success    int_list_sum(InputRef(0))
  max      success    int_list_max(InputRef(0))
  min      success    int_list_min(InputRef(0))
  length   success    int_list_length(InputRef(0))
  sort     success    int_list_sort(InputRef(0))
```

## Local pre-flight

- [x] \`pytest tests/test_channels/test_program_synthesis/ tests/test_mcp/test_pse_tools.py\` → **2016 passed, 10 skipped**
- [x] \`ruff format --check\` clean
- [x] \`ruff check\` clean
- [x] \`mypy --strict list_primitives.py\` clean

## Stack note

This branch carries PR#1 + PR#2 + PR#3's cherry-picked foundational commits so it stands alone. When earlier PRs land, the rebase here resolves to a no-op on identical text.

## Track B summary — DSL-Coverage 3 → 10

| PR | Theme | Primitives | DSL-Coverage |
|---|---|---|---|
| ✅ #343 | String-DSL + generic input typing | +14 | 3 → 6 |
| ✅ #344 | Regex/Pattern-DSL family | +14 | 6 → 7 |
| ✅ #345 | Number/Int-DSL + Int as first-class | +12 | 7 → 9 |
| ✅ **this** | List/Sequence-DSL + IntList type | +14 | 9 → **10** |
| | **Total** | **+54** | **3 → 10** |

After this PR lands, the Open-World Readiness scorecard reaches:

- ✅ Engine-Performance — 10/10 (PR #342)
- ✅ Infrastruktur — 10/10 (PR #341)
- ✅ Cognithor-Runtime-Integration — 10/10 (PRs #337, #338, #340)
- ✅ Verifier-Robustheit — 10/10 (PR #339)
- ✅ Budget-Verhalten — 10/10 (PR #339)
- ✅ **DSL-Coverage** — 10/10 (this PR)
- ✅ **Input-Typing** — 10/10 (this PR)