### PR TITLE
feat(pse): Sprint-24 — PSE auto-switch in ContextPipeline produktiv schalten

### DIFF
--- a/src/cognithor/config.py
+++ b/src/cognithor/config.py
@@ -644,6 +644,17 @@ class ContextPipelineConfig(BaseModel):
     ]
     """Patterns die als Smalltalk erkannt werden (keine Kontext-Suche)."""
 
+    auto_switch_context_profile: bool = Field(
+        default=True,
+        description=(
+            "Sprint-24: Wenn True, ruft die Pipeline vor dem Planner-Call "
+            "``recommend_context_profile(...)`` auf und aktiviert das "
+            "empfohlene Profil per ContextVar (request-scoped, asyncio-"
+            "isoliert) auf dem injizierten ModelRouter. False = kein "
+            "Auto-Switch (Profil wird nicht angefasst)."
+        ),
+    )
+
 
 class SkillLifecycleConfig(BaseModel):
     """Skill Lifecycle Manager -- periodic audit, repair, and suggestion of skills."""

--- a/src/cognithor/core/context_pipeline.py
+++ b/src/cognithor/core/context_pipeline.py
@@ -40,6 +40,13 @@ class ContextResult:
     wave2_ms: float = 0.0
     skipped: bool = False
     skip_reason: str = ""
+    # Sprint-24: PSE Auto-Switch — which profile the heuristic picked
+    # for this request and why. Populated only when
+    # ``ContextPipelineConfig.auto_switch_context_profile`` is True and
+    # a ModelRouter is wired in. Empty string means the auto-switch did
+    # not run for this request.
+    selected_profile: str = ""
+    profile_reason: str = ""
 
 
 class ContextPipeline:
@@ -61,6 +68,11 @@ class ContextPipeline:
         self._vault_tools: Any | None = None  # VaultTools (async search)
         self._skill_registry: Any | None = None  # SkillRegistry
         self._user_pref_store: Any | None = None  # UserPreferenceStore
+        # Sprint-24: PSE Auto-Switch — wired by the gateway after
+        # ``ModelRouter`` is initialised. Set via ``set_model_router``.
+        # When None, the pipeline still runs but the auto-switch step
+        # is a no-op.
+        self._model_router: Any | None = None
 
     # ── Dependency Injection ──────────────────────────────────────
 
@@ -75,6 +87,17 @@ class ContextPipeline:
     def set_skill_registry(self, sr: Any) -> None:
         """Set the SkillRegistry for skill context injection."""
         self._skill_registry = sr
+
+    def set_model_router(self, mr: Any) -> None:
+        """Sprint-24: wire the ModelRouter for auto-switch profile activation.
+
+        When set and ``config.auto_switch_context_profile`` is True,
+        :meth:`enrich` calls ``recommend_context_profile(...)`` and
+        applies the result via ``ModelRouter.set_context_profile(...)``.
+        ContextVar isolation makes the change request-scoped — concurrent
+        requests do not interfere.
+        """
+        self._model_router = mr
 
     def set_correction_memory(self, cm: Any) -> None:
         """Set the CorrectionMemory for correction reminders."""
@@ -92,6 +115,7 @@ class ContextPipeline:
         wm: WorkingMemory,
         *,
         user_id: str = "",
+        channel_kind: str | None = None,
     ) -> ContextResult:
         """Collect relevant context and inject it into WorkingMemory.
 
@@ -104,14 +128,29 @@ class ContextPipeline:
             user_message: The current user message.
             wm: The active WorkingMemory instance.
             user_id: Optional user ID for preference lookup.
+            channel_kind: Optional channel identifier (``"cli"``,
+                ``"telegram"``, ``"arc_agi3"``, ...). Sprint-24 uses
+                this to bias the auto-switch heuristic toward heavy
+                channels (game-loop wants the 128 k window).
 
         Returns:
-            ContextResult with collected data and metrics.
+            ContextResult with collected data, metrics, and the
+            selected context profile (Sprint-24 auto-switch).
         """
         if not self._config.enabled:
             return ContextResult(skipped=True, skip_reason="disabled")
 
         t0 = time.perf_counter()
+
+        # Sprint-24: PSE Auto-Switch — runs *before* the smalltalk
+        # short-circuit so latency-tight smalltalk responses still get
+        # the right (small) window. Returns the selected profile + reason
+        # so callers / tests can verify.
+        selected_profile, profile_reason = self._maybe_apply_context_profile(
+            user_message=user_message,
+            wm=wm,
+            channel_kind=channel_kind,
+        )
 
         # Smalltalk/Short-Message Check
         if self._is_smalltalk(user_message):
@@ -119,6 +158,8 @@ class ContextPipeline:
                 skipped=True,
                 skip_reason="smalltalk",
                 duration_ms=(time.perf_counter() - t0) * 1000,
+                selected_profile=selected_profile,
+                profile_reason=profile_reason,
             )
 
         # ── Wave 1+2: All enrichment in parallel ──────────────────
@@ -230,9 +271,84 @@ class ContextPipeline:
             duration_ms=duration_ms,
             wave1_ms=wave1_ms,
             wave2_ms=wave2_ms,
+            selected_profile=selected_profile,
+            profile_reason=profile_reason,
         )
 
     # ── Helper methods ─────────────────────────────────────────────
+
+    def _maybe_apply_context_profile(
+        self,
+        *,
+        user_message: str,
+        wm: WorkingMemory,
+        channel_kind: str | None,
+    ) -> tuple[str, str]:
+        """Sprint-24: pick + activate the recommended context profile.
+
+        Reads the auto-switch flag, runs ``recommend_context_profile``,
+        and applies the result to the wired ``ModelRouter``. Returns
+        ``(profile_name, reason)`` so callers can log / assert.
+
+        No-op when the flag is False, the router isn't wired, or the
+        active model_router rejects the recommendation (we never let
+        a profile mismatch break enrichment).
+        """
+        if not getattr(self._config, "auto_switch_context_profile", False):
+            return "", ""
+        if self._model_router is None:
+            return "", "no model_router wired"
+
+        # Lazy import to avoid the circular reference flagged in
+        # ``context_profile_selector``'s docstring (model_router →
+        # config → core → ... ).
+        try:
+            from cognithor.core.context_profile_selector import (
+                recommend_context_profile,
+            )
+        except Exception:
+            log.debug("context_profile_selector_import_failed", exc_info=True)
+            return "", "selector import failed"
+
+        # Detect attachments straight off the WorkingMemory — Sprint-23's
+        # heuristic uses this to nudge medium prompts up one notch.
+        has_attachments = bool(
+            getattr(wm, "image_attachments", None) or getattr(wm, "video_attachment", None)
+        )
+
+        try:
+            recommendation = recommend_context_profile(
+                prompt_chars=len(user_message or ""),
+                channel_kind=channel_kind,
+                has_attachments=has_attachments,
+            )
+        except Exception:
+            log.debug("context_profile_recommend_failed", exc_info=True)
+            return "", "recommend failed"
+
+        # Apply via the request-scoped ContextVar so concurrent requests
+        # do not bleed into each other. ``set_context_profile`` raises
+        # ValueError on unknown names — we swallow + log to avoid
+        # breaking enrichment for an unrelated reason.
+        try:
+            self._model_router.set_context_profile(recommendation.profile)
+        except Exception:
+            log.warning(
+                "context_profile_set_failed",
+                profile=recommendation.profile,
+                reason=recommendation.reason,
+                exc_info=True,
+            )
+            return "", "set failed"
+
+        log.info(
+            "context_profile_auto_switch",
+            profile=recommendation.profile,
+            reason=recommendation.reason,
+            channel=channel_kind or "",
+            attachments=has_attachments,
+        )
+        return recommendation.profile, recommendation.reason
 
     def _is_smalltalk(self, text: str) -> bool:
         """Check whether message is smalltalk (no search needed)."""

--- a/src/cognithor/gateway/gateway.py
+++ b/src/cognithor/gateway/gateway.py
@@ -362,6 +362,10 @@ class Gateway:
                 self._context_pipeline.set_memory_manager(self._memory_manager)  # type: ignore[attr-defined]
                 if hasattr(self, "_vault_tools") and self._vault_tools:
                     self._context_pipeline.set_vault_tools(self._vault_tools)  # type: ignore[attr-defined]
+                # Sprint-24: PSE Auto-Switch — wire ModelRouter so the
+                # pipeline can flip the request-scoped context profile.
+                if getattr(self, "_model_router", None) is not None:
+                    self._context_pipeline.set_model_router(self._model_router)  # type: ignore[attr-defined]
                 log.info("context_pipeline_initialized")
         except Exception:
             log.debug("context_pipeline_init_skipped", exc_info=True)

--- a/src/cognithor/gateway/message_handler.py
+++ b/src/cognithor/gateway/message_handler.py
@@ -229,7 +229,11 @@ async def handle_message(
             return
         if gw._context_pipeline is not None:
             try:
-                ctx_result = await gw._context_pipeline.enrich(msg.text, wm)
+                ctx_result = await gw._context_pipeline.enrich(
+                    msg.text,
+                    wm,
+                    channel_kind=msg.channel,
+                )
                 if not ctx_result.skipped:
                     log.info(
                         "context_enriched",
@@ -237,6 +241,7 @@ async def handle_message(
                         vault=len(ctx_result.vault_snippets),
                         episodes=len(ctx_result.episode_snippets),
                         ms=f"{ctx_result.duration_ms:.1f}",
+                        profile=ctx_result.selected_profile or "(none)",
                     )
             except Exception:
                 log.warning("context_pipeline_failed", exc_info=True)

--- a/tests/test_core/test_context_pipeline_auto_switch.py
+++ b/tests/test_core/test_context_pipeline_auto_switch.py
@@ -1,0 +1,202 @@
+"""Sprint-24 — ContextPipeline auto-switches the model_router context profile.
+
+The pure heuristic from ``cognithor.core.context_profile_selector`` lives
+in its own module and is well-covered. This file verifies the
+*production wiring* side:
+
+* When ``ContextPipelineConfig.auto_switch_context_profile`` is True and
+  a ModelRouter is wired in, ``enrich(...)`` calls
+  ``recommend_context_profile`` and applies the picked profile via
+  ``ModelRouter.set_context_profile``.
+* The choice is reflected on the returned ``ContextResult`` (so callers
+  / observers can log + assert *why* a profile was picked).
+* The auto-switch is skipped when the config flag is False, when no
+  router is wired, or when the recommendation cannot be applied.
+* Smalltalk skips enrichment but still applies the profile (latency-
+  tight smalltalk on a chat channel still benefits from ``quick``).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from cognithor.config import ContextPipelineConfig
+from cognithor.core.context_pipeline import ContextPipeline
+from cognithor.models import WorkingMemory
+
+
+@pytest.fixture
+def pipeline_config() -> ContextPipelineConfig:
+    return ContextPipelineConfig()
+
+
+def _make_router() -> MagicMock:
+    """Mock ModelRouter that records context-profile activations."""
+    router = MagicMock()
+    router.set_context_profile = MagicMock()
+    return router
+
+
+@pytest.mark.asyncio
+async def test_auto_switch_picks_quick_for_short_cli_prompt(
+    pipeline_config: ContextPipelineConfig,
+) -> None:
+    """Short prompt on a simple channel → quick profile."""
+    pipeline = ContextPipeline(pipeline_config)
+    router = _make_router()
+    pipeline.set_model_router(router)
+
+    wm = WorkingMemory()
+    result = await pipeline.enrich("Was ist 2+2?", wm, channel_kind="cli")
+
+    assert result.selected_profile == "quick"
+    assert "simple channel" in result.profile_reason
+    router.set_context_profile.assert_called_once_with("quick")
+
+
+@pytest.mark.asyncio
+async def test_auto_switch_picks_arc_agi3_on_game_channel(
+    pipeline_config: ContextPipelineConfig,
+) -> None:
+    """ARC-AGI-3 channel pins to the validated 128 k profile."""
+    pipeline = ContextPipeline(pipeline_config)
+    router = _make_router()
+    pipeline.set_model_router(router)
+
+    wm = WorkingMemory()
+    result = await pipeline.enrich("step 1234", wm, channel_kind="arc_agi3")
+
+    assert result.selected_profile == "arc_agi3"
+    assert "channel_kind='arc_agi3'" in result.profile_reason
+    router.set_context_profile.assert_called_once_with("arc_agi3")
+
+
+@pytest.mark.asyncio
+async def test_auto_switch_picks_default_for_medium_prompt(
+    pipeline_config: ContextPipelineConfig,
+) -> None:
+    """Prompt that exceeds the quick ceiling but not default → default."""
+    pipeline = ContextPipeline(pipeline_config)
+    router = _make_router()
+    pipeline.set_model_router(router)
+
+    # 32 KB prompt → ~8 k tokens (above quick ceiling at 6 k, below default at 24 k)
+    medium_prompt = "x" * 32_000
+
+    wm = WorkingMemory()
+    result = await pipeline.enrich(medium_prompt, wm, channel_kind="cli")
+
+    assert result.selected_profile == "default"
+    router.set_context_profile.assert_called_once_with("default")
+
+
+@pytest.mark.asyncio
+async def test_auto_switch_attachments_push_medium_to_deep(
+    pipeline_config: ContextPipelineConfig,
+) -> None:
+    """Image attachment + medium prompt → deep (extra recall window)."""
+    pipeline = ContextPipeline(pipeline_config)
+    router = _make_router()
+    pipeline.set_model_router(router)
+
+    wm = WorkingMemory()
+    wm.image_attachments = ["/tmp/screenshot.png"]
+    medium_prompt = "x" * 30_000  # ~7.5 k tokens, > quick ceiling
+
+    result = await pipeline.enrich(medium_prompt, wm, channel_kind="cli")
+
+    assert result.selected_profile == "deep"
+    router.set_context_profile.assert_called_once_with("deep")
+
+
+@pytest.mark.asyncio
+async def test_auto_switch_disabled_via_config_skips_router_call(
+    pipeline_config: ContextPipelineConfig,
+) -> None:
+    """Flag off → never touches the router, returns empty profile fields."""
+    pipeline_config.auto_switch_context_profile = False
+    pipeline = ContextPipeline(pipeline_config)
+    router = _make_router()
+    pipeline.set_model_router(router)
+
+    wm = WorkingMemory()
+    result = await pipeline.enrich("Was ist 2+2?", wm, channel_kind="cli")
+
+    assert result.selected_profile == ""
+    assert result.profile_reason == ""
+    router.set_context_profile.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_auto_switch_skipped_when_no_router_wired(
+    pipeline_config: ContextPipelineConfig,
+) -> None:
+    """Flag on but no router → no-op + diagnostic reason."""
+    pipeline = ContextPipeline(pipeline_config)
+    # Deliberately do NOT call set_model_router(...).
+
+    wm = WorkingMemory()
+    result = await pipeline.enrich("Was ist 2+2?", wm, channel_kind="cli")
+
+    assert result.selected_profile == ""
+    assert result.profile_reason == "no model_router wired"
+
+
+@pytest.mark.asyncio
+async def test_auto_switch_swallows_router_failure(
+    pipeline_config: ContextPipelineConfig,
+) -> None:
+    """If the router rejects the profile (e.g. ValueError), enrichment continues."""
+    pipeline = ContextPipeline(pipeline_config)
+    router = MagicMock()
+    router.set_context_profile = MagicMock(side_effect=ValueError("nope"))
+    pipeline.set_model_router(router)
+
+    wm = WorkingMemory()
+    result = await pipeline.enrich("Was ist 2+2?", wm, channel_kind="cli")
+
+    # The auto-switch step recorded its failure but the pipeline still
+    # produced a result (smalltalk-skip path here).
+    assert result.profile_reason == "set failed"
+    assert result.selected_profile == ""
+
+
+@pytest.mark.asyncio
+async def test_auto_switch_runs_even_for_smalltalk(
+    pipeline_config: ContextPipelineConfig,
+) -> None:
+    """Smalltalk skips enrichment but still flips the profile —
+    latency-tight short replies should not run on the deep profile.
+    """
+    pipeline = ContextPipeline(pipeline_config)
+    router = _make_router()
+    pipeline.set_model_router(router)
+
+    wm = WorkingMemory()
+    result = await pipeline.enrich("hallo", wm, channel_kind="cli")
+
+    assert result.skipped is True
+    assert result.skip_reason == "smalltalk"
+    # Profile was picked + applied before the smalltalk shortcut returned.
+    assert result.selected_profile == "quick"
+    router.set_context_profile.assert_called_once_with("quick")
+
+
+@pytest.mark.asyncio
+async def test_auto_switch_no_channel_kind_falls_back_to_length_only(
+    pipeline_config: ContextPipelineConfig,
+) -> None:
+    """No channel_kind → heuristic uses prompt length only."""
+    pipeline = ContextPipeline(pipeline_config)
+    router = _make_router()
+    pipeline.set_model_router(router)
+
+    wm = WorkingMemory()
+    # Short prompt, no channel: heuristic returns ``default`` (Rule 5
+    # fallback) because the simple-channel rule needs an explicit kind.
+    result = await pipeline.enrich("Was ist 2+2?", wm)
+
+    assert result.selected_profile == "default"
+    router.set_context_profile.assert_called_once_with("default")


### PR DESCRIPTION
## Headline

Sprint-23 PR#A shipped a pure heuristic (``recommend_context_profile``) for picking a model-router context profile (``quick`` / ``default`` / ``deep`` / ``arc_agi3``). It has been sitting next to the production code path without ever being called. **Sprint-24 wires it in.**

After this PR every request silently picks the right window — short CLI prompts run on ``quick`` (8 k, latency-tight), long prompts on ``deep`` (64 k), ARC-AGI-3 channel pinned on ``arc_agi3`` (128 k from the qwen3.6 probe). The downstream chat loop already overlays the profile's ``num_ctx`` / ``temperature`` / ``top_p`` (Sprint-23 PR#D/E shipped that through ``LLMBackend``). End-to-end without callers having to think about it.

## What changes

| Where | Change |
|---|---|
| ``ContextPipelineConfig.auto_switch_context_profile`` | New bool, **default True**. Off → no behaviour change. |
| ``ContextPipeline.set_model_router(mr)`` | DI hook (same pattern as ``set_memory_manager``/``set_vault_tools``). |
| ``ContextPipeline.enrich(..., channel_kind=...)`` | Runs the recommendation **before** the smalltalk shortcut so even short-message replies get the right (small) window. |
| ``ContextResult.selected_profile`` + ``profile_reason`` | Populated by the auto-switch so callers / tests / observability can assert *why* a profile was picked. |
| Gateway init | After building ``ModelRouter``, calls ``self._context_pipeline.set_model_router(self._model_router)`` (defensively gated via ``getattr(...)``). |
| ``message_handler._run_context_pipeline`` | Passes ``channel_kind=msg.channel`` so the heuristic can recognise heavy channels and pin them to the 128 k window. |

The profile-set call is wrapped in ``try/except``: a router rejection (unknown profile name, etc.) records the failure reason in ``ContextResult`` but does **not** break enrichment.

## Tests

``tests/test_core/test_context_pipeline_auto_switch.py`` — 9 cases:

- ``cli`` short prompt → ``quick``
- ``arc_agi3`` channel → ``arc_agi3`` (channel pin overrides length)
- medium prompt → ``default``
- attachments + medium → ``deep`` (extra recall window)
- ``auto_switch_context_profile=False`` → no router call
- no router wired → no-op + diagnostic reason
- router raises ValueError → enrichment still completes (failure reason captured)
- smalltalk path still applies the profile (latency-tight short replies don't get the deep profile)
- no ``channel_kind`` → length-only fallback

Plus the existing 88 ``test_core/test_context_*`` tests still pass — the new ``ContextResult`` fields default to empty strings so consumers stay backwards-compatible.

## Result

- ``mypy --strict`` clean across all four touched modules
- 88 / 88 context-pipeline + profile-selector tests pass
- Repo-wide ``ruff check`` + ``ruff format --check`` both green
- Default-on so the win lands without a config flip

🤖 Generated with [Claude Code](https://claude.com/claude-code)