### PR TITLE
feat(api): GET /api/crew/trace/{trace_id}/receipt

### DIFF
--- a/src/cognithor/api/crew_traces.py
+++ b/src/cognithor/api/crew_traces.py
@@ -300,3 +300,41 @@ def get_trace_stats(trace_id: str, _user: str = Depends(_require_owner_dep)) -> 
             detail={"error": "trace_not_found", "trace_id": trace_id},
         )
     return derive_trace_stats(grouped[trace_id])
+
+
+@router.get("/trace/{trace_id}/receipt")
+def get_trace_receipt(
+    trace_id: str,
+    include_trust: bool = Query(
+        default=False,
+        description="Fold the TRUST-5..10 ledger bundle into the receipt",
+    ),
+    _user: str = Depends(_require_owner_dep),
+) -> dict[str, Any]:
+    """Return the TRUST-1 audit run-receipt for ``trace_id``.
+
+    Optionally folds the TRUST-5..10 trust bundle (permission scopes,
+    cost, fingerprints, escalations, provenance, migrations) under a
+    top-level ``"trust"`` key when ``include_trust=true``.
+
+    No HMAC signing here — the operator who needs a signed receipt
+    uses the ``cognithor receipt show ... --key`` CLI offline. The
+    REST endpoint stays simple and read-only; the on-disk audit
+    hash-chain is the primary integrity gate.
+
+    404 when ``trace_id`` is not in the audit log.
+    """
+    from cognithor.audit import AuditLogger
+
+    events, _skipped = read_audit_lines(_audit_path())
+    grouped = group_by_trace(events)
+    if trace_id not in grouped:
+        raise HTTPException(
+            status_code=404,
+            detail={"error": "trace_not_found", "trace_id": trace_id},
+        )
+    return AuditLogger.build_receipt_from_entries(
+        trace_id,
+        grouped[trace_id],
+        include_trust=include_trust,
+    )

--- a/src/cognithor/audit/__init__.py
+++ b/src/cognithor/audit/__init__.py
@@ -968,9 +968,6 @@ class AuditLogger:
         logger or post-mortem on disk-only entries via a logger
         instantiated against the persisted ``log_dir``.
         """
-        import hashlib
-        import hmac
-
         # 1. Pull matching entries from the in-memory ring buffer.
         entries = [e for e in self._entries if e.session_id == session_id]
 
@@ -999,12 +996,45 @@ class AuditLogger:
         else:
             entry_dicts = from_disk
 
+        # 4. Aggregate (delegate to the static builder so the REST
+        # endpoint and other callers can produce the same receipt
+        # shape from already-loaded dicts without going through the
+        # in-memory ring buffer).
+        return self.build_receipt_from_entries(
+            session_id,
+            entry_dicts,
+            signing_key=signing_key,
+            include_trust=include_trust,
+        )
+
+    @classmethod
+    def build_receipt_from_entries(
+        cls,
+        session_id: str,
+        entry_dicts: list[dict[str, Any]],
+        *,
+        signing_key: str | None = None,
+        include_trust: bool = False,
+    ) -> dict[str, Any]:
+        """Build a TRUST-1 receipt from already-loaded entry dicts.
+
+        Lets non-AuditLogger callers (REST endpoints, post-mortem
+        tools) produce the same receipt shape without going through
+        the in-memory ring buffer or the ``audit_<date>.jsonl`` glob.
+        ``entry_dicts`` is the list of ``AuditEntry.to_dict()`` (or
+        equivalent JSONL-parsed) dicts already filtered by
+        ``session_id``.
+
+        Same return shape and signing semantics as
+        :meth:`run_receipt`. ``include_trust=True`` folds the
+        TRUST-5..10 bundle under ``"trust"``.
+        """
+        import hashlib
+        import hmac
+
         if not entry_dicts:
-            # Empty receipt is still valid — return a structured "no
-            # match" rather than raising, so callers can distinguish
-            # "this run never happened" from "exception".
             bundle: dict[str, Any] = {
-                "schema_version": self.RECEIPT_SCHEMA_VERSION,
+                "schema_version": cls.RECEIPT_SCHEMA_VERSION,
                 "session_id": session_id,
                 "period_start": "",
                 "period_end": "",
@@ -1023,102 +1053,78 @@ class AuditLogger:
                 "hash_chain_tail": "",
                 "signature": "",
             }
-            if include_trust:
-                from cognithor.security.trust_bundle import build_trust_bundle
-
-                bundle["trust"] = build_trust_bundle(session_id)
-            if signing_key:
-                canonical = json.dumps(
-                    {k: v for k, v in bundle.items() if k != "signature"},
-                    sort_keys=True,
-                    ensure_ascii=False,
+        else:
+            by_category: dict[str, int] = {}
+            by_severity: dict[str, int] = {}
+            by_tool: dict[str, int] = {}
+            total_duration = 0.0
+            success_count = 0
+            failure_count = 0
+            pii_count = 0
+            for d in entry_dicts:
+                by_category[d.get("category", "unknown")] = (
+                    by_category.get(d.get("category", "unknown"), 0) + 1
                 )
-                bundle["signature"] = hmac.new(
-                    signing_key.encode("utf-8"),
-                    canonical.encode("utf-8"),
-                    hashlib.sha256,
-                ).hexdigest()
-            return bundle
+                by_severity[d.get("severity", "unknown")] = (
+                    by_severity.get(d.get("severity", "unknown"), 0) + 1
+                )
+                tool = d.get("tool_name", "")
+                if tool:
+                    by_tool[tool] = by_tool.get(tool, 0) + 1
+                total_duration += float(d.get("duration_ms", 0.0))
+                if d.get("success", True):
+                    success_count += 1
+                else:
+                    failure_count += 1
+                if d.get("contains_pii", False):
+                    pii_count += 1
 
-        # 4. Aggregate.
-        by_category: dict[str, int] = {}
-        by_severity: dict[str, int] = {}
-        by_tool: dict[str, int] = {}
-        total_duration = 0.0
-        success_count = 0
-        failure_count = 0
-        pii_count = 0
-        for d in entry_dicts:
-            by_category[d.get("category", "unknown")] = (
-                by_category.get(d.get("category", "unknown"), 0) + 1
-            )
-            by_severity[d.get("severity", "unknown")] = (
-                by_severity.get(d.get("severity", "unknown"), 0) + 1
-            )
-            tool = d.get("tool_name", "")
-            if tool:
-                by_tool[tool] = by_tool.get(tool, 0) + 1
-            total_duration += float(d.get("duration_ms", 0.0))
-            if d.get("success", True):
-                success_count += 1
-            else:
-                failure_count += 1
-            if d.get("contains_pii", False):
-                pii_count += 1
+            def _entry_sort_key(d: dict[str, Any]) -> tuple[int, str]:
+                eid = str(d.get("entry_id", ""))
+                try:
+                    return (int(eid.rsplit("_", 1)[-1]), eid)
+                except (ValueError, IndexError):
+                    return (0, eid)
 
-        # Sort entries by entry_id for deterministic ordering. entry_id
-        # has the form ``audit_<n>`` so a numeric tail-sort is stable.
-        def _entry_sort_key(d: dict[str, Any]) -> tuple[int, str]:
-            eid = str(d.get("entry_id", ""))
-            try:
-                return (int(eid.rsplit("_", 1)[-1]), eid)
-            except (ValueError, IndexError):
-                return (0, eid)
+            ordered = sorted(entry_dicts, key=_entry_sort_key)
 
-        ordered = sorted(entry_dicts, key=_entry_sort_key)
-
-        bundle = {
-            "schema_version": self.RECEIPT_SCHEMA_VERSION,
-            "session_id": session_id,
-            "period_start": ordered[0].get("timestamp", ""),
-            "period_end": ordered[-1].get("timestamp", ""),
-            "entry_count": len(ordered),
-            "aggregate": {
-                "by_category": by_category,
-                "by_severity": by_severity,
-                "by_tool": by_tool,
-                "total_duration_ms": round(total_duration, 2),
-                "success_count": success_count,
-                "failure_count": failure_count,
-                "pii_count": pii_count,
-            },
-            "entries": ordered,
-            "hash_chain_head": ordered[0].get("prev_hash", ""),
-            "hash_chain_tail": ordered[-1].get("prev_hash", ""),
-            "signature": "",
-        }
+            bundle = {
+                "schema_version": cls.RECEIPT_SCHEMA_VERSION,
+                "session_id": session_id,
+                "period_start": ordered[0].get("timestamp", ""),
+                "period_end": ordered[-1].get("timestamp", ""),
+                "entry_count": len(ordered),
+                "aggregate": {
+                    "by_category": by_category,
+                    "by_severity": by_severity,
+                    "by_tool": by_tool,
+                    "total_duration_ms": round(total_duration, 2),
+                    "success_count": success_count,
+                    "failure_count": failure_count,
+                    "pii_count": pii_count,
+                },
+                "entries": ordered,
+                "hash_chain_head": ordered[0].get("prev_hash", ""),
+                "hash_chain_tail": ordered[-1].get("prev_hash", ""),
+                "signature": "",
+            }
 
         if include_trust:
             from cognithor.security.trust_bundle import build_trust_bundle
 
             bundle["trust"] = build_trust_bundle(session_id)
 
-        # 5. Optional HMAC-SHA-256 over the canonical (signature-less)
-        # form. Lets the operator verify the bundle wasn't tampered
-        # with after extraction. Without a key, leave empty — the
-        # underlying hash chain on disk is the primary integrity gate.
         if signing_key:
             canonical = json.dumps(
                 {k: v for k, v in bundle.items() if k != "signature"},
                 sort_keys=True,
                 ensure_ascii=False,
             )
-            sig = hmac.new(
+            bundle["signature"] = hmac.new(
                 signing_key.encode("utf-8"),
                 canonical.encode("utf-8"),
                 hashlib.sha256,
             ).hexdigest()
-            bundle["signature"] = sig
 
         return bundle
 

--- a/tests/test_api/test_crew_traces.py
+++ b/tests/test_api/test_crew_traces.py
@@ -285,3 +285,103 @@ def test_app_smoke_includes_crew_traces_router() -> None:
     paths = {r.path for r in app.routes if hasattr(r, "path")}
     assert "/api/crew/traces" in paths
     assert "/api/crew/trace/{trace_id}" in paths
+
+
+def test_get_trace_receipt_endpoint_returns_receipt(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``GET /api/crew/trace/{trace_id}/receipt`` returns the TRUST-1 receipt."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from cognithor.api.crew_traces import router
+
+    monkeypatch.setattr("cognithor.api.crew_traces._audit_path", lambda: FIXTURE)
+    monkeypatch.setenv("COGNITHOR_OWNER_USER_ID", "test-owner")
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+    resp = client.get(
+        "/api/crew/trace/trace-aaa/receipt",
+        headers={"X-Cognithor-User": "test-owner"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["session_id"] == "trace-aaa"
+    assert body["entry_count"] == 4
+    # Default — include_trust=False — no top-level trust key.
+    assert "trust" not in body
+    assert "aggregate" in body
+    assert "entries" in body
+
+
+def test_get_trace_receipt_endpoint_supports_include_trust(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from cognithor.api.crew_traces import router
+
+    monkeypatch.setattr("cognithor.api.crew_traces._audit_path", lambda: FIXTURE)
+    monkeypatch.setenv("COGNITHOR_OWNER_USER_ID", "test-owner")
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+    resp = client.get(
+        "/api/crew/trace/trace-aaa/receipt?include_trust=true",
+        headers={"X-Cognithor-User": "test-owner"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "trust" in body
+    trust = body["trust"]
+    assert trust["run_id"] == "trace-aaa"
+    for key in (
+        "permission_scopes",
+        "cost",
+        "fingerprints",
+        "escalations",
+        "provenance",
+        "migrations",
+    ):
+        assert key in trust
+
+
+def test_get_trace_receipt_endpoint_returns_404_for_unknown_trace(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from cognithor.api.crew_traces import router
+
+    monkeypatch.setattr("cognithor.api.crew_traces._audit_path", lambda: FIXTURE)
+    monkeypatch.setenv("COGNITHOR_OWNER_USER_ID", "test-owner")
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+    resp = client.get(
+        "/api/crew/trace/does-not-exist/receipt",
+        headers={"X-Cognithor-User": "test-owner"},
+    )
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["detail"]["error"] == "trace_not_found"
+    assert body["detail"]["trace_id"] == "does-not-exist"
+
+
+def test_get_trace_receipt_endpoint_requires_owner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    from cognithor.api.crew_traces import router
+
+    monkeypatch.setattr("cognithor.api.crew_traces._audit_path", lambda: FIXTURE)
+    monkeypatch.setenv("COGNITHOR_OWNER_USER_ID", "test-owner")
+    app = FastAPI()
+    app.include_router(router)
+    client = TestClient(app)
+    # Missing header — owner gate denies.
+    resp = client.get("/api/crew/trace/trace-aaa/receipt")
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

Surfaces the TRUST-1 audit run-receipt + TRUST-5..10 trust bundle over the existing crew-traces REST API used by the Flutter Trace-UI. Owner-gated, read-only.

## Endpoint

```
GET /api/crew/trace/{trace_id}/receipt[?include_trust=true]
```

| code | meaning |
|------|---------|
| 200  | receipt for the trace |
| 403  | caller is not the owner |
| 404  | trace_id not found in the audit log |

No HMAC signing on the wire — operators who need signed bundles use `cognithor receipt show ... --key` offline (#404). The on-disk audit hash-chain remains the primary integrity gate.

## Refactor — `AuditLogger.build_receipt_from_entries(...)`

Extracted the receipt-aggregation logic out of `AuditLogger.run_receipt` into a static method. The same shape is now produced regardless of whether the dicts come from:

- the in-memory ring buffer (existing `run_receipt`), or
- JSONL parsed by `read_audit_lines` (the new endpoint).

`run_receipt` keeps its existing public surface; it now just delegates after entry-collection. Side effect: fixes the latent shape mismatch where `AuditLogger.run_receipt` globs `audit_<date>.jsonl` while the rest of the codebase writes `audit.jsonl` (hashline-guard chain). The endpoint reads from the same source as `/api/crew/traces` and `/api/crew/trace/{trace_id}` — single source of truth.

## Test plan

- [x] `pytest tests/test_api/test_crew_traces.py -x -q` — 21 passed (+4 new), 1 skipped (pre-existing).
- [x] `pytest tests/test_audit/test_audit_logger.py tests/test_receipt_cmd.py -x -q` — 81 passed.
- [x] `mypy --strict src/cognithor/api/crew_traces.py src/cognithor/audit/__init__.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

4 new cases:
- default 200 + correct entry_count + no `"trust"` key.
- `include_trust=true` round-trip with all 6 ledger sections.
- 404 for unknown trace_id.
- 403 when the X-Cognithor-User header is absent (owner gate).

## Why this completes the TRUST-1 surface

The TRUST-5..10 stack now ships a complete chain: foundations (#395-#401) → bundle composer (#402) → audit-receipt integration (#403) → CLI (#404) → REST endpoint (this PR). The Flutter Trace-UI can now hit `/api/crew/trace/{id}/receipt?include_trust=true` and render the full operational-trust picture for any past run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)