### PR TITLE
fix(security): route start_background through destructive-command guard (SEC-CRIT-1)

### DIFF
--- a/src/cognithor/core/gatekeeper.py
+++ b/src/cognithor/core/gatekeeper.py
@@ -380,7 +380,14 @@ class Gatekeeper:
                 return code_check
 
         # --- Step 4b: Destructive shell commands ---
-        if action.tool in ("exec_command", "shell_exec", "shell"):
+        # ``start_background`` runs ``subprocess.Popen(command, shell=True)``
+        # via ``BackgroundTaskManager.start`` — same threat surface as a
+        # synchronous ``exec_command`` call, just detached. SEC-CRIT-1
+        # (autonomous security audit, 2026-05-04) — without this entry
+        # the destructive-command regex never fires for it, so a
+        # jailbroken Planner could spawn ``rm -rf $HOME`` as a
+        # background job that the Gatekeeper auto-allows under YELLOW.
+        if action.tool in ("exec_command", "shell_exec", "shell", "start_background"):
             cmd = str(action.params.get("command", ""))
             cmd_check = self._check_command(cmd, action)
             if cmd_check is not None:

--- a/tests/test_core/test_gatekeeper.py
+++ b/tests/test_core/test_gatekeeper.py
@@ -261,6 +261,43 @@ class TestDestructiveCommands:
                 f"'{cmd}' should NOT match blocked patterns"
             )
 
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            "rm -rf /",
+            "rm -rf /home",
+            "shutdown -h now",
+            "format C:",
+        ],
+    )
+    def test_start_background_destructive_commands_blocked(
+        self, gatekeeper: Gatekeeper, session: SessionContext, cmd: str
+    ) -> None:
+        """SEC-CRIT-1 (autonomous security audit, 2026-05-04):
+        ``start_background`` runs ``subprocess.Popen(shell=True)`` —
+        same threat surface as ``exec_command``. The destructive-
+        command regex/AST chain MUST fire for it too. Without this
+        guard, a jailbroken Planner could spawn ``rm -rf $HOME`` as a
+        background job that the YELLOW classification auto-allows.
+        """
+        action = PlannedAction(tool="start_background", params={"command": cmd})
+        decision = gatekeeper.evaluate(action, session)
+        assert decision.status == GateStatus.BLOCK, f"start_background('{cmd}') should be BLOCKED"
+        assert decision.is_blocked
+
+    def test_start_background_safe_command_not_blocked(
+        self, gatekeeper: Gatekeeper, session: SessionContext
+    ) -> None:
+        """Legitimate background commands (``npm run dev`` etc.) must
+        still pass the destructive check. They get YELLOW (auto-execute
+        with informational notice) like before — only the dangerous
+        patterns are now caught.
+        """
+        action = PlannedAction(tool="start_background", params={"command": "npm run dev"})
+        decision = gatekeeper.evaluate(action, session)
+        assert decision.policy_name != "blocked_command"
+        assert decision.policy_name != "blocked_command_ast"
+
 
 # ============================================================================
 # Credential-Erkennung


### PR DESCRIPTION
## Summary

`BackgroundTaskManager.start` runs `subprocess.Popen(command, shell=True)` (Windows) / `bash -c` (POSIX) directly with the raw Planner-supplied command. The Gatekeeper classifies `start_background` as **YELLOW** (auto-execute, just inform), but the destructive-command regex+AST chain at `gatekeeper.py:383` only fired for the tuple `("exec_command", "shell_exec", "shell")`. **`start_background` was not listed and bypassed both Layer-1 (AST) and Layer-2 (regex) shell-injection defenses entirely.**

Found by autonomous security audit (SEC-CRIT-1), 2026-05-04.

## Threat

A jailbroken Planner can spawn `rm -rf $HOME`, `shutdown -h now`, or `format C:` as a "background job" that the Gatekeeper auto-allows under YELLOW — same blast radius as the worst `exec_command`, just detached.

## Fix

Add `"start_background"` to the destructive-command tuple. `_check_command` now runs against background-task commands too:
- **Layer-1 (`analyse_shell` AST)**: catches substitution, chaining, path-traversal bypasses
- **Layer-2 (regex)**: catches well-known patterns (`rm -rf`, `shutdown`, `mkfs`, `dd if=…`, `format C:`, fork bombs, etc.)

Legitimate background commands (`npm run dev`, `python server.py`) still pass — only the destructive ones are blocked.

## Test plan

- [x] New parametrised `test_start_background_destructive_commands_blocked` (4 attack patterns: `rm -rf /`, `rm -rf /home`, `shutdown -h now`, `format C:`) — all BLOCKED
- [x] `test_start_background_safe_command_not_blocked` confirms `npm run dev` still passes
- [x] Existing 9 `exec_command` destructive tests + 1 safe-command test still pass
- [x] Full `test_gatekeeper.py`: 86 passed
- [x] mypy --strict + ruff: clean
- [ ] CI

## Follow-up

Full sandbox-routing of `BackgroundTaskManager.start` via `ShellTools.exec_command` is a larger refactor for a separate PR. This PR closes the highest-leverage attack vector (the destructive-command guard) — the residual risk after merging is "non-RED-listed but still problematic" commands, which a future sandbox PR will mitigate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)