### PR TITLE
chore(gateway): delete dead _idle_loop class attribute

### DIFF
--- a/src/cognithor/gateway/gateway.py
+++ b/src/cognithor/gateway/gateway.py
@@ -366,7 +366,6 @@ class Gateway:
     _idle_detector: Any = None
     _trace_bus: Any = None
     _heartbeat_scheduler: Any = None
-    _idle_loop: Any = None
     _flow_engine: Any = None
     _workflow_engine: Any = None
     _backup_scheduler: Any = None


### PR DESCRIPTION
## Summary

`Gateway._idle_loop: Any = None` (`gateway.py:369`) is declared once in the Phase-H attribute block and never set, never referenced anywhere in source or tests.

* `declare_advanced_attrs` does NOT include it
* `init_advanced` never assigns it
* zero test references
* `grep -rn _idle_loop src/ tests/`: 1 hit (the declaration itself)

The MEMORY note on Evolution Engine v0.80.0 mentioned an "IdleLoop" phase, but the actual class shipped was `IdleDetector` (instantiated at `gateway.py:1133`), not `IdleLoop`. This attribute is residue from a renamed/dropped iteration.

Found by autonomous workflow audit (WF-5), 2026-05-04.

## Why pure delete is safe

Any plugin or test still using `getattr(gateway, "_idle_loop", None)` continues to receive `None` — class-level default disappears, but `getattr` falls through to its 3rd argument default, so external behaviour is unchanged.

## Test plan

- [x] `mypy --strict src/cognithor/gateway/gateway.py`: clean
- [x] `ruff check`: clean
- [x] `pytest tests/test_gateway/ tests/test_core/test_gatekeeper.py`: 409 passed
- [x] `grep -rn _idle_loop src/ tests/`: 0 remaining references after delete
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)