### PR TITLE
feat(audit): TRUST-3 FailureMode enum + classifier + aggregator

### DIFF
--- a/src/cognithor/audit/__init__.py
+++ b/src/cognithor/audit/__init__.py
@@ -33,6 +33,8 @@ from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import TYPE_CHECKING, Any
 
+from cognithor.models import FailureMode
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -103,6 +105,11 @@ class AuditEntry:
     success: bool = True
     duration_ms: float = 0.0
     contains_pii: bool = False  # Contains personal data
+    # TRUST-3: structured failure-mode classification (operational-trust
+    # audit, 2026-05-04). ``None`` for successful entries; a
+    # ``FailureMode`` enum value otherwise. Aggregated by
+    # ``AuditLogger.failures_by_mode``.
+    failure_mode: FailureMode | None = None
     # SEC-HIGH-5: SHA-256 of the previous entry's canonical JSON.
     # Empty for the first entry written to a freshly-rotated log file.
     prev_hash: str = ""
@@ -122,6 +129,7 @@ class AuditEntry:
             "success": self.success,
             "duration_ms": self.duration_ms,
             "contains_pii": self.contains_pii,
+            "failure_mode": self.failure_mode.value if self.failure_mode else None,
             "prev_hash": self.prev_hash,
         }
 
@@ -794,6 +802,93 @@ class AuditLogger:
             return False, errors
 
         return len(errors) == 0, errors
+
+    # ── Failure-Mode classification + aggregator (TRUST-3) ─────────
+
+    @staticmethod
+    def classify_failure(entry: AuditEntry) -> FailureMode | None:
+        """Map an audit entry to a structured ``FailureMode``.
+
+        TRUST-3 (operational-trust audit, 2026-05-04). Reviewer asked
+        for "failure-mode classification" so an operator can answer
+        *what kind of thing went wrong* without parsing free-text.
+
+        Returns ``None`` for successful entries. For failures, walks
+        a deterministic decision-tree over the existing fields
+        (``category``, ``action``, ``description``) and falls back to
+        ``FailureMode.UNKNOWN`` when nothing matches — that's the
+        signal that a new enum value is needed.
+
+        Pure function. Callers can pre-set ``entry.failure_mode``
+        explicitly (more reliable); when None this classifier infers.
+        """
+        if entry.success:
+            return None
+        if entry.failure_mode is not None:
+            return entry.failure_mode
+
+        action = entry.action or ""
+        description = (entry.description or "").lower()
+
+        # Category-driven routing first — most reliable signal.
+        if entry.category == AuditCategory.GATEKEEPER:
+            if "approve" in description or "approval" in description:
+                return FailureMode.GATEKEEPER_APPROVAL_DENIED
+            return FailureMode.GATEKEEPER_BLOCK
+
+        if entry.category == AuditCategory.SECURITY:
+            if "sandbox" in description:
+                return FailureMode.SANDBOX_REFUSED
+            if "auth" in description or "credential" in description:
+                return FailureMode.AUTH_ERROR
+            return FailureMode.GATEKEEPER_BLOCK
+
+        if entry.category == AuditCategory.NETWORK:
+            return FailureMode.NETWORK_ERROR
+
+        if entry.category == AuditCategory.TOOL_CALL:
+            if "timeout" in description or action.endswith("timeout"):
+                return FailureMode.TOOL_TIMEOUT
+            if "not found" in description or "no such tool" in description:
+                return FailureMode.TOOL_NOT_FOUND
+            if "invalid" in description and ("param" in description or "argument" in description):
+                return FailureMode.TOOL_INVALID_PARAMS
+            if "sandbox" in description or "refused" in description:
+                return FailureMode.SANDBOX_REFUSED
+            if "quota" in description or "rate limit" in description:
+                return FailureMode.QUOTA_EXCEEDED
+            return FailureMode.TOOL_INTERNAL_ERROR
+
+        return FailureMode.UNKNOWN
+
+    def failures_by_mode(
+        self,
+        *,
+        hours: int = 24,
+    ) -> dict[str, int]:
+        """Aggregate failure counts by ``FailureMode`` for the last
+        *hours* hours.
+
+        Returns a dict keyed by the FailureMode enum value (string),
+        sorted descending by count for stable display order. Empty
+        dict means "no failures in the window" — the operator can
+        treat this as a success signal.
+        """
+        cutoff = datetime.now(UTC) - timedelta(hours=hours)
+        counts: dict[str, int] = {}
+        for entry in self._entries:
+            try:
+                ts = datetime.fromisoformat(entry.timestamp)
+            except (ValueError, TypeError):
+                continue
+            if ts < cutoff:
+                continue
+            mode = self.classify_failure(entry)
+            if mode is None:
+                continue
+            key = mode.value
+            counts[key] = counts.get(key, 0) + 1
+        return dict(sorted(counts.items(), key=lambda kv: kv[1], reverse=True))
 
     @staticmethod
     def _sanitize_params(params: dict[str, Any]) -> dict[str, Any]:

--- a/src/cognithor/models.py
+++ b/src/cognithor/models.py
@@ -118,6 +118,50 @@ class SandboxLevel(StrEnum):
     JOBOBJECT = "jobobject"  # Windows Job Objects
 
 
+class FailureMode(StrEnum):
+    """Operational failure-mode classification (TRUST-3, 2026-05-04).
+
+    Reddit reviewer asked for a structured failure-mode enum so an
+    operator can answer "what *kind* of thing went wrong?" without
+    parsing free-text error messages. Every distinct failure path
+    surfaced by the system maps to one of these classes; the audit
+    aggregator counts by mode for trend analysis per pack / channel /
+    tool.
+
+    Stable string values — bumping requires a schema-version bump on
+    receipts that include this field.
+    """
+
+    # Planning-layer failures (Planner → ActionPlan)
+    PLAN_PARSE_FAILED = "plan_parse_failed"
+    PLAN_LLM_ERROR = "plan_llm_error"
+    PLAN_TIMEOUT = "plan_timeout"
+
+    # Gatekeeper-layer failures
+    GATEKEEPER_BLOCK = "gatekeeper_block"
+    GATEKEEPER_APPROVAL_DENIED = "gatekeeper_approval_denied"
+
+    # Tool / Executor failures
+    TOOL_TIMEOUT = "tool_timeout"
+    TOOL_NOT_FOUND = "tool_not_found"
+    TOOL_INVALID_PARAMS = "tool_invalid_params"
+    TOOL_INTERNAL_ERROR = "tool_internal_error"
+    SANDBOX_REFUSED = "sandbox_refused"
+
+    # External / environmental
+    NETWORK_ERROR = "network_error"
+    AUTH_ERROR = "auth_error"
+    QUOTA_EXCEEDED = "quota_exceeded"
+
+    # Higher-order failures (require LLM-level reasoning)
+    LLM_HALLUCINATION = "llm_hallucination"
+    LLM_REFUSAL = "llm_refusal"
+
+    # Catch-all — only when none of the above fits. Aggregator should
+    # surface any non-trivial counts here as "needs new enum value".
+    UNKNOWN = "unknown"
+
+
 # ============================================================================
 # Nachrichten (E3: Alles ist eine Message)
 # ============================================================================

--- a/tests/test_audit/test_audit_logger.py
+++ b/tests/test_audit/test_audit_logger.py
@@ -446,3 +446,132 @@ class TestHashChain:
 
         ok, errors = second.validate_chain(log_file)
         assert ok, f"chain broken after restart: {errors}"
+
+
+# ============================================================================
+# TRUST-3 — Failure-mode classification (operational-trust audit, 2026-05-04)
+# ============================================================================
+
+
+class TestFailureModeClassification:
+    """``AuditLogger.classify_failure(entry)`` maps a failed entry to a
+    structured ``FailureMode``. ``failures_by_mode`` aggregates counts
+    over a time window. Reviewer asked: "what *kind* of thing went
+    wrong?" — this is the structured answer.
+    """
+
+    def test_successful_entry_returns_none(self) -> None:
+        logger = AuditLogger()
+        entry = logger.log_tool_call("ok_tool", success=True)
+        assert AuditLogger.classify_failure(entry) is None
+
+    def test_gatekeeper_block_classified(self) -> None:
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger.log_gatekeeper("BLOCK", "Command refused", tool_name="exec")
+        assert AuditLogger.classify_failure(entry) == FailureMode.GATEKEEPER_BLOCK
+
+    def test_gatekeeper_approval_denied_classified(self) -> None:
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger.log_gatekeeper(
+            "BLOCK", "User denied approval request", tool_name="email_send"
+        )
+        assert AuditLogger.classify_failure(entry) == FailureMode.GATEKEEPER_APPROVAL_DENIED
+
+    def test_tool_timeout_classified(self) -> None:
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        # log_tool_call sets description="Tool 'X' called" — too generic
+        # for inference. Use _log directly with a specific description.
+        entry_timeout = logger._log(
+            category=AuditCategory.TOOL_CALL,
+            severity=AuditSeverity.ERROR,
+            action="tool:slow_tool",
+            tool_name="slow_tool",
+            description="Tool slow_tool exceeded 30s timeout",
+            success=False,
+        )
+        assert AuditLogger.classify_failure(entry_timeout) == FailureMode.TOOL_TIMEOUT
+
+    def test_sandbox_refused_classified(self) -> None:
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger.log_security("Sandbox refused execution", blocked=True)
+        assert AuditLogger.classify_failure(entry) == FailureMode.SANDBOX_REFUSED
+
+    def test_network_error_classified(self) -> None:
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger.log_network("https://api.example.com", "GET", success=False)
+        assert AuditLogger.classify_failure(entry) == FailureMode.NETWORK_ERROR
+
+    def test_explicit_failure_mode_wins_over_inference(self) -> None:
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger._log(
+            category=AuditCategory.TOOL_CALL,
+            severity=AuditSeverity.ERROR,
+            action="tool:x",
+            description="Tool x failed",
+            success=False,
+            failure_mode=FailureMode.LLM_HALLUCINATION,
+        )
+        assert AuditLogger.classify_failure(entry) == FailureMode.LLM_HALLUCINATION
+
+    def test_unknown_failure_falls_through_to_unknown(self) -> None:
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger._log(
+            category=AuditCategory.SYSTEM,
+            severity=AuditSeverity.ERROR,
+            action="system:weird_thing",
+            description="Something bizarre happened",
+            success=False,
+        )
+        assert AuditLogger.classify_failure(entry) == FailureMode.UNKNOWN
+
+    def test_failures_by_mode_counts_and_sorts(self) -> None:
+        logger = AuditLogger()
+        for _ in range(3):
+            logger.log_gatekeeper("BLOCK", "denied", tool_name="x")
+        logger.log_network("https://api.x", "GET", success=False)
+        logger.log_tool_call("ok", success=True)  # success — must not count
+
+        counts = logger.failures_by_mode(hours=24)
+        assert counts == {"gatekeeper_block": 3, "network_error": 1}
+        assert list(counts.keys()) == ["gatekeeper_block", "network_error"]
+
+    def test_failures_by_mode_respects_time_window(self) -> None:
+        logger = AuditLogger()
+        logger.log_gatekeeper("BLOCK", "no", tool_name="x")
+        counts_24h = logger.failures_by_mode(hours=24)
+        assert counts_24h.get("gatekeeper_block", 0) >= 1
+
+    def test_failure_mode_in_to_dict(self) -> None:
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger._log(
+            category=AuditCategory.TOOL_CALL,
+            severity=AuditSeverity.ERROR,
+            action="tool:x",
+            description="quota exceeded",
+            success=False,
+            failure_mode=FailureMode.QUOTA_EXCEEDED,
+        )
+        d = entry.to_dict()
+        assert d["failure_mode"] == "quota_exceeded"
+
+    def test_failure_mode_none_serialises_as_none(self) -> None:
+        logger = AuditLogger()
+        entry = logger.log_tool_call("ok", success=True)
+        d = entry.to_dict()
+        assert d["failure_mode"] is None


### PR DESCRIPTION
## Summary

Reddit reviewer asked for "failure-mode classification" — *what kind of thing went wrong?* — without parsing free-text error messages. Today errors arrive as freeform strings; this PR adds the structured layer.

## API

- **`cognithor.models.FailureMode`** StrEnum, 16 stable values:
  - **Plan-layer**: PLAN_PARSE_FAILED, PLAN_LLM_ERROR, PLAN_TIMEOUT
  - **Gatekeeper**: GATEKEEPER_BLOCK, GATEKEEPER_APPROVAL_DENIED
  - **Tool/Executor**: TOOL_TIMEOUT, TOOL_NOT_FOUND, TOOL_INVALID_PARAMS, TOOL_INTERNAL_ERROR, SANDBOX_REFUSED
  - **External**: NETWORK_ERROR, AUTH_ERROR, QUOTA_EXCEEDED
  - **Higher-order**: LLM_HALLUCINATION, LLM_REFUSAL
  - **Catch-all**: UNKNOWN (signals "operator needs to add a new enum value")

- **`AuditEntry.failure_mode: FailureMode | None = None`** — additive, backward compatible.

- **`AuditLogger.classify_failure(entry) → FailureMode | None`** — pure function. Successful entries → None. Failures walk a deterministic decision-tree over category + action + description. Explicit `entry.failure_mode` wins; falls through to UNKNOWN when nothing matches.

- **`AuditLogger.failures_by_mode(*, hours=24) → dict[str, int]`** — aggregates failure counts within a time window, sorted descending.

## Test plan

12 new `TestFailureModeClassification` cases:
- [x] successful entry → None
- [x] gatekeeper block + approval-denied path
- [x] tool timeout via specific description
- [x] sandbox refused, network error
- [x] explicit failure_mode wins over inference
- [x] unknown failure → UNKNOWN (not silently dropped)
- [x] failures_by_mode counts + sorts correctly
- [x] time-window respected
- [x] `to_dict()` serialises enum → string value
- [x] `to_dict()` serialises None → null

All 76 audit tests pass (64 existing + 12 new). mypy --strict + ruff: clean across 736 files.

## Combines with TRUST-1 (#374) + TRUST-2 (#375)

A Run-Receipt for a session that hit failures now carries:
- **what** ran (TRUST-1 entries with hash-chain integrity)
- **why** the Gatekeeper allowed/denied (TRUST-2 `explanation.rule_id`)
- **kind** of failure (TRUST-3 `failure_mode` per entry + aggregate)

The reviewer's reconstruction question — "what did the agent know, what did it decide, why was it allowed, what changed?" — is answered structurally end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)