### PR TITLE
fix(workflow): drop double /api/v1 prefix in 3 Flutter providers

### DIFF
--- a/flutter_app/lib/providers/packs_provider.dart
+++ b/flutter_app/lib/providers/packs_provider.dart
@@ -40,7 +40,7 @@ class PacksProvider extends ChangeNotifier {
   Future<void> refresh() async {
     if (_api == null) return;
     try {
-      final resp = await _api!.get('/api/v1/packs/loaded');
+      final resp = await _api!.get('packs/loaded');
       final raw = resp['packs'] as List? ?? [];
       _packs = raw
           .map((e) => LoadedPack.fromJson(e as Map<String, dynamic>))

--- a/flutter_app/lib/providers/research_provider.dart
+++ b/flutter_app/lib/providers/research_provider.dart
@@ -90,7 +90,7 @@ class ResearchProvider extends ChangeNotifier {
     _activeResult = null;
     notifyListeners();
     try {
-      final resp = await _api!.post('/api/v1/research/query', {'query': query});
+      final resp = await _api!.post('research/query', {'query': query});
       _activeResearchId = resp['id'] as String?;
       if (_activeResearchId != null) {
         await _pollResult(_activeResearchId!);
@@ -108,7 +108,7 @@ class ResearchProvider extends ChangeNotifier {
     for (int i = 0; i < 60; i++) {
       await Future<void>.delayed(const Duration(seconds: 2));
       try {
-        final resp = await _api!.get('/api/v1/research/$id');
+        final resp = await _api!.get('research/$id');
         if (resp['status'] == 'complete' || resp['report_md'] != null) {
           _activeResult = ResearchResult.fromJson(resp);
           notifyListeners();
@@ -122,7 +122,7 @@ class ResearchProvider extends ChangeNotifier {
   Future<void> loadHistory() async {
     if (_api == null) return;
     try {
-      final resp = await _api!.get('/api/v1/research/history');
+      final resp = await _api!.get('research/history');
       final raw = resp['results'] as List? ?? [];
       _history = raw
           .map((e) => ResearchSummary.fromJson(e as Map<String, dynamic>))
@@ -136,7 +136,7 @@ class ResearchProvider extends ChangeNotifier {
     _loading = true;
     notifyListeners();
     try {
-      final resp = await _api!.get('/api/v1/research/$id');
+      final resp = await _api!.get('research/$id');
       _activeResult = ResearchResult.fromJson(resp);
     } catch (e) {
       _error = e.toString();
@@ -149,7 +149,7 @@ class ResearchProvider extends ChangeNotifier {
   Future<void> deleteResearch(String id) async {
     if (_api == null) return;
     try {
-      await _api!.delete('/api/v1/research/$id');
+      await _api!.delete('research/$id');
       _history.removeWhere((r) => r.id == id);
       if (_activeResult?.id == id) _activeResult = null;
       notifyListeners();
@@ -159,9 +159,7 @@ class ResearchProvider extends ChangeNotifier {
   Future<String?> exportResearch(String id, String format) async {
     if (_api == null) return null;
     try {
-      final resp = await _api!.post('/api/v1/research/$id/export', {
-        'format': format,
-      });
+      final resp = await _api!.post('research/$id/export', {'format': format});
       return resp['path'] as String?;
     } catch (_) {
       return null;

--- a/flutter_app/lib/providers/sources_provider.dart
+++ b/flutter_app/lib/providers/sources_provider.dart
@@ -52,7 +52,7 @@ class SourcesProvider extends ChangeNotifier {
     _error = null;
     notifyListeners();
     try {
-      final resp = await _api!.get('/api/v1/leads/sources');
+      final resp = await _api!.get('leads/sources');
       final raw = resp['sources'] as List? ?? [];
       _sources = raw
           .map((e) => LeadSourceInfo.fromJson(e as Map<String, dynamic>))

--- a/flutter_app/test/providers/packs_provider_test.dart
+++ b/flutter_app/test/providers/packs_provider_test.dart
@@ -22,7 +22,7 @@ void main() {
     });
 
     test('refresh populates packs from API response', () async {
-      when(() => api.get('/api/v1/packs/loaded')).thenAnswer(
+      when(() => api.get('packs/loaded')).thenAnswer(
         (_) async => {
           'packs': [
             {
@@ -52,7 +52,7 @@ void main() {
 
     test('refresh swallows errors and leaves packs unchanged', () async {
       when(
-        () => api.get('/api/v1/packs/loaded'),
+        () => api.get('packs/loaded'),
       ).thenThrow(Exception('offline'));
 
       await provider.refresh();
@@ -61,7 +61,7 @@ void main() {
     });
 
     test('refresh handles missing "packs" key gracefully', () async {
-      when(() => api.get('/api/v1/packs/loaded')).thenAnswer((_) async => {});
+      when(() => api.get('packs/loaded')).thenAnswer((_) async => {});
 
       await provider.refresh();
 
@@ -70,7 +70,7 @@ void main() {
 
     test('refresh notifies listeners', () async {
       when(
-        () => api.get('/api/v1/packs/loaded'),
+        () => api.get('packs/loaded'),
       ).thenAnswer((_) async => {'packs': []});
 
       var notifyCount = 0;

--- a/flutter_app/test/providers/research_provider_test.dart
+++ b/flutter_app/test/providers/research_provider_test.dart
@@ -122,7 +122,7 @@ void main() {
     });
 
     test('loadHistory populates history list', () async {
-      when(() => api.get('/api/v1/research/history')).thenAnswer(
+      when(() => api.get('research/history')).thenAnswer(
         (_) async => {
           'results': [
             {'id': 'r1', 'query': 'q1'},
@@ -139,7 +139,7 @@ void main() {
 
     test('loadHistory swallows errors silently', () async {
       when(
-        () => api.get('/api/v1/research/history'),
+        () => api.get('research/history'),
       ).thenThrow(Exception('offline'));
 
       await provider.loadHistory();
@@ -151,7 +151,7 @@ void main() {
 
     test('loadResult sets activeResult', () async {
       when(
-        () => api.get('/api/v1/research/r1'),
+        () => api.get('research/r1'),
       ).thenAnswer((_) async => {'id': 'r1', 'query': 'q', 'report_md': '# R'});
 
       await provider.loadResult('r1');
@@ -163,7 +163,7 @@ void main() {
 
     test('loadResult sets error on failure', () async {
       when(
-        () => api.get('/api/v1/research/missing'),
+        () => api.get('research/missing'),
       ).thenThrow(Exception('404'));
 
       await provider.loadResult('missing');
@@ -176,7 +176,7 @@ void main() {
       'deleteResearch removes from history + clears active if matching',
       () async {
         // Seed history.
-        when(() => api.get('/api/v1/research/history')).thenAnswer(
+        when(() => api.get('research/history')).thenAnswer(
           (_) async => {
             'results': [
               {'id': 'r1', 'query': 'a'},
@@ -187,7 +187,7 @@ void main() {
         await provider.loadHistory();
 
         when(
-          () => api.delete('/api/v1/research/r1'),
+          () => api.delete('research/r1'),
         ).thenAnswer((_) async => {});
         await provider.deleteResearch('r1');
 
@@ -197,7 +197,7 @@ void main() {
 
     test('exportResearch returns path on success', () async {
       when(
-        () => api.post('/api/v1/research/r1/export', {'format': 'pdf'}),
+        () => api.post('research/r1/export', {'format': 'pdf'}),
       ).thenAnswer((_) async => {'path': '/tmp/r1.pdf'});
 
       final path = await provider.exportResearch('r1', 'pdf');

--- a/flutter_app/test/providers/sources_provider_test.dart
+++ b/flutter_app/test/providers/sources_provider_test.dart
@@ -25,7 +25,7 @@ void main() {
     });
 
     test('refresh populates sources from API response', () async {
-      when(() => api.get('/api/v1/leads/sources')).thenAnswer(
+      when(() => api.get('leads/sources')).thenAnswer(
         (_) async => {
           'sources': [
             {
@@ -58,7 +58,7 @@ void main() {
 
     test('refresh sets error on failure', () async {
       when(
-        () => api.get('/api/v1/leads/sources'),
+        () => api.get('leads/sources'),
       ).thenThrow(Exception('unreachable'));
 
       await provider.refresh();
@@ -69,7 +69,7 @@ void main() {
     });
 
     test('refresh handles missing "sources" key gracefully', () async {
-      when(() => api.get('/api/v1/leads/sources')).thenAnswer((_) async => {});
+      when(() => api.get('leads/sources')).thenAnswer((_) async => {});
 
       await provider.refresh();
 


### PR DESCRIPTION
## Summary

`flutter_app/lib/services/api_client.dart::get/post/delete` already prepend `${baseUrl}/api/v1` to every path. Three providers were passing already-prefixed paths, producing `/api/v1/api/v1/...` requests that 404 silently.

**Files fixed:**
- `lib/providers/sources_provider.dart:55` — SourcesProvider stays empty → Leads sidebar tab hidden (per MEMORY) even with packs installed
- `lib/providers/packs_provider.dart:43` — loaded packs never refresh → upsell UI shows wrong state
- `lib/providers/research_provider.dart` (6 sites) — research screen perpetual spinner

Detected by autonomous workflow audit. Pure UI fix — no backend changes (FastAPI routes at the single-prefix paths already exist).

## Test plan

- [x] `dart format --check` on the 3 files: clean
- [x] `flutter analyze`: No issues found (ran in 0.4s)
- [ ] CI: lint + Flutter (analyze + test)

## Follow-ups

The `research_screen` still calls a deep-research backend that was extracted to a private pack (separate WF-1 finding). This PR only fixes the prefix duplication bug; the research screen visibility gate is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)