### PR TITLE
fix(workflow): WF-1 gate research screen API calls behind deep-research pack

### DIFF
--- a/flutter_app/lib/screens/research_screen.dart
+++ b/flutter_app/lib/screens/research_screen.dart
@@ -2,10 +2,13 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
 import 'package:cognithor_ui/providers/connection_provider.dart';
+import 'package:cognithor_ui/providers/packs_provider.dart';
 import 'package:cognithor_ui/providers/research_provider.dart';
 import 'package:cognithor_ui/widgets/research/hop_progress_indicator.dart';
 import 'package:cognithor_ui/widgets/research/research_history_list.dart';
 import 'package:cognithor_ui/widgets/research/research_report_view.dart';
+
+const String _kDeepResearchPackId = 'cognithor-official/deep-research-analyst';
 
 class ResearchScreen extends StatefulWidget {
   const ResearchScreen({super.key});
@@ -25,7 +28,11 @@ class _ResearchScreenState extends State<ResearchScreen> {
     if (!_initialized) {
       _initialized = true;
       final conn = context.read<ConnectionProvider>();
-      if (conn.state == CognithorConnectionState.connected) {
+      final packs = context.read<PacksProvider>();
+      // Deep Research V2 lives in a private pack — skip endpoint calls when
+      // the pack isn't loaded so we don't fire 6 endpoints that 404.
+      if (conn.state == CognithorConnectionState.connected &&
+          packs.hasPackLoaded(_kDeepResearchPackId)) {
         final provider = context.read<ResearchProvider>();
         provider.setApi(conn.api);
         provider.loadHistory();


### PR DESCRIPTION
## Summary

Workflow-cleanup WF-1. Deep Research V2 was extracted to the private \`cognithor-official/deep-research-analyst\` pack in v0.92.0 but the Flutter \`ResearchScreen\` unconditionally fired six endpoint calls at mount (\`research/history\`, \`research/query\`, \`research/{id}\`, etc.) — they 404 when the pack isn't installed. \`PackPreviewOverlay\` covered them visually, but the calls still ran and polluted audit logs.

Now the screen checks \`PacksProvider.hasPackLoaded(...)\` in \`didChangeDependencies\` and skips the API wiring entirely when the pack is absent.

## Test plan

- [x] \`flutter analyze lib/screens/research_screen.dart\` clean
- [x] \`dart format --set-exit-if-changed lib/screens/research_screen.dart\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)