### PR TITLE
fix(tests): main CI hotfix — import-sort I001 in test_context_profile_routes

### DIFF
--- a/tests/test_channels/test_context_profile_routes.py
+++ b/tests/test_channels/test_context_profile_routes.py
@@ -11,13 +11,13 @@ from cognithor.channels.config_routes.profile import (
     _profile_payload,
     _register_context_profile_routes,
 )
+from cognithor.config import CognithorConfig
 from cognithor.core.model_router import (
     CONTEXT_PROFILES,
     ModelRouter,
     OllamaClient,
     _context_profile_var,
 )
-from cognithor.config import CognithorConfig
 
 
 class _FakeApp:


### PR DESCRIPTION
Sprint-23 PR#J (#356) introduced a new test file whose imports weren't in ruff-sort order. Ruff's local pre-flight only ran on `src/cognithor/`, missing the test file. CI's `ruff check src/ tests/` caught it on main → red. Reorder is pure formatting, zero behaviour change.