### PR TITLE
feat(security): TRUST-5-Lite — PermissionScope foundation

### DIFF
--- a/src/cognithor/security/permission_scope.py
+++ b/src/cognithor/security/permission_scope.py
@@ -1,0 +1,278 @@
+"""``PermissionScope`` foundation (TRUST-5, operational-trust audit, 2026-05-04).
+
+Reviewer-feedback gap: today's gatekeeper applies one global GREEN/
+YELLOW/ORANGE/RED set per tool. Channels, users, and workflows have
+no separate permission boundaries — all callers see the same tool
+whitelist. A Telegram message and a Slack DM hit the same risk
+classifier; an unattended cron run inherits the same approvals as an
+interactive chat session.
+
+This module ships the **foundation**: a frozen ``PermissionScope``
+data model + an in-memory ``ScopeRegistry`` + a ``ScopeViolation``
+exception. Wiring scopes into the gatekeeper, channel base class, and
+DB persistence is **deliberately deferred** to a follow-up — a single
+mergeable commit shouldn't touch ten files at once.
+
+Contract:
+
+* A scope is keyed by ``(axis, identity)`` — e.g.
+  ``("channel", "telegram")`` or ``("user", "alex@cognithor.ai")``.
+* Each scope declares ``tool_allowlist``, ``tool_denylist``, and a
+  ``max_risk`` ceiling.
+* ``ScopeRegistry.evaluate(scope_keys, tool_name, tool_risk)`` returns
+  the most-restrictive verdict across the matching scopes — denylist
+  beats allowlist beats max-risk.
+* No DB, no IO. Persistence is the next PR's job.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+
+from cognithor.models import RiskLevel
+
+
+class ScopeAxis(StrEnum):
+    """Axes a scope can be keyed on.
+
+    Sprint-26-Lite picks four axes that map to existing concepts in
+    the codebase. New axes can be added by extending this enum + the
+    corresponding identity field on ``PermissionScope``.
+    """
+
+    CHANNEL = "channel"
+    USER = "user"
+    WORKFLOW = "workflow"
+    PACK = "pack"
+
+
+# Total ordering of risk levels — denser ints sort lower-to-higher
+# severity. Used by ``max_risk`` ceiling check.
+_RISK_ORDER: dict[RiskLevel, int] = {
+    RiskLevel.GREEN: 0,
+    RiskLevel.YELLOW: 1,
+    RiskLevel.ORANGE: 2,
+    RiskLevel.RED: 3,
+}
+
+
+def _risk_value(level: RiskLevel) -> int:
+    return _RISK_ORDER.get(level, len(_RISK_ORDER))
+
+
+class ScopeViolation(Exception):
+    """Raised when a tool call violates a permission scope.
+
+    The message names the (axis, identity, tool, reason) tuple so the
+    audit log + Trace-UI can render a structured ``DecisionExplanation``
+    (TRUST-2 hook) without re-parsing.
+    """
+
+    def __init__(
+        self,
+        *,
+        axis: str,
+        identity: str,
+        tool: str,
+        reason: str,
+    ) -> None:
+        super().__init__(f"Scope violation: {axis}={identity!r} blocks {tool!r} ({reason})")
+        self.axis = axis
+        self.identity = identity
+        self.tool = tool
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class PermissionScope:
+    """A typed permission slice for one (axis, identity) pair.
+
+    Frozen so the registry can hash it for de-duplication. The fields
+    are intentionally minimal — extending the surface (rate-limits,
+    cost ceilings, time-of-day windows) is the follow-up PR's job.
+
+    Semantics:
+
+    * ``tool_allowlist`` empty ⇒ all tools allowed (subject to
+      denylist + max_risk). Non-empty ⇒ only listed tools allowed.
+    * ``tool_denylist`` always wins over allowlist.
+    * ``max_risk`` ceiling — any tool classified above this level is
+      denied regardless of allowlist membership.
+    """
+
+    axis: ScopeAxis
+    identity: str
+    tool_allowlist: frozenset[str] = field(default_factory=frozenset)
+    tool_denylist: frozenset[str] = field(default_factory=frozenset)
+    max_risk: RiskLevel = RiskLevel.RED
+
+    def __post_init__(self) -> None:
+        if not self.identity:
+            msg = "PermissionScope.identity must be a non-empty string"
+            raise ValueError(msg)
+        overlap = self.tool_allowlist & self.tool_denylist
+        if overlap:
+            msg = (
+                f"Scope ({self.axis}, {self.identity!r}) has tools in both "
+                f"allowlist and denylist: {sorted(overlap)}"
+            )
+            raise ValueError(msg)
+
+    @property
+    def key(self) -> tuple[str, str]:
+        """Stable hash key for the registry."""
+        return (self.axis.value, self.identity)
+
+
+@dataclass(frozen=True)
+class ScopeVerdict:
+    """Outcome of a scope evaluation.
+
+    Frozen so the audit log can embed it directly. ``allowed`` is the
+    binary verdict; ``reasons`` lists every contributing rule
+    (deterministic ordering for stable display in Trace-UI).
+    """
+
+    allowed: bool
+    reasons: tuple[str, ...] = ()
+
+    @property
+    def denied(self) -> bool:
+        return not self.allowed
+
+
+class ScopeRegistry:
+    """In-memory registry of permission scopes.
+
+    Process-local on purpose — persistence (writing to a DB, reloading
+    on boot) is the follow-up PR's job. Keeping this layer storage-free
+    makes it cheap to test and lets callers pin a specific scope-set
+    per request without polluting global state.
+    """
+
+    def __init__(self) -> None:
+        self._scopes: dict[tuple[str, str], PermissionScope] = {}
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def register(self, scope: PermissionScope) -> None:
+        """Add or replace a scope. Existing key is overwritten silently
+        — scopes are config-driven and re-config should not raise.
+        """
+        self._scopes[scope.key] = scope
+
+    def remove(self, axis: ScopeAxis, identity: str) -> bool:
+        """Remove a scope by key. Returns True if a scope was deleted."""
+        key = (axis.value, identity)
+        return self._scopes.pop(key, None) is not None
+
+    def clear(self) -> None:
+        self._scopes.clear()
+
+    # ------------------------------------------------------------------
+    # Lookup
+    # ------------------------------------------------------------------
+
+    def get(self, axis: ScopeAxis, identity: str) -> PermissionScope | None:
+        return self._scopes.get((axis.value, identity))
+
+    def list_scopes(self) -> list[PermissionScope]:
+        """Return all scopes sorted by (axis, identity) for stable display."""
+        return [self._scopes[k] for k in sorted(self._scopes)]
+
+    def __len__(self) -> int:
+        return len(self._scopes)
+
+    # ------------------------------------------------------------------
+    # Evaluation
+    # ------------------------------------------------------------------
+
+    def evaluate(
+        self,
+        scope_keys: list[tuple[ScopeAxis, str]],
+        tool_name: str,
+        tool_risk: RiskLevel,
+    ) -> ScopeVerdict:
+        """Return the most-restrictive verdict for the given tool call.
+
+        ``scope_keys`` lists every (axis, identity) the caller falls
+        under — usually ``[(CHANNEL, "telegram"), (USER, "alex"),
+        (WORKFLOW, "morning_brief")]``. Missing scopes are skipped.
+
+        Decision precedence (most-restrictive wins):
+
+        1. Any matching scope's denylist contains ``tool_name`` ⇒ deny
+        2. Any matching scope's max_risk lower than ``tool_risk`` ⇒ deny
+        3. Any matching scope has a non-empty allowlist that does NOT
+           contain ``tool_name`` ⇒ deny
+        4. Otherwise ⇒ allow
+        """
+        reasons: list[str] = []
+        for axis, identity in scope_keys:
+            scope = self._scopes.get((axis.value, identity))
+            if scope is None:
+                continue
+
+            if tool_name in scope.tool_denylist:
+                return ScopeVerdict(
+                    allowed=False,
+                    reasons=(f"{axis.value}={identity!r}: tool {tool_name!r} in denylist",),
+                )
+
+            if _risk_value(tool_risk) > _risk_value(scope.max_risk):
+                return ScopeVerdict(
+                    allowed=False,
+                    reasons=(
+                        f"{axis.value}={identity!r}: tool risk "
+                        f"{tool_risk.value} exceeds max_risk "
+                        f"{scope.max_risk.value}",
+                    ),
+                )
+
+            if scope.tool_allowlist and tool_name not in scope.tool_allowlist:
+                return ScopeVerdict(
+                    allowed=False,
+                    reasons=(f"{axis.value}={identity!r}: tool {tool_name!r} not in allowlist",),
+                )
+
+            reasons.append(f"{axis.value}={identity!r}: ok")
+
+        return ScopeVerdict(allowed=True, reasons=tuple(reasons))
+
+    def assert_allowed(
+        self,
+        scope_keys: list[tuple[ScopeAxis, str]],
+        tool_name: str,
+        tool_risk: RiskLevel,
+    ) -> None:
+        """Raise :class:`ScopeViolation` when the call is denied.
+
+        Convenience wrapper for the gatekeeper: the audit log already
+        knows how to format a ``ScopeViolation``, so callers that just
+        want a binary fail-fast can use this instead of branching on
+        :meth:`evaluate`.
+        """
+        verdict = self.evaluate(scope_keys, tool_name, tool_risk)
+        if verdict.allowed:
+            return
+        if not verdict.reasons:
+            reason = "no matching scope verdict"
+            axis = "?"
+            identity = "?"
+        else:
+            head = verdict.reasons[0]
+            # head shape: "<axis>=<repr(identity)>: <reason>"
+            axis_part, _, rest = head.partition("=")
+            ident_part, _, reason = rest.partition(": ")
+            axis = axis_part
+            identity = ident_part.strip("'\"")
+        raise ScopeViolation(axis=axis, identity=identity, tool=tool_name, reason=reason)
+
+
+# Process-local default registry. The gateway boot path can populate
+# it from config / DB; tests construct fresh registries to keep state
+# out of globals.
+SCOPE_REGISTRY: ScopeRegistry = ScopeRegistry()

--- a/tests/test_security/test_permission_scope.py
+++ b/tests/test_security/test_permission_scope.py
@@ -1,0 +1,256 @@
+"""Tests for the TRUST-5 PermissionScope foundation."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from cognithor.models import RiskLevel
+from cognithor.security.permission_scope import (
+    PermissionScope,
+    ScopeAxis,
+    ScopeRegistry,
+    ScopeViolation,
+)
+
+
+class TestPermissionScope:
+    def test_minimal_scope(self) -> None:
+        scope = PermissionScope(axis=ScopeAxis.CHANNEL, identity="telegram")
+        assert scope.key == ("channel", "telegram")
+        assert scope.max_risk == RiskLevel.RED
+        assert scope.tool_allowlist == frozenset()
+        assert scope.tool_denylist == frozenset()
+
+    def test_empty_identity_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            PermissionScope(axis=ScopeAxis.CHANNEL, identity="")
+
+    def test_overlap_allowlist_denylist_rejected(self) -> None:
+        with pytest.raises(ValueError, match="both"):
+            PermissionScope(
+                axis=ScopeAxis.USER,
+                identity="alex",
+                tool_allowlist=frozenset({"web_fetch"}),
+                tool_denylist=frozenset({"web_fetch"}),
+            )
+
+    def test_frozen_via_dataclass(self) -> None:
+        scope = PermissionScope(axis=ScopeAxis.USER, identity="alex")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            scope.identity = "bob"  # type: ignore[misc]
+
+
+class TestScopeRegistryBasic:
+    def test_empty_registry_passes_everything(self) -> None:
+        reg = ScopeRegistry()
+        verdict = reg.evaluate([], "any_tool", RiskLevel.GREEN)
+        assert verdict.allowed
+        assert verdict.reasons == ()
+
+    def test_register_get_remove(self) -> None:
+        reg = ScopeRegistry()
+        scope = PermissionScope(axis=ScopeAxis.USER, identity="alex")
+        reg.register(scope)
+        assert reg.get(ScopeAxis.USER, "alex") is scope
+        assert len(reg) == 1
+        assert reg.remove(ScopeAxis.USER, "alex") is True
+        assert reg.get(ScopeAxis.USER, "alex") is None
+        assert reg.remove(ScopeAxis.USER, "alex") is False
+
+    def test_register_replaces_existing(self) -> None:
+        reg = ScopeRegistry()
+        reg.register(PermissionScope(axis=ScopeAxis.USER, identity="alex"))
+        replacement = PermissionScope(
+            axis=ScopeAxis.USER,
+            identity="alex",
+            tool_denylist=frozenset({"shell"}),
+        )
+        reg.register(replacement)
+        assert reg.get(ScopeAxis.USER, "alex") is replacement
+
+    def test_list_scopes_sorted(self) -> None:
+        reg = ScopeRegistry()
+        for axis, ident in (
+            (ScopeAxis.USER, "bob"),
+            (ScopeAxis.CHANNEL, "slack"),
+            (ScopeAxis.USER, "alex"),
+        ):
+            reg.register(PermissionScope(axis=axis, identity=ident))
+        keys = [s.key for s in reg.list_scopes()]
+        assert keys == [("channel", "slack"), ("user", "alex"), ("user", "bob")]
+
+    def test_clear(self) -> None:
+        reg = ScopeRegistry()
+        reg.register(PermissionScope(axis=ScopeAxis.USER, identity="x"))
+        reg.clear()
+        assert len(reg) == 0
+
+
+class TestScopeEvaluation:
+    def test_denylist_blocks(self) -> None:
+        reg = ScopeRegistry()
+        reg.register(
+            PermissionScope(
+                axis=ScopeAxis.CHANNEL,
+                identity="telegram",
+                tool_denylist=frozenset({"shell"}),
+            )
+        )
+        verdict = reg.evaluate([(ScopeAxis.CHANNEL, "telegram")], "shell", RiskLevel.GREEN)
+        assert verdict.denied
+        assert "denylist" in verdict.reasons[0]
+
+    def test_allowlist_outside_blocks(self) -> None:
+        reg = ScopeRegistry()
+        reg.register(
+            PermissionScope(
+                axis=ScopeAxis.USER,
+                identity="alex",
+                tool_allowlist=frozenset({"web_fetch", "memory_search"}),
+            )
+        )
+        verdict = reg.evaluate([(ScopeAxis.USER, "alex")], "shell", RiskLevel.GREEN)
+        assert verdict.denied
+        assert "not in allowlist" in verdict.reasons[0]
+
+    def test_allowlist_member_passes(self) -> None:
+        reg = ScopeRegistry()
+        reg.register(
+            PermissionScope(
+                axis=ScopeAxis.USER,
+                identity="alex",
+                tool_allowlist=frozenset({"web_fetch"}),
+            )
+        )
+        verdict = reg.evaluate([(ScopeAxis.USER, "alex")], "web_fetch", RiskLevel.GREEN)
+        assert verdict.allowed
+
+    def test_max_risk_blocks_higher(self) -> None:
+        reg = ScopeRegistry()
+        reg.register(
+            PermissionScope(
+                axis=ScopeAxis.CHANNEL,
+                identity="cron",
+                max_risk=RiskLevel.YELLOW,
+            )
+        )
+        verdict = reg.evaluate([(ScopeAxis.CHANNEL, "cron")], "shell", RiskLevel.RED)
+        assert verdict.denied
+        assert "max_risk" in verdict.reasons[0]
+
+    def test_max_risk_passes_equal_or_lower(self) -> None:
+        reg = ScopeRegistry()
+        reg.register(
+            PermissionScope(
+                axis=ScopeAxis.CHANNEL,
+                identity="cron",
+                max_risk=RiskLevel.YELLOW,
+            )
+        )
+        # GREEN is below ceiling
+        v1 = reg.evaluate([(ScopeAxis.CHANNEL, "cron")], "memory_search", RiskLevel.GREEN)
+        assert v1.allowed
+        # YELLOW equals ceiling — allowed
+        v2 = reg.evaluate([(ScopeAxis.CHANNEL, "cron")], "create_file", RiskLevel.YELLOW)
+        assert v2.allowed
+
+    def test_unknown_scope_key_skipped(self) -> None:
+        reg = ScopeRegistry()
+        verdict = reg.evaluate([(ScopeAxis.USER, "stranger")], "any_tool", RiskLevel.GREEN)
+        assert verdict.allowed  # no scope ⇒ no restriction
+
+    def test_most_restrictive_wins_across_axes(self) -> None:
+        reg = ScopeRegistry()
+        # User allows web_fetch
+        reg.register(
+            PermissionScope(
+                axis=ScopeAxis.USER,
+                identity="alex",
+                tool_allowlist=frozenset({"web_fetch"}),
+            )
+        )
+        # Channel denylists web_fetch
+        reg.register(
+            PermissionScope(
+                axis=ScopeAxis.CHANNEL,
+                identity="cron",
+                tool_denylist=frozenset({"web_fetch"}),
+            )
+        )
+        # Cron-channel + alex-user — cron's denylist wins
+        verdict = reg.evaluate(
+            [(ScopeAxis.CHANNEL, "cron"), (ScopeAxis.USER, "alex")],
+            "web_fetch",
+            RiskLevel.GREEN,
+        )
+        assert verdict.denied
+
+    def test_denylist_beats_allowlist(self) -> None:
+        # Same axis: a single scope can't have a tool in both lists
+        # (constructor rejects), but two scopes on different axes can
+        # disagree. Denylist always wins.
+        reg = ScopeRegistry()
+        reg.register(
+            PermissionScope(
+                axis=ScopeAxis.WORKFLOW,
+                identity="morning_brief",
+                tool_denylist=frozenset({"shell"}),
+            )
+        )
+        reg.register(
+            PermissionScope(
+                axis=ScopeAxis.USER,
+                identity="alex",
+                tool_allowlist=frozenset({"shell"}),
+            )
+        )
+        verdict = reg.evaluate(
+            [
+                (ScopeAxis.WORKFLOW, "morning_brief"),
+                (ScopeAxis.USER, "alex"),
+            ],
+            "shell",
+            RiskLevel.GREEN,
+        )
+        assert verdict.denied
+        assert "denylist" in verdict.reasons[0]
+
+
+class TestAssertAllowed:
+    def test_passes_silently_when_allowed(self) -> None:
+        reg = ScopeRegistry()
+        # Empty registry → always allowed
+        reg.assert_allowed([(ScopeAxis.CHANNEL, "telegram")], "any_tool", RiskLevel.GREEN)
+
+    def test_raises_violation_on_deny(self) -> None:
+        reg = ScopeRegistry()
+        reg.register(
+            PermissionScope(
+                axis=ScopeAxis.CHANNEL,
+                identity="cron",
+                max_risk=RiskLevel.YELLOW,
+            )
+        )
+        with pytest.raises(ScopeViolation) as exc_info:
+            reg.assert_allowed([(ScopeAxis.CHANNEL, "cron")], "shell", RiskLevel.RED)
+        violation = exc_info.value
+        assert violation.tool == "shell"
+        assert violation.axis == "channel"
+        assert violation.identity == "cron"
+        assert "max_risk" in violation.reason
+
+
+class TestScopeViolation:
+    def test_message_includes_context(self) -> None:
+        v = ScopeViolation(
+            axis="channel",
+            identity="cron",
+            tool="shell",
+            reason="max_risk exceeded",
+        )
+        msg = str(v)
+        assert "cron" in msg
+        assert "shell" in msg
+        assert "max_risk" in msg


### PR DESCRIPTION
## Summary

Reviewer-feedback gap (operational-trust audit, 2026-05-04, point 2): today's gatekeeper applies one global GREEN/YELLOW/ORANGE/RED set per tool. Channels, users, and workflows have no separate permission boundaries — a Telegram message and a Slack DM hit the same risk classifier; an unattended cron run inherits the same approvals as an interactive chat session.

This PR ships the **foundation** (data model + in-memory registry + exception). Wiring into the gatekeeper, channel base class, and DB persistence is deliberately deferred to follow-up PRs.

## Surface

\`\`\`python
from cognithor.security.permission_scope import (
    PermissionScope, ScopeAxis, ScopeRegistry, ScopeViolation,
)

reg = ScopeRegistry()
reg.register(PermissionScope(
    axis=ScopeAxis.CHANNEL,
    identity="cron",
    max_risk=RiskLevel.YELLOW,
    tool_denylist=frozenset({"shell"}),
))
verdict = reg.evaluate(
    [(ScopeAxis.CHANNEL, "cron"), (ScopeAxis.USER, "alex")],
    "shell", RiskLevel.RED,
)
# verdict.denied == True
# verdict.reasons == ("channel='cron': tool 'shell' in denylist",)
\`\`\`

## Decision precedence (most-restrictive wins)

1. Any matching scope's denylist contains tool ⇒ deny
2. Any matching scope's max_risk lower than tool risk ⇒ deny
3. Any matching scope's non-empty allowlist excludes tool ⇒ deny
4. Otherwise ⇒ allow

## Test plan

- [x] 20 tests in \`tests/test_security/test_permission_scope.py\`
- [x] \`mypy --strict\` clean
- [x] \`ruff check\` + \`ruff format --check\` clean
- [ ] CI green

## Follow-up PRs (not in this commit)

- Gatekeeper hook so tool calls go through scope evaluation before risk classification
- Channel base class threads \`(axis, identity)\` into the gateway per-call context
- DB persistence under \`~/.cognithor/scopes.db\`
- REST + Flutter UI for editing scopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)