### PR TITLE
feat(cli): cognithor receipt show / verify

### DIFF
--- a/src/cognithor/__main__.py
+++ b/src/cognithor/__main__.py
@@ -262,6 +262,54 @@ def parse_args() -> argparse.Namespace:
         help="Run the Crew defined in the current scaffolded project directory",
     )
 
+    # `cognithor receipt …` — dump + verify TRUST-1 receipts (with optional
+    # TRUST-5..10 trust bundle and HMAC signature).
+    receipt_parser = sub.add_parser(
+        "receipt",
+        help="Dump and verify TRUST-1 audit run-receipts",
+    )
+    receipt_sub = receipt_parser.add_subparsers(dest="receipt_action")
+    show_p = receipt_sub.add_parser(
+        "show",
+        help="Print the receipt for a given session_id",
+    )
+    show_p.add_argument("session_id", help="TRUST-1 session / run id to aggregate")
+    show_p.add_argument(
+        "--log-dir",
+        dest="receipt_log_dir",
+        default=None,
+        help="Audit-log directory (default: in-memory only)",
+    )
+    show_p.add_argument(
+        "--include-trust",
+        dest="receipt_include_trust",
+        action="store_true",
+        help="Fold the TRUST-5..10 ledger bundle into the receipt",
+    )
+    show_p.add_argument(
+        "--key",
+        dest="receipt_signing_key",
+        default=None,
+        help="HMAC-SHA-256 signing key (omitted ⇒ unsigned)",
+    )
+    show_p.add_argument(
+        "--out",
+        dest="receipt_out",
+        default=None,
+        help="Write the JSON to this path (default: stdout)",
+    )
+    verify_p = receipt_sub.add_parser(
+        "verify",
+        help="Verify the HMAC signature on a persisted receipt",
+    )
+    verify_p.add_argument("bundle", help="Path to the receipt JSON file")
+    verify_p.add_argument(
+        "--key",
+        dest="verify_signing_key",
+        required=True,
+        help="HMAC-SHA-256 signing key the bundle was signed with",
+    )
+
     return parser.parse_args()
 
 
@@ -511,6 +559,32 @@ def main() -> None:
         from cognithor.crew.cli.run_cmd import run_project_crew
 
         sys.exit(run_project_crew())
+
+    if getattr(args, "command", None) == "receipt":
+        from cognithor.cli import receipt_cmd
+
+        action = getattr(args, "receipt_action", None)
+        if action == "show":
+            log_dir_arg = getattr(args, "receipt_log_dir", None)
+            sys.exit(
+                receipt_cmd.cmd_show(
+                    session_id=args.session_id,
+                    log_dir=Path(log_dir_arg) if log_dir_arg else None,
+                    include_trust=getattr(args, "receipt_include_trust", False),
+                    signing_key=getattr(args, "receipt_signing_key", None),
+                    out=Path(args.receipt_out) if getattr(args, "receipt_out", None) else None,
+                )
+            )
+        elif action == "verify":
+            sys.exit(
+                receipt_cmd.cmd_verify(
+                    bundle_path=Path(args.bundle),
+                    signing_key=args.verify_signing_key,
+                )
+            )
+        else:
+            print("Usage: cognithor receipt <show|verify>", file=sys.stderr)
+            sys.exit(2)
 
     # 0a. Auto-migrate data from ~/.jarvis/ to ~/.cognithor/ (one-time, on upgrade)
     _migrate_jarvis_home()

--- a/src/cognithor/audit/__init__.py
+++ b/src/cognithor/audit/__init__.py
@@ -1027,6 +1027,17 @@ class AuditLogger:
                 from cognithor.security.trust_bundle import build_trust_bundle
 
                 bundle["trust"] = build_trust_bundle(session_id)
+            if signing_key:
+                canonical = json.dumps(
+                    {k: v for k, v in bundle.items() if k != "signature"},
+                    sort_keys=True,
+                    ensure_ascii=False,
+                )
+                bundle["signature"] = hmac.new(
+                    signing_key.encode("utf-8"),
+                    canonical.encode("utf-8"),
+                    hashlib.sha256,
+                ).hexdigest()
             return bundle
 
         # 4. Aggregate.

--- a/src/cognithor/cli/receipt_cmd.py
+++ b/src/cognithor/cli/receipt_cmd.py
@@ -1,0 +1,118 @@
+"""CLI commands for ``cognithor receipt show`` / ``... verify``.
+
+Operator-facing front door to the TRUST-1 audit run-receipt API +
+the TRUST-5..10 trust bundle (#402, #403). Lets an operator dump a
+receipt for a given session_id (optionally including the trust
+bundle and an HMAC signature) and later verify a persisted bundle
+without spinning up the full agent.
+
+Kept intentionally thin — the real work lives in
+:meth:`cognithor.audit.AuditLogger.run_receipt` and
+:meth:`cognithor.audit.AuditLogger.verify_receipt_signature`.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import TYPE_CHECKING, Any
+
+from cognithor.audit import AuditLogger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def cmd_show(
+    *,
+    session_id: str,
+    log_dir: Path | None = None,
+    include_trust: bool = False,
+    signing_key: str | None = None,
+    out: Path | None = None,
+) -> int:
+    """Print a TRUST-1 receipt to stdout (or write it to ``out``).
+
+    Parameters
+    ----------
+    session_id:
+        Session / run id to aggregate. Must be non-empty.
+    log_dir:
+        Directory holding ``audit_*.jsonl`` files. ``None`` → the
+        logger's in-memory ring buffer only (useful for in-process
+        introspection; usually you want to point at the on-disk
+        audit log so the post-mortem covers restarted processes).
+    include_trust:
+        Fold the TRUST-5..10 ledger bundle into the receipt under a
+        top-level ``"trust"`` key (#403).
+    signing_key:
+        HMAC-SHA-256 signing key. ``None`` leaves the ``signature``
+        field empty.
+    out:
+        Optional path to write the bundle. When omitted, the bundle
+        prints to stdout.
+
+    Returns
+    -------
+    0 on success, 2 on bad arguments. Empty receipts (ghost session)
+    still return 0 — the structured "no match" payload is the
+    answer the operator asked for.
+    """
+    if not session_id:
+        print("error: session_id is required", file=sys.stderr)
+        return 2
+    logger = AuditLogger(log_dir=log_dir)
+    bundle = logger.run_receipt(
+        session_id,
+        signing_key=signing_key,
+        include_trust=include_trust,
+    )
+    payload = json.dumps(bundle, indent=2, ensure_ascii=False)
+    if out is not None:
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(payload, encoding="utf-8")
+        print(f"wrote {out}")
+    else:
+        print(payload)
+    return 0
+
+
+def cmd_verify(*, bundle_path: Path, signing_key: str) -> int:
+    """Verify the HMAC-SHA-256 signature on a persisted bundle.
+
+    Returns
+    -------
+    0  if the signature is valid.
+    1  if the bundle has no signature, or the signature does not match.
+    2  on bad arguments / unreadable / non-JSON bundle.
+    """
+    if not signing_key:
+        print("error: --key is required for verify", file=sys.stderr)
+        return 2
+    try:
+        raw = bundle_path.read_text(encoding="utf-8")
+    except (OSError, FileNotFoundError) as exc:
+        print(f"error: cannot read {bundle_path}: {exc}", file=sys.stderr)
+        return 2
+    try:
+        bundle: dict[str, Any] = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        print(f"error: invalid JSON in {bundle_path}: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(bundle, dict):
+        print(
+            f"error: bundle at {bundle_path} is not a JSON object",
+            file=sys.stderr,
+        )
+        return 2
+    if not bundle.get("signature"):
+        print("invalid: bundle has no signature", file=sys.stderr)
+        return 1
+    if AuditLogger.verify_receipt_signature(bundle, signing_key):
+        print("ok: signature valid")
+        return 0
+    print("invalid: signature does not match the provided key", file=sys.stderr)
+    return 1
+
+
+__all__ = ["cmd_show", "cmd_verify"]

--- a/tests/test_receipt_cmd.py
+++ b/tests/test_receipt_cmd.py
@@ -1,0 +1,175 @@
+"""Tests for ``cognithor.cli.receipt_cmd`` (TRUST-1 receipt CLI)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cognithor.audit import AuditLogger
+from cognithor.cli.receipt_cmd import cmd_show, cmd_verify
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture()
+def receipt_logger() -> AuditLogger:
+    """A fresh logger with two tagged entries for a single session."""
+    logger = AuditLogger()
+    logger.log_tool_call("read_file", session_id="run_42")
+    logger.log_gatekeeper("ALLOW", "GREEN tool", tool_name="read_file", session_id="run_42")
+    return logger
+
+
+# ---------------------------------------------------------------------------
+# show
+# ---------------------------------------------------------------------------
+
+
+class TestCmdShow:
+    def test_empty_session_id_rejected(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cmd_show(session_id="")
+        assert rc == 2
+        assert "session_id is required" in capsys.readouterr().err
+
+    def test_show_writes_to_out(self, tmp_path: Path) -> None:
+        out = tmp_path / "receipt.json"
+        # No on-disk audit log + ghost session — receipt is empty but valid.
+        rc = cmd_show(session_id="run_xyz", out=out)
+        assert rc == 0
+        assert out.exists()
+        bundle = json.loads(out.read_text(encoding="utf-8"))
+        assert bundle["session_id"] == "run_xyz"
+        assert bundle["entry_count"] == 0
+        # Default — no trust block when not requested.
+        assert "trust" not in bundle
+
+    def test_show_with_trust(self, tmp_path: Path) -> None:
+        out = tmp_path / "receipt.json"
+        rc = cmd_show(session_id="run_xyz", include_trust=True, out=out)
+        assert rc == 0
+        bundle = json.loads(out.read_text(encoding="utf-8"))
+        assert "trust" in bundle
+        trust = bundle["trust"]
+        assert trust["run_id"] == "run_xyz"
+        for key in (
+            "permission_scopes",
+            "cost",
+            "fingerprints",
+            "escalations",
+            "provenance",
+            "migrations",
+        ):
+            assert key in trust
+
+    def test_show_with_signing_key(self, tmp_path: Path) -> None:
+        out = tmp_path / "receipt.json"
+        rc = cmd_show(
+            session_id="run_xyz",
+            signing_key="hunter2",
+            include_trust=True,
+            out=out,
+        )
+        assert rc == 0
+        bundle = json.loads(out.read_text(encoding="utf-8"))
+        assert bundle["signature"]
+        # Round-trip via verify_receipt_signature.
+        assert AuditLogger.verify_receipt_signature(bundle, "hunter2") is True
+
+    def test_show_to_stdout(self, capsys: pytest.CaptureFixture[str]) -> None:
+        rc = cmd_show(session_id="run_xyz")
+        assert rc == 0
+        out = capsys.readouterr().out
+        bundle = json.loads(out)
+        assert bundle["session_id"] == "run_xyz"
+
+
+# ---------------------------------------------------------------------------
+# verify
+# ---------------------------------------------------------------------------
+
+
+class TestCmdVerify:
+    def test_empty_key_rejected(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        bundle_path = tmp_path / "b.json"
+        bundle_path.write_text("{}", encoding="utf-8")
+        rc = cmd_verify(bundle_path=bundle_path, signing_key="")
+        assert rc == 2
+        assert "key is required" in capsys.readouterr().err
+
+    def test_missing_file_returns_2(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = cmd_verify(bundle_path=tmp_path / "does_not_exist.json", signing_key="hunter2")
+        assert rc == 2
+        assert "cannot read" in capsys.readouterr().err
+
+    def test_invalid_json_returns_2(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        bundle_path = tmp_path / "bad.json"
+        bundle_path.write_text("not json {", encoding="utf-8")
+        rc = cmd_verify(bundle_path=bundle_path, signing_key="hunter2")
+        assert rc == 2
+        assert "invalid JSON" in capsys.readouterr().err
+
+    def test_non_object_bundle_rejected(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        bundle_path = tmp_path / "list.json"
+        bundle_path.write_text("[1, 2, 3]", encoding="utf-8")
+        rc = cmd_verify(bundle_path=bundle_path, signing_key="hunter2")
+        assert rc == 2
+        assert "not a JSON object" in capsys.readouterr().err
+
+    def test_unsigned_bundle_returns_1(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        bundle_path = tmp_path / "unsigned.json"
+        bundle_path.write_text(json.dumps({"session_id": "x", "signature": ""}), encoding="utf-8")
+        rc = cmd_verify(bundle_path=bundle_path, signing_key="hunter2")
+        assert rc == 1
+        assert "no signature" in capsys.readouterr().err
+
+    def test_valid_signature_returns_0(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        out = tmp_path / "signed.json"
+        cmd_show(
+            session_id="run_xyz",
+            signing_key="hunter2",
+            include_trust=True,
+            out=out,
+        )
+        rc = cmd_verify(bundle_path=out, signing_key="hunter2")
+        assert rc == 0
+        assert "signature valid" in capsys.readouterr().out
+
+    def test_wrong_key_returns_1(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        out = tmp_path / "signed.json"
+        cmd_show(
+            session_id="run_xyz",
+            signing_key="hunter2",
+            include_trust=True,
+            out=out,
+        )
+        rc = cmd_verify(bundle_path=out, signing_key="WRONG")
+        assert rc == 1
+        assert "does not match" in capsys.readouterr().err
+
+    def test_tampered_bundle_returns_1(self, tmp_path: Path) -> None:
+        out = tmp_path / "signed.json"
+        cmd_show(
+            session_id="run_xyz",
+            signing_key="hunter2",
+            include_trust=True,
+            out=out,
+        )
+        bundle = json.loads(out.read_text(encoding="utf-8"))
+        # Tamper with the trust block.
+        bundle["trust"]["run_id"] = "tampered"
+        out.write_text(json.dumps(bundle), encoding="utf-8")
+        rc = cmd_verify(bundle_path=out, signing_key="hunter2")
+        assert rc == 1


### PR DESCRIPTION
## Summary

Operator-facing CLI for the TRUST-1 audit receipt + the TRUST-5..10 trust bundle. Lets an operator dump a receipt for a given session_id (optionally including the trust bundle and an HMAC signature) and later verify a persisted bundle without spinning up the full agent.

## Subcommands

```
cognithor receipt show <session_id> [--include-trust] [--key KEY] [--log-dir DIR] [--out PATH]
cognithor receipt verify <bundle.json> --key KEY
```

Exit codes:
- `0`  success / signature valid
- `1`  bundle has no signature, or signature does not match
- `2`  bad arguments / unreadable / non-JSON / non-object bundle

## Bonus fix

The empty-receipt path (ghost session_id) in `AuditLogger.run_receipt` now also signs when `signing_key=` is provided. Without this fix, `cognithor receipt show <ghost> --key K` produced an unsignable bundle and `verify` couldn't be smoke-tested without a real session. The signing logic is now uniform across both the entry-bearing and empty paths.

## Test plan

- [x] `pytest tests/test_receipt_cmd.py -x -q` — 13 passed.
- [x] `pytest tests/test_audit/test_audit_logger.py -x -q` — 68 unchanged.
- [x] `mypy --strict src/cognithor/cli/receipt_cmd.py src/cognithor/audit/__init__.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

13 cases cover: empty-session_id rejection, file-write + stdout shapes, `include_trust` + signing round-trip, verify edge cases (missing file → 2, bad JSON → 2, non-object → 2, unsigned → 1, valid → 0, wrong key → 1, tampered trust block → 1).

## Why this fits the autonomous-mode work

The TRUST-5..10 foundations + composer (#395-#403) sit at the library layer. Operators need a way to *exercise* them without writing Python. This CLI surfaces every signed-receipt round-trip use case in two commands and proves the integration path end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)