### PR TITLE
feat(gatekeeper): TRUST-2 structured DecisionExplanation for "why" reconstruction

### DIFF
--- a/src/cognithor/core/gatekeeper.py
+++ b/src/cognithor/core/gatekeeper.py
@@ -29,6 +29,7 @@ import yaml
 from cognithor.i18n import t
 from cognithor.models import (
     AuditEntry,
+    DecisionExplanation,
     GateDecision,
     GateStatus,
     OperationMode,
@@ -355,6 +356,12 @@ class Gatekeeper:
                     risk_level=risk,
                     original_action=action,
                     policy_name=rule.name,
+                    # TRUST-2: structured explanation for the receipt + UI
+                    explanation=DecisionExplanation(
+                        rule_id=f"policy:{rule.name}",
+                        rule_source=f"policy:{rule.name}",
+                        matched_pattern=action.tool,
+                    ),
                 )
                 self._write_audit(action, decision, context)
                 log.debug(
@@ -1088,6 +1095,12 @@ class Gatekeeper:
                     risk_level=RiskLevel.RED,
                     original_action=action,
                     policy_name="blocked_command_ast",
+                    # TRUST-2: structured explanation for the receipt + UI
+                    explanation=DecisionExplanation(
+                        rule_id="dest_cmd_ast",
+                        rule_source="cognithor.security.shell_ast_guard:analyse_shell",
+                        matched_pattern=details[:200],
+                    ),
                 )
         except Exception:
             log.debug("shell_ast_guard_failed", exc_info=True)
@@ -1101,6 +1114,12 @@ class Gatekeeper:
                     risk_level=RiskLevel.RED,
                     original_action=action,
                     policy_name="blocked_command",
+                    # TRUST-2: structured explanation for the receipt + UI
+                    explanation=DecisionExplanation(
+                        rule_id="dest_cmd_regex",
+                        rule_source="cognithor.core.gatekeeper:_blocked_command_patterns",
+                        matched_pattern=pattern.pattern,
+                    ),
                 )
 
         return None

--- a/src/cognithor/models.py
+++ b/src/cognithor/models.py
@@ -218,6 +218,35 @@ class ActionPlan(BaseModel, frozen=True):
         return len(self.steps) > 0
 
 
+class DecisionExplanation(BaseModel, frozen=True):
+    """Structured "why did the Gatekeeper allow/deny this?" record.
+
+    TRUST-2 (operational-trust audit, 2026-05-04). Reviewer asked for
+    operator-readable explanations beyond a free-text ``reason``. This
+    record makes the decision path inspectable in UI + receipts:
+
+      * ``rule_id``: stable short identifier ("dest_cmd_ast",
+        "dest_cmd_regex", "red_tool", "orange_default", "approval",
+        "credential_mask", "capability_violation", "pack_risk_green")
+      * ``rule_source``: code location of the rule. ``"file:line"`` for
+        rules that live in source (gatekeeper.py:383); ``"policy:<name>"``
+        for YAML-loaded policies; ``"pack:<qid>"`` for pack-injected risks.
+      * ``matched_pattern``: the actual literal that triggered (e.g.
+        ``"rm -rf"`` for regex, the AST node descriptor for AST hits,
+        the tool-name for green/red list hits). Empty when N/A.
+      * ``policy_version``: optional version string when the rule comes
+        from a versioned policy bundle.
+
+    Backward-compat: every field has a default — old callers that only
+    set ``reason`` keep working; the explanation field is ``None``.
+    """
+
+    rule_id: str = ""
+    rule_source: str = ""
+    matched_pattern: str = ""
+    policy_version: str = ""
+
+
 class GateDecision(BaseModel, frozen=True):
     """Entscheidung des Gatekeepers fuer eine einzelne Aktion. [B§3.2]
 
@@ -228,6 +257,7 @@ class GateDecision(BaseModel, frozen=True):
     risk_level: RiskLevel = RiskLevel.GREEN
     reason: str = ""
     policy_name: str = ""  # Name der auslösenden Policy-Regel
+    explanation: DecisionExplanation | None = None  # TRUST-2 structured "why"
     original_action: PlannedAction | None = None  # Referenz auf geprüfte Aktion
     masked_params: dict[str, Any] | None = None  # Params nach Credential-Maskierung
     confidence_score: float | None = None  # Pre-execution confidence (0.0-1.0)

--- a/tests/test_core/test_gatekeeper.py
+++ b/tests/test_core/test_gatekeeper.py
@@ -502,3 +502,79 @@ class TestGateDecisionFromGatekeeper:
         action = PlannedAction(tool="read_file", params={"path": "/test"})
         decision = gatekeeper.evaluate(action, session)
         assert decision.policy_name  # Sollte gesetzt sein
+
+
+# ============================================================================
+# TRUST-2: structured "why" explanations (operational-trust audit, 2026-05-04)
+# ============================================================================
+
+
+class TestDecisionExplanation:
+    """Reddit reviewer asked for operator-readable Gatekeeper "why".
+    ``GateDecision.explanation`` (DecisionExplanation) carries
+    ``rule_id``, ``rule_source``, ``matched_pattern`` so receipts and
+    Trace-UI can render the decision path without parsing free-text
+    ``reason``.
+    """
+
+    def test_destructive_command_attaches_explanation(
+        self, gatekeeper: Gatekeeper, session: SessionContext
+    ) -> None:
+        """``exec_command rm -rf /`` is blocked. Whichever guard fires
+        first (YAML policy / AST / regex) MUST attach a structured
+        explanation — that's the entire point.
+        """
+        action = PlannedAction(tool="exec_command", params={"command": "rm -rf /"})
+        decision = gatekeeper.evaluate(action, session)
+        assert decision.is_blocked
+        assert decision.explanation is not None
+        assert decision.explanation.rule_id  # any non-empty id
+        # rule_source must be a code/policy reference, never bare text.
+        assert ":" in decision.explanation.rule_source
+
+    def test_destructive_regex_path_explanation(
+        self, gatekeeper: Gatekeeper, session: SessionContext
+    ) -> None:
+        """``start_background`` doesn't match the YAML
+        ``no_destructive_shell`` policy (which targets exec_command) so
+        it falls through to ``_check_command`` regex/AST — the path
+        added in SEC-CRIT-1. That's where dest_cmd_ast / dest_cmd_regex
+        fire.
+        """
+        action = PlannedAction(tool="start_background", params={"command": "shutdown -h now"})
+        decision = gatekeeper.evaluate(action, session)
+        assert decision.is_blocked
+        assert decision.explanation is not None
+        assert decision.explanation.rule_id in {"dest_cmd_ast", "dest_cmd_regex"}
+        assert decision.explanation.matched_pattern
+
+    def test_safe_command_no_explanation(
+        self, gatekeeper: Gatekeeper, session: SessionContext
+    ) -> None:
+        """A non-destructive command shouldn't trigger the explain
+        path — explanation stays None for the catch-all default.
+        """
+        action = PlannedAction(tool="exec_command", params={"command": "ls -la"})
+        decision = gatekeeper.evaluate(action, session)
+        # Either the action passes (no explanation) or hits a different
+        # default — but the destructive rule must NOT fire.
+        if decision.explanation is not None:
+            assert decision.explanation.rule_id not in {
+                "dest_cmd_ast",
+                "dest_cmd_regex",
+            }
+
+    def test_explanation_is_structured_not_freetext(
+        self, gatekeeper: Gatekeeper, session: SessionContext
+    ) -> None:
+        """The structured fields must not be empty strings when set —
+        the reviewer's whole point was 'don't make me parse text'.
+        """
+        action = PlannedAction(tool="exec_command", params={"command": "rm -rf /"})
+        decision = gatekeeper.evaluate(action, session)
+        assert decision.explanation is not None
+        # rule_id is a stable short identifier
+        assert decision.explanation.rule_id
+        assert " " not in decision.explanation.rule_id  # no whitespace = stable
+        # rule_source points at code location (file:line or module:func)
+        assert ":" in decision.explanation.rule_source


### PR DESCRIPTION
## Summary

Reddit reviewer asked: "why did the gatekeeper allow/deny this?" and wanted structured explanations beyond a free-text `reason` string. Today `GateDecision` carries `reason: str` + `policy_name: str` (a stable id) but no rule-source pointer or matched-pattern hint that a UI can render as a tooltip.

This PR adds the structured layer.

## API surface

- **New `DecisionExplanation`** (frozen Pydantic):
  - `rule_id` — stable short identifier (`"dest_cmd_ast"`, `"dest_cmd_regex"`, `"policy:<rule.name>"`)
  - `rule_source` — code/policy location pointer (`"cognithor.security.shell_ast_guard:analyse_shell"`, `"policy:no_destructive_shell"`)
  - `matched_pattern` — the literal that triggered (regex pattern, AST detail, tool name). Truncated to 200 chars.
  - `policy_version` — optional, for versioned policy bundles.

- **`GateDecision.explanation: DecisionExplanation | None = None`** — additive field, backward compatible.

- **Three primary block sites in `gatekeeper.py`** now attach an explanation:
  - YAML policy match → `rule_id="policy:<rule.name>"`, source=`"policy:..."`
  - Layer 1 destructive AST guard → `rule_id="dest_cmd_ast"`, source=`shell_ast_guard.analyse_shell`
  - Layer 2 destructive regex fallback → `rule_id="dest_cmd_regex"`, source=`_blocked_command_patterns`

The explanation rides through the existing flow into the audit log and (via TRUST-1 receipts in #374) into post-mortem bundles — no separate plumbing.

## Test plan

- [x] `exec_command rm -rf /` → blocked WITH explanation (YAML policy first)
- [x] `start_background shutdown -h now` → blocked via `_check_command` (the SEC-CRIT-1 path) WITH `dest_cmd_*` explanation
- [x] safe `ls -la` → no destructive explanation
- [x] structured fields contract: `rule_id` no whitespace, `rule_source` has `:` separator
- [x] All 90 gatekeeper tests pass (86 existing + 4 new)
- [x] mypy --strict + ruff: clean across 736 files

## Combines with TRUST-1 (#374)

A Run-Receipt for a session that hit a Gatekeeper block now carries both the chained-hash `prev_hash` integrity AND the structured `explanation.rule_id` per blocked entry — operator gets the full "what + why" for post-mortem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)