### PR TITLE
feat(memory): TRUST-9 ProvenanceTag foundation

### DIFF
--- a/src/cognithor/memory/provenance.py
+++ b/src/cognithor/memory/provenance.py
@@ -1,0 +1,400 @@
+"""``ProvenanceTag`` foundation (TRUST-9, operational-trust audit, 2026-05-04).
+
+Reviewer-feedback gap: today's memory items have ``source`` and
+``created_at`` fields scattered across the tiers (semantic, vault,
+episodic, relations). There is no uniform provenance contract — an
+operator looking at "Owner lives in Mainz" cannot tell whether that
+came from a chat utterance two years ago, a tool call yesterday, or a
+config import last hour.
+
+This module ships the **foundation**: a frozen ``ProvenanceTag`` data
+model + an in-memory ``ProvenanceLedger`` keyed by memory-item id,
+plus an ``ExpiryPolicy`` enum so callers can declare staleness rules
+deterministically. Wiring this into the four memory tiers is a
+follow-up — a single mergeable commit shouldn't rewrite ten memory
+modules at once.
+
+Contract:
+
+* Each provenance tag is keyed by ``item_id`` (the memory-tier's
+  primary key — semantic-memory uuid, vault-record-id, episodic-event-id,
+  relation-edge-id).
+* The tag is **append-only**: re-tagging the same item appends a new
+  version to the chain rather than overwriting. The ledger keeps the
+  full chain so post-mortem reconstruction can walk backwards.
+* ``valid_from`` / ``valid_until`` are *advisory*: they tell consumers
+  when the source's claim is supposed to be true. ``expired(now)``
+  surfaces items past their TTL or with ``valid_until < now``.
+* No DB. The follow-up PR persists to ``~/.cognithor/provenance.db``;
+  this layer stays storage-free for cheap testing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, replace
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+
+from cognithor.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Source typing
+# ---------------------------------------------------------------------------
+
+
+class SourceType(StrEnum):
+    """Where a memory item came from.
+
+    The set is closed so consumers can switch on it without hitting an
+    Unknown-fallback branch. Add a new value here when a new ingestion
+    path lands; that's an intentional review point.
+    """
+
+    CHAT_UTTERANCE = "chat_utterance"
+    TOOL_OUTPUT = "tool_output"
+    AGENT_INFERENCE = "agent_inference"
+    CONFIG_IMPORT = "config_import"
+    PACK_REGISTRATION = "pack_registration"
+    SCHEDULED_INGEST = "scheduled_ingest"
+    MIGRATION = "migration"
+    USER_DIRECTIVE = "user_directive"
+    UNKNOWN = "unknown"
+
+
+class ExpiryPolicy(StrEnum):
+    """Staleness-rule for a provenance tag.
+
+    Drives :meth:`ProvenanceLedger.expired` — an item with policy
+    ``PERMANENT`` never expires; ``TTL`` expires when ``valid_until``
+    is set and ``now > valid_until``; ``REPLACE_ON_NEW`` expires
+    automatically once a newer tag for the same item lands;
+    ``MANUAL`` expires only when an operator removes it explicitly.
+    """
+
+    PERMANENT = "permanent"
+    TTL = "ttl"
+    REPLACE_ON_NEW = "replace_on_new"
+    MANUAL = "manual"
+
+
+# ---------------------------------------------------------------------------
+# Provenance tag
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProvenanceTag:
+    """Immutable provenance record for a single memory item.
+
+    Frozen so the ledger can hash it for de-duplication and embed it
+    into audit-log entries without copy. Default values keep the
+    constructor cheap for the common case (TOOL_OUTPUT with TTL=24h).
+
+    Attributes
+    ----------
+    source_type:
+        Where the item came from. Drives downstream filtering — e.g.
+        the planner can skip CHAT_UTTERANCE items older than 7 days
+        without affecting CONFIG_IMPORT items.
+    source_id:
+        Stable identifier of the source within its type. For
+        TOOL_OUTPUT this is the audit-log entry id; for CHAT_UTTERANCE
+        this is the message id; for CONFIG_IMPORT this is the config
+        file path.
+    source_url:
+        Optional URL/URI for human-followable provenance. Empty when
+        the source is internal (no addressable URL).
+    ingested_at:
+        UTC timestamp the item entered cognithor's memory. Distinct
+        from ``valid_from`` because the same source claim can be
+        re-ingested after a migration without resetting validity.
+    valid_from:
+        UTC timestamp the source's claim starts being true. Defaults
+        to ``ingested_at`` for sources that don't carry temporal
+        information of their own.
+    valid_until:
+        UTC timestamp the source's claim stops being true. ``None``
+        means "no declared end" — combined with ``ExpiryPolicy.TTL``
+        this means the policy is effectively PERMANENT.
+    expiry_policy:
+        Staleness rule (see :class:`ExpiryPolicy`).
+    confidence:
+        0..1 confidence score the source attaches to the claim.
+        Defaults to 1.0 (fully trusted source). LLM-extracted facts
+        from low-confidence reasoning runs ship lower values.
+    attribution_chain:
+        Tuple of upstream item-ids the current item was derived from.
+        Empty for primary ingests; non-empty when the item is a
+        consolidation or distillation of multiple inputs.
+    notes:
+        Free-text breadcrumb for the audit log. Keep it short — full
+        diagnostics live in the audit chain.
+    """
+
+    source_type: SourceType
+    source_id: str
+    source_url: str = ""
+    ingested_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    valid_from: datetime | None = None
+    valid_until: datetime | None = None
+    expiry_policy: ExpiryPolicy = ExpiryPolicy.PERMANENT
+    confidence: float = 1.0
+    attribution_chain: tuple[str, ...] = ()
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.source_id:
+            msg = "ProvenanceTag.source_id must be a non-empty string"
+            raise ValueError(msg)
+        if not 0.0 <= self.confidence <= 1.0:
+            msg = f"ProvenanceTag.confidence must be in [0.0, 1.0], got {self.confidence}"
+            raise ValueError(msg)
+        if self.expiry_policy == ExpiryPolicy.TTL and self.valid_until is None:
+            msg = (
+                "ProvenanceTag with expiry_policy=TTL must set "
+                "valid_until — without an end, use PERMANENT instead"
+            )
+            raise ValueError(msg)
+        if (
+            self.valid_from is not None
+            and self.valid_until is not None
+            and self.valid_from > self.valid_until
+        ):
+            msg = (
+                f"ProvenanceTag.valid_from ({self.valid_from.isoformat()}) "
+                f"must be <= valid_until ({self.valid_until.isoformat()})"
+            )
+            raise ValueError(msg)
+
+    @property
+    def effective_valid_from(self) -> datetime:
+        """``valid_from`` falling back to ``ingested_at``."""
+        return self.valid_from if self.valid_from is not None else self.ingested_at
+
+    def with_chain(self, *parents: str) -> ProvenanceTag:
+        """Return a copy with ``parents`` appended to ``attribution_chain``."""
+        return replace(self, attribution_chain=self.attribution_chain + parents)
+
+
+# ---------------------------------------------------------------------------
+# Ledger
+# ---------------------------------------------------------------------------
+
+
+class ProvenanceLedger:
+    """Append-only in-memory ledger of provenance tags per memory item.
+
+    The ledger maps ``item_id → tuple[ProvenanceTag, ...]``. Each
+    ``tag()`` call appends; the most recent tag is the one a consumer
+    typically reads via :meth:`current`. Tests construct fresh
+    ledgers; production code uses :data:`PROVENANCE_LEDGER` (the
+    process-local default).
+    """
+
+    def __init__(self) -> None:
+        self._chains: dict[str, tuple[ProvenanceTag, ...]] = {}
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def tag(self, item_id: str, tag: ProvenanceTag) -> None:
+        """Append ``tag`` to the chain for ``item_id``.
+
+        REPLACE_ON_NEW policy: the previous tag remains in the chain
+        (history-preserving) but :meth:`current` returns the new tag,
+        and :meth:`expired` flags the previous one as stale.
+        """
+        if not item_id:
+            msg = "tag(): item_id must be a non-empty string"
+            raise ValueError(msg)
+        existing = self._chains.get(item_id, ())
+        self._chains[item_id] = (*existing, tag)
+
+    def remove(self, item_id: str) -> bool:
+        """Drop the entire chain for ``item_id``. Returns True iff it existed."""
+        return self._chains.pop(item_id, None) is not None
+
+    def clear(self) -> None:
+        self._chains.clear()
+
+    # ------------------------------------------------------------------
+    # Lookup
+    # ------------------------------------------------------------------
+
+    def chain(self, item_id: str) -> tuple[ProvenanceTag, ...]:
+        """Return the full append-only history for ``item_id`` (oldest first)."""
+        return self._chains.get(item_id, ())
+
+    def current(self, item_id: str) -> ProvenanceTag | None:
+        """Return the most recent tag for ``item_id`` or ``None``."""
+        chain = self._chains.get(item_id)
+        return chain[-1] if chain else None
+
+    def __contains__(self, item_id: object) -> bool:
+        return item_id in self._chains
+
+    def __len__(self) -> int:
+        return len(self._chains)
+
+    def items(self) -> list[tuple[str, tuple[ProvenanceTag, ...]]]:
+        """Return all (item_id, chain) pairs sorted by item_id."""
+        return [(k, self._chains[k]) for k in sorted(self._chains)]
+
+    # ------------------------------------------------------------------
+    # Expiry
+    # ------------------------------------------------------------------
+
+    def expired(self, *, now: datetime | None = None) -> list[str]:
+        """Return item_ids whose *current* tag is stale at ``now``.
+
+        Stale rules:
+
+        * ``PERMANENT`` — never stale.
+        * ``TTL`` — stale when ``now > valid_until``.
+        * ``REPLACE_ON_NEW`` — stale when the chain has more than one
+          tag (the older ones were superseded). The current head is
+          fresh by definition; the *previous* tag in the chain is
+          stale and would be reported on its own item if it still had
+          a unique id, but in practice REPLACE_ON_NEW chains share
+          one item_id so we report the item only when the head is
+          itself superseded by a newer tag — which never happens by
+          construction. We therefore *don't* report REPLACE_ON_NEW
+          here; consumers walk :meth:`chain` to find superseded
+          history.
+        * ``MANUAL`` — never automatically stale.
+
+        ``now`` defaults to :func:`datetime.now(UTC)`.
+        """
+        cutoff = now if now is not None else datetime.now(UTC)
+        out: list[str] = []
+        for item_id, chain in self._chains.items():
+            if not chain:
+                continue
+            head = chain[-1]
+            if (
+                head.expiry_policy == ExpiryPolicy.TTL
+                and head.valid_until is not None
+                and cutoff > head.valid_until
+            ):
+                out.append(item_id)
+        return sorted(out)
+
+    def superseded(self, item_id: str) -> tuple[ProvenanceTag, ...]:
+        """Return the prefix of an item's chain that's been replaced.
+
+        Useful for memory-tier consumers that periodically prune
+        REPLACE_ON_NEW items: every tag in the returned tuple is no
+        longer the source-of-truth for ``item_id`` and can be moved
+        to cold storage.
+        """
+        chain = self._chains.get(item_id, ())
+        if len(chain) <= 1:
+            return ()
+        return chain[:-1]
+
+    # ------------------------------------------------------------------
+    # Filtering
+    # ------------------------------------------------------------------
+
+    def filter_by_source_type(self, source_type: SourceType) -> list[tuple[str, ProvenanceTag]]:
+        """Return ``(item_id, current_tag)`` pairs for matching items."""
+        out: list[tuple[str, ProvenanceTag]] = []
+        for item_id in sorted(self._chains):
+            tag = self._chains[item_id][-1]
+            if tag.source_type == source_type:
+                out.append((item_id, tag))
+        return out
+
+    def filter_by_source_id(self, source_id: str) -> list[str]:
+        """Return item_ids whose current tag has ``source_id``.
+
+        Lets the audit-log answer "which memory items came from the
+        run XYZ?" — a TRUST-1 receipt query — without walking every
+        memory tier.
+        """
+        return sorted(
+            item_id
+            for item_id, chain in self._chains.items()
+            if chain and chain[-1].source_id == source_id
+        )
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> dict[str, list[dict[str, object]]]:
+        """JSON-serialisable snapshot of the ledger.
+
+        Used by the TRUST-1 run-receipt to embed the provenance chain
+        for every memory item touched during a run; the cognithor.ai
+        Trace-UI renders the chain as a vertical timeline.
+        """
+        return {
+            item_id: [
+                {
+                    "source_type": tag.source_type.value,
+                    "source_id": tag.source_id,
+                    "source_url": tag.source_url,
+                    "ingested_at": tag.ingested_at.isoformat(),
+                    "valid_from": (tag.valid_from.isoformat() if tag.valid_from else None),
+                    "valid_until": (tag.valid_until.isoformat() if tag.valid_until else None),
+                    "expiry_policy": tag.expiry_policy.value,
+                    "confidence": round(tag.confidence, 4),
+                    "attribution_chain": list(tag.attribution_chain),
+                    "notes": tag.notes,
+                }
+                for tag in chain
+            ]
+            for item_id, chain in sorted(self._chains.items())
+        }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_ttl_tag(
+    *,
+    source_type: SourceType,
+    source_id: str,
+    ttl: timedelta,
+    confidence: float = 1.0,
+    notes: str = "",
+) -> ProvenanceTag:
+    """Build a TTL-policy tag with ``valid_until = now + ttl``.
+
+    Sugar for the common LLM-inference case: the agent extracts a fact
+    that's only known to be true for ``ttl`` (e.g. "this user's
+    timezone is Europe/Berlin — true for the duration of this
+    session"). Defaults align with the rest of cognithor's UTC-only
+    timestamping.
+    """
+    if ttl.total_seconds() < 0:
+        msg = f"make_ttl_tag: ttl must be non-negative, got {ttl}"
+        raise ValueError(msg)
+    now = datetime.now(UTC)
+    return ProvenanceTag(
+        source_type=source_type,
+        source_id=source_id,
+        ingested_at=now,
+        valid_from=now,
+        valid_until=now + ttl,
+        expiry_policy=ExpiryPolicy.TTL,
+        confidence=confidence,
+        notes=notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Process-local default
+# ---------------------------------------------------------------------------
+
+# Memory tiers wire into this instance via a follow-up PR; the
+# ledger stays empty in production until that wiring lands. Tests
+# construct their own :class:`ProvenanceLedger` for isolation.
+PROVENANCE_LEDGER: ProvenanceLedger = ProvenanceLedger()

--- a/tests/test_memory/test_provenance.py
+++ b/tests/test_memory/test_provenance.py
@@ -1,0 +1,511 @@
+"""Tests for the TRUST-9 ProvenanceTag foundation."""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from cognithor.memory.provenance import (
+    PROVENANCE_LEDGER,
+    ExpiryPolicy,
+    ProvenanceLedger,
+    ProvenanceTag,
+    SourceType,
+    make_ttl_tag,
+)
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# ProvenanceTag construction + validation
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceTagBasics:
+    def test_minimal_tag(self) -> None:
+        tag = ProvenanceTag(
+            source_type=SourceType.CHAT_UTTERANCE,
+            source_id="msg-42",
+        )
+        assert tag.source_type == SourceType.CHAT_UTTERANCE
+        assert tag.source_id == "msg-42"
+        assert tag.expiry_policy == ExpiryPolicy.PERMANENT
+        assert tag.confidence == 1.0
+        assert tag.attribution_chain == ()
+        assert tag.notes == ""
+        # ingested_at defaults to now(UTC)
+        assert tag.ingested_at.tzinfo == UTC
+
+    def test_frozen_via_dataclass(self) -> None:
+        tag = ProvenanceTag(source_type=SourceType.TOOL_OUTPUT, source_id="audit-1")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            tag.source_id = "audit-2"  # type: ignore[misc]
+
+    def test_effective_valid_from_falls_back_to_ingested_at(self) -> None:
+        ingested = _utc(2026, 5, 4, 12, 0)
+        tag = ProvenanceTag(
+            source_type=SourceType.TOOL_OUTPUT,
+            source_id="audit-1",
+            ingested_at=ingested,
+        )
+        assert tag.effective_valid_from == ingested
+
+    def test_effective_valid_from_uses_explicit_value(self) -> None:
+        ingested = _utc(2026, 5, 4, 12, 0)
+        valid_from = _utc(2026, 5, 1, 0, 0)
+        tag = ProvenanceTag(
+            source_type=SourceType.CONFIG_IMPORT,
+            source_id="config.yaml",
+            ingested_at=ingested,
+            valid_from=valid_from,
+        )
+        assert tag.effective_valid_from == valid_from
+
+    def test_with_chain_appends_parents(self) -> None:
+        base = ProvenanceTag(
+            source_type=SourceType.AGENT_INFERENCE,
+            source_id="run-1",
+            attribution_chain=("a",),
+        )
+        derived = base.with_chain("b", "c")
+        assert derived.attribution_chain == ("a", "b", "c")
+        # original is unchanged
+        assert base.attribution_chain == ("a",)
+
+
+class TestProvenanceTagValidation:
+    def test_empty_source_id_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            ProvenanceTag(source_type=SourceType.UNKNOWN, source_id="")
+
+    def test_confidence_below_zero_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"\[0.0, 1.0\]"):
+            ProvenanceTag(
+                source_type=SourceType.AGENT_INFERENCE,
+                source_id="run-1",
+                confidence=-0.1,
+            )
+
+    def test_confidence_above_one_rejected(self) -> None:
+        with pytest.raises(ValueError, match=r"\[0.0, 1.0\]"):
+            ProvenanceTag(
+                source_type=SourceType.AGENT_INFERENCE,
+                source_id="run-1",
+                confidence=1.5,
+            )
+
+    def test_ttl_without_valid_until_rejected(self) -> None:
+        with pytest.raises(ValueError, match="valid_until"):
+            ProvenanceTag(
+                source_type=SourceType.TOOL_OUTPUT,
+                source_id="audit-1",
+                expiry_policy=ExpiryPolicy.TTL,
+            )
+
+    def test_valid_from_after_valid_until_rejected(self) -> None:
+        with pytest.raises(ValueError, match="valid_from"):
+            ProvenanceTag(
+                source_type=SourceType.CONFIG_IMPORT,
+                source_id="config.yaml",
+                valid_from=_utc(2026, 5, 5),
+                valid_until=_utc(2026, 5, 4),
+            )
+
+    def test_valid_from_equal_to_valid_until_allowed(self) -> None:
+        # Edge case — single-instant validity is legal.
+        instant = _utc(2026, 5, 4, 12, 0)
+        tag = ProvenanceTag(
+            source_type=SourceType.SCHEDULED_INGEST,
+            source_id="cron-1",
+            valid_from=instant,
+            valid_until=instant,
+            expiry_policy=ExpiryPolicy.TTL,
+        )
+        assert tag.valid_from == tag.valid_until
+
+
+# ---------------------------------------------------------------------------
+# ProvenanceLedger basic ops
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceLedgerBasic:
+    def test_empty_ledger(self) -> None:
+        ledger = ProvenanceLedger()
+        assert len(ledger) == 0
+        assert ledger.current("missing") is None
+        assert ledger.chain("missing") == ()
+        assert "missing" not in ledger
+
+    def test_tag_appends_to_chain(self) -> None:
+        ledger = ProvenanceLedger()
+        tag = ProvenanceTag(source_type=SourceType.TOOL_OUTPUT, source_id="audit-1")
+        ledger.tag("item-1", tag)
+        assert len(ledger) == 1
+        assert "item-1" in ledger
+        assert ledger.current("item-1") is tag
+        assert ledger.chain("item-1") == (tag,)
+
+    def test_tag_empty_item_id_rejected(self) -> None:
+        ledger = ProvenanceLedger()
+        tag = ProvenanceTag(source_type=SourceType.UNKNOWN, source_id="x")
+        with pytest.raises(ValueError, match="non-empty"):
+            ledger.tag("", tag)
+
+    def test_tag_appends_history(self) -> None:
+        ledger = ProvenanceLedger()
+        t1 = ProvenanceTag(source_type=SourceType.CHAT_UTTERANCE, source_id="msg-1")
+        t2 = ProvenanceTag(source_type=SourceType.AGENT_INFERENCE, source_id="run-1")
+        ledger.tag("item-1", t1)
+        ledger.tag("item-1", t2)
+        assert ledger.chain("item-1") == (t1, t2)
+        assert ledger.current("item-1") is t2
+
+    def test_remove_existing(self) -> None:
+        ledger = ProvenanceLedger()
+        ledger.tag(
+            "item-1",
+            ProvenanceTag(source_type=SourceType.UNKNOWN, source_id="x"),
+        )
+        assert ledger.remove("item-1") is True
+        assert "item-1" not in ledger
+
+    def test_remove_missing_returns_false(self) -> None:
+        ledger = ProvenanceLedger()
+        assert ledger.remove("nope") is False
+
+    def test_clear(self) -> None:
+        ledger = ProvenanceLedger()
+        ledger.tag(
+            "a",
+            ProvenanceTag(source_type=SourceType.UNKNOWN, source_id="x"),
+        )
+        ledger.tag(
+            "b",
+            ProvenanceTag(source_type=SourceType.UNKNOWN, source_id="y"),
+        )
+        ledger.clear()
+        assert len(ledger) == 0
+
+    def test_items_sorted_by_id(self) -> None:
+        ledger = ProvenanceLedger()
+        for item_id in ("zeta", "alpha", "mu"):
+            ledger.tag(
+                item_id,
+                ProvenanceTag(source_type=SourceType.UNKNOWN, source_id=item_id),
+            )
+        assert [k for k, _ in ledger.items()] == ["alpha", "mu", "zeta"]
+
+
+# ---------------------------------------------------------------------------
+# Expiry semantics
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceLedgerExpiry:
+    def test_permanent_never_expires(self) -> None:
+        ledger = ProvenanceLedger()
+        ledger.tag(
+            "item-1",
+            ProvenanceTag(
+                source_type=SourceType.CONFIG_IMPORT,
+                source_id="config.yaml",
+                expiry_policy=ExpiryPolicy.PERMANENT,
+            ),
+        )
+        far_future = _utc(2099, 1, 1)
+        assert ledger.expired(now=far_future) == []
+
+    def test_ttl_expires_after_valid_until(self) -> None:
+        ledger = ProvenanceLedger()
+        ledger.tag(
+            "item-1",
+            ProvenanceTag(
+                source_type=SourceType.TOOL_OUTPUT,
+                source_id="audit-1",
+                valid_from=_utc(2026, 5, 4, 0, 0),
+                valid_until=_utc(2026, 5, 4, 12, 0),
+                expiry_policy=ExpiryPolicy.TTL,
+            ),
+        )
+        assert ledger.expired(now=_utc(2026, 5, 4, 11, 0)) == []
+        assert ledger.expired(now=_utc(2026, 5, 4, 13, 0)) == ["item-1"]
+
+    def test_ttl_at_boundary_not_expired(self) -> None:
+        ledger = ProvenanceLedger()
+        boundary = _utc(2026, 5, 4, 12, 0)
+        ledger.tag(
+            "item-1",
+            ProvenanceTag(
+                source_type=SourceType.TOOL_OUTPUT,
+                source_id="audit-1",
+                valid_from=_utc(2026, 5, 4, 0, 0),
+                valid_until=boundary,
+                expiry_policy=ExpiryPolicy.TTL,
+            ),
+        )
+        # cutoff > valid_until is the expiry condition; at-boundary stays fresh.
+        assert ledger.expired(now=boundary) == []
+
+    def test_manual_never_auto_expires(self) -> None:
+        ledger = ProvenanceLedger()
+        ledger.tag(
+            "item-1",
+            ProvenanceTag(
+                source_type=SourceType.USER_DIRECTIVE,
+                source_id="owner-says",
+                valid_until=_utc(2020, 1, 1),
+                expiry_policy=ExpiryPolicy.MANUAL,
+            ),
+        )
+        assert ledger.expired(now=_utc(2099, 1, 1)) == []
+
+    def test_replace_on_new_not_reported_by_expired(self) -> None:
+        ledger = ProvenanceLedger()
+        old = ProvenanceTag(
+            source_type=SourceType.AGENT_INFERENCE,
+            source_id="run-1",
+            expiry_policy=ExpiryPolicy.REPLACE_ON_NEW,
+        )
+        new = ProvenanceTag(
+            source_type=SourceType.AGENT_INFERENCE,
+            source_id="run-2",
+            expiry_policy=ExpiryPolicy.REPLACE_ON_NEW,
+        )
+        ledger.tag("item-1", old)
+        ledger.tag("item-1", new)
+        # Head is fresh — superseded() reports the history.
+        assert ledger.expired(now=_utc(2099, 1, 1)) == []
+        assert ledger.superseded("item-1") == (old,)
+
+    def test_expired_default_now(self) -> None:
+        ledger = ProvenanceLedger()
+        ledger.tag(
+            "item-1",
+            ProvenanceTag(
+                source_type=SourceType.TOOL_OUTPUT,
+                source_id="audit-1",
+                valid_until=_utc(2020, 1, 1),
+                expiry_policy=ExpiryPolicy.TTL,
+            ),
+        )
+        # Default now() is real-time and definitely past 2020-01-01.
+        assert ledger.expired() == ["item-1"]
+
+    def test_expired_returns_sorted_ids(self) -> None:
+        ledger = ProvenanceLedger()
+        for item_id in ("zeta", "alpha", "mu"):
+            ledger.tag(
+                item_id,
+                ProvenanceTag(
+                    source_type=SourceType.TOOL_OUTPUT,
+                    source_id=item_id,
+                    valid_until=_utc(2020, 1, 1),
+                    expiry_policy=ExpiryPolicy.TTL,
+                ),
+            )
+        assert ledger.expired(now=_utc(2099, 1, 1)) == ["alpha", "mu", "zeta"]
+
+    def test_superseded_single_tag_returns_empty(self) -> None:
+        ledger = ProvenanceLedger()
+        ledger.tag(
+            "item-1",
+            ProvenanceTag(source_type=SourceType.UNKNOWN, source_id="x"),
+        )
+        assert ledger.superseded("item-1") == ()
+
+    def test_superseded_unknown_item(self) -> None:
+        ledger = ProvenanceLedger()
+        assert ledger.superseded("missing") == ()
+
+
+# ---------------------------------------------------------------------------
+# Filtering
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceLedgerFilter:
+    def test_filter_by_source_type(self) -> None:
+        ledger = ProvenanceLedger()
+        ledger.tag(
+            "a",
+            ProvenanceTag(source_type=SourceType.TOOL_OUTPUT, source_id="audit-1"),
+        )
+        ledger.tag(
+            "b",
+            ProvenanceTag(source_type=SourceType.CHAT_UTTERANCE, source_id="msg-1"),
+        )
+        ledger.tag(
+            "c",
+            ProvenanceTag(source_type=SourceType.TOOL_OUTPUT, source_id="audit-2"),
+        )
+        result = ledger.filter_by_source_type(SourceType.TOOL_OUTPUT)
+        assert [item_id for item_id, _ in result] == ["a", "c"]
+        assert all(tag.source_type == SourceType.TOOL_OUTPUT for _, tag in result)
+
+    def test_filter_by_source_id(self) -> None:
+        ledger = ProvenanceLedger()
+        # Two memory items derived from the same audit-log run.
+        ledger.tag(
+            "fact-1",
+            ProvenanceTag(source_type=SourceType.TOOL_OUTPUT, source_id="run-42"),
+        )
+        ledger.tag(
+            "fact-2",
+            ProvenanceTag(source_type=SourceType.TOOL_OUTPUT, source_id="run-42"),
+        )
+        ledger.tag(
+            "fact-3",
+            ProvenanceTag(source_type=SourceType.TOOL_OUTPUT, source_id="run-99"),
+        )
+        assert ledger.filter_by_source_id("run-42") == ["fact-1", "fact-2"]
+
+    def test_filter_uses_current_tag_only(self) -> None:
+        ledger = ProvenanceLedger()
+        ledger.tag(
+            "item-1",
+            ProvenanceTag(source_type=SourceType.CHAT_UTTERANCE, source_id="msg-1"),
+        )
+        ledger.tag(
+            "item-1",
+            ProvenanceTag(source_type=SourceType.TOOL_OUTPUT, source_id="audit-1"),
+        )
+        # Earlier CHAT_UTTERANCE tag is in the chain but not the head.
+        assert ledger.filter_by_source_type(SourceType.CHAT_UTTERANCE) == []
+        assert [item_id for item_id, _ in ledger.filter_by_source_type(SourceType.TOOL_OUTPUT)] == [
+            "item-1"
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Snapshot serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceLedgerSnapshot:
+    def test_snapshot_empty(self) -> None:
+        assert ProvenanceLedger().snapshot() == {}
+
+    def test_snapshot_round_trip_shape(self) -> None:
+        ledger = ProvenanceLedger()
+        ingested = _utc(2026, 5, 4, 12, 0)
+        valid_from = _utc(2026, 5, 4, 0, 0)
+        valid_until = _utc(2026, 5, 5, 0, 0)
+        tag = ProvenanceTag(
+            source_type=SourceType.TOOL_OUTPUT,
+            source_id="audit-1",
+            source_url="https://example.test/audit/1",
+            ingested_at=ingested,
+            valid_from=valid_from,
+            valid_until=valid_until,
+            expiry_policy=ExpiryPolicy.TTL,
+            confidence=0.85,
+            attribution_chain=("parent-1", "parent-2"),
+            notes="probe",
+        )
+        ledger.tag("item-1", tag)
+        snap = ledger.snapshot()
+        assert list(snap.keys()) == ["item-1"]
+        entry = snap["item-1"][0]
+        assert entry["source_type"] == "tool_output"
+        assert entry["source_id"] == "audit-1"
+        assert entry["source_url"] == "https://example.test/audit/1"
+        assert entry["ingested_at"] == ingested.isoformat()
+        assert entry["valid_from"] == valid_from.isoformat()
+        assert entry["valid_until"] == valid_until.isoformat()
+        assert entry["expiry_policy"] == "ttl"
+        assert entry["confidence"] == 0.85
+        assert entry["attribution_chain"] == ["parent-1", "parent-2"]
+        assert entry["notes"] == "probe"
+
+    def test_snapshot_handles_none_dates(self) -> None:
+        ledger = ProvenanceLedger()
+        ledger.tag(
+            "item-1",
+            ProvenanceTag(
+                source_type=SourceType.CONFIG_IMPORT,
+                source_id="config.yaml",
+            ),
+        )
+        entry = ledger.snapshot()["item-1"][0]
+        assert entry["valid_from"] is None
+        assert entry["valid_until"] is None
+
+    def test_snapshot_emits_full_chain_oldest_first(self) -> None:
+        ledger = ProvenanceLedger()
+        ledger.tag(
+            "item-1",
+            ProvenanceTag(source_type=SourceType.CHAT_UTTERANCE, source_id="msg-1"),
+        )
+        ledger.tag(
+            "item-1",
+            ProvenanceTag(source_type=SourceType.AGENT_INFERENCE, source_id="run-1"),
+        )
+        chain = ledger.snapshot()["item-1"]
+        assert len(chain) == 2
+        assert chain[0]["source_id"] == "msg-1"
+        assert chain[1]["source_id"] == "run-1"
+
+    def test_snapshot_keys_are_sorted(self) -> None:
+        ledger = ProvenanceLedger()
+        for item_id in ("z", "a", "m"):
+            ledger.tag(
+                item_id,
+                ProvenanceTag(source_type=SourceType.UNKNOWN, source_id=item_id),
+            )
+        assert list(ledger.snapshot().keys()) == ["a", "m", "z"]
+
+
+# ---------------------------------------------------------------------------
+# make_ttl_tag helper
+# ---------------------------------------------------------------------------
+
+
+class TestMakeTtlTag:
+    def test_builds_ttl_policy(self) -> None:
+        tag = make_ttl_tag(
+            source_type=SourceType.AGENT_INFERENCE,
+            source_id="run-42",
+            ttl=timedelta(hours=24),
+            confidence=0.7,
+            notes="extracted user timezone",
+        )
+        assert tag.expiry_policy == ExpiryPolicy.TTL
+        assert tag.valid_until is not None
+        assert tag.valid_from is not None
+        assert tag.valid_until - tag.valid_from == timedelta(hours=24)
+        assert tag.confidence == 0.7
+        assert tag.notes == "extracted user timezone"
+
+    def test_zero_ttl_allowed(self) -> None:
+        # A zero TTL is degenerate but not invalid — used as a fence
+        # by callers that immediately re-tag.
+        tag = make_ttl_tag(
+            source_type=SourceType.UNKNOWN,
+            source_id="probe",
+            ttl=timedelta(seconds=0),
+        )
+        assert tag.valid_from == tag.valid_until
+
+    def test_negative_ttl_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-negative"):
+            make_ttl_tag(
+                source_type=SourceType.UNKNOWN,
+                source_id="probe",
+                ttl=timedelta(seconds=-1),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+
+class TestProcessLocalLedger:
+    def test_default_ledger_is_a_provenance_ledger(self) -> None:
+        assert isinstance(PROVENANCE_LEDGER, ProvenanceLedger)


### PR DESCRIPTION
## Summary

TRUST-9 (memory provenance) foundation. Closes the reviewer-feedback gap that today's memory tiers each carry their own ad-hoc `source` / `created_at` fields, with no uniform contract that lets an operator answer **"where did this fact come from, when did it become true, when does it stop being true?"**

Ships the **foundation only** — wiring into the four memory tiers (semantic / vault / episodic / relations) is a deliberate follow-up so a single mergeable PR doesn't rewrite ten memory modules at once.

## What's in this PR

- `cognithor.memory.provenance.SourceType` — closed StrEnum (9 values). No Unknown-fallback branch needed downstream.
- `cognithor.memory.provenance.ExpiryPolicy` — `PERMANENT` / `TTL` / `REPLACE_ON_NEW` / `MANUAL`.
- `cognithor.memory.provenance.ProvenanceTag` — frozen dataclass with `__post_init__` validation: non-empty `source_id`, `confidence ∈ [0, 1]`, `TTL` requires `valid_until`, `valid_from <= valid_until`. Frozen so the ledger can hash + audit-embed without copy.
- `cognithor.memory.provenance.ProvenanceLedger` — append-only in-memory ledger keyed by `item_id`:
  - `tag()`, `chain()`, `current()`, `remove()`, `clear()`, `items()`
  - `expired(now=...)` honours policy semantics (TTL is the only auto-expiring path; head of REPLACE_ON_NEW is fresh by definition).
  - `superseded(item_id)` returns the prefix replaced by the head.
  - `filter_by_source_type()` / `filter_by_source_id()` — the latter answers "which memory items came from run XYZ?", a TRUST-1 receipt query.
  - `snapshot()` emits JSON-serialisable shape the TRUST-1 run-receipt can embed for the Trace-UI vertical-timeline render.
- `make_ttl_tag()` helper for the common LLM-inference case.
- `PROVENANCE_LEDGER` process-local default; tests construct fresh ledgers for isolation.

## Why a foundation PR (and not the full wiring)

The four memory tiers (`memory/semantic.py`, `memory/vault/`, `memory/episodic.py`, `memory/relations.py`) each have their own ingest paths, persistence layers, and fixture suites. Threading provenance into all four in one PR would balloon the diff past meaningful review. The foundation here is independently useful (Trace-UI / TRUST-1 receipts can embed snapshots immediately) and makes each tier-wiring PR small and bounded.

## Test plan

- [x] `pytest tests/test_memory/test_provenance.py -x -q` — 40 passed.
- [x] `mypy --strict src/cognithor/memory/provenance.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

40 cases across 7 classes cover: construction + validation, ledger basic ops, expiry semantics (incl. boundary + default-now), `filter_by_source_*` (head-only), `snapshot()` round-trip shape + sorted keys + chain ordering, `make_ttl_tag` edge cases.

## Follow-ups (deferred, separate PRs)

1. Tier wiring (semantic / vault / episodic / relations).
2. Disk persistence at `~/.cognithor/provenance.db` (SQLCipher).
3. TRUST-1 run-receipt extension to embed `ledger.snapshot()` for items touched during a run.
4. Flutter Trace-UI vertical-timeline widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)