### PR TITLE
feat(backends): TRUST-7 auto-wire fingerprint_model on first chat()

### DIFF
--- a/src/cognithor/core/llm_backend.py
+++ b/src/cognithor/core/llm_backend.py
@@ -287,6 +287,11 @@ class OllamaBackend(LLMBackend):
         num_ctx: int | None = None,
     ) -> ChatResponse:
         client = await self._ensure_client()
+        # TRUST-7: lazy fingerprint capture on first use of each
+        # model. Idempotent + cached on the backend instance, so
+        # subsequent chat() calls don't pay the /api/show cost.
+        # Best-effort: fingerprint failures NEVER block chat().
+        await self.fingerprint_model(model)
 
         options: dict[str, Any] = {"temperature": temperature, "top_p": top_p}
         if num_ctx is not None:
@@ -345,6 +350,8 @@ class OllamaBackend(LLMBackend):
         num_ctx: int | None = None,
     ) -> AsyncIterator[str]:
         client = await self._ensure_client()
+        # TRUST-7: lazy fingerprint, idempotent + cached.
+        await self.fingerprint_model(model)
         options: dict[str, Any] = {"temperature": temperature, "top_p": top_p}
         if num_ctx is not None:
             options["num_ctx"] = int(num_ctx)

--- a/tests/test_core/test_llm_backend.py
+++ b/tests/test_core/test_llm_backend.py
@@ -1111,3 +1111,78 @@ class TestOllamaBackendFingerprintModel:
             assert len(fp_mod.FINGERPRINT_LEDGER) == 0  # type: ignore[arg-type]
         finally:
             fp_mod.FINGERPRINT_LEDGER = original  # type: ignore[misc]
+
+    @pytest.mark.asyncio
+    async def test_chat_triggers_fingerprint_capture(self) -> None:
+        # Lazy auto-wire: chat() calls fingerprint_model(model) at the
+        # top so a real run instruments models without an explicit
+        # boot hook.
+        from cognithor.security.fingerprint import BinaryKind
+
+        fp_mod, original = self._isolate_ledger()
+        try:
+            digest = "f" * 64
+            # Both endpoints (/api/show + /api/chat) use the same
+            # mock — the chat path doesn't actually look at digest,
+            # and the fingerprint path will accept the digest field.
+            shared_resp = MagicMock()
+            shared_resp.status_code = 200
+            shared_resp.json.return_value = {
+                "digest": digest,
+                "details": {"parameter_size": "8B"},
+                "message": {"content": "ok", "role": "assistant"},
+                "prompt_eval_count": 1,
+                "eval_count": 1,
+            }
+            mock_client = AsyncMock()
+            mock_client.is_closed = False
+            mock_client.post = AsyncMock(return_value=shared_resp)
+
+            b = OllamaBackend("http://localhost:11434")
+            b._client = mock_client
+
+            await b.chat("qwen3:auto", [{"role": "user", "content": "hi"}])
+            history = fp_mod.FINGERPRINT_LEDGER.history("qwen3:auto")  # type: ignore[attr-defined]
+            assert len(history) == 1
+            assert history[0].kind == BinaryKind.MODEL
+            assert history[0].content_hash == digest
+        finally:
+            fp_mod.FINGERPRINT_LEDGER = original  # type: ignore[misc]
+
+    @pytest.mark.asyncio
+    async def test_chat_proceeds_when_fingerprint_fails(self) -> None:
+        # Critical invariant: chat() MUST succeed even if the
+        # fingerprint probe fails. Use side_effect to make the
+        # /api/show call raise, but the /api/chat call return.
+        fp_mod, original = self._isolate_ledger()
+        try:
+            chat_resp = MagicMock()
+            chat_resp.status_code = 200
+            chat_resp.json.return_value = {
+                "message": {"content": "ok", "role": "assistant"},
+                "prompt_eval_count": 1,
+                "eval_count": 1,
+            }
+            call_count = {"n": 0}
+
+            async def fake_post(*_: object, **__: object) -> object:
+                call_count["n"] += 1
+                if call_count["n"] == 1:
+                    # First call is fingerprint /api/show — fail it.
+                    raise httpx.ConnectError("down")
+                return chat_resp
+
+            mock_client = AsyncMock()
+            mock_client.is_closed = False
+            mock_client.post = AsyncMock(side_effect=fake_post)
+
+            b = OllamaBackend("http://localhost:11434")
+            b._client = mock_client
+
+            result = await b.chat("qwen3:flaky", [{"role": "user", "content": "hi"}])
+            # Chat completed despite fingerprint failure.
+            assert result.content == "ok"
+            # Model still cached as fingerprinted (won't retry).
+            assert "qwen3:flaky" in b._fingerprinted_models
+        finally:
+            fp_mod.FINGERPRINT_LEDGER = original  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Closes the auto-wire deferred from #413. `OllamaBackend.chat()` and `chat_stream()` now call `self.fingerprint_model(model)` at the top of every invocation. Models get fingerprinted on first use without any explicit boot hook.

## Cost analysis

- **First call per model**: ~10ms HTTP round-trip to `/api/show`, parse digest, register `ToolFingerprint(MODEL)`.
- **All subsequent calls**: O(1) — short-circuits via `self._fingerprinted_models` cache (set lookup on the model name).

## Critical invariant

`chat()` succeeds **even when** the fingerprint probe fails (`httpx.ConnectError` on `/api/show`, 404, etc). The fingerprint code path swallows everything; chat proceeds with the user's actual request.

## Test plan

- [x] `pytest tests/test_core/test_llm_backend.py -x -q` — 66 passed (+2 new, 64 unchanged).
- [x] `mypy --strict src/cognithor/core/llm_backend.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

2 new cases on top of the 8 from #413:
- `test_chat_triggers_fingerprint_capture`: chat call leaves a `MODEL`-kind fingerprint with the right digest in the ledger.
- `test_chat_proceeds_when_fingerprint_fails`: `/api/show` raises `ConnectError` but `/api/chat` returns 200; the chat result has `content="ok"` and the model is still cached as fingerprinted (won't retry).

The mock side-effects in existing 56 OllamaBackend tests are deterministic — the same mocked response that returned the chat data also satisfied the fingerprint `/api/show` parser (without a digest field), so no test needed retrofitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)