### PR TITLE
feat(packs): TRUST-4 automatic rollback for pack upgrades

### DIFF
--- a/src/cognithor/packs/cli.py
+++ b/src/cognithor/packs/cli.py
@@ -118,6 +118,38 @@ def _cmd_update(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_rollback(args: argparse.Namespace) -> int:
+    """``cognithor pack rollback <qualified_id> [--to-version X]``.
+
+    TRUST-4 (operational-trust audit, 2026-05-04). Restore a pack from
+    its pre-upgrade snapshot taken automatically during the last
+    ``install``. With ``--list`` shows available versions instead of
+    rolling back.
+    """
+    installer = _make_installer()
+    try:
+        if args.list:
+            versions = installer.list_backups(args.qualified_id)
+            if not versions:
+                print(f"No backups available for {args.qualified_id}.")
+                return 0
+            print(f"Available rollback versions for {args.qualified_id}:")
+            for v in versions:
+                print(f"  - {v}")
+            return 0
+
+        manifest = installer.rollback(
+            args.qualified_id,
+            to_version=args.to_version,
+        )
+    except PackInstallError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"[OK] Rolled back {args.qualified_id} to version {manifest.version}")
+    return 0
+
+
 def _cmd_accept_eula(args: argparse.Namespace) -> int:
     installer = _make_installer()
     try:
@@ -215,6 +247,30 @@ def build_parser() -> argparse.ArgumentParser:
         help="Qualified pack identifier.",
     )
     p_eula.set_defaults(func=_cmd_accept_eula)
+
+    # rollback (TRUST-4)
+    p_rollback = sub.add_parser(
+        "rollback",
+        help="Roll an installed pack back to a previously-snapshotted version.",
+    )
+    p_rollback.add_argument(
+        "qualified_id",
+        metavar="NAMESPACE/PACK_ID",
+        help="Qualified pack identifier.",
+    )
+    p_rollback.add_argument(
+        "--to-version",
+        dest="to_version",
+        metavar="VERSION",
+        default=None,
+        help="Specific version to restore. Default: most recent snapshot.",
+    )
+    p_rollback.add_argument(
+        "--list",
+        action="store_true",
+        help="List available rollback versions instead of rolling back.",
+    )
+    p_rollback.set_defaults(func=_cmd_rollback)
 
     # create
     p_create = sub.add_parser("create", help="Scaffold a new pack from template.")

--- a/src/cognithor/packs/installer.py
+++ b/src/cognithor/packs/installer.py
@@ -164,6 +164,139 @@ class PackInstaller:
         loader = PackLoader(packs_dir=self._root, cognithor_version=_LIST_VERSION)
         return loader.discover()
 
+    # ── Rollback (TRUST-4) ───────────────────────────────────────────
+
+    def _backups_root(self) -> Path:
+        """Return ``<packs_root>/.backups``. Hidden from ``PackLoader``
+        thanks to its dot-prefix skip in ``discover()``.
+        """
+        return self._root / ".backups"
+
+    def list_backups(self, qualified_id: str) -> list[str]:
+        """Return the list of versions available for rollback for
+        *qualified_id*, sorted oldest → newest.
+
+        Each version corresponds to a snapshot taken just before that
+        version was overwritten by a newer install. The currently
+        installed version is NOT included.
+
+        TRUST-4 (operational-trust audit, 2026-05-04).
+        """
+        namespace, pack_id = self._split_qid(qualified_id)
+        backup_dir = self._backups_root() / namespace / pack_id
+        if not backup_dir.exists():
+            return []
+        versions = [p.name for p in backup_dir.iterdir() if p.is_dir()]
+
+        # Best-effort version sort: split on dots, parse ints. Unknown
+        # forms fall back to lexical via a synthetic ``(-1, ...)`` key
+        # that always sorts before semver tuples.
+        def _vkey(v: str) -> tuple[int, ...]:
+            try:
+                parts = v.split("-", 1)[0].split(".")
+                return tuple(int(p) for p in parts)
+            except (ValueError, AttributeError):
+                # Sentinel: lexical hash collapsed into a leading
+                # negative slot so non-semver versions sort first.
+                return (-1, hash(v) & 0xFFFF)
+
+        return sorted(versions, key=_vkey)
+
+    def rollback(
+        self,
+        qualified_id: str,
+        *,
+        to_version: str | None = None,
+    ) -> PackManifest:
+        """Roll an installed pack back to a previously-snapshotted version.
+
+        TRUST-4 (operational-trust audit, 2026-05-04). Reviewer asked
+        for "rollback for plugin/pack updates" — until now ``cognithor
+        pack update`` was a stub with no downgrade path.
+
+        Parameters
+        ----------
+        qualified_id:
+            ``namespace/pack_id`` of the installed pack.
+        to_version:
+            Specific version to restore. Defaults to the most-recent
+            snapshot (latest version EXCLUDING the currently installed
+            one). ``ValueError`` if no snapshot is available.
+
+        Returns
+        -------
+        PackManifest
+            The manifest of the now-restored pack.
+
+        Raises
+        ------
+        PackInstallError
+            If the pack is not installed, no backups exist, or the
+            requested ``to_version`` is unavailable.
+
+        Side effect
+        -----------
+        Before restoring, the *current* version is itself snapshotted
+        (so ``rollback`` is reversible — calling it twice with no
+        arguments alternates between the two latest versions).
+        """
+        namespace, pack_id = self._split_qid(qualified_id)
+        target_dir = self._root / namespace / pack_id
+        if not target_dir.exists():
+            raise PackInstallError(
+                f"Pack {qualified_id!r} is not installed — nothing to roll back."
+            )
+
+        backups = self.list_backups(qualified_id)
+        if not backups:
+            raise PackInstallError(
+                f"No backups available for {qualified_id!r}. Backups are taken on "
+                "every upgrade — first install creates no snapshot."
+            )
+
+        if to_version is None:
+            chosen = backups[-1]  # most-recent backup
+        elif to_version not in backups:
+            raise PackInstallError(
+                f"Version {to_version!r} not available for {qualified_id!r}. Available: {backups}"
+            )
+        else:
+            chosen = to_version
+
+        backup_dir = self._backups_root() / namespace / pack_id / chosen
+        if not backup_dir.exists():
+            # Race / concurrent removal. Defensive.
+            raise PackInstallError(f"Backup directory disappeared: {backup_dir}")
+
+        # Snapshot the CURRENT install before swapping, so rollback is
+        # itself reversible.
+        try:
+            current = self._read_manifest(target_dir)
+            if current.version != chosen:
+                pre_swap = self._backups_root() / namespace / pack_id / current.version
+                if pre_swap.exists():
+                    shutil.rmtree(pre_swap)
+                pre_swap.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copytree(target_dir, pre_swap)
+        except Exception as exc:
+            _log.warning(
+                "pack.rollback_pre_swap_backup_failed",
+                qualified_id=qualified_id,
+                error=str(exc)[:200],
+            )
+
+        # Swap.
+        shutil.rmtree(target_dir)
+        shutil.copytree(backup_dir, target_dir)
+        manifest = self._read_manifest(target_dir)
+
+        _log.info(
+            "pack.rolled_back",
+            qualified_id=qualified_id,
+            to_version=manifest.version,
+        )
+        return manifest
+
     def accept_eula(self, qualified_id: str) -> None:
         """Re-prompt and (re-)write ``.eula_accepted`` for an installed pack.
 
@@ -258,6 +391,44 @@ class PackInstaller:
                 raise PackInstallError(
                     f"EULA declined — pack {manifest.qualified_id!r} was not installed."
                 )
+
+            # --- Backup current install before overwrite (TRUST-4) ---
+            # Operational-trust audit (2026-05-04) — reviewer asked for
+            # "rollback for plugin/pack updates". Snapshot the existing
+            # install into ``<root>/.backups/<ns>/<id>/<old_version>/``
+            # so ``rollback()`` can restore it later. Skipped on first
+            # install (target_dir doesn't exist).
+            if target_dir.exists():
+                try:
+                    existing = self._read_manifest(target_dir)
+                    backup_dir = (
+                        self._backups_root()
+                        / manifest.namespace
+                        / manifest.pack_id
+                        / existing.version
+                    )
+                    if backup_dir.exists():
+                        # Same-version backup already exists (re-install
+                        # of an older version after rollback). Replace
+                        # the snapshot so the most recent state of that
+                        # version wins.
+                        shutil.rmtree(backup_dir)
+                    backup_dir.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copytree(target_dir, backup_dir)
+                    _log.info(
+                        "pack.backed_up",
+                        qualified_id=manifest.qualified_id,
+                        version=existing.version,
+                        backup_path=str(backup_dir),
+                    )
+                except Exception as exc:
+                    # Backup failure must not block the install — log
+                    # and continue. Rollback is a best-effort feature.
+                    _log.warning(
+                        "pack.backup_failed",
+                        qualified_id=manifest.qualified_id,
+                        error=str(exc)[:200],
+                    )
 
             # --- Place files ---
             if target_dir.exists():

--- a/src/cognithor/packs/loader.py
+++ b/src/cognithor/packs/loader.py
@@ -123,8 +123,14 @@ class PackLoader:
         for namespace_dir in sorted(self._root.iterdir()):
             if not namespace_dir.is_dir():
                 continue
+            # Skip dot-prefixed directories (TRUST-4: ``.backups/`` etc.
+            # are PackInstaller bookkeeping, not user-visible packs).
+            if namespace_dir.name.startswith("."):
+                continue
             for pack_dir in sorted(namespace_dir.iterdir()):
                 if not pack_dir.is_dir():
+                    continue
+                if pack_dir.name.startswith("."):
                     continue
                 manifest = self._validate_pack(pack_dir)
                 if manifest is not None:

--- a/tests/test_packs/test_installer.py
+++ b/tests/test_packs/test_installer.py
@@ -183,3 +183,134 @@ class TestList:
         installed = installer.list_installed()
         ids = {m.pack_id for m in installed}
         assert ids == {"a", "b"}
+
+
+# ============================================================================
+# TRUST-4 — Rollback (operational-trust audit, 2026-05-04)
+# ============================================================================
+
+
+class TestRollback:
+    """``PackInstaller.rollback(qualified_id, to_version=...)`` restores
+    a previously-snapshotted version. Snapshots are taken automatically
+    on every upgrade (to ``<root>/.backups/<ns>/<id>/<old_version>/``).
+    """
+
+    def test_first_install_creates_no_backup(
+        self, tmp_path: Path, packs_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        z = _build_pack_zip(tmp_path, version="1.0.0")
+        installer = PackInstaller(packs_root=packs_root)
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+        installer.install_from_path(z)
+
+        assert installer.list_backups("cognithor-official/installed-test") == []
+
+    def test_upgrade_creates_backup_of_previous_version(
+        self, tmp_path: Path, packs_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        z1 = _build_pack_zip(tmp_path, version="1.0.0")
+        z2_dir = tmp_path / "v2"
+        z2_dir.mkdir()
+        z2 = _build_pack_zip(z2_dir, version="2.0.0")
+
+        installer = PackInstaller(packs_root=packs_root)
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+        installer.install_from_path(z1)
+        installer.install_from_path(z2)
+
+        backups = installer.list_backups("cognithor-official/installed-test")
+        assert backups == ["1.0.0"]
+
+    def test_rollback_restores_previous_version(
+        self, tmp_path: Path, packs_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        z1 = _build_pack_zip(tmp_path, version="1.0.0")
+        z2_dir = tmp_path / "v2"
+        z2_dir.mkdir()
+        z2 = _build_pack_zip(z2_dir, version="2.0.0")
+
+        installer = PackInstaller(packs_root=packs_root)
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+        installer.install_from_path(z1)
+        installer.install_from_path(z2)
+        installed = installer.list_installed()
+        assert next(m.version for m in installed if m.pack_id == "installed-test") == "2.0.0"
+
+        manifest = installer.rollback("cognithor-official/installed-test")
+        assert manifest.version == "1.0.0"
+        installed_after = installer.list_installed()
+        assert next(m.version for m in installed_after if m.pack_id == "installed-test") == "1.0.0"
+
+    def test_rollback_is_reversible(
+        self, tmp_path: Path, packs_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Calling rollback twice flips back to the newer version —
+        the swap snapshots the current install before restoring.
+        """
+        z1 = _build_pack_zip(tmp_path, version="1.0.0")
+        z2_dir = tmp_path / "v2"
+        z2_dir.mkdir()
+        z2 = _build_pack_zip(z2_dir, version="2.0.0")
+
+        installer = PackInstaller(packs_root=packs_root)
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+        installer.install_from_path(z1)
+        installer.install_from_path(z2)
+
+        installer.rollback("cognithor-official/installed-test")  # 2.0.0 → 1.0.0
+        manifest_back = installer.rollback("cognithor-official/installed-test", to_version="2.0.0")
+        assert manifest_back.version == "2.0.0"
+
+    def test_rollback_to_version_not_in_backups_raises(
+        self, tmp_path: Path, packs_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        z1 = _build_pack_zip(tmp_path, version="1.0.0")
+        z2_dir = tmp_path / "v2"
+        z2_dir.mkdir()
+        z2 = _build_pack_zip(z2_dir, version="2.0.0")
+
+        installer = PackInstaller(packs_root=packs_root)
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+        installer.install_from_path(z1)
+        installer.install_from_path(z2)
+
+        with pytest.raises(PackInstallError, match="not available"):
+            installer.rollback("cognithor-official/installed-test", to_version="9.9.9")
+
+    def test_rollback_with_no_backups_raises(
+        self, tmp_path: Path, packs_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        z = _build_pack_zip(tmp_path, version="1.0.0")
+        installer = PackInstaller(packs_root=packs_root)
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+        installer.install_from_path(z)
+
+        with pytest.raises(PackInstallError, match="No backups"):
+            installer.rollback("cognithor-official/installed-test")
+
+    def test_rollback_uninstalled_pack_raises(self, packs_root: Path) -> None:
+        installer = PackInstaller(packs_root=packs_root)
+        with pytest.raises(PackInstallError, match="not installed"):
+            installer.rollback("cognithor-official/never-installed")
+
+    def test_backup_directory_hidden_from_loader(
+        self, tmp_path: Path, packs_root: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``.backups/`` must NOT show up in ``list_installed`` —
+        otherwise old versions would leak into runtime registration.
+        """
+        z1 = _build_pack_zip(tmp_path, version="1.0.0")
+        z2_dir = tmp_path / "v2"
+        z2_dir.mkdir()
+        z2 = _build_pack_zip(z2_dir, version="2.0.0")
+
+        installer = PackInstaller(packs_root=packs_root)
+        monkeypatch.setattr("builtins.input", lambda _prompt="": "y")
+        installer.install_from_path(z1)
+        installer.install_from_path(z2)
+
+        assert (packs_root / ".backups").is_dir()
+        installed = installer.list_installed()
+        assert len(installed) == 1
+        assert installed[0].version == "2.0.0"


### PR DESCRIPTION
## Summary

TRUST-4 (operational-trust audit, 2026-05-04). Adds automatic pre-upgrade snapshots and a `cognithor pack rollback` CLI so a botched pack update can be undone without re-downloading.

- `PackInstaller.install_from_path` now snapshots the previous install to `<packs_root>/.backups/<ns>/<id>/<old_version>/` before overwriting on upgrade.
- New `PackInstaller.list_backups(qualified_id)` and `PackInstaller.rollback(qualified_id, *, to_version=None)` — rollback is reversible (it snapshots the current install before swapping in the older one).
- `PackLoader.discover()` skips dot-prefixed namespace and pack directories so `.backups/` cannot leak into runtime registration.
- New CLI subcommand: `cognithor pack rollback <namespace/id> [--to-version VERSION] [--list]`.

Addresses Reddit reviewer's *"how do I roll back a bad pack update?"* gap.

## Test plan

- [x] 8 new unit tests in `tests/test_packs/test_installer.py::TestRollback` — first-install-no-backup, upgrade-creates-backup, rollback-restores, rollback-is-reversible, version-not-available, no-backups, uninstalled-pack, .backups-hidden-from-loader
- [x] Full `tests/test_packs/` suite passes locally (76 tests)
- [x] `mypy --strict src/cognithor/packs/installer.py src/cognithor/packs/loader.py src/cognithor/packs/cli.py` clean
- [x] `ruff check` and `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)