### PR TITLE
feat(pse): wire Sprint-26 domains into gateway boot

### DIFF
--- a/src/cognithor/gateway/phases/tools.py
+++ b/src/cognithor/gateway/phases/tools.py
@@ -199,6 +199,35 @@ async def init_tools(
     except Exception:
         log.debug("pse_tools_not_available", exc_info=True)
 
+    # Sprint-26: register the seven Domain-Expansion catalogs (sql,
+    # json, datetime, ast, bytes, float, image_v2) into the canonical
+    # DOMAIN_REGISTRY. The synthesis pipeline reads from this
+    # registry; without this call the registry stays empty and every
+    # cross-domain query falls back to the free-form path. Defensive
+    # wrapper because re-running the gateway in a single Python
+    # process (test fixtures, hot-reload) hits the
+    # DomainAlreadyRegisteredError guard — that's not fatal here.
+    try:
+        from cognithor.channels.program_synthesis.domains import (
+            DOMAIN_REGISTRY,
+            SPRINT26_DOMAIN_NAMES,
+            register_all_sprint26_domains,
+        )
+
+        if len(DOMAIN_REGISTRY) == 0:
+            register_all_sprint26_domains(DOMAIN_REGISTRY)
+            log.info(
+                "pse_sprint26_domains_registered",
+                domains=list(SPRINT26_DOMAIN_NAMES),
+            )
+        else:
+            log.debug(
+                "pse_sprint26_domains_already_registered",
+                count=len(DOMAIN_REGISTRY),
+            )
+    except Exception:
+        log.debug("pse_sprint26_domains_not_available", exc_info=True)
+
     # Browser-Use v17: Autonomous browser automation (optional)
     browser_agent = None
     try:


### PR DESCRIPTION
## Summary

After Sprint-26 polish (#393) shipped \`register_all_sprint26_domains\`, the gateway boot path needed to actually call it so the canonical \`DOMAIN_REGISTRY\` isn't empty at runtime.

Adds the call right after \`register_pse_tools\` in \`gateway/phases/tools.py::init_tools\`. Defensive against re-init via the \`len(DOMAIN_REGISTRY) == 0\` guard — test fixtures and hot-reload paths can re-enter \`init_tools\` without tripping the \`DomainAlreadyRegisteredError\` guard.

## Test plan

- [x] mypy --strict clean
- [x] ruff check + format clean
- [ ] CI green (existing test_pse/test_domains/test_register_all.py covers the helper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)