### PR TITLE
chore(types): Sprint-23 PR#M — diminishing-returns endpoint (970 → 965, total 1849 → 965 = -48 %)

### DIFF
--- a/scripts/_mass_mypy_fixer_round3.py
+++ b/scripts/_mass_mypy_fixer_round3.py
@@ -1,0 +1,146 @@
+"""Round-3 mass fixer: var-annotated + remaining type-arg.
+
+Fixes only ``var-annotated`` errors via AST inspection of the
+assignment node — looks at the RHS expression to infer ``list[Any]``
+/ ``dict[str, Any]`` / ``set[Any]``. Strings, docstrings, comments
+are never touched.
+"""
+
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+import subprocess
+from collections import defaultdict
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+SRC = ROOT / "src" / "cognithor"
+
+
+def collect_errors() -> dict[pathlib.Path, list[tuple[int, str, str]]]:
+    proc = subprocess.run(
+        ["mypy", "--strict", str(SRC)],
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+    )
+    grouped: dict[pathlib.Path, list[tuple[int, str, str]]] = defaultdict(list)
+    pat = re.compile(r"^(.+?):(\d+): error: (.+?)  \[([a-z-]+)\]$")
+    for line in proc.stdout.splitlines():
+        m = pat.match(line)
+        if m:
+            grouped[pathlib.Path(m.group(1)).resolve()].append(
+                (int(m.group(2)), m.group(3), m.group(4))
+            )
+    return grouped
+
+
+def patch_var_annotated(text: str, line_nos: set[int]) -> tuple[str, int]:
+    """Add an explicit type annotation to bare assignments on the given lines.
+
+    Patterns handled:
+      * ``x = []``   → ``x: list[Any] = []``
+      * ``x = {}``   → ``x: dict[str, Any] = {}``
+      * ``x = set()``→ ``x: set[Any] = set()``
+      * ``x = ()``   → ``x: tuple[Any, ...] = ()``
+    """
+    if not line_nos:
+        return text, 0
+    try:
+        tree = ast.parse(text)
+    except SyntaxError:
+        return text, 0
+
+    # Map ``lineno -> name`` for assigments we can patch
+    targets: dict[int, tuple[str, str]] = {}
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign) and node.lineno in line_nos:
+            if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
+                continue
+            name = node.targets[0].id
+            ann = None
+            if isinstance(node.value, ast.List) and not node.value.elts:
+                ann = "list[Any]"
+            elif isinstance(node.value, ast.Dict) and not node.value.keys:
+                ann = "dict[str, Any]"
+            elif isinstance(node.value, ast.Call) and isinstance(node.value.func, ast.Name):
+                if node.value.func.id == "set" and not node.value.args:
+                    ann = "set[Any]"
+                elif node.value.func.id == "list" and not node.value.args:
+                    ann = "list[Any]"
+                elif node.value.func.id == "dict" and not node.value.args:
+                    ann = "dict[str, Any]"
+            elif isinstance(node.value, ast.Tuple) and not node.value.elts:
+                ann = "tuple[Any, ...]"
+            if ann:
+                targets[node.lineno] = (name, ann)
+
+    if not targets:
+        return text, 0
+
+    lines = text.splitlines(keepends=True)
+    count = 0
+    for lineno, (name, ann) in targets.items():
+        idx = lineno - 1
+        if not (0 <= idx < len(lines)):
+            continue
+        line = lines[idx]
+        # Replace ``<name> =`` with ``<name>: <ann> =`` once
+        new_line = re.sub(
+            rf"(\b{re.escape(name)}\s*)=",
+            rf"\1: {ann} =",
+            line,
+            count=1,
+        )
+        if new_line != line:
+            lines[idx] = new_line
+            count += 1
+    return "".join(lines), count
+
+
+def ensure_any_import(text: str) -> str:
+    if "Any" not in text:
+        return text
+    if re.search(r"\bfrom typing import [^\n]*\bAny\b", text):
+        return text
+    m = re.search(r"^from typing import (.+)$", text, flags=re.MULTILINE)
+    if m:
+        return text.replace(m.group(0), f"from typing import Any, {m.group(1)}", 1)
+    m2 = re.search(r"^from __future__ import [^\n]+\n", text, flags=re.MULTILINE)
+    if m2:
+        return text[: m2.end()] + "\nfrom typing import Any\n" + text[m2.end() :]
+    return text
+
+
+def main() -> None:
+    print("[1/2] Collecting mypy errors ...", flush=True)
+    grouped = collect_errors()
+    print("[2/2] Applying var-annotated fixes ...", flush=True)
+
+    files_changed = 0
+    for path, errors in sorted(grouped.items()):
+        if not path.exists():
+            continue
+        var_lines: set[int] = set()
+        for lineno, _, cat in errors:
+            if cat == "var-annotated":
+                var_lines.add(lineno)
+        if not var_lines:
+            continue
+        try:
+            original = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        text, n = patch_var_annotated(original, var_lines)
+        if text != original:
+            text = ensure_any_import(text)
+            path.write_text(text, encoding="utf-8")
+            files_changed += 1
+            print(f"  {path.relative_to(ROOT)}: {n} fixes", flush=True)
+
+    print(f"Done. {files_changed} files modified.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/cognithor/channels/config_routes/system.py
+++ b/src/cognithor/channels/config_routes/system.py
@@ -229,7 +229,7 @@ def _register_system_routes(
             raise HTTPException(400, "Name is required")
 
         agents_path = config_manager.config.cognithor_home / "agents.yaml"
-        raw = {}
+        raw: dict[str, Any] = {}
         if agents_path.exists():
             raw = yaml.safe_load(agents_path.read_text(encoding="utf-8")) or {}
         agents = raw.get("agents", [])

--- a/src/cognithor/evolution/loop.py
+++ b/src/cognithor/evolution/loop.py
@@ -1127,7 +1127,7 @@ class EvolutionLoop:
                         log.debug("evolution_retest_failed", exc_info=True)
 
         # --- Tier 2: User learning goals ---
-        raw_goals = []
+        raw_goals: list[Any] = []
         if self._config and hasattr(self._config, "learning_goals"):
             raw_goals = self._config.learning_goals or []
 

--- a/src/cognithor/memory/manager.py
+++ b/src/cognithor/memory/manager.py
@@ -581,7 +581,7 @@ class MemoryManager:
 
         # Merge: Baue results-Liste in Chunk-Reihenfolge
         new_iter = iter(new_results)
-        results = []
+        results: list[Any] = []
         for c in chunks:
             if c.content_hash in cached_results:
                 # Erstelle ein Pseudo-EmbeddingResult fuer gecachte Embeddings

--- a/src/cognithor/security/code_audit.py
+++ b/src/cognithor/security/code_audit.py
@@ -269,7 +269,7 @@ class PatternScanner:
         return findings
 
     def _scan_ast(self, code: str, pattern: CodePattern, file_path: str) -> list[CodeFinding]:
-        findings = []
+        findings: list[Any] = []
         try:
             tree = ast.parse(code)
         except SyntaxError:

--- a/src/cognithor/skills/registry.py
+++ b/src/cognithor/skills/registry.py
@@ -218,7 +218,7 @@ class SkillRegistry:
         content = path.read_text(encoding="utf-8")
 
         # Extract frontmatter
-        frontmatter = {}
+        frontmatter: dict[str, Any] = {}
         body = content
 
         if content.startswith("---"):


### PR DESCRIPTION
Final round of the autonomous mass-mypy push. Brings the project from **1849 → 965** mypy --strict errors (**-48 %**) over PRs #347-#359.

The remaining 965 errors are dominated by **attr-defined (344)** and **no-any-return (224)** patterns that need per-function context analysis. The 3 mass-fixer scripts in `scripts/` have cleared every safe mechanical pattern; continuing autonomously would risk subtle regressions.

**Hot file**: `gateway/gateway.py` carries 155 of the remaining errors and is memory-flagged as a queued split target.

**Tests**: 5575 passed, 2 skipped, 0 failed across test_core/ + test_security/ + test_skills/ + test_memory/ + test_channels/test_config_routes/test_context_profile_routes.

Recommend per-subpackage follow-up PRs (gateway/, identity/cognitio/, channels/non-config_routes) for the rest.