### PR TITLE
feat(memory): TRUST-9 wiring into EpisodicMemory.append_entry

### DIFF
--- a/src/cognithor/memory/episodic.py
+++ b/src/cognithor/memory/episodic.py
@@ -45,6 +45,9 @@ class EpisodicMemory:
         content: str,
         *,
         timestamp: datetime | None = None,
+        provenance_source_type: str | None = None,
+        provenance_source_id: str | None = None,
+        provenance_notes: str = "",
     ) -> str:
         """Fuegt einen Eintrag zum Tageslog hinzu. Append-only.
 
@@ -52,6 +55,16 @@ class EpisodicMemory:
             topic: Short title of the entry.
             content: Detail text (can be multiline).
             timestamp: Timestamp (default: now).
+            provenance_source_type: Optional TRUST-9 SourceType value
+                (``"chat_utterance"``, ``"tool_output"``, etc.). When
+                set together with ``provenance_source_id``, a
+                ProvenanceTag is written to the canonical ledger
+                keyed by ``episode:{date}:{HH:MM}:{topic-slug}``.
+            provenance_source_id: Stable upstream id (audit-log
+                entry id, message id, …). Required when
+                ``provenance_source_type`` is set.
+            provenance_notes: Short audit-log breadcrumb. MUST NOT
+                contain prompt or response content.
 
         Returns:
             The written entry as string.
@@ -83,7 +96,77 @@ class EpisodicMemory:
                 with open(file_path, "a", encoding="utf-8") as f:
                     f.write(entry)
 
+        if provenance_source_type and provenance_source_id:
+            self._tag_provenance(
+                item_id=self._episode_item_id(timestamp, topic),
+                source_type_value=provenance_source_type,
+                source_id=provenance_source_id,
+                notes=provenance_notes,
+            )
+
         return entry.strip()
+
+    @staticmethod
+    def _episode_item_id(timestamp: datetime, topic: str) -> str:
+        """Build a deterministic provenance item_id for an episode entry.
+
+        Shape: ``episode:{YYYY-MM-DD}:{HH:MM}:{topic-slug}``. The
+        slug lower-cases ASCII letters, replaces non-alphanumerics
+        with ``-``, and collapses runs. Stable enough for cross-session
+        lookups while staying URL-safe for the Trace-UI.
+        """
+        date_str = timestamp.date().isoformat()
+        time_str = timestamp.strftime("%H:%M")
+        slug_chars: list[str] = []
+        prev_dash = False
+        for ch in topic.lower():
+            if ch.isalnum():
+                slug_chars.append(ch)
+                prev_dash = False
+            elif not prev_dash:
+                slug_chars.append("-")
+                prev_dash = True
+        slug = "".join(slug_chars).strip("-") or "untitled"
+        return f"episode:{date_str}:{time_str}:{slug}"
+
+    @staticmethod
+    def _tag_provenance(
+        *,
+        item_id: str,
+        source_type_value: str,
+        source_id: str,
+        notes: str,
+    ) -> None:
+        """Best-effort TRUST-9 provenance tag — failures are swallowed.
+
+        Unknown ``source_type_value`` is coerced to
+        :data:`SourceType.UNKNOWN` rather than raising, so a typo at
+        the call site doesn't break log appends.
+        """
+        from cognithor.memory.provenance import (
+            PROVENANCE_LEDGER,
+            ProvenanceTag,
+            SourceType,
+        )
+
+        try:
+            try:
+                source_type = SourceType(source_type_value)
+            except ValueError:
+                source_type = SourceType.UNKNOWN
+            PROVENANCE_LEDGER.tag(
+                item_id,
+                ProvenanceTag(
+                    source_type=source_type,
+                    source_id=source_id,
+                    notes=notes,
+                ),
+            )
+        except ValueError:
+            # Construction-time validation may reject empty source_id
+            # or out-of-range confidence — silently skip; logging
+            # episodic events MUST NEVER fail.
+            pass
 
     def get_today(self) -> str:
         """Return today's daily log."""

--- a/tests/test_memory/test_episodic.py
+++ b/tests/test_memory/test_episodic.py
@@ -106,3 +106,133 @@ class TestEpisodicMemory:
 
     def test_directory_property(self, ep: EpisodicMemory, ep_dir: Path):
         assert ep.directory == ep_dir
+
+
+class TestEpisodicMemoryProvenance:
+    """TRUST-9 wiring: passing ``provenance_source_type`` +
+    ``provenance_source_id`` to ``append_entry`` writes a tag to the
+    canonical PROVENANCE_LEDGER keyed by a deterministic episode id.
+    """
+
+    def test_episode_item_id_shape(self) -> None:
+        ts = datetime(2026, 2, 21, 14, 30)
+        item_id = EpisodicMemory._episode_item_id(ts, "  My Topic / Slug!  ")
+        assert item_id == "episode:2026-02-21:14:30:my-topic-slug"
+
+    def test_episode_item_id_empty_topic_falls_back(self) -> None:
+        ts = datetime(2026, 2, 21, 14, 30)
+        item_id = EpisodicMemory._episode_item_id(ts, "!!!")
+        assert item_id == "episode:2026-02-21:14:30:untitled"
+
+    def test_append_without_provenance_does_not_tag(self, ep: EpisodicMemory) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            ep.append_entry(
+                "Probe",
+                "content",
+                timestamp=datetime(2026, 2, 21, 14, 30),
+            )
+            assert len(isolated) == 0
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_append_with_provenance_tags_ledger(self, ep: EpisodicMemory) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger, SourceType
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            ts = datetime(2026, 2, 21, 14, 30)
+            ep.append_entry(
+                "User says hello",
+                "content",
+                timestamp=ts,
+                provenance_source_type="chat_utterance",
+                provenance_source_id="msg-7",
+                provenance_notes="from telegram",
+            )
+            tag = isolated.current("episode:2026-02-21:14:30:user-says-hello")
+            assert tag is not None
+            assert tag.source_type == SourceType.CHAT_UTTERANCE
+            assert tag.source_id == "msg-7"
+            assert tag.notes == "from telegram"
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_unknown_source_type_falls_back(self, ep: EpisodicMemory) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger, SourceType
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            ts = datetime(2026, 2, 21, 14, 30)
+            ep.append_entry(
+                "Probe",
+                "content",
+                timestamp=ts,
+                provenance_source_type="not_real",
+                provenance_source_id="x",
+            )
+            tag = isolated.current("episode:2026-02-21:14:30:probe")
+            assert tag is not None
+            assert tag.source_type == SourceType.UNKNOWN
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_partial_provenance_args_skip_tag(self, ep: EpisodicMemory) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            ts = datetime(2026, 2, 21, 14, 30)
+            ep.append_entry(
+                "Only-Type",
+                "c",
+                timestamp=ts,
+                provenance_source_type="chat_utterance",
+            )
+            ep.append_entry(
+                "Only-Id",
+                "c",
+                timestamp=ts,
+                provenance_source_id="msg-7",
+            )
+            assert len(isolated) == 0
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_empty_source_id_does_not_break_append(self, ep: EpisodicMemory) -> None:
+        # ProvenanceTag construction rejects empty source_id; the
+        # episodic helper must swallow that ValueError so log-write
+        # still succeeds.
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            # source_id is "" → fails the both-required check, no tag.
+            result = ep.append_entry(
+                "Probe",
+                "c",
+                timestamp=datetime(2026, 2, 21, 14, 30),
+                provenance_source_type="chat_utterance",
+                provenance_source_id="",
+            )
+            assert "Probe" in result
+            assert len(isolated) == 0
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Second of the four memory-tier wirings deferred from #397 (after #409 wired `SemanticMemory`). The episodic-memory tier (tier 2 — daily Markdown logs of "what happened when") now optionally records a provenance tag into the canonical `PROVENANCE_LEDGER` keyed by a deterministic episode id.

## What's in this PR

- New keyword-only parameters on `EpisodicMemory.append_entry`: `provenance_source_type`, `provenance_source_id`, `provenance_notes`.
- **Both `source_type` AND `source_id` required to tag** — partial args silently skip.
- New static helper `_episode_item_id(timestamp, topic)` builds a deterministic id of shape:
  ```
  episode:{YYYY-MM-DD}:{HH:MM}:{topic-slug}
  ```
  The slug lower-cases ASCII letters, replaces non-alphanumerics with `-`, collapses runs, falls back to `"untitled"` for empty slugs. URL-safe for the Trace-UI; stable across sessions.
- Static helper `_tag_provenance(...)` coerces unknown source-type values to `SourceType.UNKNOWN`. `ValueError` on `ProvenanceTag` construction (e.g. empty `source_id`) is silently swallowed — **log appends MUST NEVER fail because of provenance tagging.**
- The `PROVENANCE_LEDGER` import is lazy.

## Test plan

- [x] `pytest tests/test_memory/test_episodic.py -x -q` — 19 passed (+7 new, 12 unchanged).
- [x] `mypy --strict src/cognithor/memory/episodic.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

7 new cases in `TestEpisodicMemoryProvenance`:
- `_episode_item_id` slug shape (special chars + collapse runs).
- `_episode_item_id` empty topic falls back to `"untitled"`.
- without provenance args: no ledger entry.
- with both args: tag written, source_type/source_id/notes match.
- unknown source_type string falls back to `UNKNOWN`.
- partial args: no tag.
- empty source_id: append still succeeds, no ledger entry.

## Two memory tiers wired, two to go

- ✅ #409 — SemanticMemory (tier 3, knowledge graph)
- ✅ this PR — EpisodicMemory (tier 2, daily logs)
- ⬜ relations / knowledge-graph edges
- ⬜ vault (encrypted secrets / records)

🤖 Generated with [Claude Code](https://claude.com/claude-code)