### PR TITLE
feat(router): Sprint-23 — task-aware context profile selection

### DIFF
--- a/src/cognithor/core/model_router.py
+++ b/src/cognithor/core/model_router.py
@@ -81,6 +81,87 @@ _coding_override_var: contextvars.ContextVar[str | None] = contextvars.ContextVa
 )
 
 
+# ---------------------------------------------------------------------------
+# Sprint-23 — Task-aware context profiles.
+# ---------------------------------------------------------------------------
+#
+# The urgency / concierge profile selects *which model* to call. The
+# context profile selects *how much context* to feed the chosen model
+# and *how creative* its sampling should be. The two are orthogonal:
+# you can run ``asap × deep`` (largest model, biggest window) or
+# ``no_hurry × quick`` (smallest model, tight window) — they compose.
+#
+# Four built-in profiles cover the spectrum from "snappy chat reply"
+# to "interactive ARC-AGI-3 game agent at 128 k context":
+#
+#   * ``quick``    —  8 k context,    tight sampling. Routine Q&A.
+#   * ``default``  — 32 k context,    balanced sampling. Cognithor's
+#                    standard PGE-Trinity loop.
+#   * ``deep``     — 65 k context,    creative sampling. Long-document
+#                    reasoning, retrieval-augmented generation.
+#   * ``arc_agi3`` — 128 k context, deterministic sampling. The
+#                    Sprint-22 side-quest probe verified Qwen3.6:27b
+#                    at 128k decodes correctly under vLLM (15 tok/s,
+#                    105 s init) — settings re-used here so the same
+#                    profile drives game-loop interaction.
+
+
+@dataclasses.dataclass(frozen=True)
+class ContextProfile:
+    """Task-aware context window + sampling profile.
+
+    Composes orthogonally with :class:`ConciergeProfile`: urgency picks
+    the model, the context profile decides how big a window the model
+    sees and how creative its sampling is.
+    """
+
+    name: str
+    num_ctx: int
+    temperature: float
+    top_p: float
+    description: str
+
+
+CONTEXT_PROFILES: dict[str, ContextProfile] = {
+    "quick": ContextProfile(
+        name="quick",
+        num_ctx=8192,
+        temperature=0.3,
+        top_p=0.9,
+        description="Tight 8k window for short Q&A and routine tool calls.",
+    ),
+    "default": ContextProfile(
+        name="default",
+        num_ctx=32768,
+        temperature=0.7,
+        top_p=0.9,
+        description="Balanced 32k window — Cognithor's standard PGE-Trinity setting.",
+    ),
+    "deep": ContextProfile(
+        name="deep",
+        num_ctx=65536,
+        temperature=0.8,
+        top_p=0.95,
+        description="Wide 64k window for long-document reasoning and RAG.",
+    ),
+    "arc_agi3": ContextProfile(
+        name="arc_agi3",
+        num_ctx=131072,
+        temperature=0.2,
+        top_p=0.9,
+        description=(
+            "128k window with deterministic sampling — Sprint-22 side-quest "
+            "settings for ARC-AGI-3 game-loop interaction (vLLM/Qwen3.6:27b)."
+        ),
+    ),
+}
+
+# Per-task context-profile override using ContextVar for concurrency safety.
+_context_profile_var: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "_context_profile", default=None
+)
+
+
 def _prepare_image_payload(images: list[str]) -> list[str]:
     """Normalize a mixed list of image paths + raw base64 strings.
 
@@ -579,6 +660,50 @@ class ModelRouter:
         """Look up a concierge profile by urgency name."""
         return CONCIERGE_PROFILES.get(urgency)
 
+    # ------------------------------------------------------------------
+    # Sprint-23 — task-aware context profiles
+    # ------------------------------------------------------------------
+    #
+    # Context profiles are orthogonal to urgency: urgency picks the
+    # model, context profile picks the window + sampling. Both are
+    # ContextVar-isolated so concurrent requests cannot bleed.
+
+    def set_context_profile(self, profile_name: str) -> None:
+        """Set the active context profile for downstream model calls.
+
+        Valid values: any key in :data:`CONTEXT_PROFILES`
+        (``"quick"``, ``"default"``, ``"deep"``, ``"arc_agi3"``).
+
+        When set, :meth:`get_model_config` overlays the profile's
+        ``num_ctx`` / ``temperature`` / ``top_p`` on top of the model
+        family defaults. ContextVar isolation means each async task
+        (asyncio.Task / ``contextvars.copy_context()``) gets its own
+        value — concurrent requests cannot interfere.
+        """
+        if profile_name not in CONTEXT_PROFILES:
+            raise ValueError(
+                f"Unknown context profile {profile_name!r}. "
+                f"Valid options: {sorted(CONTEXT_PROFILES)}"
+            )
+        _context_profile_var.set(profile_name)
+        log.info("context_profile_set", profile=profile_name)
+
+    def get_context_profile(self) -> str | None:
+        """Return the active context profile name, or ``None`` if not set."""
+        return _context_profile_var.get()
+
+    def clear_context_profile(self) -> None:
+        """Remove the context-profile override."""
+        current = _context_profile_var.get()
+        if current:
+            log.info("context_profile_cleared", profile=current)
+        _context_profile_var.set(None)
+
+    @staticmethod
+    def get_context_profile_spec(profile_name: str) -> ContextProfile | None:
+        """Look up a context profile by name. Returns ``None`` if unknown."""
+        return CONTEXT_PROFILES.get(profile_name)
+
     async def initialize(self) -> None:
         """Check which models are available.
 
@@ -745,7 +870,16 @@ class ModelRouter:
         return getattr(cfg, "backend", "") or ""
 
     def get_model_config(self, model_name: str) -> dict[str, Any]:
-        """Return the configuration parameters for a model."""
+        """Return the configuration parameters for a model.
+
+        Sprint-23: when a context profile is active for the current
+        async task, the profile's ``num_ctx`` / ``temperature`` /
+        ``top_p`` overlay the model family defaults. Embedding models
+        ignore the overlay because their sampling settings are
+        embedding-implementation specific. The overlay is task-local
+        (ContextVar) so concurrent requests with different profiles
+        don't bleed into each other.
+        """
         configs = {
             self._config.models.planner.name: self._config.models.planner,
             self._config.models.executor.name: self._config.models.executor,
@@ -755,13 +889,28 @@ class ModelRouter:
         }
         config = configs.get(model_name)
         if config:
-            return {
+            base = {
                 "temperature": config.temperature,
                 "top_p": config.top_p,
                 "context_window": config.context_window,
             }
-        # Default values for unknown models
-        return {"temperature": 0.7, "top_p": 0.9, "context_window": 32768}
+        else:
+            base = {"temperature": 0.7, "top_p": 0.9, "context_window": 32768}
+
+        # Sprint-23: apply the active context profile overlay. The
+        # embedding model keeps its hard-coded sampling because the
+        # profile's temperature / top_p are inappropriate for embedding.
+        profile_name = _context_profile_var.get()
+        is_embedding_model = model_name == self._config.models.embedding.name
+        if profile_name and not is_embedding_model:
+            profile = CONTEXT_PROFILES.get(profile_name)
+            if profile:
+                base = {
+                    "temperature": profile.temperature,
+                    "top_p": profile.top_p,
+                    "context_window": profile.num_ctx,
+                }
+        return base
 
 
 def messages_to_ollama(messages: list[Message]) -> list[dict[str, Any]]:

--- a/tests/test_core/test_context_profile_routing.py
+++ b/tests/test_core/test_context_profile_routing.py
@@ -1,0 +1,260 @@
+"""Tests for Sprint-23 task-aware context profile routing.
+
+Tests:
+  - ContextProfile dataclass shape + frozen
+  - CONTEXT_PROFILES registry contents (4 profiles, expected num_ctx)
+  - set_context_profile / get_context_profile / clear_context_profile
+  - Invalid profile name raises ValueError with available options listed
+  - get_model_config() overlays the profile when set
+  - Embedding model ignores the overlay
+  - Profile + urgency compose orthogonally (urgency picks model, profile picks ctx)
+  - ContextVar isolation across asyncio tasks (no cross-request leakage)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextvars
+
+import pytest
+
+from cognithor.config import CognithorConfig
+from cognithor.core.model_router import (
+    CONTEXT_PROFILES,
+    ContextProfile,
+    ModelRouter,
+    OllamaClient,
+    _context_profile_var,
+    _urgency_var,
+)
+
+
+@pytest.fixture()
+def config(tmp_path) -> CognithorConfig:
+    return CognithorConfig(cognithor_home=tmp_path)
+
+
+@pytest.fixture()
+def client(config: CognithorConfig) -> OllamaClient:
+    return OllamaClient(config)
+
+
+@pytest.fixture()
+def router(config: CognithorConfig, client: OllamaClient) -> ModelRouter:
+    return ModelRouter(config, client)
+
+
+@pytest.fixture(autouse=True)
+def _reset_context_state():
+    """Reset both ContextVars between tests to avoid cross-test bleed."""
+    _context_profile_var.set(None)
+    _urgency_var.set(None)
+    yield
+    _context_profile_var.set(None)
+    _urgency_var.set(None)
+
+
+# ============================================================================
+# ContextProfile dataclass
+# ============================================================================
+
+
+class TestContextProfile:
+    def test_profile_is_frozen(self) -> None:
+        p = ContextProfile(name="test", num_ctx=1024, temperature=0.5, top_p=0.9, description="d")
+        with pytest.raises(AttributeError):
+            p.num_ctx = 2048  # type: ignore[misc]
+
+    def test_profile_fields(self) -> None:
+        p = ContextProfile(
+            name="x",
+            num_ctx=8192,
+            temperature=0.3,
+            top_p=0.95,
+            description="X profile",
+        )
+        assert p.name == "x"
+        assert p.num_ctx == 8192
+        assert p.temperature == 0.3
+        assert p.top_p == 0.95
+        assert p.description == "X profile"
+
+
+# ============================================================================
+# CONTEXT_PROFILES registry
+# ============================================================================
+
+
+class TestContextProfileRegistry:
+    def test_all_four_profiles_exist(self) -> None:
+        assert set(CONTEXT_PROFILES) == {"quick", "default", "deep", "arc_agi3"}
+
+    def test_quick_window_is_8k(self) -> None:
+        assert CONTEXT_PROFILES["quick"].num_ctx == 8192
+
+    def test_default_window_is_32k(self) -> None:
+        assert CONTEXT_PROFILES["default"].num_ctx == 32768
+
+    def test_deep_window_is_64k(self) -> None:
+        assert CONTEXT_PROFILES["deep"].num_ctx == 65536
+
+    def test_arc_agi3_window_is_128k(self) -> None:
+        # Sprint-22 side-quest probe verified Qwen3.6:27b decodes
+        # correctly at 128 k under vLLM. Pin the value here so the
+        # ARC-AGI-3 game-loop interaction inherits it.
+        assert CONTEXT_PROFILES["arc_agi3"].num_ctx == 131072
+
+    def test_window_sizes_are_strictly_monotonic(self) -> None:
+        # quick < default < deep < arc_agi3
+        order = ("quick", "default", "deep", "arc_agi3")
+        widths = [CONTEXT_PROFILES[name].num_ctx for name in order]
+        assert widths == sorted(widths)
+        assert len(set(widths)) == len(widths)
+
+    def test_arc_agi3_uses_low_temperature(self) -> None:
+        # Game-loop interaction needs deterministic action selection,
+        # so the profile must keep temperature below 0.5.
+        assert CONTEXT_PROFILES["arc_agi3"].temperature <= 0.5
+
+    def test_get_context_profile_spec_found(self) -> None:
+        p = ModelRouter.get_context_profile_spec("quick")
+        assert p is not None
+        assert p.name == "quick"
+
+    def test_get_context_profile_spec_unknown(self) -> None:
+        assert ModelRouter.get_context_profile_spec("nonexistent") is None
+
+
+# ============================================================================
+# set_context_profile / get / clear
+# ============================================================================
+
+
+class TestContextProfileLifecycle:
+    def test_default_is_none(self, router: ModelRouter) -> None:
+        assert router.get_context_profile() is None
+
+    def test_set_then_get(self, router: ModelRouter) -> None:
+        router.set_context_profile("deep")
+        assert router.get_context_profile() == "deep"
+
+    def test_set_then_clear(self, router: ModelRouter) -> None:
+        router.set_context_profile("arc_agi3")
+        router.clear_context_profile()
+        assert router.get_context_profile() is None
+
+    def test_invalid_name_raises_with_valid_options(self, router: ModelRouter) -> None:
+        with pytest.raises(ValueError, match="Unknown context profile"):
+            router.set_context_profile("nuclear")
+
+    def test_invalid_name_lists_available_options(self, router: ModelRouter) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            router.set_context_profile("bogus")
+        # Each registered profile must appear in the error message so
+        # the caller knows what they can use instead.
+        for valid in ("quick", "default", "deep", "arc_agi3"):
+            assert valid in str(excinfo.value)
+
+
+# ============================================================================
+# get_model_config overlay
+# ============================================================================
+
+
+class TestContextProfileOverlay:
+    def test_no_profile_uses_model_defaults(self, router: ModelRouter, config) -> None:
+        # Without an active profile, the model's own defaults from
+        # config flow through unchanged.
+        cfg = router.get_model_config(config.models.planner.name)
+        assert cfg["context_window"] == config.models.planner.context_window
+
+    def test_quick_overlay_shrinks_ctx_to_8k(self, router: ModelRouter, config) -> None:
+        router.set_context_profile("quick")
+        cfg = router.get_model_config(config.models.planner.name)
+        assert cfg["context_window"] == 8192
+        assert cfg["temperature"] == 0.3
+
+    def test_arc_agi3_overlay_grows_ctx_to_128k(self, router: ModelRouter, config) -> None:
+        router.set_context_profile("arc_agi3")
+        cfg = router.get_model_config(config.models.planner.name)
+        assert cfg["context_window"] == 131072
+
+    def test_unknown_model_still_gets_overlay(self, router: ModelRouter) -> None:
+        # Unknown model names normally fall back to {temp 0.7, top_p 0.9,
+        # ctx 32k}. The overlay must apply to that fallback too —
+        # otherwise switching providers (vLLM, OpenAI, …) would silently
+        # drop the profile.
+        router.set_context_profile("deep")
+        cfg = router.get_model_config("some-third-party-model:8b")
+        assert cfg["context_window"] == 65536
+        assert cfg["temperature"] == 0.8
+
+    def test_embedding_model_ignores_overlay(self, router: ModelRouter, config) -> None:
+        # Embedding models have no notion of "creative sampling" — the
+        # profile's temperature / top_p are inappropriate. They must
+        # keep the family defaults from config.
+        router.set_context_profile("arc_agi3")
+        cfg = router.get_model_config(config.models.embedding.name)
+        assert cfg["temperature"] == config.models.embedding.temperature
+        assert cfg["top_p"] == config.models.embedding.top_p
+
+
+# ============================================================================
+# Orthogonality with ConciergeProfile (urgency)
+# ============================================================================
+
+
+class TestProfileOrthogonality:
+    def test_urgency_and_context_profile_compose(self, router: ModelRouter) -> None:
+        # Urgency chooses the model, context profile chooses the
+        # window+sampling. They are independent dimensions.
+        router.set_urgency("asap")
+        router.set_context_profile("quick")
+        assert router.get_urgency() == "asap"
+        assert router.get_context_profile() == "quick"
+
+    def test_clearing_one_does_not_affect_the_other(self, router: ModelRouter) -> None:
+        router.set_urgency("balanced")
+        router.set_context_profile("deep")
+        router.clear_context_profile()
+        assert router.get_urgency() == "balanced"
+        assert router.get_context_profile() is None
+
+
+# ============================================================================
+# ContextVar isolation under concurrent asyncio tasks
+# ============================================================================
+
+
+class TestContextVarIsolation:
+    def test_two_tasks_get_independent_profiles(self, router: ModelRouter) -> None:
+        """Concurrent asyncio.Tasks each see only their own profile.
+
+        Without ContextVar isolation, request A setting ``arc_agi3``
+        before yielding would leak into request B's get_model_config,
+        ballooning their context window 16x and throwing GPU OOM. This
+        test pins the isolation guarantee.
+        """
+
+        async def _task(profile_name: str, holder: dict[str, str | None]) -> None:
+            ctx = contextvars.copy_context()
+
+            def _inside() -> None:
+                router.set_context_profile(profile_name)
+                holder[profile_name] = router.get_context_profile()
+
+            ctx.run(_inside)
+
+        async def _drive() -> dict[str, str | None]:
+            holder: dict[str, str | None] = {}
+            await asyncio.gather(
+                _task("quick", holder),
+                _task("arc_agi3", holder),
+                _task("deep", holder),
+            )
+            return holder
+
+        result = asyncio.run(_drive())
+        assert result == {"quick": "quick", "arc_agi3": "arc_agi3", "deep": "deep"}
+        # The outer test ContextVar is untouched.
+        assert router.get_context_profile() is None


### PR DESCRIPTION
## Summary

Adds a second routing dimension orthogonal to the existing \`ConciergeProfile\` urgency dimension. Where **urgency picks *which* model** to call, the new **\`ContextProfile\` picks *how much context*** that model sees and *how creative* its sampling is — the two compose, so \`asap × deep\` (largest model + biggest window) and \`no_hurry × quick\` (smallest model + tight window) are both expressible without code changes.

This closes the user-requested feature from Sprint-22:
> "Ich will, dass cognithor im Router mehrere Modell-Settings bekommt — je nach Komplexität der Aufgabe... auch das arc agi 3 game testing settings als 4. Option"

## Four built-in profiles

| Profile | num_ctx | Temp | Top_p | Use |
|---|---:|---:|---:|---|
| \`quick\` | **8 k** | 0.3 | 0.9 | Short Q&A, routine tool calls |
| \`default\` | **32 k** | 0.7 | 0.9 | Standard PGE-Trinity loop |
| \`deep\` | **64 k** | 0.8 | 0.95 | Long-document reasoning, RAG |
| \`arc_agi3\` | **128 k** | 0.2 | 0.9 | ARC-AGI-3 game-loop, Sprint-22 probe settings |

The \`arc_agi3\` profile is pinned to the values verified by the Sprint-22 side-quest probe (Qwen3.6:27b @ 15 tok/s, 105 s init, vLLM with FlashInfer + enforce_eager).

## API surface (mirrors the existing urgency API)

\`\`\`python
router.set_context_profile("arc_agi3")     # activates for the current async task
router.get_context_profile()                # → "arc_agi3"
router.clear_context_profile()              # back to model defaults

ModelRouter.get_context_profile_spec("deep")  # static lookup, → ContextProfile
\`\`\`

## Concurrency safety

The profile is held in a \`ContextVar\` so each \`asyncio.Task\` / \`contextvars.copy_context()\` block gets its own value. Without this isolation, request A setting \`arc_agi3\` then yielding would balloon request B's context window 16× and trigger GPU OOM. Pinned by \`TestContextVarIsolation\`.

## Integration point

\`get_model_config()\` overlays the active profile's \`num_ctx\` / \`temperature\` / \`top_p\` on top of the model family defaults. Embedding models keep their hard-coded sampling because the profile temperature is inappropriate for embedding.

## Tests (24 new, all green)

| Class | Coverage |
|---|---|
| TestContextProfile | Frozen dataclass shape |
| TestContextProfileRegistry | 4 profiles present, monotonic window sizes, arc_agi3 = 128 k + low-T |
| TestContextProfileLifecycle | set/get/clear; invalid name raises with valid options listed |
| TestContextProfileOverlay | Applied to known + unknown models; embedding ignored |
| TestProfileOrthogonality | urgency + context profile compose; clearing is independent |
| TestContextVarIsolation | 3 concurrent asyncio.Tasks each see only their own profile |

## Local pre-flight

- [x] \`pytest tests/test_core/\` → **2410 passed, 1 skipped**
- [x] \`pytest test_context_profile_routing.py\` → **24 passed**
- [x] \`ruff format --check\` clean
- [x] \`ruff check\` clean
- [x] \`mypy --strict model_router.py\` clean

## Test plan

- [ ] CI green
- [ ] No regression in concierge / urgency tests (\`tests/test_core/test_concierge_routing.py\`, \`test_model_router_contextvar.py\`)
- [ ] Profile orthogonality holds in mypy --strict