### PR TITLE
docs(integrations): A-2 sevdesk is in development, not v1.0 Launch

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -19,7 +19,7 @@ Siehe `catalog.json` für die vollständige Liste. Hauptkategorien:
 - `memory` — Zugriff auf das 6-Tier Cognitive Memory
 - `identity` — Ed25519-Key-Management
 - `shell` — Sandboxed Shell-Execution
-- `sevdesk` — **DACH:** sevDesk-Buchhaltung (v1.0 Launch)
+- `sevdesk` — **DACH:** sevDesk-Buchhaltung (in Entwicklung — Modul liegt unter `src/cognithor/mcp/sevdesk/` aber ist noch nicht im MCP-Server registriert; wird über Agent Pack ausgeliefert)
 
 ## MCP-Protokoll
 


### PR DESCRIPTION
## Summary

Architecture-cleanup A-2. \`docs/integrations/README.md\` listed \`sevdesk\` as a "v1.0 Launch" capability, but \`src/cognithor/mcp/sevdesk/\` is unwired — no module imports \`register_sevdesk_tools()\`, and the catalog generator deliberately filters the prefix via \`NOT_YET_REGISTERED_PREFIXES\`. The "v1.0 Launch" badge overpromised.

Updates the README to reflect reality: the module exists but isn't wired into the live MCP server yet, and the production path will ship via the Agent Pack system rather than the core distribution.

## Test plan

- [x] No code changes — docs only
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)