### PR TITLE
feat(packs): TRUST-7 fingerprint capture in PackLoader

### DIFF
--- a/src/cognithor/packs/loader.py
+++ b/src/cognithor/packs/loader.py
@@ -298,6 +298,7 @@ class PackLoader:
             self._register_tool_risks(manifest, context)
             self._loaded[qid] = instance
             _log.info("pack.loaded", qualified_id=qid, version=manifest.version)
+            self._fingerprint_pack(manifest, entrypoint)
         except Exception as exc:
             _log.warning(
                 "pack.load_failed",
@@ -305,6 +306,42 @@ class PackLoader:
                 error=str(exc),
             )
             raise PackLoadError(f"Failed to load pack {qid!r}: {exc}") from exc
+
+    @staticmethod
+    def _fingerprint_pack(manifest: PackManifest, entrypoint: Path) -> None:
+        """Best-effort PACK-kind fingerprint of the loaded pack's entrypoint.
+
+        TRUST-7 hook (#398). The fingerprint registers the pack's
+        qualified_id as the logical name and the entrypoint's
+        SHA-256 (line-ending normalised) as the content hash. Lets
+        the operational-trust receipt answer "which pack version
+        was active during run X". Failures are silently logged and
+        swallowed — pack loading NEVER fails because of fingerprinting.
+        """
+        from cognithor.security.fingerprint import (
+            FINGERPRINT_LEDGER,
+            BinaryKind,
+            ToolFingerprint,
+            hash_python_source,
+        )
+
+        try:
+            content_hash = hash_python_source(entrypoint)
+            FINGERPRINT_LEDGER.register(
+                ToolFingerprint(
+                    name=manifest.qualified_id,
+                    kind=BinaryKind.PACK,
+                    content_hash=content_hash,
+                    version=manifest.version,
+                    source_path=str(entrypoint),
+                )
+            )
+        except (OSError, ValueError) as exc:
+            _log.debug(
+                "pack.fingerprint_skipped",
+                qualified_id=manifest.qualified_id,
+                error=str(exc),
+            )
 
     @staticmethod
     def _register_tool_risks(manifest: PackManifest, context: PackContext) -> None:

--- a/tests/test_packs/test_loader.py
+++ b/tests/test_packs/test_loader.py
@@ -155,3 +155,62 @@ class TestPackLoaderVersionRange:
         _write_pack(packs_dir, pack_id="exact", min_version=">=0.92.0")
         loader = PackLoader(packs_dir=packs_dir, cognithor_version="0.92.0")
         assert len(loader.discover()) == 1
+
+
+class TestPackLoaderFingerprint:
+    """TRUST-7 hook: every successfully loaded pack registers a
+    PACK-kind fingerprint in the canonical FINGERPRINT_LEDGER so the
+    operational-trust receipt can show which exact pack version was
+    active during a run.
+    """
+
+    def test_load_registers_pack_fingerprint(self, packs_dir: Path) -> None:
+        import cognithor.security.fingerprint as fp_mod
+        from cognithor.security.fingerprint import BinaryKind, FingerprintLedger
+
+        body = (
+            "from cognithor.packs.interface import AgentPack\n\n"
+            "class Pack(AgentPack):\n"
+            "    def register(self, ctx): pass\n"
+        )
+        _write_pack(packs_dir, pack_id="fp-probe", pack_py_body=body)
+
+        isolated = FingerprintLedger()
+        original = fp_mod.FINGERPRINT_LEDGER
+        fp_mod.FINGERPRINT_LEDGER = isolated  # type: ignore[misc]
+        try:
+            loader = PackLoader(packs_dir=packs_dir, cognithor_version="0.92.0")
+            loader.load_all(PackContext())
+            history = isolated.history("cognithor-official/fp-probe")
+            assert len(history) == 1
+            fp = history[0]
+            assert fp.kind == BinaryKind.PACK
+            assert fp.version == "1.0.0"  # default in _write_pack
+            assert len(fp.content_hash) == 64
+            assert fp.source_path.endswith("pack.py")
+        finally:
+            fp_mod.FINGERPRINT_LEDGER = original  # type: ignore[misc]
+
+    def test_failed_pack_does_not_register_fingerprint(self, packs_dir: Path) -> None:
+        # A pack whose register() blows up must not leave a stale
+        # fingerprint behind — the load failed, so the ledger should
+        # not pretend the pack is "in scope".
+        import cognithor.security.fingerprint as fp_mod
+        from cognithor.security.fingerprint import FingerprintLedger
+
+        body_broken = (
+            "from cognithor.packs.interface import AgentPack\n\n"
+            "class Pack(AgentPack):\n"
+            "    def register(self, ctx): raise RuntimeError('boom')\n"
+        )
+        _write_pack(packs_dir, pack_id="exploding", pack_py_body=body_broken)
+
+        isolated = FingerprintLedger()
+        original = fp_mod.FINGERPRINT_LEDGER
+        fp_mod.FINGERPRINT_LEDGER = isolated  # type: ignore[misc]
+        try:
+            loader = PackLoader(packs_dir=packs_dir, cognithor_version="0.92.0")
+            loader.load_all(PackContext())  # exception is swallowed
+            assert isolated.history("cognithor-official/exploding") == ()
+        finally:
+            fp_mod.FINGERPRINT_LEDGER = original  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Counterpart to #407 (MCP-tool fingerprinting): every successfully loaded pack now registers a `PACK`-kind fingerprint into the canonical `FINGERPRINT_LEDGER`. The operational-trust receipt can answer **"which exact pack version was active during run X"** for the agent-pack universe (Reddit / Discord / HN / RSS lead hunters, Deep Research, Insurance, Voice, etc.).

## Implementation

- New static helper `PackLoader._fingerprint_pack(manifest, entrypoint)` fires *after* `instance.register()` succeeds and `_register_tool_risks` completes. A failed pack load (which raises before the fingerprint call) leaves no stale fingerprint in the ledger — pack rollback semantics flow through.
- Uses `hash_python_source()` for CRLF→LF normalisation, then constructs a `ToolFingerprint` with `kind=BinaryKind.PACK`, `name=manifest.qualified_id`, `version=manifest.version`.
- **Best-effort**: `OSError | ValueError` silently logged + swallowed. Pack loading NEVER fails because of fingerprinting.

## Test plan

- [x] `pytest tests/test_packs/ -x -q` — 80 passed (+2 new, 78 unchanged).
- [x] `mypy --strict src/cognithor/packs/loader.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

2 new cases in `TestPackLoaderFingerprint`:
- successful load registers a PACK-kind fingerprint with the right version, source path, and 64-char hash.
- a pack whose `register()` raises does NOT leave a stale fingerprint (the exception is swallowed by `load_all`, but `_fingerprint_pack` runs after the success path so the failed pack is never fingerprinted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)