### PR TITLE
fix(workflow): WF-4 iMessage on non-macOS reads BlueBubbles env or skips with warning

### DIFF
--- a/src/cognithor/__main__.py
+++ b/src/cognithor/__main__.py
@@ -2454,11 +2454,29 @@ def main() -> None:
             if getattr(config.channels, "imessage_enabled", False):
                 from cognithor.channels.imessage import IMessageChannel
 
-                # iMessage hat keine Token; weitere Parameter (BlueBubbles-URL,
-                # Passwort, allowed_handles) werden via Config/Env abgegriffen
-                # sobald wir sie wieder benötigen — die Defaults reichen für die
-                # native macOS-Anbindung (mode="auto").
-                gateway.register_channel(IMessageChannel())
+                imessage_bb_url = os.environ.get("COGNITHOR_IMESSAGE_BB_URL", "")
+                imessage_bb_password = os.environ.get("COGNITHOR_IMESSAGE_BB_PASSWORD", "")
+                imessage_allowed_raw = os.environ.get("COGNITHOR_IMESSAGE_ALLOWED_HANDLES", "")
+                imessage_allowed = [h.strip() for h in imessage_allowed_raw.split(",") if h.strip()]
+
+                # On non-macOS the channel auto-selects BlueBubbles mode and
+                # needs a self-hosted server URL. Without it the channel
+                # registered but never started — silent failure. Skip the
+                # registration with a clear warning instead.
+                if sys.platform != "darwin" and not imessage_bb_url:
+                    log.warning(
+                        "imessage_enabled_but_no_bb_url",
+                        platform=sys.platform,
+                        hint=("Set COGNITHOR_IMESSAGE_BB_URL and COGNITHOR_IMESSAGE_BB_PASSWORD"),
+                    )
+                else:
+                    gateway.register_channel(
+                        IMessageChannel(
+                            bb_url=imessage_bb_url,
+                            bb_password=imessage_bb_password,
+                            allowed_handles=imessage_allowed,
+                        )
+                    )
 
             # IRC channel (config-flag based, server is the gating field)
             if getattr(config.channels, "irc_enabled", False):


### PR DESCRIPTION
## Summary

Workflow-cleanup WF-4. The iMessage channel auto-selects BlueBubbles mode on non-darwin platforms but \`__main__.py\` registered \`IMessageChannel()\` with no kwargs — \`bb_url\` and \`bb_password\` defaulted to empty strings. The channel started, the polling loop logged an error and bailed, and the channel sat registered-but-inert. A silent failure mode.

Now \`__main__.py\` reads \`COGNITHOR_IMESSAGE_BB_URL\`, \`COGNITHOR_IMESSAGE_BB_PASSWORD\`, and \`COGNITHOR_IMESSAGE_ALLOWED_HANDLES\` from the environment and threads them through. On non-darwin with no \`bb_url\` configured, the registration is skipped entirely with a clear warning that names the env vars. macOS native mode (\`mode='auto'\` → \`'native'\`) is unaffected.

## Test plan

- [x] \`mypy --strict src/cognithor/__main__.py\` clean
- [x] \`ruff check\` and \`ruff format --check\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)