### PR TITLE
feat(security): TRUST-1 trust-bundle composer

### DIFF
--- a/src/cognithor/security/trust_bundle.py
+++ b/src/cognithor/security/trust_bundle.py
@@ -1,0 +1,227 @@
+"""TRUST-1 receipt bundle composer (operational-trust audit, 2026-05-04).
+
+The six TRUST-5..10 foundations each ship their own in-memory ledger:
+
+* :data:`cognithor.security.permission_scope.SCOPE_REGISTRY` (TRUST-5)
+* :data:`cognithor.security.cost_ledger.COST_LEDGER` (TRUST-6)
+* :data:`cognithor.security.fingerprint.FINGERPRINT_LEDGER` (TRUST-7)
+* :data:`cognithor.security.cloud_escalation.ESCALATION_LEDGER` (TRUST-8)
+* :data:`cognithor.memory.provenance.PROVENANCE_LEDGER` (TRUST-9)
+* :data:`cognithor.security.migration_ledger.MIGRATION_LEDGER` (TRUST-10)
+
+The TRUST-1 :meth:`~cognithor.audit.AuditLogger.run_receipt` API stops
+at audit-entry aggregation. To answer the reviewer-feedback question
+**"can an operator reconstruct exactly what the agent knew, what it
+decided, which tool it called, why it was allowed, what changed, and
+how to roll it back?"** we need to fold the six ledger snapshots into
+the same receipt.
+
+This module is the glue. ``build_trust_bundle(run_id, *, ledgers=None)``
+returns a single JSON-serialisable dict that the receipt API can
+embed under a top-level ``"trust"`` key. Filterable views per-run for
+the ledgers that carry a ``run_id`` axis (cost + escalation); full
+snapshots for the rest, since they describe *the world the agent
+ran in* (fingerprints, provenance, migrations) or are session-scoped
+already (permission scopes).
+
+The bundle is *additive* on TRUST-1 — existing consumers see no
+change to ``run_receipt()`` until they opt in.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from cognithor.memory.provenance import PROVENANCE_LEDGER
+from cognithor.security.cloud_escalation import ESCALATION_LEDGER
+from cognithor.security.cost_ledger import COST_LEDGER
+from cognithor.security.fingerprint import FINGERPRINT_LEDGER
+from cognithor.security.migration_ledger import MIGRATION_LEDGER
+from cognithor.security.permission_scope import SCOPE_REGISTRY
+
+if TYPE_CHECKING:
+    from cognithor.memory.provenance import ProvenanceLedger
+    from cognithor.security.cloud_escalation import EscalationLedger
+    from cognithor.security.cost_ledger import CostLedger
+    from cognithor.security.fingerprint import FingerprintLedger
+    from cognithor.security.migration_ledger import MigrationLedger
+    from cognithor.security.permission_scope import ScopeRegistry
+
+
+# Schema version of the trust-bundle. Bump on breaking changes
+# (renamed keys, removed sections, new required fields). Additive
+# additions don't bump.
+TRUST_BUNDLE_SCHEMA_VERSION = 1
+
+
+@dataclass(frozen=True)
+class TrustLedgers:
+    """Override-bag so callers can inject test ledgers.
+
+    Production code passes ``None`` to :func:`build_trust_bundle` and
+    gets the canonical process-local instances. Tests construct fresh
+    ledgers and pass them via :func:`build_trust_bundle(...,
+    ledgers=TrustLedgers(...))` to keep state isolated.
+    """
+
+    permission_scope: ScopeRegistry = SCOPE_REGISTRY
+    cost: CostLedger = COST_LEDGER
+    fingerprint: FingerprintLedger = FINGERPRINT_LEDGER
+    escalation: EscalationLedger = ESCALATION_LEDGER
+    provenance: ProvenanceLedger = PROVENANCE_LEDGER
+    migration: MigrationLedger = MIGRATION_LEDGER
+
+
+def _scope_snapshot(registry: ScopeRegistry) -> list[dict[str, object]]:
+    """Build a JSON-serialisable scope snapshot.
+
+    ``ScopeRegistry`` does not expose a built-in snapshot method —
+    this helper formats the active scopes into the same shape as the
+    other foundations (sorted by axis + identity, sets coerced to
+    sorted lists).
+    """
+    out: list[dict[str, object]] = []
+    for scope in registry.list_scopes():
+        out.append(
+            {
+                "axis": scope.axis.value,
+                "identity": scope.identity,
+                "tool_allowlist": sorted(scope.tool_allowlist),
+                "tool_denylist": sorted(scope.tool_denylist),
+                "max_risk": scope.max_risk.value,
+            }
+        )
+    return out
+
+
+def build_trust_bundle(
+    run_id: str,
+    *,
+    ledgers: TrustLedgers | None = None,
+) -> dict[str, object]:
+    """Compose the cross-ledger trust bundle for ``run_id``.
+
+    Parameters
+    ----------
+    run_id:
+        TRUST-1 run / session id. Used to filter the ledgers that
+        carry a ``run_id`` axis (:class:`CostLedger`,
+        :class:`EscalationLedger`). When empty, those sections come
+        out empty too — they would otherwise dump every cost ever,
+        which the receipt doesn't want.
+    ledgers:
+        Inject test instances. ``None`` ⇒ canonical process-local
+        ledgers.
+
+    Returns
+    -------
+    Dict shape::
+
+        {
+          "schema_version": 1,
+          "run_id": "<run_id>",
+          "permission_scopes": [{...}, ...],
+          "cost": {
+            "summary": {
+              "entry_count": int,
+              "total_cost_usd_micro": int,
+              "total_cost_usd": float,
+              "by_kind": {<kind>: micro_usd, ...},
+              "by_tool": {...},
+              "by_backend": {...},
+            },
+            "entries": [{...}, ...]
+          },
+          "fingerprints": {
+            "all": [{...}, ...],
+            "divergent_names": [str, ...]
+          },
+          "escalations": {
+            "summary": {...},
+            "entries": [{...}, ...]
+          },
+          "provenance": {<item_id>: [{...}, ...]},
+          "migrations": {"head_version": {...}, "steps": [{...}, ...]}
+        }
+    """
+    actual_ledgers = ledgers if ledgers is not None else TrustLedgers()
+
+    # --- Permission scopes (full snapshot — registry is process-scoped).
+    scopes = _scope_snapshot(actual_ledgers.permission_scope)
+
+    # --- Cost (run-scoped where possible).
+    cost_entries = actual_ledgers.cost.by_run(run_id) if run_id else ()
+    cost_summary = actual_ledgers.cost.summarise(cost_entries)
+    cost_block = {
+        "summary": {
+            "entry_count": cost_summary.entry_count,
+            "total_cost_usd_micro": cost_summary.total_cost_usd_micro,
+            "total_cost_usd": round(cost_summary.total_cost_usd, 6),
+            "by_kind": {kind.value: amount for kind, amount in cost_summary.by_kind.items()},
+            "by_tool": dict(cost_summary.by_tool),
+            "by_backend": dict(cost_summary.by_backend),
+        },
+        "entries": (
+            [entry for entry in actual_ledgers.cost.snapshot() if entry.get("run_id") == run_id]
+            if run_id
+            else []
+        ),
+    }
+
+    # --- Fingerprints (full snapshot — describes the boot-time world).
+    fingerprints_block = {
+        "all": actual_ledgers.fingerprint.snapshot(),
+        "divergent_names": actual_ledgers.fingerprint.divergent_names(),
+    }
+
+    # --- Cloud-escalations (run-scoped).
+    escalation_events = actual_ledgers.escalation.by_run(run_id) if run_id else ()
+    escalation_summary = actual_ledgers.escalation.summarise(escalation_events)
+    escalation_block = {
+        "summary": {
+            "event_count": escalation_summary.event_count,
+            "total_prompt_tokens": escalation_summary.total_prompt_tokens,
+            "total_response_tokens": escalation_summary.total_response_tokens,
+            "total_tokens": escalation_summary.total_tokens,
+            "total_cost_usd_micro": escalation_summary.total_cost_usd_micro,
+            "total_cost_usd": round(escalation_summary.total_cost_usd, 6),
+            "by_reason": {
+                reason.value: count for reason, count in escalation_summary.by_reason.items()
+            },
+            "by_destination": dict(escalation_summary.by_destination),
+        },
+        "entries": (
+            [
+                entry
+                for entry in actual_ledgers.escalation.snapshot()
+                if entry.get("run_id") == run_id
+            ]
+            if run_id
+            else []
+        ),
+    }
+
+    # --- Provenance (full snapshot — memory items don't carry run_id).
+    provenance_block = actual_ledgers.provenance.snapshot()
+
+    # --- Migrations (full snapshot — describes the schema chain).
+    migrations_block = actual_ledgers.migration.snapshot()
+
+    return {
+        "schema_version": TRUST_BUNDLE_SCHEMA_VERSION,
+        "run_id": run_id,
+        "permission_scopes": scopes,
+        "cost": cost_block,
+        "fingerprints": fingerprints_block,
+        "escalations": escalation_block,
+        "provenance": provenance_block,
+        "migrations": migrations_block,
+    }
+
+
+__all__ = [
+    "TRUST_BUNDLE_SCHEMA_VERSION",
+    "TrustLedgers",
+    "build_trust_bundle",
+]

--- a/tests/test_security/test_trust_bundle.py
+++ b/tests/test_security/test_trust_bundle.py
@@ -1,0 +1,352 @@
+"""Tests for the TRUST-1 trust-bundle composer."""
+
+from __future__ import annotations
+
+from cognithor.memory.provenance import (
+    ExpiryPolicy,
+    ProvenanceLedger,
+    ProvenanceTag,
+    SourceType,
+)
+from cognithor.models import RiskLevel
+from cognithor.security.cloud_escalation import (
+    EscalationEvent,
+    EscalationLedger,
+    EscalationReason,
+)
+from cognithor.security.cost_ledger import (
+    CostEntry,
+    CostKind,
+    CostLedger,
+)
+from cognithor.security.fingerprint import (
+    BinaryKind,
+    FingerprintLedger,
+    ToolFingerprint,
+)
+from cognithor.security.migration_ledger import (
+    MigrationDomain,
+    MigrationLedger,
+    MigrationStatus,
+    MigrationStep,
+)
+from cognithor.security.permission_scope import (
+    PermissionScope,
+    ScopeAxis,
+    ScopeRegistry,
+)
+from cognithor.security.trust_bundle import (
+    TRUST_BUNDLE_SCHEMA_VERSION,
+    TrustLedgers,
+    build_trust_bundle,
+)
+
+_HEX_A = "a" * 64
+_HEX_B = "b" * 64
+
+
+def _isolated_ledgers() -> TrustLedgers:
+    """Build a TrustLedgers with all-fresh ledger instances."""
+    return TrustLedgers(
+        permission_scope=ScopeRegistry(),
+        cost=CostLedger(),
+        fingerprint=FingerprintLedger(),
+        escalation=EscalationLedger(),
+        provenance=ProvenanceLedger(),
+        migration=MigrationLedger(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Empty bundle
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyBundle:
+    def test_empty_inputs_produce_well_shaped_bundle(self) -> None:
+        bundle = build_trust_bundle("run-42", ledgers=_isolated_ledgers())
+        assert bundle["schema_version"] == TRUST_BUNDLE_SCHEMA_VERSION
+        assert bundle["run_id"] == "run-42"
+        assert bundle["permission_scopes"] == []
+        assert bundle["cost"] == {
+            "summary": {
+                "entry_count": 0,
+                "total_cost_usd_micro": 0,
+                "total_cost_usd": 0.0,
+                "by_kind": {},
+                "by_tool": {},
+                "by_backend": {},
+            },
+            "entries": [],
+        }
+        assert bundle["fingerprints"] == {"all": [], "divergent_names": []}
+        assert bundle["escalations"]["summary"]["event_count"] == 0
+        assert bundle["escalations"]["entries"] == []
+        assert bundle["provenance"] == {}
+        assert bundle["migrations"] == {"head_version": {}, "steps": []}
+
+    def test_empty_run_id_keeps_run_scoped_sections_empty(self) -> None:
+        # Even if ledgers contain entries, an empty run_id must NOT
+        # leak every cost/escalation entry into the bundle.
+        ledgers = _isolated_ledgers()
+        ledgers.cost.record(
+            CostEntry(
+                kind=CostKind.LLM_INFERENCE,
+                tool="qwen3:30b",
+                cost_usd_micro=10_000,
+                run_id="run-42",
+            )
+        )
+        ledgers.escalation.record(
+            EscalationEvent(
+                reason=EscalationReason.OWNER_OVERRIDE,
+                from_backend="ollama:qwen3:30b",
+                to_backend="anthropic:claude-opus-4-7",
+                prompt_tokens=100,
+                response_tokens=50,
+                run_id="run-42",
+            )
+        )
+        bundle = build_trust_bundle("", ledgers=ledgers)
+        assert bundle["cost"]["entries"] == []
+        assert bundle["cost"]["summary"]["entry_count"] == 0
+        assert bundle["escalations"]["entries"] == []
+        assert bundle["escalations"]["summary"]["event_count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Run filtering
+# ---------------------------------------------------------------------------
+
+
+class TestRunScopedFiltering:
+    def test_cost_filter_by_run(self) -> None:
+        ledgers = _isolated_ledgers()
+        ledgers.cost.record(
+            CostEntry(
+                kind=CostKind.LLM_INFERENCE,
+                tool="qwen3:30b",
+                cost_usd_micro=10_000,
+                run_id="run-42",
+            )
+        )
+        ledgers.cost.record(
+            CostEntry(
+                kind=CostKind.LLM_INFERENCE,
+                tool="anthropic:claude-opus-4-7",
+                cost_usd_micro=99_999,
+                run_id="run-99",
+            )
+        )
+        bundle = build_trust_bundle("run-42", ledgers=ledgers)
+        cost = bundle["cost"]
+        assert isinstance(cost, dict)
+        summary = cost["summary"]
+        assert isinstance(summary, dict)
+        assert summary["entry_count"] == 1
+        assert summary["total_cost_usd_micro"] == 10_000
+        entries = cost["entries"]
+        assert isinstance(entries, list)
+        assert len(entries) == 1
+        assert entries[0]["tool"] == "qwen3:30b"
+        assert entries[0]["run_id"] == "run-42"
+
+    def test_escalation_filter_by_run(self) -> None:
+        ledgers = _isolated_ledgers()
+        ledgers.escalation.record(
+            EscalationEvent(
+                reason=EscalationReason.OWNER_OVERRIDE,
+                from_backend="ollama:qwen3:30b",
+                to_backend="anthropic:claude-opus-4-7",
+                prompt_tokens=1000,
+                response_tokens=200,
+                cost_usd_micro=15_000,
+                run_id="run-42",
+            )
+        )
+        ledgers.escalation.record(
+            EscalationEvent(
+                reason=EscalationReason.CONTEXT_TOO_LARGE,
+                from_backend="ollama:qwen3:30b",
+                to_backend="openai:gpt-5",
+                prompt_tokens=20_000,
+                response_tokens=2_000,
+                cost_usd_micro=200_000,
+                run_id="run-99",
+            )
+        )
+        bundle = build_trust_bundle("run-42", ledgers=ledgers)
+        escalations = bundle["escalations"]
+        assert isinstance(escalations, dict)
+        summary = escalations["summary"]
+        assert isinstance(summary, dict)
+        assert summary["event_count"] == 1
+        assert summary["total_cost_usd_micro"] == 15_000
+        assert summary["by_reason"] == {"owner_override": 1}
+        entries = escalations["entries"]
+        assert isinstance(entries, list)
+        assert len(entries) == 1
+        assert entries[0]["run_id"] == "run-42"
+
+
+# ---------------------------------------------------------------------------
+# Full snapshot sections
+# ---------------------------------------------------------------------------
+
+
+class TestFullSnapshotSections:
+    def test_permission_scope_snapshot_inline(self) -> None:
+        ledgers = _isolated_ledgers()
+        ledgers.permission_scope.register(
+            PermissionScope(
+                axis=ScopeAxis.CHANNEL,
+                identity="telegram",
+                tool_allowlist=frozenset({"web_search", "memory_search"}),
+                tool_denylist=frozenset(),
+                max_risk=RiskLevel.YELLOW,
+            )
+        )
+        ledgers.permission_scope.register(
+            PermissionScope(
+                axis=ScopeAxis.USER,
+                identity="alex",
+                tool_allowlist=frozenset(),
+                tool_denylist=frozenset({"shell"}),
+                max_risk=RiskLevel.RED,
+            )
+        )
+        bundle = build_trust_bundle("run-42", ledgers=ledgers)
+        scopes = bundle["permission_scopes"]
+        assert isinstance(scopes, list)
+        assert len(scopes) == 2
+        # list_scopes() sorts by (axis, identity) — channel before user.
+        assert scopes[0]["axis"] == "channel"
+        assert scopes[0]["identity"] == "telegram"
+        assert scopes[0]["tool_allowlist"] == ["memory_search", "web_search"]
+        assert scopes[0]["tool_denylist"] == []
+        assert scopes[0]["max_risk"] == "yellow"
+        assert scopes[1]["axis"] == "user"
+        assert scopes[1]["tool_denylist"] == ["shell"]
+
+    def test_fingerprint_snapshot_includes_divergent_names(self) -> None:
+        ledgers = _isolated_ledgers()
+        ledgers.fingerprint.register(
+            ToolFingerprint(
+                name="web_fetch",
+                kind=BinaryKind.TOOL,
+                content_hash=_HEX_A,
+            )
+        )
+        ledgers.fingerprint.register(
+            ToolFingerprint(
+                name="web_fetch",
+                kind=BinaryKind.TOOL,
+                content_hash=_HEX_B,
+            )
+        )
+        bundle = build_trust_bundle("run-42", ledgers=ledgers)
+        fingerprints = bundle["fingerprints"]
+        assert isinstance(fingerprints, dict)
+        all_fps = fingerprints["all"]
+        assert isinstance(all_fps, list)
+        assert len(all_fps) == 2
+        assert fingerprints["divergent_names"] == ["web_fetch"]
+
+    def test_provenance_snapshot_full(self) -> None:
+        ledgers = _isolated_ledgers()
+        ledgers.provenance.tag(
+            "fact-1",
+            ProvenanceTag(
+                source_type=SourceType.TOOL_OUTPUT,
+                source_id="audit-7",
+                expiry_policy=ExpiryPolicy.PERMANENT,
+            ),
+        )
+        bundle = build_trust_bundle("run-42", ledgers=ledgers)
+        provenance = bundle["provenance"]
+        assert isinstance(provenance, dict)
+        assert "fact-1" in provenance
+        chain = provenance["fact-1"]
+        assert isinstance(chain, list)
+        assert len(chain) == 1
+        assert chain[0]["source_type"] == "tool_output"
+
+    def test_migration_snapshot_full(self) -> None:
+        ledgers = _isolated_ledgers()
+        ledgers.migration.record(
+            MigrationStep(
+                domain=MigrationDomain.AUDIT_LOG,
+                source_version="v1",
+                target_version="v2",
+                status=MigrationStatus.APPLIED,
+                migration_id="audit_log:v1:v2",
+            )
+        )
+        bundle = build_trust_bundle("run-42", ledgers=ledgers)
+        migrations = bundle["migrations"]
+        assert isinstance(migrations, dict)
+        assert migrations["head_version"] == {"audit_log": "v2"}
+        steps = migrations["steps"]
+        assert isinstance(steps, list)
+        assert len(steps) == 1
+
+
+# ---------------------------------------------------------------------------
+# Cross-ledger consistency
+# ---------------------------------------------------------------------------
+
+
+class TestCrossLedgerConsistency:
+    def test_run_id_stitches_cost_and_escalation(self) -> None:
+        # The same run_id must surface aligned data in both the cost
+        # and escalation sections — that's the value-add of the bundle.
+        ledgers = _isolated_ledgers()
+        ledgers.cost.record(
+            CostEntry(
+                kind=CostKind.LLM_INFERENCE,
+                tool="anthropic:claude-opus-4-7",
+                cost_usd_micro=15_000,
+                backend="anthropic",
+                run_id="run-42",
+            )
+        )
+        ledgers.escalation.record(
+            EscalationEvent(
+                reason=EscalationReason.OWNER_OVERRIDE,
+                from_backend="ollama:qwen3:30b",
+                to_backend="anthropic:claude-opus-4-7",
+                prompt_tokens=100,
+                response_tokens=50,
+                cost_usd_micro=15_000,
+                run_id="run-42",
+            )
+        )
+        bundle = build_trust_bundle("run-42", ledgers=ledgers)
+        cost = bundle["cost"]
+        escalations = bundle["escalations"]
+        assert isinstance(cost, dict)
+        assert isinstance(escalations, dict)
+        cost_summary = cost["summary"]
+        esc_summary = escalations["summary"]
+        assert isinstance(cost_summary, dict)
+        assert isinstance(esc_summary, dict)
+        # Same total — the operator can verify the two ledgers agree.
+        assert cost_summary["total_cost_usd_micro"] == esc_summary["total_cost_usd_micro"]
+
+    def test_canonical_ledgers_used_when_omitted(self) -> None:
+        # build_trust_bundle(...) without ledgers= must reach for the
+        # process-local singletons. We don't assert specific contents
+        # (production state may have been wired) — just that the keys
+        # are present and the schema is honoured.
+        bundle = build_trust_bundle("run-non-existent")
+        assert bundle["schema_version"] == TRUST_BUNDLE_SCHEMA_VERSION
+        assert bundle["run_id"] == "run-non-existent"
+        for key in (
+            "permission_scopes",
+            "cost",
+            "fingerprints",
+            "escalations",
+            "provenance",
+            "migrations",
+        ):
+            assert key in bundle


### PR DESCRIPTION
## Summary

Glue layer that ties the six TRUST-5..10 foundations (#395, #397, #398, #399, #400, #401) to the existing TRUST-1 run-receipt API. Adds `cognithor.security.trust_bundle.build_trust_bundle(run_id)` — a single JSON-serialisable dict that an audit consumer can embed under a top-level `"trust"` key.

This closes the "reconstruction" leg of the reviewer-feedback question by surfacing **the world the agent ran in** plus **what it spent / escalated** in one place, keyed by the same `run_id` the audit log already uses.

## What's in this PR

- `cognithor.security.trust_bundle.TRUST_BUNDLE_SCHEMA_VERSION` — versioned shape; bumps on breaking changes.
- `cognithor.security.trust_bundle.TrustLedgers` — frozen override-bag so tests inject fresh ledger instances; production passes `None` and gets the canonical singletons.
- `cognithor.security.trust_bundle.build_trust_bundle(run_id, *, ledgers=None)`:
  - **run-scoped views** for Cost + Escalation (only entries tied to `run_id` flow in). Empty `run_id` → empty sections (no leaking every cost ever).
  - **full snapshots** for Fingerprints / Provenance / Migrations (these describe the world the agent ran in) and PermissionScopes (already session-scoped).
  - Cross-ledger run_id consistency means an operator can verify cost ↔ escalation totals agree.

## Why a glue PR (and not full integration into AuditLogger.run_receipt)

`AuditLogger.run_receipt` is on a hot path used by the public API + Trace-UI. Threading the bundle directly into it would (a) bump its schema_version, (b) require updating every existing test that asserts the old shape, (c) widen the diff. This composer is the additive primitive — the next PR can opt-in `run_receipt` callers to call `build_trust_bundle` and merge under a `"trust"` key.

## Test plan

- [x] `pytest tests/test_security/test_trust_bundle.py -x -q` — 10 passed.
- [x] `mypy --strict src/cognithor/security/trust_bundle.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

10 cases cover: empty-bundle shape, empty-run_id guard against leaking unrelated entries, run-scoped filtering for cost + escalation, full snapshots for each ledger, cross-ledger run_id consistency (cost + escalation totals agree), canonical-ledger fallback when no override is passed.

## Follow-ups (deferred, separate PRs)

1. Opt-in `AuditLogger.run_receipt(..., include_trust=True)` parameter.
2. Public REST endpoint exposing the bundle for the Flutter Trace-UI.
3. Per-ledger production wiring (each foundation's "deferred follow-ups" list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)