### PR TITLE
fix(security): SQLCipher fail-closed when encryption requested but unavailable (SEC-HIGH-4)

### DIFF
--- a/src/cognithor/config.py
+++ b/src/cognithor/config.py
@@ -2314,6 +2314,16 @@ class DatabaseConfig(BaseModel):
         default="keyring",
         description="Schluessel-Backend: 'keyring' (OS Credential Store)",
     )
+    allow_plaintext_fallback: bool = Field(
+        default=False,
+        description=(
+            "Wenn ``encryption_enabled=True`` aber SQLCipher bzw. der "
+            "Schluessel fehlt: nur dann lautlos auf Plain-SQLite "
+            "ausweichen, wenn dieses Flag explizit gesetzt ist. Sonst "
+            "wirft ``encrypted_connect`` einen RuntimeError statt "
+            "stillschweigend Klartext zu schreiben (SEC-HIGH-4)."
+        ),
+    )
     sqlite_max_retries: int = Field(default=5, ge=0, le=20)
     sqlite_retry_base_delay: float = Field(default=0.1, ge=0.01, le=5.0)
 

--- a/src/cognithor/security/encrypted_db.py
+++ b/src/cognithor/security/encrypted_db.py
@@ -103,6 +103,7 @@ _KEYRING_KEY_NAME = "db_encryption_key"
 
 # Cache the encryption_enabled flag to avoid re-reading config.yaml on every connect
 _encryption_enabled_cache: bool | None = None
+_allow_plaintext_fallback_cache: bool | None = None
 
 
 def _check_encryption_enabled() -> bool:
@@ -139,6 +140,42 @@ def _check_encryption_enabled() -> bool:
     # Default: encryption disabled (safe fallback — avoids VirtualLock on first run)
     _encryption_enabled_cache = False
     return _encryption_enabled_cache
+
+
+def _check_allow_plaintext_fallback() -> bool:
+    """Read ``database.allow_plaintext_fallback`` from config.yaml.
+
+    Default ``False`` — the operator must explicitly opt into the
+    legacy plaintext fallback when SQLCipher / a key is unavailable.
+    Caches per-process like ``_check_encryption_enabled``. SEC-HIGH-4.
+    """
+    global _allow_plaintext_fallback_cache
+    if _allow_plaintext_fallback_cache is not None:
+        return _allow_plaintext_fallback_cache
+
+    try:
+        from pathlib import Path
+
+        candidates = [
+            Path(os.environ.get("COGNITHOR_HOME", "")) / "config.yaml",
+            Path.home() / ".cognithor" / "config.yaml",
+        ]
+        for cfg_path in candidates:
+            if cfg_path.is_file():
+                import yaml
+
+                with open(cfg_path) as f:
+                    data = yaml.safe_load(f) or {}
+                db_section = data.get("database", {})
+                _allow_plaintext_fallback_cache = bool(
+                    db_section.get("allow_plaintext_fallback", False)
+                )
+                return _allow_plaintext_fallback_cache
+    except Exception:
+        log.debug("encrypted_db_allow_plaintext_read_failed", exc_info=True)
+
+    _allow_plaintext_fallback_cache = False
+    return _allow_plaintext_fallback_cache
 
 
 def is_encryption_available() -> bool:
@@ -285,7 +322,9 @@ def encrypted_connect(
     Args:
         db_path: Path to the SQLite database file
         key: Encryption key. If None, auto-detected from env/keyring/credential store.
-            Pass empty string "" to force plain sqlite3 (no encryption).
+            Pass empty string "" to force plain sqlite3 (no encryption); this
+            is the explicit "I know what I'm doing" escape-hatch and bypasses
+            the SEC-HIGH-4 fail-closed guard.
         check_same_thread: sqlite3 check_same_thread parameter
         timeout: How many seconds to wait for the database lock (default 5.0)
 
@@ -293,6 +332,9 @@ def encrypted_connect(
         sqlite3.Connection (either encrypted or standard)
     """
     db_path = str(db_path)  # Ensure string — Path objects break concatenation + slicing
+    # Remember whether the caller explicitly opted out (key="" sentinel)
+    # so the SEC-HIGH-4 fail-closed guard further down can skip them.
+    _caller_opted_out = key == ""
     # Respect the global encryption_enabled config flag.
     # If encryption is disabled, skip SQLCipher entirely — avoids
     # VirtualLock quota exhaustion on Windows from dozens of open
@@ -397,7 +439,30 @@ def encrypted_connect(
             hint="pip install pysqlcipher3 keyring",
         )
 
-    # Fallback: standard sqlite3 (unencrypted)
+    # SEC-HIGH-4: We're about to fall back to *plain* sqlite3, even
+    # though the user asked for encryption (the early-out at line 314
+    # would have returned already if encryption_enabled was False). If
+    # the operator did not explicitly opt into plaintext fallback,
+    # refuse to open the DB rather than silently storing secrets in
+    # plaintext on disk. The ``key=""`` escape-hatch ALWAYS wins —
+    # callers that pass it documented they want unencrypted storage.
+    if (
+        not _caller_opted_out
+        and _check_encryption_enabled()
+        and not _check_allow_plaintext_fallback()
+    ):
+        reason = "SQLCipher unavailable" if not _sqlcipher_available else "no encryption key"
+        raise RuntimeError(
+            f"Refusing to open {db_path[-40:]!r} as plaintext sqlite3: "
+            f"encryption is enabled but {reason}. Install pysqlcipher3 "
+            "and configure a key, OR set "
+            "``database.allow_plaintext_fallback: true`` in config.yaml "
+            "to opt into the legacy fallback."
+        )
+
+    # Fallback: standard sqlite3 (unencrypted) — only reached when the
+    # user explicitly opted in via allow_plaintext_fallback=true OR
+    # encryption_enabled=false.
     conn = sqlite3.connect(db_path, check_same_thread=check_same_thread, timeout=timeout)
     conn.execute("PRAGMA journal_mode=WAL")
     return conn

--- a/tests/test_security/test_encrypted_db.py
+++ b/tests/test_security/test_encrypted_db.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import pytest
+
+from cognithor.security import encrypted_db
 from cognithor.security.encrypted_db import encrypted_connect, is_encryption_available
 
 
@@ -45,3 +48,86 @@ def test_is_encryption_available():
     """Should return bool without crashing."""
     result = is_encryption_available()
     assert isinstance(result, bool)
+
+
+# ---------------------------------------------------------------------------
+# SEC-HIGH-4: fail-closed when encryption requested but unavailable
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def reset_caches(monkeypatch):
+    """Reset module-level caches so each test sees a clean state."""
+    monkeypatch.setattr(encrypted_db, "_encryption_enabled_cache", None)
+    monkeypatch.setattr(encrypted_db, "_allow_plaintext_fallback_cache", None)
+    yield
+
+
+class TestFailClosedSqlcipher:
+    """SEC-HIGH-4 (autonomous security audit, 2026-05-04): when the
+    operator enables encryption in config but SQLCipher / a key is
+    unavailable, ``encrypted_connect`` MUST raise rather than silently
+    storing plaintext on disk.
+    """
+
+    def test_raises_when_encryption_enabled_no_key_no_sqlcipher(
+        self, tmp_path, monkeypatch, reset_caches
+    ):
+        """Default behaviour: refuse the plaintext fallback."""
+        monkeypatch.setattr(encrypted_db, "_check_encryption_enabled", lambda: True)
+        monkeypatch.setattr(encrypted_db, "_check_allow_plaintext_fallback", lambda: False)
+        # Force "no key" + "no sqlcipher" — covers the worst case.
+        monkeypatch.setattr(encrypted_db, "_get_db_key", lambda: "")
+        monkeypatch.setattr(encrypted_db, "_sqlcipher_available", False)
+
+        db_path = str(tmp_path / "test.db")
+        with pytest.raises(RuntimeError, match="Refusing to open"):
+            encrypted_connect(db_path)
+
+    def test_allows_plaintext_when_explicit_opt_in(self, tmp_path, monkeypatch, reset_caches):
+        """``allow_plaintext_fallback=True`` reactivates the legacy
+        behaviour for operators who knowingly accept it.
+        """
+        monkeypatch.setattr(encrypted_db, "_check_encryption_enabled", lambda: True)
+        monkeypatch.setattr(encrypted_db, "_check_allow_plaintext_fallback", lambda: True)
+        monkeypatch.setattr(encrypted_db, "_get_db_key", lambda: "")
+        monkeypatch.setattr(encrypted_db, "_sqlcipher_available", False)
+
+        db_path = str(tmp_path / "test.db")
+        conn = encrypted_connect(db_path)
+        # Plaintext sqlite3 connection — write something and confirm.
+        conn.execute("CREATE TABLE x (id INTEGER)")
+        conn.execute("INSERT INTO x VALUES (1)")
+        conn.commit()
+        assert conn.execute("SELECT id FROM x").fetchone()[0] == 1
+        conn.close()
+
+    def test_no_raise_when_encryption_disabled_in_config(self, tmp_path, monkeypatch, reset_caches):
+        """Existing path: encryption_enabled=false in config still
+        permits plaintext sqlite3 (the early-out at the top of
+        encrypted_connect short-circuits before our guard).
+        """
+        monkeypatch.setattr(encrypted_db, "_check_encryption_enabled", lambda: False)
+        monkeypatch.setattr(encrypted_db, "_check_allow_plaintext_fallback", lambda: False)
+
+        db_path = str(tmp_path / "test.db")
+        conn = encrypted_connect(db_path)
+        conn.execute("CREATE TABLE x (id INTEGER)")
+        conn.commit()
+        conn.close()
+
+    def test_explicit_empty_key_still_allowed(self, tmp_path, monkeypatch, reset_caches):
+        """``key=""`` is the documented escape-hatch for callers that
+        deliberately want plain sqlite3. Must keep working.
+        """
+        monkeypatch.setattr(encrypted_db, "_check_encryption_enabled", lambda: True)
+        monkeypatch.setattr(encrypted_db, "_check_allow_plaintext_fallback", lambda: False)
+
+        db_path = str(tmp_path / "test.db")
+        # Note: passing key="" bypasses the _check_encryption_enabled
+        # path and the fail-closed guard never triggers — the function
+        # treats this as "I know what I'm doing".
+        conn = encrypted_connect(db_path, key="")
+        conn.execute("CREATE TABLE x (id INTEGER)")
+        conn.commit()
+        conn.close()


### PR DESCRIPTION
## Summary

`encrypted_connect` previously fell through to plain `sqlite3` when `encryption_enabled=true` in config but pysqlcipher3 was missing OR no key was available. The only signal to the operator was a `log.warning` that fires once per process — easy to miss, especially on Windows where pysqlcipher3 is rarely installed by default. **Result: vault, kanban, background_tasks, trace_store and other DBs were stored on disk in plaintext while the user believed they were encrypted.**

Found by autonomous security audit (SEC-HIGH-4), 2026-05-04.

## Fix

- New `database.allow_plaintext_fallback: bool = False` config flag in `DatabaseConfig`. Default refuses the silent fallback.
- New `_check_allow_plaintext_fallback()` helper mirroring the existing `_check_encryption_enabled` cache pattern.
- Before falling through to plain sqlite3, `encrypted_connect` now raises `RuntimeError` with a clear remediation hint, unless one of these escape-hatches applies:
  - operator explicitly opted in via the config flag
  - caller passed `key=""` (the documented "I know what I'm doing" escape-hatch)
  - `encryption_enabled=false` (the early-out at the top of the function returns plaintext before this guard)

## Test plan

- [x] 4 new `TestFailClosedSqlcipher` cases: raises by default, allow_plaintext_fallback opt-in, encryption disabled, explicit `key=""`
- [x] 4 existing `test_encrypted_db.py` tests pass unchanged
- [x] Wider security suite: 1320 passed
- [x] `mypy --strict src/cognithor/`: 0 errors / 736 files
- [x] `ruff check + format`: clean
- [ ] CI

## Operator action required

Users running with `encryption_enabled=true` but no pysqlcipher3 will now hit a `RuntimeError` on first DB connect. To restore the legacy behaviour:

\`\`\`yaml
# ~/.cognithor/config.yaml
database:
  allow_plaintext_fallback: true   # explicit opt-in
\`\`\`

Or, recommended: `pip install pysqlcipher3 keyring`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)