### PR TITLE
fix(workflow): WF-6 pack update stub exits 2 and requires qualified_id

### DIFF
--- a/src/cognithor/packs/cli.py
+++ b/src/cognithor/packs/cli.py
@@ -110,12 +110,22 @@ def _cmd_remove(args: argparse.Namespace) -> int:
 
 
 def _cmd_update(args: argparse.Namespace) -> int:
+    """``cognithor pack update <namespace/id>`` — not yet automated.
+
+    Returns exit code 2 (EX_USAGE) so scripts and CI pipelines can detect
+    that no update was performed instead of mistakenly treating the stub
+    output as success.
+    """
+    target = args.qualified_id or "<namespace/pack-id>"
     print(
-        "Update is not yet automated.\n"
+        f"Update is not yet automated for {target}.\n"
         "To update a pack, re-install it with the URL from your purchase email:\n"
-        "  cognithor pack install https://example.com/updated-pack.zip"
+        "  cognithor pack install https://example.com/updated-pack.zip\n"
+        "If you upgrade a pack and want to revert, use:\n"
+        f"  cognithor pack rollback {target}",
+        file=sys.stderr,
     )
-    return 0
+    return 2
 
 
 def _cmd_accept_eula(args: argparse.Namespace) -> int:
@@ -198,12 +208,14 @@ def build_parser() -> argparse.ArgumentParser:
     p_remove.set_defaults(func=_cmd_remove)
 
     # update
-    p_update = sub.add_parser("update", help="Update an installed pack (MVP stub).")
+    p_update = sub.add_parser(
+        "update",
+        help="Update an installed pack (not yet automated — exits 2).",
+    )
     p_update.add_argument(
         "qualified_id",
         metavar="NAMESPACE/PACK_ID",
-        nargs="?",
-        help="Qualified pack identifier (optional for stub).",
+        help="Qualified pack identifier, e.g. cognithor-official/my-pack.",
     )
     p_update.set_defaults(func=_cmd_update)
 

--- a/tests/test_packs/test_cli.py
+++ b/tests/test_packs/test_cli.py
@@ -107,3 +107,39 @@ class TestCliList:
         out = capsys.readouterr().out
         assert "cli-test" in out
         assert "1.0.0" in out
+
+
+class TestCliUpdate:
+    """``cognithor pack update`` is not yet automated.
+
+    Until it is, the stub must (a) require a qualified_id and (b) exit
+    with a non-zero code so wrapping scripts and CI pipelines do not
+    treat the printed message as a successful update (WF-6).
+    """
+
+    def test_update_requires_qualified_id(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        import pytest as _pytest
+
+        monkeypatch.setenv("COGNITHOR_PACKS_DIR", str(tmp_path / "packs"))
+        with _pytest.raises(SystemExit) as exc_info:
+            pack_main(["update"])
+        assert exc_info.value.code == 2
+
+    def test_update_stub_exits_2(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        monkeypatch.setenv("COGNITHOR_PACKS_DIR", str(tmp_path / "packs"))
+        rc = pack_main(["update", "cognithor-official/some-pack"])
+        assert rc == 2
+        captured = capsys.readouterr()
+        assert "not yet automated" in captured.err
+        assert "cognithor-official/some-pack" in captured.err
+        assert "rollback" in captured.err


### PR DESCRIPTION
## Summary

Workflow-cleanup WF-6. \`cognithor pack update\` was a misleading stub: it printed "update is not yet automated" to stdout, returned 0, and made the qualified_id optional. Scripts and CI pipelines treated it as a successful no-op update.

Now the stub:

- requires the qualified_id (no more \`nargs='?'\`)
- prints to stderr
- exits 2 (\`EX_USAGE\`) so callers can detect that no update happened
- cross-references \`cognithor pack rollback\` for users who want to revert after a manual re-install

## Test plan

- [x] \`tests/test_packs/test_cli.py::TestCliUpdate\` — 2 new tests (rc==2 with stub message, requires qualified_id)
- [x] \`mypy --strict src/cognithor/packs/cli.py tests/test_packs/test_cli.py\` clean
- [x] \`ruff check\` and \`ruff format --check\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)