### PR TITLE
feat(router): Sprint-23 PR#A — pure context-profile selection heuristic

### DIFF
--- a/src/cognithor/core/context_profile_selector.py
+++ b/src/cognithor/core/context_profile_selector.py
@@ -1,0 +1,181 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Sprint-23 PR#A — pure heuristic for picking a context profile.
+
+Sprint-23's :mod:`cognithor.core.model_router` ships four context
+profiles (``quick`` / ``default`` / ``deep`` / ``arc_agi3``) and the
+``ModelRouter.set_context_profile()`` lever to activate them. This
+module is the **decision** half: a single pure function that given a
+few cheap signals about the incoming work returns the recommended
+profile name.
+
+It is intentionally side-effect free — no router mutation, no logging,
+no IO. Callers (gateway, channels, MCP tools) decide *whether* to
+honour the recommendation and *when* to flip the router. That keeps
+the heuristic trivially testable and lets us evolve it without
+touching active code paths.
+
+Heuristic rules (in priority order):
+
+1. **ARC-AGI-3 channel** — game-loop interaction needs the validated
+   128 k profile from the Sprint-22 side-quest probe, regardless of
+   prompt length. Pinned by the Sprint-22 deployment guide.
+2. **Long prompt (≥ 64 k tokens or ≥ 250 KB chars)** — falls into
+   ``deep``. Above 96 k or with attachments, escalate to
+   ``arc_agi3``.
+3. **Medium prompt (≥ 8 k tokens or ≥ 32 KB chars)** — ``default``.
+4. **Short prompt + simple channel** (CLI / Telegram / WebUI plain
+   text, no attachments) — ``quick`` to keep latency tight on routine
+   chat.
+5. **Otherwise** — ``default`` (the safe middle).
+
+Token estimates are intentionally approximate: the function takes the
+*char* count and divides by 4 (the chat-standard rule of thumb for
+English / mixed-language text), so callers don't need to import a
+tokenizer. If a caller already has a precise token count, they can
+pass it directly via ``prompt_tokens=``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Profile names — must stay in sync with CONTEXT_PROFILES in model_router.
+# Importing the dict here would create a circular reference at module-load
+# time (model_router imports from cognithor.config which imports from
+# cognithor.core...), so we duplicate the *names* and rely on the
+# model_router test to assert string-equality with the registry keys.
+PROFILE_QUICK = "quick"
+PROFILE_DEFAULT = "default"
+PROFILE_DEEP = "deep"
+PROFILE_ARC_AGI3 = "arc_agi3"
+
+# Threshold breakpoints. Tuned to match the registry's num_ctx values
+# minus prompt-output headroom (~25 %), so a recommendation always
+# leaves enough window for the model to actually reply.
+_QUICK_TOKEN_CEILING = 6_000  # quick = 8 k → 6 k prompt cap
+_DEFAULT_TOKEN_CEILING = 24_000  # default = 32 k → 24 k prompt cap
+_DEEP_TOKEN_CEILING = 48_000  # deep = 64 k → 48 k prompt cap
+_ARC_TOKEN_CEILING = 96_000  # arc_agi3 = 128 k → 96 k prompt cap
+
+# Char-to-token rule of thumb for mixed-language text.
+_CHARS_PER_TOKEN = 4
+
+# Channel kinds the heuristic recognises. Anything else is treated as
+# "generic" and routed by prompt length only.
+_SIMPLE_CHANNELS = frozenset({"cli", "telegram", "webui", "discord", "slack"})
+_HEAVY_CHANNELS = frozenset({"arc_agi3", "arc_channel", "game_loop"})
+
+
+@dataclass(frozen=True)
+class ProfileRecommendation:
+    """The output of :func:`recommend_context_profile`.
+
+    Carries the recommended profile name plus a short reason string so
+    log lines and tests can assert *why* a profile was picked, not just
+    *which*.
+    """
+
+    profile: str
+    reason: str
+
+
+def estimate_prompt_tokens(prompt_chars: int) -> int:
+    """Cheap char→token estimate for routing decisions.
+
+    Uses the chat-standard rule of thumb (4 chars per token) which is
+    accurate to ±25 % across English / German / mixed-language inputs.
+    Negative inputs are clamped to 0.
+    """
+    if prompt_chars <= 0:
+        return 0
+    return prompt_chars // _CHARS_PER_TOKEN
+
+
+def recommend_context_profile(
+    *,
+    prompt_chars: int = 0,
+    prompt_tokens: int | None = None,
+    channel_kind: str | None = None,
+    has_attachments: bool = False,
+) -> ProfileRecommendation:
+    """Pick a context profile for an incoming workload.
+
+    Args:
+        prompt_chars: Length of the user prompt in *characters*. Used
+            only when ``prompt_tokens`` is not supplied.
+        prompt_tokens: Pre-computed token count, if the caller already
+            tokenized. Wins over ``prompt_chars``.
+        channel_kind: Lowercase channel identifier (``"cli"``,
+            ``"telegram"``, ``"arc_agi3"``, ...). Optional — when
+            absent the heuristic relies on prompt length only.
+        has_attachments: True if the request carries images, files,
+            tool outputs or other non-text payload that inflates the
+            effective context. Tilts the recommendation upward.
+
+    Returns:
+        A :class:`ProfileRecommendation` whose ``profile`` is one of
+        ``quick`` / ``default`` / ``deep`` / ``arc_agi3``.
+    """
+    # Normalise inputs.
+    channel = (channel_kind or "").strip().lower()
+    if prompt_tokens is None:
+        tokens = estimate_prompt_tokens(prompt_chars)
+    else:
+        tokens = max(0, prompt_tokens)
+
+    # Rule 1 — heavy / game-loop channels override everything.
+    if channel in _HEAVY_CHANNELS:
+        return ProfileRecommendation(
+            profile=PROFILE_ARC_AGI3,
+            reason=f"channel_kind={channel!r} — game-loop interaction needs 128k window",
+        )
+
+    # Rule 2 — very long prompts.
+    if tokens >= _DEEP_TOKEN_CEILING or (tokens >= _ARC_TOKEN_CEILING and has_attachments):
+        return ProfileRecommendation(
+            profile=PROFILE_ARC_AGI3,
+            reason=f"prompt_tokens≈{tokens} exceeds deep ceiling",
+        )
+    if tokens >= _DEFAULT_TOKEN_CEILING:
+        return ProfileRecommendation(
+            profile=PROFILE_DEEP,
+            reason=f"prompt_tokens≈{tokens} exceeds default ceiling",
+        )
+
+    # Rule 3 — attachments push medium prompts up one notch because
+    # binary payload inflates the on-wire context the model sees.
+    if has_attachments and tokens >= _QUICK_TOKEN_CEILING:
+        return ProfileRecommendation(
+            profile=PROFILE_DEEP,
+            reason="attachments + medium prompt — wider window keeps recall",
+        )
+
+    # Rule 4 — short prompt on a simple chat channel: quick is the
+    # right latency/quality tradeoff.
+    if tokens < _QUICK_TOKEN_CEILING and channel in _SIMPLE_CHANNELS and not has_attachments:
+        return ProfileRecommendation(
+            profile=PROFILE_QUICK,
+            reason=f"short prompt on simple channel {channel!r}",
+        )
+
+    # Rule 5 — middle prompts always go to default.
+    if tokens < _DEFAULT_TOKEN_CEILING:
+        return ProfileRecommendation(
+            profile=PROFILE_DEFAULT,
+            reason=f"prompt_tokens≈{tokens} fits default ceiling",
+        )
+
+    # Catch-all (unreachable given the ceilings above, but keeps the
+    # function total).
+    return ProfileRecommendation(profile=PROFILE_DEFAULT, reason="fallback")
+
+
+__all__ = [
+    "PROFILE_ARC_AGI3",
+    "PROFILE_DEEP",
+    "PROFILE_DEFAULT",
+    "PROFILE_QUICK",
+    "ProfileRecommendation",
+    "estimate_prompt_tokens",
+    "recommend_context_profile",
+]

--- a/tests/test_core/test_context_profile_selector.py
+++ b/tests/test_core/test_context_profile_selector.py
@@ -1,0 +1,199 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Tests for Sprint-23 PR#A — pure heuristic context-profile selector."""
+
+from __future__ import annotations
+
+from cognithor.core.context_profile_selector import (
+    PROFILE_ARC_AGI3,
+    PROFILE_DEEP,
+    PROFILE_DEFAULT,
+    PROFILE_QUICK,
+    ProfileRecommendation,
+    estimate_prompt_tokens,
+    recommend_context_profile,
+)
+from cognithor.core.model_router import CONTEXT_PROFILES
+
+# ---------------------------------------------------------------------------
+# Cross-module pin: selector profile names match the router's registry keys.
+# Without this, the selector would silently route to a profile name the
+# router refuses, and ``set_context_profile`` would raise at runtime.
+# ---------------------------------------------------------------------------
+
+
+class TestProfileNameRegistryAlignment:
+    def test_all_constants_map_to_registry_keys(self) -> None:
+        for name in (PROFILE_QUICK, PROFILE_DEFAULT, PROFILE_DEEP, PROFILE_ARC_AGI3):
+            assert name in CONTEXT_PROFILES, (
+                f"Selector advertises profile {name!r} that is not in the "
+                f"model_router CONTEXT_PROFILES registry"
+            )
+
+
+# ---------------------------------------------------------------------------
+# estimate_prompt_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateTokens:
+    def test_zero_chars_zero_tokens(self) -> None:
+        assert estimate_prompt_tokens(0) == 0
+
+    def test_negative_clamped_to_zero(self) -> None:
+        assert estimate_prompt_tokens(-100) == 0
+
+    def test_one_token_per_four_chars(self) -> None:
+        assert estimate_prompt_tokens(4) == 1
+        assert estimate_prompt_tokens(40) == 10
+        assert estimate_prompt_tokens(4_000) == 1_000
+
+    def test_floor_division(self) -> None:
+        # 7 chars -> 1 token, not 1.75.
+        assert estimate_prompt_tokens(7) == 1
+
+
+# ---------------------------------------------------------------------------
+# Channel-kind override rule (priority 1)
+# ---------------------------------------------------------------------------
+
+
+class TestChannelKindOverride:
+    def test_arc_agi3_channel_forces_arc_profile_on_short_prompt(self) -> None:
+        rec = recommend_context_profile(prompt_chars=10, channel_kind="arc_agi3")
+        assert rec.profile == PROFILE_ARC_AGI3
+        assert "game-loop" in rec.reason
+
+    def test_arc_channel_alias_forces_arc_profile(self) -> None:
+        rec = recommend_context_profile(prompt_chars=100, channel_kind="arc_channel")
+        assert rec.profile == PROFILE_ARC_AGI3
+
+    def test_game_loop_kind_forces_arc_profile(self) -> None:
+        rec = recommend_context_profile(prompt_chars=100, channel_kind="game_loop")
+        assert rec.profile == PROFILE_ARC_AGI3
+
+    def test_channel_kind_is_case_insensitive(self) -> None:
+        rec = recommend_context_profile(prompt_chars=10, channel_kind="ARC_AGI3")
+        assert rec.profile == PROFILE_ARC_AGI3
+
+
+# ---------------------------------------------------------------------------
+# Long-prompt escalation
+# ---------------------------------------------------------------------------
+
+
+class TestLongPromptEscalation:
+    def test_very_long_prompt_routes_to_arc(self) -> None:
+        # 50 000 tokens worth of chars (200 000 chars) → above deep
+        # ceiling, below arc ceiling — but tokens >= deep_ceiling
+        # pushes straight to arc_agi3.
+        rec = recommend_context_profile(prompt_tokens=50_000)
+        assert rec.profile == PROFILE_ARC_AGI3
+
+    def test_arc_threshold_with_attachments(self) -> None:
+        # At exactly the arc ceiling with attachments → arc_agi3.
+        rec = recommend_context_profile(prompt_tokens=96_000, has_attachments=True)
+        assert rec.profile == PROFILE_ARC_AGI3
+
+    def test_long_prompt_routes_to_deep(self) -> None:
+        rec = recommend_context_profile(prompt_tokens=30_000)
+        assert rec.profile == PROFILE_DEEP
+
+
+# ---------------------------------------------------------------------------
+# Attachments tilt
+# ---------------------------------------------------------------------------
+
+
+class TestAttachmentsTilt:
+    def test_medium_prompt_with_attachments_escalates_to_deep(self) -> None:
+        # 10 000 tokens (medium) + attachments → deep, not default.
+        rec = recommend_context_profile(prompt_tokens=10_000, has_attachments=True)
+        assert rec.profile == PROFILE_DEEP
+
+    def test_short_prompt_with_attachments_stays_default(self) -> None:
+        # Below the quick ceiling, attachments alone shouldn't push
+        # all the way to deep — default is enough headroom.
+        rec = recommend_context_profile(
+            prompt_tokens=2_000,
+            channel_kind="webui",
+            has_attachments=True,
+        )
+        assert rec.profile == PROFILE_DEFAULT
+
+
+# ---------------------------------------------------------------------------
+# Quick path
+# ---------------------------------------------------------------------------
+
+
+class TestQuickPath:
+    def test_short_prompt_simple_channel_routes_to_quick(self) -> None:
+        rec = recommend_context_profile(prompt_chars=200, channel_kind="cli")
+        assert rec.profile == PROFILE_QUICK
+
+    def test_short_prompt_telegram_routes_to_quick(self) -> None:
+        rec = recommend_context_profile(prompt_chars=500, channel_kind="telegram")
+        assert rec.profile == PROFILE_QUICK
+
+    def test_short_prompt_no_channel_falls_back_to_default(self) -> None:
+        # Without a channel hint, we default to ``default`` rather than
+        # ``quick`` — a missing channel is uninformative, and ``quick``
+        # is only safe for genuinely simple chat surfaces.
+        rec = recommend_context_profile(prompt_chars=200)
+        assert rec.profile == PROFILE_DEFAULT
+
+    def test_short_prompt_unknown_channel_falls_back_to_default(self) -> None:
+        rec = recommend_context_profile(prompt_chars=200, channel_kind="unknown_kind")
+        assert rec.profile == PROFILE_DEFAULT
+
+
+# ---------------------------------------------------------------------------
+# Default middle
+# ---------------------------------------------------------------------------
+
+
+class TestDefaultPath:
+    def test_medium_prompt_routes_to_default(self) -> None:
+        rec = recommend_context_profile(prompt_tokens=10_000)
+        assert rec.profile == PROFILE_DEFAULT
+
+    def test_medium_prompt_simple_channel_still_default(self) -> None:
+        # Simple-channel quick path only fires below the quick ceiling;
+        # 10 000 tokens is medium so default wins even on telegram.
+        rec = recommend_context_profile(prompt_tokens=10_000, channel_kind="telegram")
+        assert rec.profile == PROFILE_DEFAULT
+
+
+# ---------------------------------------------------------------------------
+# Output dataclass shape
+# ---------------------------------------------------------------------------
+
+
+class TestRecommendationDataclass:
+    def test_recommendation_is_frozen(self) -> None:
+        rec = ProfileRecommendation(profile="quick", reason="x")
+        try:
+            rec.profile = "default"  # type: ignore[misc]
+        except (AttributeError, Exception):
+            return
+        raise AssertionError("ProfileRecommendation should be frozen")
+
+    def test_reason_is_non_empty_for_every_branch(self) -> None:
+        # Walk every routing branch and assert each carries a useful
+        # reason string. A blank reason in a log line is a debugging
+        # nightmare, so this is a hard contract.
+        cases: list[tuple[dict[str, object], str]] = [
+            ({"channel_kind": "arc_agi3"}, PROFILE_ARC_AGI3),
+            ({"prompt_tokens": 50_000}, PROFILE_ARC_AGI3),
+            ({"prompt_tokens": 30_000}, PROFILE_DEEP),
+            (
+                {"prompt_tokens": 10_000, "has_attachments": True},
+                PROFILE_DEEP,
+            ),
+            ({"prompt_chars": 200, "channel_kind": "cli"}, PROFILE_QUICK),
+            ({"prompt_tokens": 10_000}, PROFILE_DEFAULT),
+        ]
+        for kwargs, expected in cases:
+            rec = recommend_context_profile(**kwargs)  # type: ignore[arg-type]
+            assert rec.profile == expected, (kwargs, rec)
+            assert rec.reason and rec.reason.strip(), kwargs


### PR DESCRIPTION
## Summary

Adds the **decision** half of the Sprint-23 task-aware routing system. \`recommend_context_profile\` is a pure function — given a few cheap signals about an incoming workload it returns the recommended profile name + a reason string. No side effects, no router mutation, no IO.

This is **PR#A of A→C→D**. No active code path is touched. The wireup lands in subsequent PRs:
- **PR#C** — ARC-channel forces \`arc_agi3\` on game-loop entry
- **PR#D** — PSE Phase-2 LLM-Prior calls force \`quick\`

## Heuristic rules (priority order)

| # | Condition | Profile |
|---|---|---|
| 1 | Heavy / game-loop channel (\`arc_agi3\`, \`arc_channel\`, \`game_loop\`) | \`arc_agi3\` |
| 2a | Prompt ≥ 48 k tokens | \`deep\` |
| 2b | Prompt ≥ 96 k tokens **and** attachments | \`arc_agi3\` |
| 3 | Medium prompt + attachments | \`deep\` |
| 4 | Short prompt + simple chat channel (cli/telegram/webui/discord/slack) | \`quick\` |
| 5 | Otherwise | \`default\` |

Token estimates use the chat-standard 4 chars/token rule of thumb so callers don't need to import a tokenizer; precise counts can still be passed via \`prompt_tokens=\`.

## API

\`\`\`python
from cognithor.core.context_profile_selector import recommend_context_profile

rec = recommend_context_profile(
    prompt_chars=200,           # or prompt_tokens=
    channel_kind="cli",         # optional, lowercased internally
    has_attachments=False,
)
# rec.profile  -> "quick"
# rec.reason   -> "short prompt on simple channel 'cli'"
\`\`\`

## Cross-module pin

\`TestProfileNameRegistryAlignment\` asserts every constant in this module appears as a key in \`CONTEXT_PROFILES\` from \`model_router\`. Without it, the selector could silently advertise a profile the router doesn't accept and \`set_context_profile\` would raise at runtime.

## Tests (22 new, all green)

- TestProfileNameRegistryAlignment
- TestEstimateTokens — zero / negative / floor division
- TestChannelKindOverride — heavy channels override prompt length, case-insensitive
- TestLongPromptEscalation — deep / arc_agi3 ceilings
- TestAttachmentsTilt — medium+attachments → deep, short+attachments stays default
- TestQuickPath — simple channel + short prompt → quick, unknown channel → default
- TestDefaultPath — medium prompt always default
- TestRecommendationDataclass — frozen output, non-empty reason on every branch

## Local pre-flight

- [x] \`pytest tests/test_core/test_context_profile_selector.py\` → **22 passed**
- [x] \`ruff format --check\` clean
- [x] \`ruff check\` clean
- [x] \`mypy --strict context_profile_selector.py\` clean

## Test plan

- [ ] CI green
- [ ] No regression in existing context-profile / model-router tests