### PR TITLE
docs(skills): A-8 mark 4 marketplace-scaffolding modules NOT WIRED (~1650 LOC)

### DIFF
--- a/src/cognithor/skills/governance.py
+++ b/src/cognithor/skills/governance.py
@@ -9,6 +9,15 @@ Strengeres Bewertungs-/Reputationssystem fuer das Skill-Ecosystem:
   - ReviewQueue:         Warteschlange fuer manuelle Reviews
 
 Architektur-Bibel: §7.4 (Marketplace-Security), §14.2 (Supply-Chain)
+
+.. note::
+
+    **NOT WIRED INTO PRODUCTION** (operational-trust audit, A-8,
+    2026-05-04). Tested via ``tests/test_skills/test_governance.py``
+    but no production boot path imports any of these classes. Lives
+    in the codebase as the security spec for the Q4 2026 Community
+    Marketplace; wire ``ReputationEngine`` + ``SkillRecallManager``
+    into the skill installer pipeline when the marketplace ships.
 """
 
 from __future__ import annotations

--- a/src/cognithor/skills/performance_tracker.py
+++ b/src/cognithor/skills/performance_tracker.py
@@ -5,6 +5,15 @@ disables skills that exceed failure thresholds.  Skills are re-enabled
 after a configurable cooldown period so they get a second chance.
 
 Persistence is stored in ``~/.cognithor/data/skill_performance.json``.
+
+.. note::
+
+    **NOT WIRED INTO PRODUCTION** (operational-trust audit, A-8,
+    2026-05-04). Tested via
+    ``tests/test_skills/test_performance_tracker.py`` but no
+    production boot path imports the tracker. The marketplace
+    feature that depends on this (auto-disable degraded skills) is
+    on the v1.0 roadmap.
 """
 
 from __future__ import annotations

--- a/src/cognithor/skills/remote_registry.py
+++ b/src/cognithor/skills/remote_registry.py
@@ -5,6 +5,17 @@ Handles manifest verification, signature checking, version resolution,
 dependency tracking, and local caching.
 
 Architecture: §12.4 (Plugin Marketplace Remote Registry)
+
+.. note::
+
+    **NOT WIRED INTO PRODUCTION** (operational-trust audit, A-8,
+    2026-05-04). Tested via
+    ``tests/test_skills/test_remote_registry.py`` and the F017
+    install-history safety contract, but no production boot path
+    imports ``RemoteRegistry``. The Agent Pack system
+    (``cognithor.packs``) currently fills this role for paid
+    add-ons; remote_registry will become the community-skill
+    distribution path when the Q4 2026 marketplace ships.
 """
 
 from __future__ import annotations

--- a/src/cognithor/skills/seed_data.py
+++ b/src/cognithor/skills/seed_data.py
@@ -5,6 +5,17 @@ aus ``data/procedures/``. Wird beim ersten Start oder bei leerem
 Marketplace automatisch ausgefuehrt.
 
 Architecture reference: SS14 (Skills & Ecosystem)
+
+.. note::
+
+    **NOT WIRED INTO PRODUCTION** (operational-trust audit, A-8,
+    2026-05-04). The Community Skill Marketplace is on the v1.0
+    roadmap (see ``project_strategic_backlog`` memory); this module
+    is scaffolding for it. ``seed_marketplace`` is exercised by
+    ``tests/test_skills/test_seed_data_ext.py`` but no production
+    boot path imports it. Either wire it from ``gateway.boot`` when
+    the marketplace ships, or delete with the rest of the
+    governance/remote_registry/performance_tracker quartet.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Architecture-cleanup A-8. \`cognithor.skills.{seed_data, governance, performance_tracker, remote_registry}\` (~1650 LOC together) are scaffolding for the Q4 2026 Community Skill Marketplace. They are tested but **no production boot path imports them** — easy to mistake for live code when reading docstrings that describe v1.0 capabilities.

Adds a \`.. note:: NOT WIRED INTO PRODUCTION\` block to each module docstring with: (a) the audit reference (A-8, 2026-05-04), (b) which test file currently exercises it, (c) what would need to wire it.

No code change — these blocks tell future readers (and reviewers following the operational-trust audit thread) that the modules are intentional scaffolding, not orphaned dead code.

## Test plan

- [x] \`mypy --strict\` clean across all 4 files
- [x] \`ruff check\` and \`ruff format --check\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)