### PR TITLE
feat(security): TRUST-8 cloud-escalation ledger foundation

### DIFF
--- a/src/cognithor/security/cloud_escalation.py
+++ b/src/cognithor/security/cloud_escalation.py
@@ -1,0 +1,309 @@
+"""``EscalationEvent`` foundation (TRUST-8, operational-trust audit, 2026-05-04).
+
+Reviewer-feedback gap: cognithor's selling point is "local-first", and
+the gateway routes most calls to Ollama on the operator's machine.
+But there are paths where a request *does* leave the machine — context
+overflow falling back to a 200k-window cloud model, an explicit
+owner override (``/cloud claude please summarise``), or a graceful
+degradation when the local backend is down. Today there is no
+**uniform contract** to log those escalations: they happen scattered
+across the backend layer with different log shapes (or no log at all).
+
+For an operator who needs to answer privacy / cost / compliance
+questions, that is unacceptable. "Did this query leave the machine?"
+must be a single ledger lookup, not a grep across N log files.
+
+This module ships the **foundation**: a frozen ``EscalationEvent``
+dataclass + an in-memory ``EscalationLedger`` with append-only
+semantics + summary queries. Wiring this into the backend dispatch
+layer (one event per cloud call, fired from
+``cognithor.backends.dispatch``) is a deliberate follow-up.
+
+**Privacy contract**: the event records *metadata only* — backend ids,
+token counts, USD cost, timestamps. **No prompt content, no model
+output**. The operator trusts cognithor's own audit log; this module
+must not become a back-channel that re-leaks the very content
+escalation was logged to track.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+
+from cognithor.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Reason taxonomy
+# ---------------------------------------------------------------------------
+
+
+class EscalationReason(StrEnum):
+    """Why a request was escalated from local to cloud.
+
+    Closed set so consumers can switch on it for downstream UX
+    (the Trace-UI renders different icons per reason). Adding a new
+    value is an intentional review point — privacy implications.
+    """
+
+    LOCAL_BACKEND_DOWN = "local_backend_down"
+    CONTEXT_TOO_LARGE = "context_too_large"
+    MODEL_NOT_AVAILABLE_LOCALLY = "model_not_available_locally"
+    OWNER_OVERRIDE = "owner_override"
+    RATE_LIMITED_LOCAL = "rate_limited_local"
+    COST_BUDGET_DECISION = "cost_budget_decision"
+    QUALITY_THRESHOLD = "quality_threshold"
+    UNKNOWN = "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Event
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EscalationEvent:
+    """Metadata-only record of a single local→cloud escalation.
+
+    Frozen so the audit log can hash + embed it without copy.
+
+    Privacy contract — these fields are intentionally sufficient for
+    audit but insufficient for content-reconstruction:
+
+    * ``from_backend`` / ``to_backend`` — backend ids only
+      (``"ollama:qwen3:30b"``, ``"anthropic:claude-opus-4-7"``).
+    * ``prompt_tokens`` / ``response_tokens`` — counts only.
+    * ``cost_usd_micro`` — integer micro-USD (1/1_000_000 USD) so the
+      ledger can sum without float drift.
+    * ``owner_consented`` — boolean derived from explicit override or
+      pre-approved auto-escalation policy.
+    * ``run_id`` / ``request_id`` — primary keys to cross-reference
+      with the TRUST-1 run-receipt and audit hash-chain. Empty when
+      the call happened outside a tracked run (e.g. background
+      summarisation).
+    * ``notes`` — short free-text. Must NOT contain prompt or
+      response content; the ledger trusts the caller to obey this
+      and is documented as such.
+
+    The shape is intentionally narrow — TRUST-1 receipts already
+    carry the full per-step audit trail; this module exists to
+    answer "did the request leave the machine?" in O(1).
+    """
+
+    reason: EscalationReason
+    from_backend: str
+    to_backend: str
+    prompt_tokens: int
+    response_tokens: int
+    cost_usd_micro: int = 0
+    started_at: datetime = field(default_factory=lambda: datetime.now(UTC))
+    completed_at: datetime | None = None
+    owner_consented: bool = False
+    run_id: str = ""
+    request_id: str = ""
+    notes: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.from_backend:
+            msg = "EscalationEvent.from_backend must be a non-empty string"
+            raise ValueError(msg)
+        if not self.to_backend:
+            msg = "EscalationEvent.to_backend must be a non-empty string"
+            raise ValueError(msg)
+        if self.prompt_tokens < 0:
+            msg = f"EscalationEvent.prompt_tokens must be non-negative, got {self.prompt_tokens}"
+            raise ValueError(msg)
+        if self.response_tokens < 0:
+            msg = (
+                f"EscalationEvent.response_tokens must be non-negative, got {self.response_tokens}"
+            )
+            raise ValueError(msg)
+        if self.cost_usd_micro < 0:
+            msg = f"EscalationEvent.cost_usd_micro must be non-negative, got {self.cost_usd_micro}"
+            raise ValueError(msg)
+        if self.completed_at is not None and self.completed_at < self.started_at:
+            msg = (
+                f"EscalationEvent.completed_at ({self.completed_at.isoformat()}) "
+                f"must be >= started_at ({self.started_at.isoformat()})"
+            )
+            raise ValueError(msg)
+
+    @property
+    def cost_usd(self) -> float:
+        """USD cost as a float — for display, not for accumulation.
+
+        Use the integer ``cost_usd_micro`` for sums to avoid float
+        drift; this property is for the Trace-UI cell.
+        """
+        return self.cost_usd_micro / 1_000_000.0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.response_tokens
+
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class EscalationSummary:
+    """Aggregate over an :class:`EscalationLedger` window.
+
+    Used by the Trace-UI cost-overview tile and the optional CLI
+    ``cognithor cloud-escalations`` report.
+    """
+
+    event_count: int
+    total_prompt_tokens: int
+    total_response_tokens: int
+    total_cost_usd_micro: int
+    by_reason: dict[EscalationReason, int]
+    by_destination: dict[str, int]
+
+    @property
+    def total_cost_usd(self) -> float:
+        return self.total_cost_usd_micro / 1_000_000.0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.total_prompt_tokens + self.total_response_tokens
+
+
+# ---------------------------------------------------------------------------
+# Ledger
+# ---------------------------------------------------------------------------
+
+
+class EscalationLedger:
+    """Append-only in-memory ledger of cloud-escalation events.
+
+    Production code uses :data:`ESCALATION_LEDGER`; tests construct
+    fresh ledgers for isolation. The follow-up wiring PR fires one
+    ``record()`` call per cloud completion; nothing here actually
+    issues HTTP requests.
+    """
+
+    def __init__(self) -> None:
+        self._events: list[EscalationEvent] = []
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def record(self, event: EscalationEvent) -> None:
+        """Append ``event`` to the ledger."""
+        self._events.append(event)
+
+    def clear(self) -> None:
+        self._events.clear()
+
+    # ------------------------------------------------------------------
+    # Lookup
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        return len(self._events)
+
+    def events(self) -> tuple[EscalationEvent, ...]:
+        """Return all events in insertion order."""
+        return tuple(self._events)
+
+    def by_reason(self, reason: EscalationReason) -> tuple[EscalationEvent, ...]:
+        return tuple(e for e in self._events if e.reason == reason)
+
+    def by_destination(self, to_backend: str) -> tuple[EscalationEvent, ...]:
+        return tuple(e for e in self._events if e.to_backend == to_backend)
+
+    def by_run(self, run_id: str) -> tuple[EscalationEvent, ...]:
+        """Events tied to ``run_id`` — the TRUST-1 cross-reference query."""
+        if not run_id:
+            return ()
+        return tuple(e for e in self._events if e.run_id == run_id)
+
+    def in_window(self, *, start: datetime, end: datetime) -> tuple[EscalationEvent, ...]:
+        """Events with ``start <= started_at <= end``."""
+        if start > end:
+            msg = "in_window: start must be <= end"
+            raise ValueError(msg)
+        return tuple(e for e in self._events if start <= e.started_at <= end)
+
+    # ------------------------------------------------------------------
+    # Summary
+    # ------------------------------------------------------------------
+
+    def summarise(
+        self,
+        events: tuple[EscalationEvent, ...] | None = None,
+    ) -> EscalationSummary:
+        """Aggregate ``events`` (or the full ledger if ``None``).
+
+        Works with the result of any ``by_*`` / ``in_window`` query
+        for sub-window summaries.
+        """
+        scope = events if events is not None else tuple(self._events)
+        by_reason: dict[EscalationReason, int] = {}
+        by_destination: dict[str, int] = {}
+        total_prompt = 0
+        total_response = 0
+        total_cost = 0
+        for ev in scope:
+            by_reason[ev.reason] = by_reason.get(ev.reason, 0) + 1
+            by_destination[ev.to_backend] = by_destination.get(ev.to_backend, 0) + 1
+            total_prompt += ev.prompt_tokens
+            total_response += ev.response_tokens
+            total_cost += ev.cost_usd_micro
+        return EscalationSummary(
+            event_count=len(scope),
+            total_prompt_tokens=total_prompt,
+            total_response_tokens=total_response,
+            total_cost_usd_micro=total_cost,
+            by_reason=by_reason,
+            by_destination=by_destination,
+        )
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> list[dict[str, object]]:
+        """JSON-serialisable snapshot in insertion order.
+
+        Embedded in TRUST-1 run receipts when the run had any
+        escalations; the Trace-UI renders one row per event.
+        """
+        return [
+            {
+                "reason": ev.reason.value,
+                "from_backend": ev.from_backend,
+                "to_backend": ev.to_backend,
+                "prompt_tokens": ev.prompt_tokens,
+                "response_tokens": ev.response_tokens,
+                "cost_usd_micro": ev.cost_usd_micro,
+                "cost_usd": round(ev.cost_usd, 6),
+                "started_at": ev.started_at.isoformat(),
+                "completed_at": (
+                    ev.completed_at.isoformat() if ev.completed_at is not None else None
+                ),
+                "owner_consented": ev.owner_consented,
+                "run_id": ev.run_id,
+                "request_id": ev.request_id,
+                "notes": ev.notes,
+            }
+            for ev in self._events
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Process-local default
+# ---------------------------------------------------------------------------
+
+# Backend dispatch wires into this instance via a follow-up PR; the
+# ledger stays empty in production until that wiring lands. Tests
+# construct their own :class:`EscalationLedger` for isolation.
+ESCALATION_LEDGER: EscalationLedger = EscalationLedger()

--- a/tests/test_security/test_cloud_escalation.py
+++ b/tests/test_security/test_cloud_escalation.py
@@ -1,0 +1,378 @@
+"""Tests for the TRUST-8 cloud-escalation ledger foundation."""
+
+from __future__ import annotations
+
+import dataclasses
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from cognithor.security.cloud_escalation import (
+    ESCALATION_LEDGER,
+    EscalationEvent,
+    EscalationLedger,
+    EscalationReason,
+    EscalationSummary,
+)
+
+
+def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
+    return datetime(year, month, day, hour, minute, tzinfo=UTC)
+
+
+def _event(
+    *,
+    reason: EscalationReason = EscalationReason.CONTEXT_TOO_LARGE,
+    from_backend: str = "ollama:qwen3:30b",
+    to_backend: str = "anthropic:claude-opus-4-7",
+    prompt_tokens: int = 1000,
+    response_tokens: int = 200,
+    cost_usd_micro: int = 12_000,
+    started_at: datetime | None = None,
+    completed_at: datetime | None = None,
+    owner_consented: bool = False,
+    run_id: str = "",
+    request_id: str = "",
+    notes: str = "",
+) -> EscalationEvent:
+    """Test helper — minimal event with sane defaults."""
+    return EscalationEvent(
+        reason=reason,
+        from_backend=from_backend,
+        to_backend=to_backend,
+        prompt_tokens=prompt_tokens,
+        response_tokens=response_tokens,
+        cost_usd_micro=cost_usd_micro,
+        started_at=started_at if started_at is not None else _utc(2026, 5, 4, 12, 0),
+        completed_at=completed_at,
+        owner_consented=owner_consented,
+        run_id=run_id,
+        request_id=request_id,
+        notes=notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# EscalationEvent construction + validation
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationEventBasics:
+    def test_minimal_event(self) -> None:
+        ev = EscalationEvent(
+            reason=EscalationReason.OWNER_OVERRIDE,
+            from_backend="ollama:qwen3:30b",
+            to_backend="anthropic:claude-opus-4-7",
+            prompt_tokens=512,
+            response_tokens=128,
+        )
+        assert ev.cost_usd_micro == 0
+        assert ev.cost_usd == 0.0
+        assert ev.total_tokens == 640
+        assert ev.completed_at is None
+        assert ev.owner_consented is False
+        assert ev.started_at.tzinfo == UTC
+
+    def test_cost_usd_property(self) -> None:
+        ev = _event(cost_usd_micro=2_500_000)  # $2.50
+        assert ev.cost_usd == 2.5
+
+    def test_frozen_via_dataclass(self) -> None:
+        ev = _event()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            ev.notes = "tamper"  # type: ignore[misc]
+
+
+class TestEscalationEventValidation:
+    def test_empty_from_backend_rejected(self) -> None:
+        with pytest.raises(ValueError, match="from_backend"):
+            EscalationEvent(
+                reason=EscalationReason.UNKNOWN,
+                from_backend="",
+                to_backend="anthropic:claude-opus-4-7",
+                prompt_tokens=0,
+                response_tokens=0,
+            )
+
+    def test_empty_to_backend_rejected(self) -> None:
+        with pytest.raises(ValueError, match="to_backend"):
+            EscalationEvent(
+                reason=EscalationReason.UNKNOWN,
+                from_backend="ollama:x",
+                to_backend="",
+                prompt_tokens=0,
+                response_tokens=0,
+            )
+
+    def test_negative_prompt_tokens_rejected(self) -> None:
+        with pytest.raises(ValueError, match="prompt_tokens"):
+            _event(prompt_tokens=-1)
+
+    def test_negative_response_tokens_rejected(self) -> None:
+        with pytest.raises(ValueError, match="response_tokens"):
+            _event(response_tokens=-1)
+
+    def test_negative_cost_rejected(self) -> None:
+        with pytest.raises(ValueError, match="cost_usd_micro"):
+            _event(cost_usd_micro=-1)
+
+    def test_completed_before_started_rejected(self) -> None:
+        with pytest.raises(ValueError, match="completed_at"):
+            _event(
+                started_at=_utc(2026, 5, 4, 13, 0),
+                completed_at=_utc(2026, 5, 4, 12, 0),
+            )
+
+    def test_completed_equal_started_allowed(self) -> None:
+        # Edge case — instantaneous escalation (cached response).
+        instant = _utc(2026, 5, 4, 12, 0)
+        ev = _event(started_at=instant, completed_at=instant)
+        assert ev.completed_at == ev.started_at
+
+
+# ---------------------------------------------------------------------------
+# EscalationLedger basic ops
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationLedgerBasic:
+    def test_empty_ledger(self) -> None:
+        ledger = EscalationLedger()
+        assert len(ledger) == 0
+        assert ledger.events() == ()
+        assert ledger.by_reason(EscalationReason.UNKNOWN) == ()
+        assert ledger.by_destination("anthropic:claude-opus-4-7") == ()
+        assert ledger.by_run("run-1") == ()
+
+    def test_record_appends(self) -> None:
+        ledger = EscalationLedger()
+        ev = _event()
+        ledger.record(ev)
+        assert len(ledger) == 1
+        assert ledger.events() == (ev,)
+
+    def test_record_preserves_insertion_order(self) -> None:
+        ledger = EscalationLedger()
+        e1 = _event(notes="first", started_at=_utc(2026, 5, 4, 10, 0))
+        e2 = _event(notes="second", started_at=_utc(2026, 5, 4, 11, 0))
+        e3 = _event(notes="third", started_at=_utc(2026, 5, 4, 12, 0))
+        ledger.record(e1)
+        ledger.record(e2)
+        ledger.record(e3)
+        assert ledger.events() == (e1, e2, e3)
+
+    def test_clear(self) -> None:
+        ledger = EscalationLedger()
+        ledger.record(_event())
+        ledger.record(_event())
+        ledger.clear()
+        assert len(ledger) == 0
+
+
+class TestEscalationLedgerFilter:
+    def test_by_reason(self) -> None:
+        ledger = EscalationLedger()
+        owner = _event(reason=EscalationReason.OWNER_OVERRIDE, notes="owner")
+        oversized = _event(reason=EscalationReason.CONTEXT_TOO_LARGE, notes="big")
+        owner2 = _event(reason=EscalationReason.OWNER_OVERRIDE, notes="owner2")
+        ledger.record(owner)
+        ledger.record(oversized)
+        ledger.record(owner2)
+        assert ledger.by_reason(EscalationReason.OWNER_OVERRIDE) == (owner, owner2)
+        assert ledger.by_reason(EscalationReason.CONTEXT_TOO_LARGE) == (oversized,)
+        assert ledger.by_reason(EscalationReason.UNKNOWN) == ()
+
+    def test_by_destination(self) -> None:
+        ledger = EscalationLedger()
+        e1 = _event(to_backend="anthropic:claude-opus-4-7")
+        e2 = _event(to_backend="openai:gpt-5")
+        e3 = _event(to_backend="anthropic:claude-opus-4-7")
+        ledger.record(e1)
+        ledger.record(e2)
+        ledger.record(e3)
+        assert ledger.by_destination("anthropic:claude-opus-4-7") == (e1, e3)
+        assert ledger.by_destination("openai:gpt-5") == (e2,)
+        assert ledger.by_destination("missing") == ()
+
+    def test_by_run_skips_empty_run_id(self) -> None:
+        ledger = EscalationLedger()
+        ledger.record(_event(run_id=""))
+        # An empty run_id query must NOT match the empty-run_id events,
+        # otherwise the cross-reference becomes meaningless.
+        assert ledger.by_run("") == ()
+
+    def test_by_run(self) -> None:
+        ledger = EscalationLedger()
+        e1 = _event(run_id="run-42")
+        e2 = _event(run_id="run-99")
+        e3 = _event(run_id="run-42")
+        ledger.record(e1)
+        ledger.record(e2)
+        ledger.record(e3)
+        assert ledger.by_run("run-42") == (e1, e3)
+        assert ledger.by_run("run-99") == (e2,)
+        assert ledger.by_run("run-missing") == ()
+
+    def test_in_window(self) -> None:
+        ledger = EscalationLedger()
+        e1 = _event(started_at=_utc(2026, 5, 4, 10, 0))
+        e2 = _event(started_at=_utc(2026, 5, 4, 11, 0))
+        e3 = _event(started_at=_utc(2026, 5, 4, 12, 0))
+        ledger.record(e1)
+        ledger.record(e2)
+        ledger.record(e3)
+        result = ledger.in_window(start=_utc(2026, 5, 4, 10, 30), end=_utc(2026, 5, 4, 11, 30))
+        assert result == (e2,)
+
+    def test_in_window_inclusive_at_boundaries(self) -> None:
+        ledger = EscalationLedger()
+        ev = _event(started_at=_utc(2026, 5, 4, 12, 0))
+        ledger.record(ev)
+        # Both ends inclusive.
+        assert ledger.in_window(start=_utc(2026, 5, 4, 12, 0), end=_utc(2026, 5, 4, 12, 0)) == (ev,)
+
+    def test_in_window_invalid_range_rejected(self) -> None:
+        with pytest.raises(ValueError, match="start"):
+            EscalationLedger().in_window(start=_utc(2026, 5, 4, 12, 0), end=_utc(2026, 5, 4, 11, 0))
+
+
+# ---------------------------------------------------------------------------
+# Summarise
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationSummary:
+    def test_empty_summary(self) -> None:
+        summary = EscalationLedger().summarise()
+        assert isinstance(summary, EscalationSummary)
+        assert summary.event_count == 0
+        assert summary.total_tokens == 0
+        assert summary.total_cost_usd == 0.0
+        assert summary.by_reason == {}
+        assert summary.by_destination == {}
+
+    def test_full_ledger_summary(self) -> None:
+        ledger = EscalationLedger()
+        ledger.record(
+            _event(
+                reason=EscalationReason.OWNER_OVERRIDE,
+                to_backend="anthropic:claude-opus-4-7",
+                prompt_tokens=1000,
+                response_tokens=200,
+                cost_usd_micro=15_000,
+            )
+        )
+        ledger.record(
+            _event(
+                reason=EscalationReason.CONTEXT_TOO_LARGE,
+                to_backend="openai:gpt-5",
+                prompt_tokens=20_000,
+                response_tokens=2_000,
+                cost_usd_micro=200_000,
+            )
+        )
+        ledger.record(
+            _event(
+                reason=EscalationReason.OWNER_OVERRIDE,
+                to_backend="anthropic:claude-opus-4-7",
+                prompt_tokens=500,
+                response_tokens=100,
+                cost_usd_micro=8_000,
+            )
+        )
+        summary = ledger.summarise()
+        assert summary.event_count == 3
+        assert summary.total_prompt_tokens == 21_500
+        assert summary.total_response_tokens == 2_300
+        assert summary.total_tokens == 23_800
+        assert summary.total_cost_usd_micro == 223_000
+        assert summary.total_cost_usd == 0.223
+        assert summary.by_reason == {
+            EscalationReason.OWNER_OVERRIDE: 2,
+            EscalationReason.CONTEXT_TOO_LARGE: 1,
+        }
+        assert summary.by_destination == {
+            "anthropic:claude-opus-4-7": 2,
+            "openai:gpt-5": 1,
+        }
+
+    def test_summarise_subset(self) -> None:
+        # summarise() accepts the result of any by_* query — used for
+        # per-run cost reports.
+        ledger = EscalationLedger()
+        ledger.record(_event(run_id="run-42", cost_usd_micro=10_000))
+        ledger.record(_event(run_id="run-99", cost_usd_micro=99_999))
+        ledger.record(_event(run_id="run-42", cost_usd_micro=20_000))
+        run42 = ledger.by_run("run-42")
+        summary = ledger.summarise(run42)
+        assert summary.event_count == 2
+        assert summary.total_cost_usd_micro == 30_000
+
+
+# ---------------------------------------------------------------------------
+# Snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestEscalationLedgerSnapshot:
+    def test_snapshot_empty(self) -> None:
+        assert EscalationLedger().snapshot() == []
+
+    def test_snapshot_round_trip_shape(self) -> None:
+        ledger = EscalationLedger()
+        started = _utc(2026, 5, 4, 12, 0)
+        completed = started + timedelta(seconds=5)
+        ev = _event(
+            reason=EscalationReason.OWNER_OVERRIDE,
+            from_backend="ollama:qwen3:30b",
+            to_backend="anthropic:claude-opus-4-7",
+            prompt_tokens=1234,
+            response_tokens=200,
+            cost_usd_micro=15_000,
+            started_at=started,
+            completed_at=completed,
+            owner_consented=True,
+            run_id="run-42",
+            request_id="req-7",
+            notes="user typed /cloud",
+        )
+        ledger.record(ev)
+        snap = ledger.snapshot()
+        assert len(snap) == 1
+        entry = snap[0]
+        assert entry["reason"] == "owner_override"
+        assert entry["from_backend"] == "ollama:qwen3:30b"
+        assert entry["to_backend"] == "anthropic:claude-opus-4-7"
+        assert entry["prompt_tokens"] == 1234
+        assert entry["response_tokens"] == 200
+        assert entry["cost_usd_micro"] == 15_000
+        assert entry["cost_usd"] == 0.015
+        assert entry["started_at"] == started.isoformat()
+        assert entry["completed_at"] == completed.isoformat()
+        assert entry["owner_consented"] is True
+        assert entry["run_id"] == "run-42"
+        assert entry["request_id"] == "req-7"
+        assert entry["notes"] == "user typed /cloud"
+
+    def test_snapshot_handles_none_completed_at(self) -> None:
+        ledger = EscalationLedger()
+        ledger.record(_event(completed_at=None))
+        assert ledger.snapshot()[0]["completed_at"] is None
+
+    def test_snapshot_preserves_insertion_order(self) -> None:
+        ledger = EscalationLedger()
+        ledger.record(_event(notes="first"))
+        ledger.record(_event(notes="second"))
+        ledger.record(_event(notes="third"))
+        notes = [entry["notes"] for entry in ledger.snapshot()]
+        assert notes == ["first", "second", "third"]
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+
+class TestProcessLocalLedger:
+    def test_default_ledger_is_an_escalation_ledger(self) -> None:
+        assert isinstance(ESCALATION_LEDGER, EscalationLedger)


### PR DESCRIPTION
## Summary

TRUST-8 (local→cloud escalation log) foundation. Closes the reviewer-feedback gap where cognithor sells itself as **local-first**, but there is no uniform contract to log the paths where a request *does* leave the operator's machine — context overflow, owner override, graceful degradation. **"Did this query leave my machine?"** must be a single ledger lookup, not a grep across N log files.

Ships the **foundation only** — wiring into the backend dispatch layer (one event per cloud completion) is a deliberate follow-up.

## Privacy contract (intentional design)

The event records **metadata only**: backend ids, token counts, USD cost (integer micro-USD to dodge float drift), timestamps. **No prompt content, no model output.** The TRUST-1 run-receipt already carries the full per-step audit trail; this module exists to answer "did the request leave the machine?" in O(1).

## What's in this PR

- `cognithor.security.cloud_escalation.EscalationReason` — closed StrEnum (8 values). Each carries privacy implications, so adding a new value is an intentional review point.
- `cognithor.security.cloud_escalation.EscalationEvent` — frozen dataclass with `__post_init__` validation: non-empty backend ids, non-negative tokens + cost, `completed_at >= started_at`. `cost_usd_micro` is the canonical sum-safe form; `cost_usd` is a display property only.
- `cognithor.security.cloud_escalation.EscalationLedger` — append-only, with filters `by_reason` / `by_destination` / `by_run` (TRUST-1 cross-reference query — empty `run_id` is treated as "no match" so the cross-ref stays meaningful) / `in_window` (inclusive at boundaries, raises on inverted ranges).
- `summarise()` aggregates the full ledger or any sub-tuple from a `by_*` / `in_window` call — used for per-run cost reports.
- `snapshot()` emits insertion-order JSON for embedding in TRUST-1 run receipts.
- `EscalationSummary` frozen dataclass — `event_count`, total tokens (prompt + response), total cost (micro + display), `by_reason` and `by_destination` histograms.
- `ESCALATION_LEDGER` process-local default; tests construct fresh ledgers for isolation.

## Why a foundation PR

Wiring this into the backend dispatch layer requires touching every cloud-bound code path (Anthropic, OpenAI, Gemini, Mistral, Together, Groq, etc.) plus the rate-limited fallback in `model_router`. That's a 12+ file diff that wouldn't review well in one go. The foundation here is independently useful (Trace-UI / TRUST-1 receipts can embed snapshots immediately) and makes each subsequent backend-wiring PR small and bounded.

## Test plan

- [x] `pytest tests/test_security/test_cloud_escalation.py -x -q` — 29 passed.
- [x] `mypy --strict src/cognithor/security/cloud_escalation.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

29 cases across 7 classes cover: event construction + validation (incl. inverted-range rejection + boundary equality), ledger basic ops (insertion order preserved, clear), filter queries (by_reason / by_destination / by_run including empty-run_id guard, in_window inclusive at boundaries), summarise (empty + full ledger + subset of by_run), snapshot round-trip + None-completed_at + insertion-order preservation.

## Follow-ups (deferred, separate PRs)

1. Backend-dispatch wiring: one `record()` call per cloud completion across `cognithor.backends.*`.
2. TRUST-1 run-receipt extension to embed `ledger.snapshot()` per run.
3. CLI report `cognithor cloud-escalations --since=...` for ad-hoc audits.
4. Flutter Trace-UI cost-overview tile (uses `EscalationSummary`).
5. Disk persistence next to the audit hash-chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)