### PR TITLE
feat(security): TRUST-9 wiring into AgentVault.store

### DIFF
--- a/src/cognithor/security/agent_vault.py
+++ b/src/cognithor/security/agent_vault.py
@@ -29,6 +29,50 @@ from cryptography.fernet import Fernet, InvalidToken
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
+
+def _tag_vault_provenance(
+    *,
+    item_id: str,
+    source_type_value: str,
+    source_id: str,
+    notes: str,
+) -> None:
+    """Best-effort TRUST-9 provenance tag for a vault secret.
+
+    Failures are silently swallowed — vault operations MUST NEVER
+    fail because of provenance tagging. Unknown ``source_type_value``
+    is coerced to :data:`SourceType.UNKNOWN` so a typo at the call
+    site doesn't break secret storage.
+
+    Privacy contract: the caller is responsible for ensuring
+    ``notes`` does not contain the secret's value. This helper does
+    not introspect or sanitise the input.
+    """
+    from cognithor.memory.provenance import (
+        PROVENANCE_LEDGER,
+        ProvenanceTag,
+        SourceType,
+    )
+
+    try:
+        try:
+            source_type = SourceType(source_type_value)
+        except ValueError:
+            source_type = SourceType.UNKNOWN
+        PROVENANCE_LEDGER.tag(
+            item_id,
+            ProvenanceTag(
+                source_type=source_type,
+                source_id=source_id,
+                notes=notes,
+            ),
+        )
+    except ValueError:
+        # ProvenanceTag construction may reject empty source_id.
+        # Silently skip; logging vault writes MUST NEVER fail.
+        pass
+
+
 # ============================================================================
 # Agent Secret
 # ============================================================================
@@ -139,8 +183,24 @@ class AgentVault:
         secret_type: SecretType = SecretType.API_KEY,
         *,
         ttl_hours: int = 0,
+        provenance_source_type: str | None = None,
+        provenance_source_id: str | None = None,
+        provenance_notes: str = "",
     ) -> AgentSecret:
-        """Stores a new secret in the vault."""
+        """Stores a new secret in the vault.
+
+        Optional TRUST-9 provenance: when both
+        ``provenance_source_type`` and ``provenance_source_id`` are
+        passed, a tag is written to the canonical
+        ``PROVENANCE_LEDGER`` keyed by the new ``secret_id``. Lets
+        the operational-trust receipt answer "where did this stored
+        secret come from?" — owner-pasted? config-import? rotation
+        broker?
+
+        Privacy invariant: the secret's *value* never enters the
+        provenance ledger. Only metadata (source_type / source_id /
+        notes) flows through.
+        """
         self._counter += 1
         now = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         expires = ""
@@ -159,6 +219,13 @@ class AgentVault:
         )
         self._secrets[secret.secret_id] = secret
         self._log("store", secret.secret_id)
+        if provenance_source_type and provenance_source_id:
+            _tag_vault_provenance(
+                item_id=secret.secret_id,
+                source_type_value=provenance_source_type,
+                source_id=provenance_source_id,
+                notes=provenance_notes,
+            )
         return secret
 
     def retrieve(self, secret_id: str) -> str | None:

--- a/tests/test_security/test_vault_provenance.py
+++ b/tests/test_security/test_vault_provenance.py
@@ -1,0 +1,123 @@
+"""Tests for the TRUST-9 wiring into AgentVault.store (#412)."""
+
+from __future__ import annotations
+
+from cognithor.security.agent_vault import AgentVault, SecretType
+
+
+class TestAgentVaultProvenance:
+    """``AgentVault.store(provenance_source_type=..., provenance_source_id=...)``
+    writes a tag to the canonical PROVENANCE_LEDGER keyed by the new
+    ``secret_id`` so the operational-trust receipt can answer
+    "where did this stored secret come from?".
+    """
+
+    def test_store_without_provenance_does_not_tag(self) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            vault = AgentVault("agent-1", master_secret=b"test-secret")
+            secret = vault.store("api_key_no_prov", "value-1")
+            assert secret.secret_id not in isolated
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_store_with_provenance_tags_ledger(self) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger, SourceType
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            vault = AgentVault("agent-1", master_secret=b"test-secret")
+            secret = vault.store(
+                "api_key_with_prov",
+                "value-1",
+                secret_type=SecretType.API_KEY,
+                provenance_source_type="user_directive",
+                provenance_source_id="owner-paste-7",
+                provenance_notes="owner pasted at boot",
+            )
+            tag = isolated.current(secret.secret_id)
+            assert tag is not None
+            assert tag.source_type == SourceType.USER_DIRECTIVE
+            assert tag.source_id == "owner-paste-7"
+            assert tag.notes == "owner pasted at boot"
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_store_unknown_source_type_falls_back(self) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger, SourceType
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            vault = AgentVault("agent-1", master_secret=b"test-secret")
+            secret = vault.store(
+                "api_key_unknown",
+                "value-1",
+                provenance_source_type="not_a_real_source",
+                provenance_source_id="x",
+            )
+            tag = isolated.current(secret.secret_id)
+            assert tag is not None
+            assert tag.source_type == SourceType.UNKNOWN
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_partial_provenance_args_skip_tag(self) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            vault = AgentVault("agent-1", master_secret=b"test-secret")
+            s1 = vault.store(
+                "only_type",
+                "v",
+                provenance_source_type="user_directive",
+            )
+            s2 = vault.store(
+                "only_id",
+                "v",
+                provenance_source_id="owner-paste-7",
+            )
+            assert s1.secret_id not in isolated
+            assert s2.secret_id not in isolated
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_empty_source_id_does_not_break_store(self) -> None:
+        # ProvenanceTag construction rejects empty source_id, but the
+        # vault helper must swallow that ValueError so secret storage
+        # still succeeds.
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            vault = AgentVault("agent-1", master_secret=b"test-secret")
+            # source_id is "" → fails the both-required check, no tag.
+            secret = vault.store(
+                "k",
+                "v",
+                provenance_source_type="user_directive",
+                provenance_source_id="",
+            )
+            assert secret.secret_id is not None
+            # Round-trip retrieval still works (secret was stored).
+            assert vault.retrieve(secret.secret_id) == "v"
+            assert len(isolated) == 0
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]


### PR DESCRIPTION
## Summary

**Final memory-tier wiring** deferred from #397. After #409 (entities), #410 (episodic logs), and #411 (relations), the agent vault (encrypted secrets / API keys / tokens) now supports provenance tagging too.

The TRUST-1 receipt + `GET /api/crew/trace/{id}/receipt?include_trust=true` can now answer **"where did this stored secret come from?"** — was it owner-pasted at boot, imported from config, or rotated by an external broker? — for every vault entry that opted into provenance at storage time.

## What's in this PR

- New keyword-only parameters on `AgentVault.store`: `provenance_source_type`, `provenance_source_id`, `provenance_notes`. Identical contract to the semantic + episodic wirings.
- Tag keyed by the new `secret_id`.
- New module-level helper `_tag_vault_provenance(...)` in `cognithor.security.agent_vault`. Failures are silently swallowed — **vault writes MUST NEVER fail** because of provenance tagging.
- Privacy contract documented inline: **the secret's value never enters the provenance ledger.** Only metadata flows through. Caller is responsible for not putting secret material into `notes`; this helper does not introspect.

## Test plan

- [x] `pytest tests/test_security/ -k vault -x -q` — 101 passed (+5 new, 96 unchanged).
- [x] `mypy --strict src/cognithor/security/agent_vault.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

5 new cases in `tests/test_security/test_vault_provenance.py`:
- without provenance args: no ledger entry.
- with both args: tag written, source_type/source_id/notes match.
- unknown source_type string falls back to `UNKNOWN`.
- partial args: no tag.
- empty source_id: store still succeeds, retrieve round-trips, no ledger entry.

## All four memory tiers now TRUST-9-instrumented

- ✅ #409 — SemanticMemory.add_entity (entities)
- ✅ #410 — EpisodicMemory.append_entry (daily logs)
- ✅ #411 — SemanticMemory.add_relation (knowledge-graph edges)
- ✅ this PR — AgentVault.store (encrypted secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)