### PR TITLE
refactor(arc): A-4 mark arc.classic deprecated (1001 LOC orphaned, ARC-AGI-3 lives in channels/program_synthesis/)

### DIFF
--- a/src/cognithor/arc/classic/__init__.py
+++ b/src/cognithor/arc/classic/__init__.py
@@ -1,0 +1,23 @@
+"""``cognithor.arc.classic`` — DEPRECATED.
+
+This subpackage shipped the original ARC-AGI-1/2 grid-puzzle solver
+(``ArcSolver`` + DSL search + LLM fallback). The production ARC-AGI-3
+path now lives under ``cognithor.channels.program_synthesis.arc_agi3``
+and the higher-performance synthesis layer under
+``cognithor.channels.program_synthesis.phase2``. ``classic`` has zero
+production import sites; only its own test suite still references it.
+
+Scheduled for deletion after one minor-version cycle.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+warnings.warn(
+    "cognithor.arc.classic is deprecated; use "
+    "cognithor.channels.program_synthesis.* instead. "
+    "This subpackage will be deleted in a future release.",
+    DeprecationWarning,
+    stacklevel=2,
+)


### PR DESCRIPTION
## Summary

Architecture-cleanup A-4. \`cognithor.arc.classic\` is the original ARC-AGI-1/2 grid-puzzle solver (1001 LOC: \`ArcSolver\` + DSL search + LLM fallback). It has **zero production import sites** — the live ARC-AGI-3 path runs through \`cognithor.channels.program_synthesis.arc_agi3\` with the \`program_synthesis.phase2\` synthesis layer. Only \`tests/test_arc/test_classic/\` still references the legacy module.

Add a module-level \`DeprecationWarning\` in \`arc/classic/__init__.py\` so any consumer that imports the package gets a clear migration signal, and record the schedule: deletion after one minor-version cycle.

## Test plan

- [x] \`python -W error::DeprecationWarning -c "from cognithor.arc.classic import dsl"\` raises (warning fires)
- [x] \`pytest tests/test_arc/test_classic/\` still passes (73 tests, 1 deprecation warning logged)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)