### PR TITLE
feat(audit): include_trust= folds TRUST-5..10 into run_receipt

### DIFF
--- a/src/cognithor/audit/__init__.py
+++ b/src/cognithor/audit/__init__.py
@@ -928,6 +928,7 @@ class AuditLogger:
         session_id: str,
         *,
         signing_key: str | None = None,
+        include_trust: bool = False,
     ) -> dict[str, Any]:
         """Aggregate every audit entry tagged with *session_id* into a
         single receipt bundle, suitable for post-mortem reconstruction
@@ -953,6 +954,14 @@ class AuditLogger:
           the JSONL chain)
         * ``signature`` — HMAC-SHA-256 of the canonical bundle (without
           the signature field). Empty when *signing_key* is None.
+
+        Pass ``include_trust=True`` to fold the TRUST-5..10 ledger
+        bundle (permission scopes, cost, fingerprints, escalations,
+        provenance, migrations) into a top-level ``"trust"`` key.
+        Default is False so existing consumers see no shape change.
+        The signature, when requested, covers the merged bundle —
+        operators get tamper-detection across the audit entries AND
+        the trust state at run time.
 
         The receipt is purely an aggregation over already-persisted
         data — no side effects, no mutation. Safe to call on a live
@@ -1014,6 +1023,10 @@ class AuditLogger:
                 "hash_chain_tail": "",
                 "signature": "",
             }
+            if include_trust:
+                from cognithor.security.trust_bundle import build_trust_bundle
+
+                bundle["trust"] = build_trust_bundle(session_id)
             return bundle
 
         # 4. Aggregate.
@@ -1073,6 +1086,11 @@ class AuditLogger:
             "hash_chain_tail": ordered[-1].get("prev_hash", ""),
             "signature": "",
         }
+
+        if include_trust:
+            from cognithor.security.trust_bundle import build_trust_bundle
+
+            bundle["trust"] = build_trust_bundle(session_id)
 
         # 5. Optional HMAC-SHA-256 over the canonical (signature-less)
         # form. Lets the operator verify the bundle wasn't tampered

--- a/tests/test_audit/test_audit_logger.py
+++ b/tests/test_audit/test_audit_logger.py
@@ -742,3 +742,62 @@ class TestRunReceipt:
         logger.log_tool_call("legacy_call")  # no session_id
         receipt = logger.run_receipt("")
         assert receipt["entry_count"] == 1
+
+
+class TestRunReceiptIncludeTrust:
+    """``run_receipt(include_trust=True)`` folds the TRUST-5..10
+    ledger snapshots into the receipt under a top-level ``"trust"``
+    key. Default is False so existing consumers see no shape change.
+    """
+
+    def test_include_trust_default_false(self) -> None:
+        # Existing consumers MUST NOT see a "trust" key unless they ask.
+        logger = AuditLogger()
+        logger.log_tool_call("read_file", session_id="run_42")
+        receipt = logger.run_receipt("run_42")
+        assert "trust" not in receipt
+
+    def test_include_trust_adds_top_level_key(self) -> None:
+        logger = AuditLogger()
+        logger.log_tool_call("read_file", session_id="run_42")
+        receipt = logger.run_receipt("run_42", include_trust=True)
+        assert "trust" in receipt
+        trust = receipt["trust"]
+        assert isinstance(trust, dict)
+        # All six ledger sections must be present.
+        for key in (
+            "schema_version",
+            "run_id",
+            "permission_scopes",
+            "cost",
+            "fingerprints",
+            "escalations",
+            "provenance",
+            "migrations",
+        ):
+            assert key in trust
+        assert trust["run_id"] == "run_42"
+
+    def test_include_trust_for_unknown_session(self) -> None:
+        # Empty receipt path — ghost session — also honours include_trust.
+        logger = AuditLogger()
+        receipt = logger.run_receipt("ghost", include_trust=True)
+        assert "trust" in receipt
+        trust = receipt["trust"]
+        assert isinstance(trust, dict)
+        assert trust["run_id"] == "ghost"
+
+    def test_include_trust_with_signing_key_covers_trust(self) -> None:
+        # The HMAC must cover the merged bundle, not just the
+        # original audit fields. Tampering with the trust block
+        # invalidates the signature.
+        logger = AuditLogger()
+        logger.log_tool_call("read_file", session_id="run_42")
+        receipt = logger.run_receipt("run_42", signing_key="hunter2", include_trust=True)
+        assert receipt["signature"]
+        assert AuditLogger.verify_receipt_signature(receipt, "hunter2") is True
+        # Mutate the trust block — signature should no longer verify.
+        trust = receipt["trust"]
+        assert isinstance(trust, dict)
+        trust["run_id"] = "tampered"
+        assert AuditLogger.verify_receipt_signature(receipt, "hunter2") is False


### PR DESCRIPTION
## Summary

Production-wires the trust-bundle composer (#402) into the existing TRUST-1 receipt API. `AuditLogger.run_receipt(session_id, *, include_trust=True)` now folds the full TRUST-5..10 ledger bundle (permission scopes, cost, fingerprints, escalations, provenance, migrations) into the receipt under a top-level `"trust"` key.

## Why this is the right opt-in default

- **Default `False`** preserves existing behaviour. Every consumer of `run_receipt` keeps working exactly as before — no schema bump, no test churn outside the new test class.
- **Tamper detection** extends to the trust block: when the caller passes `signing_key=`, the HMAC covers the merged bundle. Mutating `receipt["trust"]["run_id"]` invalidates the signature.
- **Empty receipts** (ghost session_id) honour `include_trust` too — the bundle shape is consistent regardless of whether the run produced audit entries.

## Test plan

- [x] `pytest tests/test_audit/test_audit_logger.py -x -q` — 68 passed (4 new + 64 unchanged).
- [x] `mypy --strict src/cognithor/audit/__init__.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

4 new cases in `TestRunReceiptIncludeTrust`:
- default-off contract (no `"trust"` key when not requested)
- bundle shape on a normal receipt (all six ledger sections present)
- ghost-session path with `include_trust=True`
- tamper-detection guarantee (mutating `trust["run_id"]` invalidates HMAC)

## Follow-ups (deferred, separate PRs)

1. Public REST endpoint exposing receipts with the trust bundle for the Flutter Trace-UI.
2. Per-ledger production wiring (each foundation's "deferred follow-ups" list).
3. CLI `cognithor receipt <run_id> --trust` to print the bundled receipt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)