### PR TITLE
fix(security): add SHA-256 hash chain to audit log JSONL (SEC-HIGH-5)

### DIFF
--- a/src/cognithor/audit/__init__.py
+++ b/src/cognithor/audit/__init__.py
@@ -79,6 +79,13 @@ class AuditEntry:
     """A single audit entry.
 
     Immutable after creation (append-only log).
+
+    Hash chain (SEC-HIGH-5, autonomous security audit, 2026-05-04):
+    every persisted entry stores ``prev_hash`` = SHA-256 of the
+    previous entry's canonical JSON form. ``AuditLogger.validate_chain()``
+    walks the JSONL on disk and verifies each link, surfacing any
+    tampering (insertion, deletion, mutation). The first entry of a
+    chain stores the empty string.
     """
 
     entry_id: str
@@ -96,6 +103,9 @@ class AuditEntry:
     success: bool = True
     duration_ms: float = 0.0
     contains_pii: bool = False  # Contains personal data
+    # SEC-HIGH-5: SHA-256 of the previous entry's canonical JSON.
+    # Empty for the first entry written to a freshly-rotated log file.
+    prev_hash: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -112,7 +122,21 @@ class AuditEntry:
             "success": self.success,
             "duration_ms": self.duration_ms,
             "contains_pii": self.contains_pii,
+            "prev_hash": self.prev_hash,
         }
+
+    def canonical_hash(self) -> str:
+        """SHA-256 of this entry's canonical JSON form.
+
+        Used by the next entry as its ``prev_hash``. ``sort_keys=True``
+        + ``ensure_ascii=False`` make the form deterministic across
+        runs so the verification on disk matches what was hashed at
+        write time.
+        """
+        import hashlib
+
+        canon = json.dumps(self.to_dict(), sort_keys=True, ensure_ascii=False)
+        return hashlib.sha256(canon.encode("utf-8")).hexdigest()
 
 
 # ============================================================================
@@ -191,6 +215,11 @@ class AuditLogger:
         self._entries: deque[AuditEntry] = deque(maxlen=max_entries)
         self._counter = 0
         self._retention_days = retention_days
+        # SEC-HIGH-5: tracks SHA-256 of the most recently persisted
+        # entry per log file (key = file path) so the next entry can
+        # link to it via ``prev_hash``. Loaded lazily from disk on
+        # first persist to a given file (handles process restarts).
+        self._last_hash_per_file: dict[Path, str] = {}
 
         if log_dir:
             log_dir.mkdir(parents=True, exist_ok=True)
@@ -660,17 +689,111 @@ class AuditLogger:
 
         return entry
 
+    def _last_hash_for_file(self, log_file: Path) -> str:
+        """Return the canonical SHA-256 of the last entry already in
+        ``log_file``, or "" if the file is empty / missing.
+
+        Used to compute ``prev_hash`` for the next entry. Caches per
+        path so a busy logger doesn't re-read the file on every write.
+        """
+        if log_file in self._last_hash_per_file:
+            return self._last_hash_per_file[log_file]
+        if not log_file.exists():
+            self._last_hash_per_file[log_file] = ""
+            return ""
+        try:
+            # Walk the file to find the last non-blank line.
+            last_line = ""
+            with log_file.open("r", encoding="utf-8") as f:
+                for line in f:
+                    line = line.strip()
+                    if line:
+                        last_line = line
+            if not last_line:
+                self._last_hash_per_file[log_file] = ""
+                return ""
+            data = json.loads(last_line)
+            # Reconstruct a minimal AuditEntry to compute the hash; we
+            # only need the canonical JSON form, so a generic dict is
+            # fine.
+            import hashlib
+
+            canon = json.dumps(data, sort_keys=True, ensure_ascii=False)
+            h = hashlib.sha256(canon.encode("utf-8")).hexdigest()
+            self._last_hash_per_file[log_file] = h
+            return h
+        except Exception as exc:
+            logger.warning("Audit chain head read failed for %s: %s", log_file, exc)
+            self._last_hash_per_file[log_file] = ""
+            return ""
+
     def _persist_entry(self, entry: AuditEntry) -> None:
-        """Writes an entry to the audit file."""
+        """Writes an entry to the audit file with hash-chain link.
+
+        SEC-HIGH-5: ``entry.prev_hash`` is set to the SHA-256 of the
+        previous entry already on disk for this date's log file before
+        writing, then this entry's own hash is cached for the next
+        write. Tampering after-the-fact (insertion / deletion / edit)
+        can be surfaced by ``validate_chain``.
+        """
         if self._log_dir is None:
             return
         try:
             date_str = entry.timestamp[:10]  # YYYY-MM-DD
             log_file = self._log_dir / f"audit_{date_str}.jsonl"
+            entry.prev_hash = self._last_hash_for_file(log_file)
             with log_file.open("a", encoding="utf-8") as f:
                 f.write(json.dumps(entry.to_dict(), ensure_ascii=False) + "\n")
+            # Cache this entry's hash for the next persist.
+            self._last_hash_per_file[log_file] = entry.canonical_hash()
         except Exception as exc:
             logger.error("Audit persistence failed: %s", exc)
+
+    def validate_chain(self, log_file: Path) -> tuple[bool, list[str]]:
+        """Walk an audit JSONL and verify the SHA-256 hash chain.
+
+        Returns ``(ok, errors)``. ``ok=True`` means every line's
+        ``prev_hash`` matches the canonical hash of the line above it.
+        Errors carry human-readable descriptions of which entry broke
+        the chain (insertion, deletion, or mutation).
+
+        SEC-HIGH-5: invoke at startup or on demand to detect post-hoc
+        tampering of the audit log on disk.
+        """
+        import hashlib
+
+        if not log_file.exists():
+            return True, []
+
+        errors: list[str] = []
+        expected_prev = ""
+        line_no = 0
+        try:
+            with log_file.open("r", encoding="utf-8") as f:
+                for raw_line in f:
+                    line = raw_line.strip()
+                    if not line:
+                        continue
+                    line_no += 1
+                    try:
+                        data = json.loads(line)
+                    except json.JSONDecodeError as exc:
+                        errors.append(f"line {line_no}: invalid JSON ({exc})")
+                        return False, errors
+                    actual_prev = data.get("prev_hash", "")
+                    if actual_prev != expected_prev:
+                        errors.append(
+                            f"line {line_no} (entry_id={data.get('entry_id', '?')}): "
+                            f"prev_hash mismatch — expected {expected_prev[:12] or '(empty)'} "
+                            f"but found {actual_prev[:12] or '(empty)'}"
+                        )
+                    canon = json.dumps(data, sort_keys=True, ensure_ascii=False)
+                    expected_prev = hashlib.sha256(canon.encode("utf-8")).hexdigest()
+        except OSError as exc:
+            errors.append(f"read error: {exc}")
+            return False, errors
+
+        return len(errors) == 0, errors
 
     @staticmethod
     def _sanitize_params(params: dict[str, Any]) -> dict[str, Any]:

--- a/tests/test_audit/test_audit_logger.py
+++ b/tests/test_audit/test_audit_logger.py
@@ -342,3 +342,107 @@ class TestAuditPersistence:
         logger = AuditLogger()
         stats = logger.stats()
         assert stats["has_persistence"] is False
+
+
+# ============================================================================
+# SEC-HIGH-5 — hash chain (autonomous security audit, 2026-05-04)
+# ============================================================================
+
+
+class TestHashChain:
+    """``AuditLogger`` writes a per-file SHA-256 hash chain (``prev_hash``
+    on every entry). ``validate_chain`` detects post-hoc tampering.
+    """
+
+    def _write_three_entries(self, audit_dir: Path) -> Path:
+        logger = AuditLogger(log_dir=audit_dir)
+        for i in range(3):
+            logger.log_tool_call(f"tool_{i}", {"k": str(i)}, agent_name="test_agent", success=True)
+        # Find the JSONL just produced (single date file).
+        files = list(audit_dir.glob("audit_*.jsonl"))
+        assert len(files) == 1, f"expected 1 audit file, got {files}"
+        return files[0]
+
+    def test_first_entry_has_empty_prev_hash(self, tmp_path: Path) -> None:
+        log_file = self._write_three_entries(tmp_path / "audit")
+        lines = log_file.read_text(encoding="utf-8").strip().split("\n")
+        first = json.loads(lines[0])
+        assert "prev_hash" in first
+        assert first["prev_hash"] == ""
+
+    def test_subsequent_entries_link_to_previous(self, tmp_path: Path) -> None:
+        import hashlib
+
+        log_file = self._write_three_entries(tmp_path / "audit")
+        lines = log_file.read_text(encoding="utf-8").strip().split("\n")
+        for i in range(1, len(lines)):
+            prev_data = json.loads(lines[i - 1])
+            curr_data = json.loads(lines[i])
+            canon_prev = json.dumps(prev_data, sort_keys=True, ensure_ascii=False)
+            expected = hashlib.sha256(canon_prev.encode("utf-8")).hexdigest()
+            assert curr_data["prev_hash"] == expected, (
+                f"line {i + 1} prev_hash {curr_data['prev_hash'][:12]} "
+                f"!= sha256(line {i}) {expected[:12]}"
+            )
+
+    def test_validate_chain_passes_clean_log(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / "audit"
+        log_file = self._write_three_entries(audit_dir)
+        logger = AuditLogger(log_dir=audit_dir)
+        ok, errors = logger.validate_chain(log_file)
+        assert ok, f"clean chain should validate; errors: {errors}"
+        assert errors == []
+
+    def test_validate_chain_detects_mutation(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / "audit"
+        log_file = self._write_three_entries(audit_dir)
+        # Tamper: rewrite the SECOND entry's parameters in place.
+        lines = log_file.read_text(encoding="utf-8").strip().split("\n")
+        tampered = json.loads(lines[1])
+        tampered["parameters"] = {"k": "PWNED"}
+        lines[1] = json.dumps(tampered, ensure_ascii=False)
+        log_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        logger = AuditLogger(log_dir=audit_dir)
+        ok, errors = logger.validate_chain(log_file)
+        # The 3rd line's prev_hash was computed from the ORIGINAL 2nd
+        # line; after mutation it no longer matches.
+        assert not ok
+        assert any("prev_hash mismatch" in e for e in errors), errors
+
+    def test_validate_chain_detects_deletion(self, tmp_path: Path) -> None:
+        audit_dir = tmp_path / "audit"
+        log_file = self._write_three_entries(audit_dir)
+        lines = log_file.read_text(encoding="utf-8").strip().split("\n")
+        del lines[1]
+        log_file.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        logger = AuditLogger(log_dir=audit_dir)
+        ok, errors = logger.validate_chain(log_file)
+        assert not ok
+        assert any("prev_hash mismatch" in e for e in errors), errors
+
+    def test_validate_chain_handles_missing_file(self, tmp_path: Path) -> None:
+        logger = AuditLogger(log_dir=tmp_path / "audit")
+        ok, errors = logger.validate_chain(tmp_path / "audit" / "ghost.jsonl")
+        assert ok
+        assert errors == []
+
+    def test_chain_survives_logger_restart(self, tmp_path: Path) -> None:
+        """A fresh ``AuditLogger`` pointing at an existing log file
+        must reload the prior tail's hash so its first new write
+        chains correctly. Otherwise process restarts would silently
+        break the chain.
+        """
+        audit_dir = tmp_path / "audit"
+        first = AuditLogger(log_dir=audit_dir)
+        for i in range(2):
+            first.log_tool_call(f"a{i}", {}, agent_name="agent", success=True)
+
+        log_file = next(iter(audit_dir.glob("audit_*.jsonl")))
+
+        second = AuditLogger(log_dir=audit_dir)
+        second.log_tool_call("a2", {}, agent_name="agent", success=True)
+
+        ok, errors = second.validate_chain(log_file)
+        assert ok, f"chain broken after restart: {errors}"


### PR DESCRIPTION
## Summary

`AuditLogger._persist_entry` previously appended JSON lines to `audit_YYYY-MM-DD.jsonl` with **no per-entry hash, no chain-link, no signature**. The dedicated `cognithor.hashline` module exists but was wired only into FileSystemTools — the audit log itself was not protected. An attacker (or malicious tool) with FS write access could rewrite the JSONL undetectably, contradicting `gatekeeper.py:11`'s claim "Every decision is immutably logged".

Found by autonomous security audit (SEC-HIGH-5), 2026-05-04. **This closes the last of 5 CRITICAL+HIGH security findings from the audit.**

## Fix

- **`AuditEntry`** gains `prev_hash: str = ""` and a `canonical_hash()` helper returning SHA-256 of the deterministic JSON form (`sort_keys=True`, `ensure_ascii=False`).
- **`_persist_entry`** sets `entry.prev_hash` to the canonical hash of the most-recent entry on disk before appending. Per-file cache avoids re-reading on every write; on logger restart, lazily reloads the prior tail's hash so the chain survives process boundaries.
- **`validate_chain(log_file) → (ok, errors)`** walks the JSONL and verifies each link. Detects mutation, insertion, and deletion. Invoke at startup or on demand.

## Why a custom chain instead of routing through `hashline.HashlineGuard`

`HashlineGuard` is a line-level editor for safe in-place file edits with hash verification — heavy machinery designed for read-modify-write. The audit log is append-only; a 30-line `prev_hash` chain inside `AuditEntry` adds tamper detection without pulling the editor's full surface (cache, recovery, validator, formatter, tagger).

## Test plan

- [x] `test_first_entry_has_empty_prev_hash`
- [x] `test_subsequent_entries_link_to_previous` — verifies SHA-256 algorithm
- [x] `test_validate_chain_passes_clean_log`
- [x] `test_validate_chain_detects_mutation`
- [x] `test_validate_chain_detects_deletion`
- [x] `test_validate_chain_handles_missing_file`
- [x] `test_chain_survives_logger_restart` — pinned the cache-reload path
- [x] All 64 audit tests pass (57 existing + 7 new)
- [x] mypy --strict + ruff: clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)