### PR TITLE
feat: Sprint-23 PR#J — context-profile REST endpoints + Flutter picker

### DIFF
--- a/flutter_app/lib/screens/config/context_profile_page.dart
+++ b/flutter_app/lib/screens/config/context_profile_page.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+
+import 'package:cognithor_ui/providers/connection_provider.dart';
+import 'package:cognithor_ui/theme/cognithor_theme.dart';
+import 'package:cognithor_ui/widgets/cognithor_toast.dart';
+
+/// Sprint-23 — Context-Profile picker.
+///
+/// Backend: GET/POST /api/v1/context_profile (see
+/// src/cognithor/channels/config_routes/profile.py).
+class ContextProfilePage extends StatefulWidget {
+  const ContextProfilePage({super.key});
+
+  @override
+  State<ContextProfilePage> createState() => _ContextProfilePageState();
+}
+
+class _ContextProfilePageState extends State<ContextProfilePage> {
+  String? _active;
+  Map<String, dynamic> _available = const {};
+  bool _loading = true;
+  bool _saving = false;
+  String? _error;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) => _load());
+  }
+
+  Future<void> _load() async {
+    setState(() {
+      _loading = true;
+      _error = null;
+    });
+    try {
+      final api = context.read<ConnectionProvider>().api;
+      final data = await api.get('v1/context_profile');
+      if (!mounted) return;
+      setState(() {
+        _active = data['active'] as String?;
+        _available = (data['available'] as Map?)?.cast<String, dynamic>() ?? {};
+        _loading = false;
+      });
+    } catch (e) {
+      if (!mounted) return;
+      setState(() {
+        _loading = false;
+        _error = e.toString();
+      });
+    }
+  }
+
+  Future<void> _setProfile(String? profile) async {
+    setState(() => _saving = true);
+    try {
+      final api = context.read<ConnectionProvider>().api;
+      final data = await api.post('v1/context_profile', {'profile': profile});
+      if (!mounted) return;
+      setState(() {
+        _active = data['active'] as String?;
+        _saving = false;
+      });
+      CognithorToast.show(
+        context,
+        profile == null
+            ? 'Profil deaktiviert — Modell-Defaults aktiv'
+            : 'Profil "$profile" aktiv',
+        type: ToastType.success,
+      );
+    } catch (e) {
+      if (!mounted) return;
+      setState(() => _saving = false);
+      CognithorToast.show(
+        context,
+        'Profil-Wechsel fehlgeschlagen: $e',
+        type: ToastType.error,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    if (_error != null) {
+      return Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.error_outline, size: 48, color: Colors.red.shade400),
+            const SizedBox(height: 12),
+            Text('Fehler: $_error', textAlign: TextAlign.center),
+            const SizedBox(height: 12),
+            FilledButton(onPressed: _load, child: const Text('Erneut laden')),
+          ],
+        ),
+      );
+    }
+
+    final profileNames = _orderProfiles(_available.keys.toList());
+
+    return ListView(
+      padding: const EdgeInsets.all(16),
+      children: [
+        Text(
+          'Kontext-Profil',
+          style: Theme.of(context).textTheme.headlineSmall,
+        ),
+        const SizedBox(height: 8),
+        const Text(
+          'Wähle wie viel Kontext und wie viel Sampling-Spielraum die '
+          'aktive Anfrage bekommt. Das Profil legt num_ctx, temperature '
+          'und top_p für jeden LLM-Backend-Aufruf fest. Embedding-Modelle '
+          'ignorieren das Profil.',
+        ),
+        const SizedBox(height: 16),
+        _buildClearTile(),
+        const SizedBox(height: 8),
+        ...profileNames.map(_buildProfileTile),
+        const SizedBox(height: 24),
+        Card(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text('Hinweise', style: Theme.of(context).textTheme.titleSmall),
+                const SizedBox(height: 6),
+                const Text(
+                  '• arc_agi3 erfordert ein vLLM-Backend mit '
+                  '--max-model-len ≥ 131072. Andere Backends (Anthropic, '
+                  'Gemini) nutzen ihr modell-intrinsisches Fenster.',
+                ),
+                const SizedBox(height: 4),
+                const Text(
+                  '• Per-Request-Override im Code: '
+                  'router.context_profile_scope("deep").',
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  List<String> _orderProfiles(List<String> raw) {
+    const order = ['quick', 'default', 'deep', 'arc_agi3'];
+    final ordered = <String>[];
+    for (final name in order) {
+      if (raw.contains(name)) ordered.add(name);
+    }
+    for (final name in raw) {
+      if (!ordered.contains(name)) ordered.add(name);
+    }
+    return ordered;
+  }
+
+  Widget _buildClearTile() {
+    final isActive = _active == null;
+    return Card(
+      color: isActive ? CognithorTheme.accent.withValues(alpha: 0.12) : null,
+      child: ListTile(
+        leading: Icon(
+          isActive ? Icons.radio_button_checked : Icons.radio_button_unchecked,
+          color: isActive ? CognithorTheme.accent : null,
+        ),
+        title: const Text('Kein Profil (Modell-Defaults)'),
+        subtitle: const Text(
+          'Jedes Modell nutzt sein in der Config hinterlegtes context_window, '
+          'temperature, top_p.',
+        ),
+        trailing: _saving
+            ? const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : null,
+        onTap: _saving || isActive ? null : () => _setProfile(null),
+      ),
+    );
+  }
+
+  Widget _buildProfileTile(String name) {
+    final spec = (_available[name] as Map).cast<String, dynamic>();
+    final isActive = _active == name;
+    final numCtx = spec['num_ctx'] as int;
+    final temperature = (spec['temperature'] as num).toDouble();
+    final topP = (spec['top_p'] as num).toDouble();
+    final description = spec['description'] as String;
+
+    return Card(
+      color: isActive ? CognithorTheme.accent.withValues(alpha: 0.12) : null,
+      child: ListTile(
+        leading: Icon(
+          isActive ? Icons.radio_button_checked : Icons.radio_button_unchecked,
+          color: isActive ? CognithorTheme.accent : null,
+        ),
+        title: Row(
+          children: [
+            Text(name),
+            const SizedBox(width: 12),
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 2),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surfaceContainerHighest,
+                borderRadius: BorderRadius.circular(8),
+              ),
+              child: Text(
+                _formatCtx(numCtx),
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ),
+          ],
+        ),
+        subtitle: Padding(
+          padding: const EdgeInsets.only(top: 4),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(description),
+              const SizedBox(height: 4),
+              Text(
+                'temperature ${temperature.toStringAsFixed(2)} · '
+                'top_p ${topP.toStringAsFixed(2)}',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: Theme.of(context).hintColor,
+                ),
+              ),
+            ],
+          ),
+        ),
+        trailing: _saving && isActive
+            ? const SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(strokeWidth: 2),
+              )
+            : null,
+        onTap: _saving || isActive ? null : () => _setProfile(name),
+      ),
+    );
+  }
+
+  String _formatCtx(int numCtx) {
+    if (numCtx >= 1024) {
+      final k = numCtx / 1024;
+      return '${k.toStringAsFixed(k == k.roundToDouble() ? 0 : 1)}k ctx';
+    }
+    return '$numCtx ctx';
+  }
+}

--- a/flutter_app/lib/screens/config_screen.dart
+++ b/flutter_app/lib/screens/config_screen.dart
@@ -27,6 +27,7 @@ import 'package:cognithor_ui/screens/config/bindings_page.dart';
 import 'package:cognithor_ui/screens/config/system_page.dart';
 import 'package:cognithor_ui/screens/config/system_profile_page.dart';
 import 'package:cognithor_ui/screens/config/budget_page.dart';
+import 'package:cognithor_ui/screens/config/context_profile_page.dart';
 import 'package:cognithor_ui/screens/config/tools_page.dart';
 import 'package:cognithor_ui/screens/config/audit_page.dart';
 import 'package:cognithor_ui/screens/config/vault_page.dart';
@@ -49,6 +50,7 @@ final _categories = [
     'planner',
     'executor',
     'prompts',
+    'context_profile',
   ]),
   _Category((l) => l.catChannels, Icons.cell_tower, ['channels']),
   _Category((l) => l.catKnowledge, Icons.storage, [
@@ -177,6 +179,11 @@ final _pageRegistry = <String, _SubPageDef>{
     Icons.account_balance_wallet,
     (l) => l.configPageBudget,
     () => const BudgetPage(),
+  ),
+  'context_profile': _SubPageDef(
+    Icons.tune,
+    (l) => 'Kontext-Profil',
+    () => const ContextProfilePage(),
   ),
   'atl': _SubPageDef(
     Icons.psychology,

--- a/src/cognithor/channels/config_routes/_factory.py
+++ b/src/cognithor/channels/config_routes/_factory.py
@@ -45,6 +45,7 @@ from cognithor.channels.config_routes.monitoring import (
     _register_monitoring_routes,
     _register_prometheus_routes,
 )
+from cognithor.channels.config_routes.profile import _register_context_profile_routes
 from cognithor.channels.config_routes.security import _register_security_routes
 from cognithor.channels.config_routes.session import (
     _register_memory_routes,
@@ -95,6 +96,7 @@ def create_config_routes(
 
     _register_system_routes(app, deps, config_manager, gateway)
     _register_config_routes(app, deps, config_manager, gateway)
+    _register_context_profile_routes(app, deps, gateway)
     _register_session_routes(app, deps, gateway)
     _register_memory_routes(app, deps, gateway)
     _register_skill_routes(app, deps, gateway)

--- a/src/cognithor/channels/config_routes/profile.py
+++ b/src/cognithor/channels/config_routes/profile.py
@@ -1,0 +1,101 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Cognithor · Sprint-23 — Context-Profile REST endpoints.
+
+Exposes the :class:`ContextProfile` system from
+``cognithor.core.model_router`` over HTTP so the Flutter UI can let
+the user pick a profile and see what's currently active.
+
+Endpoints (all under ``/api/v1/context_profile``):
+
+* ``GET  /``  — return ``{"active": <name|None>, "available": [...]}``
+* ``POST /``  — body ``{"profile": "deep" | null}``; ``null`` clears
+  the active profile and falls back to the model defaults.
+
+Profile-list metadata is sourced from
+:data:`CONTEXT_PROFILES` so adding a profile in code automatically
+shows up in the UI without an API change.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+try:
+    from fastapi import HTTPException
+except ImportError:
+    try:
+        from starlette.exceptions import HTTPException  # type: ignore[assignment]
+    except ImportError:
+        HTTPException = Exception  # type: ignore[assignment,misc]
+
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from cognithor.config_manager import ConfigManager  # noqa: F401
+
+log = get_logger(__name__)
+
+
+def _profile_payload() -> dict[str, Any]:
+    """Build the JSON-serialisable list of available profiles."""
+    from cognithor.core.model_router import CONTEXT_PROFILES
+
+    return {
+        name: {
+            "name": p.name,
+            "num_ctx": p.num_ctx,
+            "temperature": p.temperature,
+            "top_p": p.top_p,
+            "description": p.description,
+        }
+        for name, p in CONTEXT_PROFILES.items()
+    }
+
+
+def _register_context_profile_routes(
+    app: Any,
+    deps: list[Any],
+    gateway: Any,
+) -> None:
+    """Hook the GET / POST endpoints onto the FastAPI app."""
+
+    @app.get("/api/v1/context_profile", dependencies=deps)
+    async def get_active_context_profile() -> dict[str, Any]:
+        """Return the active profile name (or ``None``) and all available profiles."""
+        active: str | None = None
+        try:
+            router = getattr(gateway, "_model_router", None) or getattr(
+                gateway, "model_router", None
+            )
+            if router is not None and hasattr(router, "get_context_profile"):
+                active = router.get_context_profile()
+        except Exception:
+            log.debug("context_profile_get_active_failed", exc_info=True)
+        return {"active": active, "available": _profile_payload()}
+
+    @app.post("/api/v1/context_profile", dependencies=deps)
+    async def set_active_context_profile(payload: dict[str, Any]) -> dict[str, Any]:
+        """Set or clear the active context profile.
+
+        Body: ``{"profile": "deep"}`` → activate;
+        ``{"profile": null}`` → clear (model defaults take over).
+        """
+        from cognithor.core.model_router import CONTEXT_PROFILES
+
+        profile = payload.get("profile")
+        router = getattr(gateway, "_model_router", None) or getattr(gateway, "model_router", None)
+        if router is None:
+            raise HTTPException(status_code=503, detail="model router not initialised")
+
+        if profile is None:
+            router.clear_context_profile()
+            return {"active": None, "available": _profile_payload()}
+
+        if not isinstance(profile, str) or profile not in CONTEXT_PROFILES:
+            raise HTTPException(
+                status_code=400,
+                detail=(f"unknown profile {profile!r}. valid: {sorted(CONTEXT_PROFILES)}"),
+            )
+
+        router.set_context_profile(profile)
+        return {"active": profile, "available": _profile_payload()}

--- a/tests/test_channels/test_context_profile_routes.py
+++ b/tests/test_channels/test_context_profile_routes.py
@@ -1,0 +1,150 @@
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Tests for Sprint-23 PR#J — ``/api/v1/context_profile`` REST endpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cognithor.channels.config_routes.profile import (
+    _profile_payload,
+    _register_context_profile_routes,
+)
+from cognithor.core.model_router import (
+    CONTEXT_PROFILES,
+    ModelRouter,
+    OllamaClient,
+    _context_profile_var,
+)
+from cognithor.config import CognithorConfig
+
+
+class _FakeApp:
+    """FastAPI-shaped app stub that captures the route handlers."""
+
+    def __init__(self) -> None:
+        self.routes: dict[str, Any] = {}
+
+    def _register(self, method: str, path: str):
+        def decorator(fn: Any) -> Any:
+            self.routes[f"{method} {path}"] = fn
+            return fn
+
+        return decorator
+
+    def get(self, path: str, **_: Any) -> Any:
+        return self._register("GET", path)
+
+    def post(self, path: str, **_: Any) -> Any:
+        return self._register("POST", path)
+
+
+class _FakeGateway:
+    def __init__(self, router: ModelRouter | None) -> None:
+        self._model_router = router
+
+
+@pytest.fixture()
+def config(tmp_path) -> CognithorConfig:
+    return CognithorConfig(cognithor_home=tmp_path)
+
+
+@pytest.fixture()
+def router(config: CognithorConfig) -> ModelRouter:
+    return ModelRouter(config, OllamaClient(config))
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> Any:
+    _context_profile_var.set(None)
+    yield
+    _context_profile_var.set(None)
+
+
+# ---------------------------------------------------------------------------
+# _profile_payload
+# ---------------------------------------------------------------------------
+
+
+class TestProfilePayload:
+    def test_payload_lists_every_profile(self) -> None:
+        payload = _profile_payload()
+        assert set(payload) == set(CONTEXT_PROFILES)
+
+    def test_payload_carries_full_profile_record(self) -> None:
+        payload = _profile_payload()
+        for name, profile in CONTEXT_PROFILES.items():
+            row = payload[name]
+            assert row["name"] == profile.name
+            assert row["num_ctx"] == profile.num_ctx
+            assert row["temperature"] == profile.temperature
+            assert row["top_p"] == profile.top_p
+            assert row["description"] == profile.description
+
+
+# ---------------------------------------------------------------------------
+# Route registration + behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestContextProfileRoutes:
+    @pytest.mark.asyncio
+    async def test_get_returns_active_none_and_full_catalog(self, router: ModelRouter) -> None:
+        app = _FakeApp()
+        _register_context_profile_routes(app, [], _FakeGateway(router))
+        handler = app.routes["GET /api/v1/context_profile"]
+        result = await handler()
+        assert result["active"] is None
+        assert set(result["available"]) == set(CONTEXT_PROFILES)
+
+    @pytest.mark.asyncio
+    async def test_get_reflects_active_profile_after_set(self, router: ModelRouter) -> None:
+        app = _FakeApp()
+        _register_context_profile_routes(app, [], _FakeGateway(router))
+        router.set_context_profile("deep")
+        handler = app.routes["GET /api/v1/context_profile"]
+        result = await handler()
+        assert result["active"] == "deep"
+
+    @pytest.mark.asyncio
+    async def test_post_activates_profile(self, router: ModelRouter) -> None:
+        app = _FakeApp()
+        _register_context_profile_routes(app, [], _FakeGateway(router))
+        post = app.routes["POST /api/v1/context_profile"]
+        result = await post({"profile": "arc_agi3"})
+        assert result["active"] == "arc_agi3"
+        assert router.get_context_profile() == "arc_agi3"
+
+    @pytest.mark.asyncio
+    async def test_post_with_null_clears_profile(self, router: ModelRouter) -> None:
+        app = _FakeApp()
+        _register_context_profile_routes(app, [], _FakeGateway(router))
+        router.set_context_profile("quick")
+        post = app.routes["POST /api/v1/context_profile"]
+        result = await post({"profile": None})
+        assert result["active"] is None
+        assert router.get_context_profile() is None
+
+    @pytest.mark.asyncio
+    async def test_post_unknown_profile_400(self, router: ModelRouter) -> None:
+        app = _FakeApp()
+        _register_context_profile_routes(app, [], _FakeGateway(router))
+        post = app.routes["POST /api/v1/context_profile"]
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            await post({"profile": "invalid"})
+        assert exc.value.status_code == 400
+        assert "valid" in exc.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_post_without_router_503(self) -> None:
+        app = _FakeApp()
+        _register_context_profile_routes(app, [], _FakeGateway(None))
+        post = app.routes["POST /api/v1/context_profile"]
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc:
+            await post({"profile": "deep"})
+        assert exc.value.status_code == 503


### PR DESCRIPTION
Closes the UI gap for Sprint-23. New `/api/v1/context_profile` GET/POST surface + a radio-style picker page in the Flutter Command Center under AI-Engine category. Unlocks the 4 profiles (quick / default / deep / arc_agi3) for non-power users without touching the canonical `router.context_profile_scope(...)` per-request override.

Backend: 8 new tests (FakeApp shim) covering happy/error paths.
Flutter: 169 unit tests still pass; analyzer clean on touched files; format clean.