### PR TITLE
feat(security): TRUST-7 ToolFingerprint foundation

### DIFF
--- a/src/cognithor/security/fingerprint.py
+++ b/src/cognithor/security/fingerprint.py
@@ -1,0 +1,345 @@
+"""``ToolFingerprint`` foundation (TRUST-7, operational-trust audit, 2026-05-04).
+
+Reviewer-feedback gap: when an operator inspects a memory item, an
+audit-log entry, or a run-receipt, they can reconstruct *what
+happened* (TRUST-1 receipts) and *why a decision was made*
+(TRUST-2 explanations) — but they cannot pin down **which exact
+implementation** produced the result. Was it ``web_fetch`` v1.4.1
+linked against urllib3 1.26.18, or v1.5.0 with the proxy-handling
+patch? Was the Planner running ``qwen3:30b`` with the 2025-12 weight
+hash or the 2026-04 retraining?
+
+Without that pinning, post-mortem reconstruction has a blind spot:
+"the same input produced different outputs" cannot be distinguished
+from "the same input produced the same output but you ran it against
+a different binary".
+
+This module ships the **foundation**: a frozen ``ToolFingerprint``
+dataclass + an in-memory ``FingerprintLedger`` indexed by content
+hash, plus a ``BinaryKind`` enum so consumers can switch on the kind
+of artefact (TOOL / MODEL / PACK / SCHEMA). Wiring this into the
+gateway boot path (one snapshot per process, embedded in every run
+receipt) is a deliberate follow-up — this layer stays storage-free.
+
+Contract:
+
+* Each fingerprint is keyed by ``content_hash`` (SHA-256 of the
+  underlying artefact's canonical bytes — Python source, model
+  weight file, pack zip, JSON schema).
+* The same logical artefact produces the **same** content_hash
+  across processes — fingerprints are deterministic, *not* keyed
+  by process-local pointers.
+* The ledger is **append-only**: re-registering the same hash is a
+  no-op (idempotent), but a new hash for the same logical name
+  appends a new entry, so an operator can spot
+  "``web_fetch`` had three different SHA-256s during this audit
+  window".
+* Inspectors carry the responsibility to compute the hash; the
+  module ships a ``hash_python_source(path)`` helper for the common
+  case but does not auto-discover artefacts (that's gateway-boot
+  territory).
+* No DB. The follow-up PR persists fingerprints alongside the audit
+  hash-chain; this layer stays memory-only for cheap testing.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+
+from cognithor.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Artefact typing
+# ---------------------------------------------------------------------------
+
+
+class BinaryKind(StrEnum):
+    """Kind of artefact a fingerprint pins.
+
+    The set is closed so consumers can switch on it without an
+    Unknown-fallback branch. Adding a new value is an intentional
+    review point.
+    """
+
+    TOOL = "tool"  # MCP tool implementation (Python source)
+    MODEL = "model"  # LLM weight file (qwen3, etc.)
+    PACK = "pack"  # Agent Pack zip / installed-tree root
+    SCHEMA = "schema"  # JSON-schema or pydantic model defining a contract
+    BINARY = "binary"  # Generic native binary (Ollama server, vLLM, etc.)
+
+
+# ---------------------------------------------------------------------------
+# Fingerprint
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ToolFingerprint:
+    """Immutable identity of a single artefact.
+
+    Frozen so the audit log can hash it for de-duplication and embed
+    it into run receipts without copy. ``content_hash`` is the
+    primary key; everything else is metadata.
+
+    Attributes
+    ----------
+    name:
+        Stable logical name. ``"web_fetch"`` for an MCP tool,
+        ``"qwen3:30b"`` for a model, ``"reddit-lead-hunter-pro"`` for
+        a pack. Doesn't change when the implementation evolves.
+    kind:
+        Which artefact category — see :class:`BinaryKind`.
+    content_hash:
+        Lowercase hex SHA-256 of the artefact's canonical bytes.
+        For Python source, the canonical bytes are the file content
+        with normalised line endings; for model weights, the on-disk
+        bytes; for pack zips, the zip bytes (not the unpacked tree).
+        64 lowercase-hex chars; the constructor enforces the shape.
+    version:
+        Best-effort semantic version string (``"1.4.1"``,
+        ``"2026.04.16"``, ``"v0.94.1"``). Empty when the artefact
+        carries no version metadata.
+    captured_at:
+        UTC timestamp the fingerprint was *computed* (not when the
+        artefact was created). Lets an operator distinguish "the
+        binary changed" from "we just re-scanned the same binary".
+    source_path:
+        Filesystem path the bytes came from. Empty for in-memory
+        artefacts. Useful for the audit log; not part of the identity
+        contract — two fingerprints with the same hash but different
+        source_paths are equal.
+    upstream_url:
+        Best-effort upstream URL (``"https://pypi.org/project/...``"``,
+        ``"https://huggingface.co/Qwen/..."``). Empty when unknown.
+    notes:
+        Free-text breadcrumb. Keep it short.
+    """
+
+    name: str
+    kind: BinaryKind
+    content_hash: str
+    version: str = ""
+    captured_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    source_path: str = ""
+    upstream_url: str = ""
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            msg = "ToolFingerprint.name must be a non-empty string"
+            raise ValueError(msg)
+        if len(self.content_hash) != 64 or any(
+            c not in "0123456789abcdef" for c in self.content_hash
+        ):
+            msg = (
+                "ToolFingerprint.content_hash must be 64 lowercase-hex "
+                f"chars (SHA-256), got {self.content_hash!r}"
+            )
+            raise ValueError(msg)
+
+    @property
+    def short_hash(self) -> str:
+        """First 12 hex chars — readable in logs / Trace-UI columns."""
+        return self.content_hash[:12]
+
+
+# ---------------------------------------------------------------------------
+# Ledger
+# ---------------------------------------------------------------------------
+
+
+class FingerprintLedger:
+    """Append-only in-memory ledger of fingerprints.
+
+    Two indices:
+
+    * ``content_hash → ToolFingerprint`` for O(1) "have I seen this
+      exact bytes before?" lookups.
+    * ``name → tuple[ToolFingerprint, ...]`` for "show me every SHA
+      I've seen for ``web_fetch``" (the audit-log query).
+
+    Tests construct fresh ledgers; production code uses
+    :data:`FINGERPRINT_LEDGER` (process-local default).
+    """
+
+    def __init__(self) -> None:
+        self._by_hash: dict[str, ToolFingerprint] = {}
+        self._by_name: dict[str, tuple[ToolFingerprint, ...]] = {}
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def register(self, fingerprint: ToolFingerprint) -> bool:
+        """Register ``fingerprint``. Returns True if it was new.
+
+        Idempotent: re-registering an identical hash is a no-op and
+        returns False. Registering a *new* hash for an existing name
+        appends to the name-index and returns True.
+        """
+        if fingerprint.content_hash in self._by_hash:
+            return False
+        self._by_hash[fingerprint.content_hash] = fingerprint
+        existing = self._by_name.get(fingerprint.name, ())
+        self._by_name[fingerprint.name] = (*existing, fingerprint)
+        return True
+
+    def remove(self, content_hash: str) -> bool:
+        """Drop a fingerprint by hash. Returns True iff it existed.
+
+        Removes the entry from both indices. Used by the test suite
+        and by post-mortem replay; production code shouldn't normally
+        forget fingerprints.
+        """
+        fp = self._by_hash.pop(content_hash, None)
+        if fp is None:
+            return False
+        chain = self._by_name.get(fp.name, ())
+        new_chain = tuple(f for f in chain if f.content_hash != content_hash)
+        if new_chain:
+            self._by_name[fp.name] = new_chain
+        else:
+            self._by_name.pop(fp.name, None)
+        return True
+
+    def clear(self) -> None:
+        self._by_hash.clear()
+        self._by_name.clear()
+
+    # ------------------------------------------------------------------
+    # Lookup
+    # ------------------------------------------------------------------
+
+    def get(self, content_hash: str) -> ToolFingerprint | None:
+        """Return the fingerprint with ``content_hash`` or ``None``."""
+        return self._by_hash.get(content_hash)
+
+    def history(self, name: str) -> tuple[ToolFingerprint, ...]:
+        """Return every fingerprint registered under ``name`` (oldest first)."""
+        return self._by_name.get(name, ())
+
+    def names(self) -> list[str]:
+        """Return the set of registered names, sorted."""
+        return sorted(self._by_name)
+
+    def __contains__(self, content_hash: object) -> bool:
+        return content_hash in self._by_hash
+
+    def __len__(self) -> int:
+        return len(self._by_hash)
+
+    # ------------------------------------------------------------------
+    # Queries
+    # ------------------------------------------------------------------
+
+    def filter_by_kind(self, kind: BinaryKind) -> list[ToolFingerprint]:
+        """Return all fingerprints of a given kind, sorted by name then hash."""
+        return sorted(
+            (fp for fp in self._by_hash.values() if fp.kind == kind),
+            key=lambda fp: (fp.name, fp.content_hash),
+        )
+
+    def divergent_names(self) -> list[str]:
+        """Return names with more than one distinct hash registered.
+
+        Lets the audit-log surface "tools that changed during this
+        audit window" — the smoking-gun query when post-mortem
+        reconstruction shows behaviour drift.
+        """
+        return sorted(name for name, chain in self._by_name.items() if len(chain) > 1)
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> list[dict[str, object]]:
+        """JSON-serialisable snapshot.
+
+        Stable ordering: by ``name`` then by ``captured_at``. Embedded
+        in TRUST-1 run receipts so the Trace-UI can render
+        "fingerprints in scope at run time".
+        """
+        return [
+            {
+                "name": fp.name,
+                "kind": fp.kind.value,
+                "content_hash": fp.content_hash,
+                "short_hash": fp.short_hash,
+                "version": fp.version,
+                "captured_at": fp.captured_at.isoformat(),
+                "source_path": fp.source_path,
+                "upstream_url": fp.upstream_url,
+                "notes": fp.notes,
+            }
+            for fp in sorted(
+                self._by_hash.values(),
+                key=lambda f: (f.name, f.captured_at, f.content_hash),
+            )
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def hash_bytes(data: bytes) -> str:
+    """Lowercase-hex SHA-256 of ``data``."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def hash_python_source(path: Path | str) -> str:
+    """Lowercase-hex SHA-256 of the file at ``path`` with normalised line endings.
+
+    Reads as bytes, replaces ``b"\\r\\n"`` with ``b"\\n"`` so the same
+    Python file produces the same hash on Windows and POSIX
+    checkouts. Raises :class:`FileNotFoundError` if the file does not
+    exist.
+    """
+    p = Path(path)
+    raw = p.read_bytes()
+    canonical = raw.replace(b"\r\n", b"\n")
+    return hash_bytes(canonical)
+
+
+def fingerprint_python_tool(
+    *,
+    name: str,
+    path: Path | str,
+    version: str = "",
+    upstream_url: str = "",
+    notes: str = "",
+) -> ToolFingerprint:
+    """Build a TOOL-kind fingerprint for a Python source file.
+
+    Convenience wrapper for the gateway-boot path (one fingerprint
+    per registered MCP tool). Reads the file, normalises line
+    endings, computes SHA-256, builds the dataclass.
+    """
+    p = Path(path)
+    return ToolFingerprint(
+        name=name,
+        kind=BinaryKind.TOOL,
+        content_hash=hash_python_source(p),
+        version=version,
+        source_path=str(p),
+        upstream_url=upstream_url,
+        notes=notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Process-local default
+# ---------------------------------------------------------------------------
+
+# The gateway boot wires fingerprints into this instance via a
+# follow-up PR; the ledger stays empty in production until that
+# wiring lands. Tests construct their own :class:`FingerprintLedger`.
+FINGERPRINT_LEDGER: FingerprintLedger = FingerprintLedger()

--- a/tests/test_security/test_fingerprint.py
+++ b/tests/test_security/test_fingerprint.py
@@ -1,0 +1,360 @@
+"""Tests for the TRUST-7 ToolFingerprint foundation."""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cognithor.security.fingerprint import (
+    FINGERPRINT_LEDGER,
+    BinaryKind,
+    FingerprintLedger,
+    ToolFingerprint,
+    fingerprint_python_tool,
+    hash_bytes,
+    hash_python_source,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# A fixed valid SHA-256 hex string for unit tests where we need a
+# concrete hash but don't care about the underlying bytes.
+_HEX_A = "a" * 64
+_HEX_B = "b" * 64
+_HEX_C = "c" * 64
+_HEX_REAL = hash_bytes(b"hello\n")
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+# ---------------------------------------------------------------------------
+# ToolFingerprint construction + validation
+# ---------------------------------------------------------------------------
+
+
+class TestToolFingerprintBasics:
+    def test_minimal_fingerprint(self) -> None:
+        fp = ToolFingerprint(
+            name="web_fetch",
+            kind=BinaryKind.TOOL,
+            content_hash=_HEX_A,
+        )
+        assert fp.name == "web_fetch"
+        assert fp.kind == BinaryKind.TOOL
+        assert fp.content_hash == _HEX_A
+        assert fp.short_hash == "a" * 12
+        assert fp.version == ""
+        assert fp.source_path == ""
+        # captured_at defaults to now(UTC)
+        assert fp.captured_at.tzinfo == UTC
+
+    def test_short_hash_is_first_12(self) -> None:
+        fp = ToolFingerprint(
+            name="t",
+            kind=BinaryKind.TOOL,
+            content_hash=_HEX_REAL,
+        )
+        assert fp.short_hash == _HEX_REAL[:12]
+        assert len(fp.short_hash) == 12
+
+    def test_frozen_via_dataclass(self) -> None:
+        fp = ToolFingerprint(name="t", kind=BinaryKind.TOOL, content_hash=_HEX_A)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            fp.name = "other"  # type: ignore[misc]
+
+
+class TestToolFingerprintValidation:
+    def test_empty_name_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            ToolFingerprint(name="", kind=BinaryKind.TOOL, content_hash=_HEX_A)
+
+    def test_short_hash_rejected(self) -> None:
+        with pytest.raises(ValueError, match="64 lowercase-hex"):
+            ToolFingerprint(name="t", kind=BinaryKind.TOOL, content_hash="a" * 16)
+
+    def test_uppercase_hex_rejected(self) -> None:
+        # The constructor enforces lowercase to keep the index stable.
+        with pytest.raises(ValueError, match="64 lowercase-hex"):
+            ToolFingerprint(name="t", kind=BinaryKind.TOOL, content_hash="A" * 64)
+
+    def test_non_hex_rejected(self) -> None:
+        with pytest.raises(ValueError, match="64 lowercase-hex"):
+            ToolFingerprint(name="t", kind=BinaryKind.TOOL, content_hash="z" * 64)
+
+    def test_equality_by_value(self) -> None:
+        # Frozen dataclasses are equal field-wise. Two fingerprints
+        # with the same hash but different captured_at values are
+        # NOT equal — `captured_at` is part of the dataclass identity.
+        captured = _utc(2026, 5, 4, 12, 0)
+        a = ToolFingerprint(
+            name="t",
+            kind=BinaryKind.TOOL,
+            content_hash=_HEX_A,
+            captured_at=captured,
+        )
+        b = ToolFingerprint(
+            name="t",
+            kind=BinaryKind.TOOL,
+            content_hash=_HEX_A,
+            captured_at=captured,
+        )
+        assert a == b
+        assert hash(a) == hash(b)
+
+
+# ---------------------------------------------------------------------------
+# FingerprintLedger basic ops
+# ---------------------------------------------------------------------------
+
+
+class TestFingerprintLedgerBasic:
+    def test_empty_ledger(self) -> None:
+        ledger = FingerprintLedger()
+        assert len(ledger) == 0
+        assert ledger.get(_HEX_A) is None
+        assert ledger.history("web_fetch") == ()
+        assert ledger.names() == []
+        assert _HEX_A not in ledger
+
+    def test_register_returns_true_first_time(self) -> None:
+        ledger = FingerprintLedger()
+        fp = ToolFingerprint(name="web_fetch", kind=BinaryKind.TOOL, content_hash=_HEX_A)
+        assert ledger.register(fp) is True
+        assert _HEX_A in ledger
+        assert ledger.get(_HEX_A) is fp
+        assert ledger.history("web_fetch") == (fp,)
+
+    def test_register_idempotent_for_same_hash(self) -> None:
+        ledger = FingerprintLedger()
+        fp1 = ToolFingerprint(name="web_fetch", kind=BinaryKind.TOOL, content_hash=_HEX_A)
+        fp2 = ToolFingerprint(
+            name="web_fetch",
+            kind=BinaryKind.TOOL,
+            content_hash=_HEX_A,
+            notes="re-scan",
+        )
+        assert ledger.register(fp1) is True
+        # Same hash → second register is a no-op even with different metadata.
+        assert ledger.register(fp2) is False
+        assert ledger.get(_HEX_A) is fp1
+        assert ledger.history("web_fetch") == (fp1,)
+
+    def test_register_new_hash_appends_to_name_history(self) -> None:
+        ledger = FingerprintLedger()
+        old = ToolFingerprint(name="web_fetch", kind=BinaryKind.TOOL, content_hash=_HEX_A)
+        new = ToolFingerprint(name="web_fetch", kind=BinaryKind.TOOL, content_hash=_HEX_B)
+        ledger.register(old)
+        ledger.register(new)
+        assert ledger.history("web_fetch") == (old, new)
+        assert len(ledger) == 2
+
+    def test_remove_existing(self) -> None:
+        ledger = FingerprintLedger()
+        fp = ToolFingerprint(name="web_fetch", kind=BinaryKind.TOOL, content_hash=_HEX_A)
+        ledger.register(fp)
+        assert ledger.remove(_HEX_A) is True
+        assert _HEX_A not in ledger
+        # name index also pruned
+        assert ledger.history("web_fetch") == ()
+        assert ledger.names() == []
+
+    def test_remove_keeps_other_versions_under_same_name(self) -> None:
+        ledger = FingerprintLedger()
+        old = ToolFingerprint(name="web_fetch", kind=BinaryKind.TOOL, content_hash=_HEX_A)
+        new = ToolFingerprint(name="web_fetch", kind=BinaryKind.TOOL, content_hash=_HEX_B)
+        ledger.register(old)
+        ledger.register(new)
+        assert ledger.remove(_HEX_A) is True
+        # The newer version stays under the same name.
+        assert ledger.history("web_fetch") == (new,)
+        assert _HEX_B in ledger
+
+    def test_remove_missing_returns_false(self) -> None:
+        ledger = FingerprintLedger()
+        assert ledger.remove(_HEX_A) is False
+
+    def test_clear(self) -> None:
+        ledger = FingerprintLedger()
+        ledger.register(ToolFingerprint(name="a", kind=BinaryKind.TOOL, content_hash=_HEX_A))
+        ledger.register(ToolFingerprint(name="b", kind=BinaryKind.MODEL, content_hash=_HEX_B))
+        ledger.clear()
+        assert len(ledger) == 0
+        assert ledger.names() == []
+
+    def test_names_sorted(self) -> None:
+        ledger = FingerprintLedger()
+        for name, h in (("zeta", _HEX_A), ("alpha", _HEX_B), ("mu", _HEX_C)):
+            ledger.register(ToolFingerprint(name=name, kind=BinaryKind.TOOL, content_hash=h))
+        assert ledger.names() == ["alpha", "mu", "zeta"]
+
+
+# ---------------------------------------------------------------------------
+# Queries
+# ---------------------------------------------------------------------------
+
+
+class TestFingerprintLedgerQueries:
+    def test_filter_by_kind(self) -> None:
+        ledger = FingerprintLedger()
+        tool = ToolFingerprint(name="web_fetch", kind=BinaryKind.TOOL, content_hash=_HEX_A)
+        model = ToolFingerprint(name="qwen3:30b", kind=BinaryKind.MODEL, content_hash=_HEX_B)
+        pack = ToolFingerprint(name="reddit-pro", kind=BinaryKind.PACK, content_hash=_HEX_C)
+        ledger.register(tool)
+        ledger.register(model)
+        ledger.register(pack)
+        assert ledger.filter_by_kind(BinaryKind.TOOL) == [tool]
+        assert ledger.filter_by_kind(BinaryKind.MODEL) == [model]
+        assert ledger.filter_by_kind(BinaryKind.PACK) == [pack]
+        assert ledger.filter_by_kind(BinaryKind.SCHEMA) == []
+
+    def test_filter_by_kind_sorted(self) -> None:
+        ledger = FingerprintLedger()
+        for name, h in (("zeta", _HEX_A), ("alpha", _HEX_B)):
+            ledger.register(ToolFingerprint(name=name, kind=BinaryKind.TOOL, content_hash=h))
+        result = ledger.filter_by_kind(BinaryKind.TOOL)
+        assert [fp.name for fp in result] == ["alpha", "zeta"]
+
+    def test_divergent_names_finds_only_multi_hash_names(self) -> None:
+        ledger = FingerprintLedger()
+        # web_fetch has two SHAs (drifted); read_file has one (stable).
+        ledger.register(
+            ToolFingerprint(name="web_fetch", kind=BinaryKind.TOOL, content_hash=_HEX_A)
+        )
+        ledger.register(
+            ToolFingerprint(name="web_fetch", kind=BinaryKind.TOOL, content_hash=_HEX_B)
+        )
+        ledger.register(
+            ToolFingerprint(name="read_file", kind=BinaryKind.TOOL, content_hash=_HEX_C)
+        )
+        assert ledger.divergent_names() == ["web_fetch"]
+
+
+# ---------------------------------------------------------------------------
+# Snapshot serialisation
+# ---------------------------------------------------------------------------
+
+
+class TestFingerprintLedgerSnapshot:
+    def test_snapshot_empty(self) -> None:
+        assert FingerprintLedger().snapshot() == []
+
+    def test_snapshot_round_trip_shape(self) -> None:
+        ledger = FingerprintLedger()
+        captured = _utc(2026, 5, 4, 12, 0)
+        fp = ToolFingerprint(
+            name="web_fetch",
+            kind=BinaryKind.TOOL,
+            content_hash=_HEX_REAL,
+            version="1.4.1",
+            captured_at=captured,
+            source_path="/tmp/web_fetch.py",
+            upstream_url="https://pypi.org/project/web-fetch/",
+            notes="initial scan",
+        )
+        ledger.register(fp)
+        snap = ledger.snapshot()
+        assert len(snap) == 1
+        entry = snap[0]
+        assert entry["name"] == "web_fetch"
+        assert entry["kind"] == "tool"
+        assert entry["content_hash"] == _HEX_REAL
+        assert entry["short_hash"] == _HEX_REAL[:12]
+        assert entry["version"] == "1.4.1"
+        assert entry["captured_at"] == captured.isoformat()
+        assert entry["source_path"] == "/tmp/web_fetch.py"
+        assert entry["upstream_url"] == "https://pypi.org/project/web-fetch/"
+        assert entry["notes"] == "initial scan"
+
+    def test_snapshot_sorted_by_name_then_captured_at(self) -> None:
+        ledger = FingerprintLedger()
+        early = _utc(2026, 5, 4, 10, 0)
+        late = _utc(2026, 5, 4, 12, 0)
+        # Same name, two timestamps — ascending captured_at expected.
+        ledger.register(
+            ToolFingerprint(
+                name="web_fetch",
+                kind=BinaryKind.TOOL,
+                content_hash=_HEX_B,
+                captured_at=late,
+            )
+        )
+        ledger.register(
+            ToolFingerprint(
+                name="web_fetch",
+                kind=BinaryKind.TOOL,
+                content_hash=_HEX_A,
+                captured_at=early,
+            )
+        )
+        # Different name comes second alphabetically.
+        ledger.register(
+            ToolFingerprint(
+                name="zzz_other",
+                kind=BinaryKind.TOOL,
+                content_hash=_HEX_C,
+                captured_at=early,
+            )
+        )
+        snap = ledger.snapshot()
+        assert [(e["name"], e["content_hash"]) for e in snap] == [
+            ("web_fetch", _HEX_A),
+            ("web_fetch", _HEX_B),
+            ("zzz_other", _HEX_C),
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Hashing helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHashHelpers:
+    def test_hash_bytes_deterministic(self) -> None:
+        h = hash_bytes(b"hello world\n")
+        assert len(h) == 64
+        assert h == hash_bytes(b"hello world\n")
+
+    def test_hash_python_source_normalises_line_endings(self, tmp_path: Path) -> None:
+        # Two files, identical content but Windows vs POSIX line endings,
+        # must hash to the same value.
+        unix = tmp_path / "unix.py"
+        win = tmp_path / "win.py"
+        unix.write_bytes(b"def x():\n    return 1\n")
+        win.write_bytes(b"def x():\r\n    return 1\r\n")
+        assert hash_python_source(unix) == hash_python_source(win)
+
+    def test_hash_python_source_missing_file_raises(self, tmp_path: Path) -> None:
+        with pytest.raises(FileNotFoundError):
+            hash_python_source(tmp_path / "does_not_exist.py")
+
+    def test_fingerprint_python_tool_builds_tool_kind(self, tmp_path: Path) -> None:
+        src = tmp_path / "tool.py"
+        src.write_bytes(b"def run():\n    return 'ok'\n")
+        fp = fingerprint_python_tool(
+            name="my_tool",
+            path=src,
+            version="0.1.0",
+            upstream_url="https://example.test/my_tool",
+        )
+        assert fp.kind == BinaryKind.TOOL
+        assert fp.name == "my_tool"
+        assert fp.version == "0.1.0"
+        assert fp.upstream_url == "https://example.test/my_tool"
+        assert fp.source_path == str(src)
+        assert fp.content_hash == hash_python_source(src)
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+
+class TestProcessLocalLedger:
+    def test_default_ledger_is_a_fingerprint_ledger(self) -> None:
+        assert isinstance(FINGERPRINT_LEDGER, FingerprintLedger)


### PR DESCRIPTION
## Summary

TRUST-7 (tool/model SHA-pinning) foundation. Closes the reviewer-feedback gap where post-mortem reconstruction can answer **what** happened and **why** a decision was made, but **not which exact implementation produced the result** — the smoking-gun question when the same input produces different outputs.

Ships the **foundation only** — wiring into the gateway boot path (one snapshot per process, embedded in TRUST-1 run receipts) is a deliberate follow-up.

## What's in this PR

- `cognithor.security.fingerprint.BinaryKind` — closed StrEnum (`TOOL` / `MODEL` / `PACK` / `SCHEMA` / `BINARY`).
- `cognithor.security.fingerprint.ToolFingerprint` — frozen dataclass keyed by SHA-256 content hash. `__post_init__` validates the 64-lowercase-hex shape so the indexer never has to deal with malformed hashes. `short_hash` property returns first-12 chars for log/UI use.
- `cognithor.security.fingerprint.FingerprintLedger` with dual-index:
  - `by_hash` for O(1) "have I seen these exact bytes before?" lookup.
  - `by_name` for "show me every SHA I've seen for `web_fetch`" — the audit-log query.
  - `register()` is idempotent for identical hashes, appends history for new hashes under existing names.
  - `divergent_names()` surfaces names with > 1 distinct hash — the smoking-gun query when behaviour drift shows up in post-mortem.
  - `filter_by_kind()` / `snapshot()` with deterministic sort orders.
- `hash_python_source()` normalises CRLF→LF so the same Python file produces the same hash on Windows and POSIX checkouts.
- `fingerprint_python_tool()` convenience wrapper for the gateway-boot path.
- `FINGERPRINT_LEDGER` process-local default; tests construct fresh ledgers for isolation.

## Why a foundation PR (and not the full wiring)

Wiring fingerprints into the gateway boot path requires touching every MCP-tool registration site, the Ollama/vLLM model loaders, and the `PackLoader.discover_packs()` path. That's a 10+ file diff that wouldn't review well in one go. The foundation here is independently useful (the Trace-UI / TRUST-1 receipts can embed snapshots immediately) and makes each subsequent wiring PR small and bounded.

## Test plan

- [x] `pytest tests/test_security/test_fingerprint.py -x -q` — 28 passed.
- [x] `mypy --strict src/cognithor/security/fingerprint.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

28 cases across 7 classes cover: fingerprint construction + validation (incl. uppercase + non-hex rejection), ledger basic ops (idempotent register, name-history pruning on remove, sorted names), queries (filter_by_kind, divergent names), snapshot serialisation (sort order), hashing helpers (determinism, CRLF normalisation, missing-file raises).

## Follow-ups (deferred, separate PRs)

1. Gateway-boot wiring: register every MCP tool / model / pack on init.
2. TRUST-1 run-receipt extension to embed `ledger.snapshot()` for fingerprints in scope at run time.
3. Audit-log emit on `divergent_names()` non-empty (warns the operator that an artefact changed mid-session).
4. Disk persistence next to the audit hash-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)