### PR TITLE
feat(memory): TRUST-9 wiring into SemanticMemory.add_relation

### DIFF
--- a/src/cognithor/memory/semantic.py
+++ b/src/cognithor/memory/semantic.py
@@ -191,6 +191,9 @@ class SemanticMemory:
         attributes: dict[str, Any] | None = None,
         source_file: str = "",
         confidence: float = 1.0,
+        provenance_source_type: str | None = None,
+        provenance_source_id: str | None = None,
+        provenance_notes: str = "",
     ) -> Relation | None:
         """Erstellt eine neue Relation zwischen zwei Entitaeten.
 
@@ -198,6 +201,19 @@ class SemanticMemory:
             source_id: Quell-Entity ID.
             relation_type: Beziehungstyp (z.B. "hat_police", "arbeitet_bei").
             target_id: Ziel-Entity ID.
+            attributes: Optional attribute payload.
+            source_file: Source file the relation was extracted from.
+            confidence: 0..1 confidence score.
+            provenance_source_type: Optional TRUST-9 ``SourceType``
+                value. When set together with
+                ``provenance_source_id``, a tag is written to the
+                canonical ``PROVENANCE_LEDGER`` keyed by the new
+                relation's id.
+            provenance_source_id: Stable upstream id (audit-log
+                entry id, message id, …). Required when
+                ``provenance_source_type`` is set.
+            provenance_notes: Short audit-log breadcrumb. MUST NOT
+                contain prompt or response content.
 
         Returns:
             Die erstellte Relation oder None wenn Entitaeten nicht existieren.
@@ -225,6 +241,14 @@ class SemanticMemory:
             relation_type,
             target_id[:8],
         )
+        if provenance_source_type and provenance_source_id:
+            self._tag_provenance(
+                item_id=relation.id,
+                source_type_value=provenance_source_type,
+                source_id=provenance_source_id,
+                confidence=confidence,
+                notes=provenance_notes,
+            )
         return relation
 
     def get_relations(

--- a/tests/test_memory/test_semantic.py
+++ b/tests/test_memory/test_semantic.py
@@ -214,3 +214,129 @@ class TestSemanticMemoryProvenance:
             assert e2.id not in isolated
         finally:
             prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+
+class TestSemanticRelationProvenance:
+    """TRUST-9 wiring: ``add_relation`` accepts ``provenance_source_type``
+    + ``provenance_source_id`` and tags the canonical PROVENANCE_LEDGER
+    keyed by the new relation's id.
+    """
+
+    def test_add_relation_without_provenance_does_not_tag(self, sem: SemanticMemory) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        e1 = sem.add_entity("A", "person")
+        e2 = sem.add_entity("B", "person")
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            rel = sem.add_relation(e1.id, "kennt", e2.id)
+            assert rel is not None
+            assert rel.id not in isolated
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_add_relation_with_provenance_tags_ledger(self, sem: SemanticMemory) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger, SourceType
+
+        e1 = sem.add_entity("A", "person")
+        e2 = sem.add_entity("B", "person")
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            rel = sem.add_relation(
+                e1.id,
+                "arbeitet_bei",
+                e2.id,
+                confidence=0.9,
+                provenance_source_type="agent_inference",
+                provenance_source_id="run-77",
+                provenance_notes="extracted by NER chain",
+            )
+            assert rel is not None
+            tag = isolated.current(rel.id)
+            assert tag is not None
+            assert tag.source_type == SourceType.AGENT_INFERENCE
+            assert tag.source_id == "run-77"
+            assert tag.confidence == 0.9
+            assert tag.notes == "extracted by NER chain"
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_add_relation_unknown_source_type_falls_back(self, sem: SemanticMemory) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger, SourceType
+
+        e1 = sem.add_entity("A", "person")
+        e2 = sem.add_entity("B", "person")
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            rel = sem.add_relation(
+                e1.id,
+                "kennt",
+                e2.id,
+                provenance_source_type="not_a_real_source",
+                provenance_source_id="x",
+            )
+            assert rel is not None
+            tag = isolated.current(rel.id)
+            assert tag is not None
+            assert tag.source_type == SourceType.UNKNOWN
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_add_relation_returns_none_when_entity_missing_skips_tag(
+        self, sem: SemanticMemory
+    ) -> None:
+        # If add_relation returns None (because an entity is missing),
+        # nothing should land in the ledger — the tag belongs to a
+        # relation that was never created.
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        e1 = sem.add_entity("A", "person")
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            rel = sem.add_relation(
+                e1.id,
+                "kennt",
+                "missing-id",
+                provenance_source_type="agent_inference",
+                provenance_source_id="run-77",
+            )
+            assert rel is None
+            assert len(isolated) == 0
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_partial_relation_provenance_args_skip_tag(self, sem: SemanticMemory) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        e1 = sem.add_entity("A", "person")
+        e2 = sem.add_entity("B", "person")
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            r1 = sem.add_relation(e1.id, "kennt", e2.id, provenance_source_type="agent_inference")
+            r2 = sem.add_relation(e1.id, "kennt", e2.id, provenance_source_id="run-77")
+            assert r1 is not None
+            assert r2 is not None
+            assert r1.id not in isolated
+            assert r2.id not in isolated
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Third of the four memory-tier wirings deferred from #397. After #409 (entities) and #410 (episodic logs), the relation edges in the knowledge graph (tier 3 — "Hans Müller arbeitet_bei TechCorp") now also support provenance tagging.

## What's in this PR

- New keyword-only parameters on `SemanticMemory.add_relation`:
  - `provenance_source_type`, `provenance_source_id`, `provenance_notes`. Identical contract to `add_entity`'s wiring (#409): both required to tag, partial args silently skip, unknown values coerce to `SourceType.UNKNOWN`, all failures swallowed.
- Reuses the existing `_tag_provenance()` static helper from #409 — no duplicate code path.
- Tag keyed by `relation.id` (Pydantic-generated UUID), not entity ids. Lets the receipt distinguish "where did this edge come from" from "where did its source/target come from".
- If `add_relation` returns `None` (entity missing), no tag lands. Provenance follows successful creation only.

## Test plan

- [x] `pytest tests/test_memory/test_semantic.py -x -q` — 26 passed (+5 new, 21 unchanged).
- [x] `mypy --strict src/cognithor/memory/semantic.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

5 new cases in `TestSemanticRelationProvenance`:
- without provenance args: no ledger entry.
- with both args: tag written, source_type/source_id/confidence/notes match.
- unknown source_type string falls back to `UNKNOWN`.
- `add_relation` returns `None` (target missing): no tag.
- partial args: no tag.

## Three memory tiers wired, one to go

- ✅ #409 — SemanticMemory.add_entity (entities)
- ✅ #410 — EpisodicMemory.append_entry (daily logs)
- ✅ this PR — SemanticMemory.add_relation (knowledge-graph edges)
- ⬜ vault (encrypted secrets / records)

🤖 Generated with [Claude Code](https://claude.com/claude-code)