### PR TITLE
feat(router): Sprint-23 PR#D — pipe num_ctx end-to-end into Ollama wire

### DIFF
--- a/src/cognithor/core/model_router.py
+++ b/src/cognithor/core/model_router.py
@@ -21,7 +21,6 @@ import contextvars
 import dataclasses
 import json
 import time
-from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
 import httpx
@@ -30,7 +29,7 @@ from cognithor.models import Message, MessageRole
 from cognithor.utils.logging import get_logger
 
 if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
+    from collections.abc import AsyncIterator, Iterator
 
     from cognithor.config import CognithorConfig
 
@@ -303,6 +302,7 @@ class OllamaClient:
         format_json: bool = False,
         options: dict[str, Any] | None = None,
         images: list[str] | None = None,
+        num_ctx: int | None = None,
     ) -> dict[str, Any]:
         """Sendet eine Chat-Completion-Anfrage an Ollama.
 
@@ -318,6 +318,15 @@ class OllamaClient:
                 base64 strings. Attached to the LAST user message so the
                 VLM (e.g. qwen3.6:27b) can see them. Ollama's chat API
                 expects ``messages[i].images = [<base64>, ...]``.
+            num_ctx: Sprint-23 — explicit context-window override sent
+                via Ollama's ``options.num_ctx``. When ``None`` (default)
+                no override is sent and Ollama uses the model's built-in
+                window. When set, Ollama loads the model with this
+                window for the call. Callers typically resolve this from
+                :meth:`ModelRouter.get_model_config` so the active
+                ``ContextProfile`` (Sprint-23) actually takes effect on
+                the wire — without this kwarg, the profile machinery is
+                a no-op end-to-end.
 
         Returns:
             Ollama-Response als Dict mit 'message' Key.
@@ -360,15 +369,22 @@ class OllamaClient:
                     by_category=by_cat,
                 )
 
+        # Sprint-23 — assemble options. ``num_ctx`` only goes on the
+        # wire when explicitly set, so unaware callers keep the previous
+        # behaviour (Ollama uses the model's built-in window).
+        merged_options: dict[str, Any] = {
+            "temperature": temperature,
+            "top_p": top_p,
+            **(options or {}),
+        }
+        if num_ctx is not None:
+            merged_options["num_ctx"] = int(num_ctx)
+
         payload: dict[str, Any] = {
             "model": model,
             "messages": messages,
             "stream": False,  # Non-streaming for this method
-            "options": {
-                "temperature": temperature,
-                "top_p": top_p,
-                **(options or {}),
-            },
+            "options": merged_options,
             "keep_alive": self._keep_alive,
         }
 
@@ -428,8 +444,14 @@ class OllamaClient:
         tools: list[dict[str, Any]] | None = None,
         temperature: float = 0.7,
         top_p: float = 0.9,
+        num_ctx: int | None = None,
     ) -> AsyncIterator[str]:
         """Streaming chat completion -- token by token.
+
+        ``num_ctx`` mirrors the kwarg on :meth:`chat`: when set, the
+        Ollama call carries an explicit context window override (used
+        by the Sprint-23 :class:`ContextProfile` system); when ``None``
+        the model's built-in window is used.
 
         Yields:
             Einzelne Text-Tokens als Strings.
@@ -450,14 +472,18 @@ class OllamaClient:
                     by_category=by_cat,
                 )
 
+        stream_options: dict[str, Any] = {
+            "temperature": temperature,
+            "top_p": top_p,
+        }
+        if num_ctx is not None:
+            stream_options["num_ctx"] = int(num_ctx)
+
         payload: dict[str, Any] = {
             "model": model,
             "messages": messages,
             "stream": True,
-            "options": {
-                "temperature": temperature,
-                "top_p": top_p,
-            },
+            "options": stream_options,
             "keep_alive": self._keep_alive,
         }
 

--- a/tests/test_core/test_ollama_num_ctx_wire.py
+++ b/tests/test_core/test_ollama_num_ctx_wire.py
@@ -1,0 +1,183 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Tests for Sprint-23 PR#D — ``num_ctx`` end-to-end into the wire payload.
+
+The Sprint-23 :class:`ContextProfile` system was a *no-op* before this
+PR because the ``num_ctx`` value resolved by ``get_model_config()``
+never reached :meth:`OllamaClient.chat` / :meth:`chat_stream` — those
+methods built an ``options`` dict from the kwargs and dropped any
+``num_ctx`` on the floor. These tests pin the contract: when a caller
+passes ``num_ctx=...``, the value lands on the wire as
+``payload.options.num_ctx``; when omitted, no override is sent so
+Ollama uses the model's built-in window (previous behaviour).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cognithor.config import CognithorConfig
+from cognithor.core.model_router import OllamaClient
+
+
+@pytest.fixture()
+def config(tmp_path) -> CognithorConfig:
+    return CognithorConfig(cognithor_home=tmp_path)
+
+
+class _CapturingClient:
+    """Pretends to be the httpx client that ``OllamaClient._ensure_client``
+    returns. ``post()`` records the JSON payload; ``stream()`` returns an
+    async context manager yielding one ``done`` frame.
+    """
+
+    def __init__(self, captured: dict[str, Any]) -> None:
+        self._captured = captured
+        self.is_closed = False
+
+    async def post(self, url: str, json: dict[str, Any]) -> Any:
+        self._captured["url"] = url
+        self._captured["payload"] = json
+
+        class _Resp:
+            status_code = 200
+
+            def raise_for_status(self) -> None:
+                return None
+
+            def json(self) -> dict[str, Any]:
+                return {
+                    "message": {"content": "ok", "role": "assistant"},
+                    "done": True,
+                    "eval_count": 1,
+                }
+
+        return _Resp()
+
+    def stream(self, _method: str, _url: str, json: dict[str, Any]) -> Any:
+        captured = self._captured
+        captured["payload"] = json
+
+        class _StreamCtx:
+            async def __aenter__(self_inner) -> Any:
+                class _Resp:
+                    status_code = 200
+
+                    async def aread(self_inner_resp) -> bytes:
+                        return b""
+
+                    async def aiter_lines(self_inner_resp):
+                        import json as _json
+
+                        yield _json.dumps(
+                            {
+                                "message": {"content": "ok"},
+                                "done": True,
+                                "eval_count": 1,
+                            }
+                        )
+
+                return _Resp()
+
+            async def __aexit__(self_inner, *_args: Any) -> None:
+                return None
+
+        return _StreamCtx()
+
+
+# ---------------------------------------------------------------------------
+# chat() non-streaming path
+# ---------------------------------------------------------------------------
+
+
+class TestChatNumCtx:
+    @pytest.mark.asyncio
+    async def test_num_ctx_set_lands_on_wire(self, config: CognithorConfig) -> None:
+        client = OllamaClient(config)
+        captured: dict[str, Any] = {}
+        client._client = _CapturingClient(captured)
+        await client.chat(
+            model="qwen3:8b",
+            messages=[{"role": "user", "content": "hi"}],
+            num_ctx=131072,
+        )
+        assert captured["payload"]["options"]["num_ctx"] == 131072
+
+    @pytest.mark.asyncio
+    async def test_num_ctx_unset_omits_key(self, config: CognithorConfig) -> None:
+        # Without an explicit num_ctx, the wire payload must NOT carry
+        # the key — otherwise we'd silently override the model default.
+        client = OllamaClient(config)
+        captured: dict[str, Any] = {}
+        client._client = _CapturingClient(captured)
+        await client.chat(
+            model="qwen3:8b",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+        assert "num_ctx" not in captured["payload"]["options"]
+
+    @pytest.mark.asyncio
+    async def test_num_ctx_coerced_to_int(self, config: CognithorConfig) -> None:
+        # Some callers (e.g. config sourced from JSON / YAML) may pass a
+        # numeric string. ``int(num_ctx)`` is the cheapest defence —
+        # without it, Ollama returns an opaque 400 if it's a string.
+        client = OllamaClient(config)
+        captured: dict[str, Any] = {}
+        client._client = _CapturingClient(captured)
+        await client.chat(
+            model="qwen3:8b",
+            messages=[{"role": "user", "content": "hi"}],
+            num_ctx="65536",  # type: ignore[arg-type]
+        )
+        assert captured["payload"]["options"]["num_ctx"] == 65536
+        assert isinstance(captured["payload"]["options"]["num_ctx"], int)
+
+    @pytest.mark.asyncio
+    async def test_num_ctx_does_not_clobber_options_dict(self, config: CognithorConfig) -> None:
+        # Caller supplies an extra options dict alongside num_ctx — both
+        # must coexist on the wire.
+        client = OllamaClient(config)
+        captured: dict[str, Any] = {}
+        client._client = _CapturingClient(captured)
+        await client.chat(
+            model="qwen3:8b",
+            messages=[{"role": "user", "content": "hi"}],
+            options={"seed": 42},
+            num_ctx=8192,
+        )
+        opts = captured["payload"]["options"]
+        assert opts["num_ctx"] == 8192
+        assert opts["seed"] == 42
+
+
+# ---------------------------------------------------------------------------
+# chat_stream() streaming path
+# ---------------------------------------------------------------------------
+
+
+class TestChatStreamNumCtx:
+    @pytest.mark.asyncio
+    async def test_stream_num_ctx_lands_on_wire(self, config: CognithorConfig) -> None:
+        client = OllamaClient(config)
+        captured: dict[str, Any] = {}
+        client._client = _CapturingClient(captured)
+        async for _ in client.chat_stream(
+            model="qwen3:8b",
+            messages=[{"role": "user", "content": "hi"}],
+            num_ctx=65536,
+        ):
+            pass
+        assert captured["payload"]["options"]["num_ctx"] == 65536
+
+    @pytest.mark.asyncio
+    async def test_stream_num_ctx_unset_omits_key(self, config: CognithorConfig) -> None:
+        client = OllamaClient(config)
+        captured: dict[str, Any] = {}
+        client._client = _CapturingClient(captured)
+        async for _ in client.chat_stream(
+            model="qwen3:8b",
+            messages=[{"role": "user", "content": "hi"}],
+        ):
+            pass
+        assert "num_ctx" not in captured["payload"]["options"]


### PR DESCRIPTION
## Summary

Closes a critical gap discovered during PR#C: the Sprint-23 \`ContextProfile\` system was a **no-op end-to-end**. \`get_model_config()\` returned the profile's \`context_window\`, but \`OllamaClient.chat\` / \`chat_stream\` never put a \`num_ctx\` field into the wire payload. The profile machinery selected (say) 128 k internally, and Ollama silently used the model's built-in 32 k window because nothing told it otherwise.

This PR plumbs the value through.

## Changes

| Method | Change |
|---|---|
| \`OllamaClient.chat\` | New \`num_ctx: int \| None = None\` kwarg. None = no override (previous behaviour). When set, \`int(num_ctx)\` lands in \`payload.options.num_ctx\`. |
| \`OllamaClient.chat_stream\` | Same kwarg, same semantics on the streaming path. |
| Options-dict assembly | Restructured so user-supplied \`options=\`, kwargs (temperature/top_p), and \`num_ctx\` coexist without clobbering. |

## Why \`int(num_ctx)\`?

Callers may resolve from JSON / YAML config where the value is a string. Ollama returns an opaque 400 on a string; the explicit cast makes the contract obvious.

## Tests (6 new, all green)

| Class | Coverage |
|---|---|
| TestChatNumCtx | set lands on wire / unset omits key / str → int coercion / doesn't clobber user options dict |
| TestChatStreamNumCtx | same contract for the streaming path |

Tests use a \`_CapturingClient\` stub that matches the surface \`OllamaClient._ensure_client()\` returns (\`post()\` / \`stream()\` / \`is_closed\`). No httpx mocking lib, no live Ollama.

## Local pre-flight

- [x] \`pytest tests/test_core/ (router + concierge + selector + scope + num_ctx_wire)\` → **108 passed**
- [x] \`pytest tests/test_core/\` (full) → **2446 passed, 1 skipped**
- [x] \`ruff format --check\` clean
- [x] \`ruff check\` clean
- [x] \`mypy --strict model_router.py\` clean

## A → C → D track summary

- ✅ **PR#A** (#348) — pure heuristic selector \`recommend_context_profile\`
- ✅ **PR#C** (#349) — \`router.context_profile_scope\` context-manager helper
- ✅ **PR#D (this)** — \`num_ctx\` actually reaches Ollama on the wire

Combined: a caller wraps an LLM call in \`with router.context_profile_scope("arc_agi3"):\` and the 128 k window **genuinely reaches Ollama** end-to-end. Before this track the profile system was decorative.

## Test plan

- [ ] CI green
- [ ] No regression in concierge / model-router tests (108 in-scope tests stayed green locally)