### PR TITLE
feat(pse): Sprint-26 polish — register_all_sprint26_domains() central wiring

### DIFF
--- a/src/cognithor/channels/program_synthesis/domains/__init__.py
+++ b/src/cognithor/channels/program_synthesis/domains/__init__.py
@@ -24,6 +24,10 @@ Tests build fresh registries via ``DomainRegistry()``.
 
 from __future__ import annotations
 
+from cognithor.channels.program_synthesis.domains._register_all import (
+    SPRINT26_DOMAIN_NAMES,
+    register_all_sprint26_domains,
+)
 from cognithor.channels.program_synthesis.domains.base import (
     Domain,
     DomainCapability,
@@ -53,6 +57,7 @@ from cognithor.channels.program_synthesis.domains.scorecard import (
 
 __all__ = [
     "DOMAIN_REGISTRY",
+    "SPRINT26_DOMAIN_NAMES",
     "Domain",
     "DomainAwareLLMPrior",
     "DomainCapability",
@@ -66,4 +71,5 @@ __all__ = [
     "PropertyVerifier",
     "Scorecard",
     "ScorecardEntry",
+    "register_all_sprint26_domains",
 ]

--- a/src/cognithor/channels/program_synthesis/domains/_register_all.py
+++ b/src/cognithor/channels/program_synthesis/domains/_register_all.py
@@ -1,0 +1,88 @@
+"""Central registration of all Sprint-26 domains.
+
+Sprint-26.1-26.4 ship the seven domain modules (sql, json_dsl,
+datetime_dsl, ast_dsl, float_dsl, bytes_dsl, image_v2). Each module
+provides a ``register_<name>_domain(registry)`` helper that adds its
+metadata + factory to the canonical :data:`DOMAIN_REGISTRY`. This
+wrapper calls all seven in order so the gateway boot path only has to
+say::
+
+    from cognithor.channels.program_synthesis.domains import (
+        DOMAIN_REGISTRY,
+        register_all_sprint26_domains,
+    )
+
+    register_all_sprint26_domains(DOMAIN_REGISTRY)
+
+Calling the wrapper twice on the same registry raises
+``DomainAlreadyRegisteredError`` from the underlying registry — the
+wrapper does NOT swallow that, because a double-init usually points
+at a real wiring bug.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from cognithor.channels.program_synthesis.domains.ast_dsl import (
+    register_ast_domain,
+)
+from cognithor.channels.program_synthesis.domains.bytes_dsl import (
+    register_bytes_domain,
+)
+from cognithor.channels.program_synthesis.domains.datetime_dsl import (
+    register_datetime_domain,
+)
+from cognithor.channels.program_synthesis.domains.float_dsl import (
+    register_float_domain,
+)
+from cognithor.channels.program_synthesis.domains.image_v2 import (
+    register_image_v2_domain,
+)
+from cognithor.channels.program_synthesis.domains.json_dsl import (
+    register_json_domain,
+)
+from cognithor.channels.program_synthesis.domains.sql import (
+    register_sql_domain,
+)
+
+if TYPE_CHECKING:
+    from cognithor.channels.program_synthesis.domains.registry import (
+        DomainRegistry,
+    )
+
+
+# Stable ordering — matches Owner-Decision D3 (Sprint-26 priority
+# sequence): SQL → JSON → Datetime → AST → BinaryData → Float →
+# Image-Boost. Tests assert on this order so any future re-shuffle
+# is intentional.
+SPRINT26_DOMAIN_NAMES: tuple[str, ...] = (
+    "sql",
+    "json",
+    "datetime",
+    "ast",
+    "bytes",
+    "float",
+    "image_v2",
+)
+
+
+def register_all_sprint26_domains(registry: DomainRegistry) -> None:
+    """Register every Sprint-26 domain into ``registry``.
+
+    Calls the seven ``register_<name>_domain`` helpers in
+    Owner-Decision-D3 order. Each underlying registration uses the
+    lazy plugin-loader pattern from Sprint-26.1, so the actual domain
+    instances aren't built until the synthesis pipeline asks for them.
+
+    Raises ``DomainAlreadyRegisteredError`` when invoked twice with
+    the same name — that's a wiring bug worth surfacing rather than
+    silently no-oping.
+    """
+    register_sql_domain(registry)
+    register_json_domain(registry)
+    register_datetime_domain(registry)
+    register_ast_domain(registry)
+    register_bytes_domain(registry)
+    register_float_domain(registry)
+    register_image_v2_domain(registry)

--- a/tests/test_pse/test_domains/test_register_all.py
+++ b/tests/test_pse/test_domains/test_register_all.py
@@ -1,0 +1,93 @@
+"""Tests for ``register_all_sprint26_domains``."""
+
+from __future__ import annotations
+
+import pytest
+
+from cognithor.channels.program_synthesis.domains import (
+    SPRINT26_DOMAIN_NAMES,
+    DomainRegistry,
+    register_all_sprint26_domains,
+)
+from cognithor.channels.program_synthesis.domains.registry import (
+    DomainAlreadyRegisteredError,
+)
+
+
+class TestRegisterAllSprint26Domains:
+    def test_registers_all_seven(self) -> None:
+        reg = DomainRegistry()
+        register_all_sprint26_domains(reg)
+        assert len(reg) == 7
+        for name in SPRINT26_DOMAIN_NAMES:
+            assert name in reg, f"missing domain {name!r}"
+
+    def test_owner_d3_priority_order(self) -> None:
+        # Owner-Decision D3: SQL → JSON → Datetime → AST → BinaryData
+        # → Float → Image-Boost. Stable ordering matters because the
+        # public scorecard renders columns in this sequence.
+        assert SPRINT26_DOMAIN_NAMES == (
+            "sql",
+            "json",
+            "datetime",
+            "ast",
+            "bytes",
+            "float",
+            "image_v2",
+        )
+
+    def test_metadata_per_domain(self) -> None:
+        reg = DomainRegistry()
+        register_all_sprint26_domains(reg)
+        for name in SPRINT26_DOMAIN_NAMES:
+            metadata = reg.metadata(name)
+            assert metadata.name == name
+            assert metadata.display_name
+            assert metadata.benchmark_target >= 0.0
+
+    def test_double_call_raises(self) -> None:
+        reg = DomainRegistry()
+        register_all_sprint26_domains(reg)
+        with pytest.raises(DomainAlreadyRegisteredError):
+            register_all_sprint26_domains(reg)
+
+    def test_lazy_factories(self) -> None:
+        # Registration is cheap — domain instances aren't built until
+        # the synthesis pipeline asks for them via reg.get(name).
+        reg = DomainRegistry()
+        register_all_sprint26_domains(reg)
+        # Materialise one to confirm the factory wires correctly.
+        sql = reg.get("sql")
+        assert sql.metadata.name == "sql"
+
+    def test_capabilities_set_per_domain(self) -> None:
+        reg = DomainRegistry()
+        register_all_sprint26_domains(reg)
+        for name in SPRINT26_DOMAIN_NAMES:
+            metadata = reg.metadata(name)
+            assert metadata.capabilities, f"domain {name!r} declared no capabilities"
+
+    def test_distinct_benchmark_names(self) -> None:
+        reg = DomainRegistry()
+        register_all_sprint26_domains(reg)
+        benchmarks = [reg.metadata(n).benchmark_name for n in SPRINT26_DOMAIN_NAMES]
+        # Each domain must point at its own external benchmark — Sprint-26
+        # public-scorecard contract.
+        assert len(set(benchmarks)) == len(benchmarks)
+
+    def test_partial_filter_by_capability(self) -> None:
+        reg = DomainRegistry()
+        register_all_sprint26_domains(reg)
+        execute_capable = list(reg.filter_by_capability("execute"))
+        # SQL + AST run programs (D5 capabilities); the others verify
+        # via interpreter or property-suite.
+        names = {m.name for m in execute_capable}
+        assert "sql" in names
+        assert "ast" in names
+
+    def test_each_domain_has_at_least_one_type_tag(self) -> None:
+        reg = DomainRegistry()
+        register_all_sprint26_domains(reg)
+        for name in SPRINT26_DOMAIN_NAMES:
+            metadata = reg.metadata(name)
+            assert metadata.type_tags, f"{name!r} has no type tags"


### PR DESCRIPTION
## Summary

After Sprint-26 (#389/#390/#391/#392 all merged), the seven domain modules each had their own \`register_<name>_domain\` helper but no central caller. Result: the canonical \`DOMAIN_REGISTRY\` was empty at runtime even though all seven domains were code-side ready.

Adds a single helper that registers all seven domains in Owner-Decision-D3 priority order: **sql → json → datetime → ast → bytes → float → image_v2**.

Gateway boot becomes a one-liner:

\`\`\`python
from cognithor.channels.program_synthesis.domains import (
    DOMAIN_REGISTRY,
    register_all_sprint26_domains,
)
register_all_sprint26_domains(DOMAIN_REGISTRY)
\`\`\`

Wiring this into actual gateway boot is a separate follow-up — this PR ships the helper + tests so the boot-side change can be a two-line touch.

## Test plan

- [x] 9 new tests covering register-all, D3 ordering, double-call rejection, lazy factories, capability filtering
- [x] \`mypy --strict\` clean across 46 source files
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)