### PR TITLE
chore(integrations): A-6 catalog now picks up pse_synthesize family + register_tool callers

### DIFF
--- a/docs/integrations/catalog.json
+++ b/docs/integrations/catalog.json
@@ -1,12 +1,68 @@
 {
-  "generated_at": "2026-04-29T07:36:40.758513+00:00",
-  "tool_count": 116,
+  "generated_at": "2026-05-04T08:34:03.675150+00:00",
+  "tool_count": 136,
   "tools": [
     {
       "name": "file_write",
       "module": "cognithor.mcp.filesystem",
       "category": "filesystem",
       "description": "Alias für write_file. Erstellt oder überschreibt eine Datei.",
+      "dach_specific": false
+    },
+    {
+      "name": "Available Tools",
+      "module": "cognithor.mcp.resources",
+      "category": "misc",
+      "description": "Liste aller verfügbaren MCP-Tools",
+      "dach_specific": false
+    },
+    {
+      "name": "Capabilities",
+      "module": "cognithor.mcp.resources",
+      "category": "misc",
+      "description": "Fähigkeiten und Konfiguration dieser Jarvis-Instanz",
+      "dach_specific": false
+    },
+    {
+      "name": "Core Memory",
+      "module": "cognithor.mcp.resources",
+      "category": "misc",
+      "description": "Langfristige Kern-Erinnerungen und Persönlichkeit von Jarvis",
+      "dach_specific": false
+    },
+    {
+      "name": "Memory Entity",
+      "module": "cognithor.mcp.resources",
+      "category": "misc",
+      "description": "Eine einzelne Entität aus dem Wissens-Graphen",
+      "dach_specific": false
+    },
+    {
+      "name": "Memory Statistics",
+      "module": "cognithor.mcp.resources",
+      "category": "misc",
+      "description": "Gesamtstatistiken des 6-Tier Memory-Systems",
+      "dach_specific": false
+    },
+    {
+      "name": "Recent Episodes",
+      "module": "cognithor.mcp.resources",
+      "category": "misc",
+      "description": "Die letzten episodischen Einträge (Tageslog)",
+      "dach_specific": false
+    },
+    {
+      "name": "System Status",
+      "module": "cognithor.mcp.resources",
+      "category": "misc",
+      "description": "Aktueller Systemstatus von Jarvis",
+      "dach_specific": false
+    },
+    {
+      "name": "Workspace Files",
+      "module": "cognithor.mcp.resources",
+      "category": "misc",
+      "description": "Verzeichnisbaum des Jarvis-Workspace",
       "dach_specific": false
     },
     {
@@ -28,6 +84,13 @@
       "module": "cognithor.mcp.code_tools",
       "category": "misc",
       "description": "Analysiert Python-Code auf Code-Smells und Sicherheitsprobleme. Kombiniert AST-basierte Qualitätsanalyse mit Security-Pattern-Scanning. Read-only, kein Risiko. Akzeptiert Code als String oder Dateipfa",
+      "dach_specific": false
+    },
+    {
+      "name": "analyze_document",
+      "module": "cognithor.mcp.prompts",
+      "category": "misc",
+      "description": "Analysiert ein Dokument mit konfigurierbarem Fokus",
       "dach_specific": false
     },
     {
@@ -91,6 +154,13 @@
       "module": "cognithor.mcp.atl_tools",
       "category": "misc",
       "description": "Show ATL status: config, cycle count, active goals.",
+      "dach_specific": false
+    },
+    {
+      "name": "brainstorm",
+      "module": "cognithor.mcp.prompts",
+      "category": "misc",
+      "description": "Strukturiertes Brainstorming mit verschiedenen Methoden",
       "dach_specific": false
     },
     {
@@ -161,6 +231,13 @@
       "module": "cognithor.mcp.background_tasks",
       "category": "misc",
       "description": "Check status and recent output of a background job.",
+      "dach_specific": false
+    },
+    {
+      "name": "code_review",
+      "module": "cognithor.mcp.prompts",
+      "category": "misc",
+      "description": "Führt ein umfassendes Code-Review mit Sicherheitsfokus durch",
       "dach_specific": false
     },
     {
@@ -238,6 +315,13 @@
       "module": "cognithor.mcp.chart_tools",
       "category": "misc",
       "description": "Rendert Daten als formatierte Tabelle in einem Bild (PNG). Optionales Highlighting der Maximalwerte. Dark-Theme.",
+      "dach_specific": false
+    },
+    {
+      "name": "daily_briefing",
+      "module": "cognithor.mcp.prompts",
+      "category": "misc",
+      "description": "Erstellt ein tägliches Briefing aus Memory-Daten und Kontext",
       "dach_specific": false
     },
     {
@@ -360,6 +444,13 @@
       "dach_specific": false
     },
     {
+      "name": "explain_concept",
+      "module": "cognithor.mcp.prompts",
+      "category": "misc",
+      "description": "Erklärt ein Konzept für verschiedene Zielgruppen",
+      "dach_specific": false
+    },
+    {
       "name": "find_and_replace",
       "module": "cognithor.mcp.search_tools",
       "category": "misc",
@@ -444,6 +535,13 @@
       "dach_specific": false
     },
     {
+      "name": "insurance_advisor",
+      "module": "cognithor.mcp.prompts",
+      "category": "misc",
+      "description": "Versicherungsberatung für BU, bAV, Risikoleben und weitere Produkte",
+      "dach_specific": false
+    },
+    {
       "name": "kanban_create_task",
       "module": "cognithor.mcp.kanban_tools",
       "category": "misc",
@@ -511,6 +609,34 @@
       "module": "cognithor.mcp.memory_server",
       "category": "misc",
       "description": "Zeigt Statistiken des Memory-Systems (Chunks, Entitäten, Prozeduren etc.).",
+      "dach_specific": false
+    },
+    {
+      "name": "pse_is_synthesizable",
+      "module": "cognithor.mcp.pse_tools",
+      "category": "misc",
+      "description": "Classifier: returns 'yes' / 'no' for whether the given examples are routable to the Cognithor Program Synthesis Engine. Cheap — no engine boot. Use before pse_synthesize.",
+      "dach_specific": false
+    },
+    {
+      "name": "pse_status",
+      "module": "cognithor.mcp.pse_tools",
+      "category": "misc",
+      "description": "Return PSE engine version + primitive count.",
+      "dach_specific": false
+    },
+    {
+      "name": "pse_synthesize",
+      "module": "cognithor.mcp.pse_tools",
+      "category": "misc",
+      "description": "Synthesize a deterministic program from input/output examples using the Cognithor PSE (enumerative search over a typed DSL with NumPy fast-path + cache). Replayable, no LLM hallucination. Anti-overfit",
+      "dach_specific": false
+    },
+    {
+      "name": "pse_synthesize_refined",
+      "module": "cognithor.mcp.pse_tools",
+      "category": "misc",
+      "description": "Sprint-25: Hybrid-Pipeline (LLM → Synthese → LLM-Refinement). Synthesises a program from input/output examples (same engine as pse_synthesize), then runs ONE LLM-refinement pass over the result and re",
       "dach_specific": false
     },
     {
@@ -672,6 +798,20 @@
       "module": "cognithor.mcp.background_tasks",
       "category": "misc",
       "description": "Stop a running background job. Use force=true for immediate SIGKILL.",
+      "dach_specific": false
+    },
+    {
+      "name": "summarize",
+      "module": "cognithor.mcp.prompts",
+      "category": "misc",
+      "description": "Erstellt eine strukturierte Zusammenfassung",
+      "dach_specific": false
+    },
+    {
+      "name": "translate",
+      "module": "cognithor.mcp.prompts",
+      "category": "misc",
+      "description": "Kontextsensitive Übersetzung mit Fachbegriff-Bewahrung",
       "dach_specific": false
     },
     {

--- a/scripts/generate_integrations_catalog.py
+++ b/scripts/generate_integrations_catalog.py
@@ -117,7 +117,11 @@ def extract_register_builtin_calls(py_file: Path) -> list[dict]:
         tool_name = name_node.value
         description = ""
         for kw in node.keywords:
-            if kw.arg == "description" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            if (
+                kw.arg == "description"
+                and isinstance(kw.value, ast.Constant)
+                and isinstance(kw.value.value, str)
+            ):
                 description = kw.value.value
                 break
             # Some call-sites use a parenthesized string-concat for description;
@@ -125,12 +129,73 @@ def extract_register_builtin_calls(py_file: Path) -> list[dict]:
             if kw.arg == "description" and isinstance(kw.value, ast.BinOp):
                 description = _fold_str_concat(kw.value)
                 break
-        module = (
-            py_file.relative_to(REPO_ROOT / "src")
-            .with_suffix("")
-            .as_posix()
-            .replace("/", ".")
+        module = py_file.relative_to(REPO_ROOT / "src").with_suffix("").as_posix().replace("/", ".")
+        category = _infer_category(py_file, description)
+        name_lower = tool_name.lower()
+        desc_lower = description.lower()
+        dach = any(marker in name_lower or marker in desc_lower for marker in DACH_MARKERS)
+        results.append(
+            {
+                "name": tool_name,
+                "module": module,
+                "category": category,
+                "description": description.split("\n")[0][:200],
+                "dach_specific": dach,
+            }
         )
+    return results
+
+
+def extract_register_tool_calls(py_file: Path) -> list[dict]:
+    """Find `<obj>.register_tool(name=..., description=...)` style registrations.
+
+    PSE tools (``mcp/pse_tools.py``) and similar modules call
+    ``mcp_client.register_tool(name=..., description=..., handler=...,
+    schema=...)`` either directly or via a local alias bound by
+    ``register = getattr(mcp_client, "register_tool", None)``. The first form
+    we match by attribute name; the second by detecting a kwarg-only call
+    that has the full ``name``/``description``/``handler`` triplet.
+    """
+    try:
+        tree = ast.parse(py_file.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return []
+    results: list[dict] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+
+        is_register_tool_attr = isinstance(func, ast.Attribute) and func.attr == "register_tool"
+        # Aliased local var: `register(name=..., description=..., handler=...)`
+        kwarg_names = {kw.arg for kw in node.keywords}
+        is_aliased_register = (
+            isinstance(func, ast.Name)
+            and not node.args
+            and {"name", "description", "handler"}.issubset(kwarg_names)
+        )
+
+        if not (is_register_tool_attr or is_aliased_register):
+            continue
+
+        tool_name = ""
+        description = ""
+        for kw in node.keywords:
+            if (
+                kw.arg == "name"
+                and isinstance(kw.value, ast.Constant)
+                and isinstance(kw.value.value, str)
+            ):
+                tool_name = kw.value.value
+            elif kw.arg == "description":
+                if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                    description = kw.value.value
+                elif isinstance(kw.value, ast.BinOp):
+                    description = _fold_str_concat(kw.value)
+        if not tool_name:
+            continue
+
+        module = py_file.relative_to(REPO_ROOT / "src").with_suffix("").as_posix().replace("/", ".")
         category = _infer_category(py_file, description)
         name_lower = tool_name.lower()
         desc_lower = description.lower()
@@ -153,13 +218,17 @@ def _fold_str_concat(node: ast.BinOp) -> str:
         left = node.left
         right = node.right
         left_s = (
-            left.value if isinstance(left, ast.Constant) and isinstance(left.value, str)
-            else _fold_str_concat(left) if isinstance(left, ast.BinOp)
+            left.value
+            if isinstance(left, ast.Constant) and isinstance(left.value, str)
+            else _fold_str_concat(left)
+            if isinstance(left, ast.BinOp)
             else ""
         )
         right_s = (
-            right.value if isinstance(right, ast.Constant) and isinstance(right.value, str)
-            else _fold_str_concat(right) if isinstance(right, ast.BinOp)
+            right.value
+            if isinstance(right, ast.Constant) and isinstance(right.value, str)
+            else _fold_str_concat(right)
+            if isinstance(right, ast.BinOp)
             else ""
         )
         return left_s + right_s
@@ -210,6 +279,7 @@ def main() -> int:
     for py in MCP_DIR.rglob("*.py"):
         tools.extend(extract_tools(py))
         tools.extend(extract_register_builtin_calls(py))
+        tools.extend(extract_register_tool_calls(py))
 
     # Filter out tools from modules that aren't wired into the live server yet.
     # See NOT_YET_REGISTERED_PREFIXES at top of file.


### PR DESCRIPTION
## Summary

Architecture-cleanup A-6. The integrations-catalog generator only matched \`register_builtin_handler(\"name\", ...)\` call sites and missed PSE tools that register via \`mcp_client.register_tool(name=..., ...)\` — sometimes through a local alias bound by \`register = getattr(mcp_client, \"register_tool\", None)\`. So \`pse_synthesize\`, \`pse_is_synthesizable\`, \`pse_status\`, \`pse_synthesize_refined\` never made it into \`docs/integrations/catalog.json\` (the file the \`cognithor.ai/integrations\` page reads).

Adds an \`extract_register_tool_calls\` extractor that handles both:

- direct \`<obj>.register_tool(name=..., description=..., handler=...)\`
- aliased \`register(name=..., description=..., handler=...)\` where the call has the full kwarg triplet but the function is a local Name node

Catalog tool count: **116 → 136** (PSE family + previously-missed callers).

## Test plan

- [x] \`python scripts/generate_integrations_catalog.py --output docs/integrations/catalog.json\` writes 136 tools
- [x] All 4 \`pse_*\` tools appear in the catalog
- [x] \`ruff check\` and \`ruff format --check\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)