### PR TITLE
feat(gatekeeper): TRUST-2 explanations on Python-code + path-validation blocks

### DIFF
--- a/src/cognithor/core/gatekeeper.py
+++ b/src/cognithor/core/gatekeeper.py
@@ -1031,6 +1031,12 @@ class Gatekeeper:
                 risk_level=RiskLevel.RED,
                 original_action=action,
                 policy_name="path_validation",
+                # TRUST-2: structured explanation for the receipt + UI.
+                explanation=DecisionExplanation(
+                    rule_id="path_unparseable",
+                    rule_source="cognithor.core.gatekeeper:_check_path",
+                    matched_pattern=path_str[:200],
+                ),
             )
 
         # Check whether path is in an allowed directory
@@ -1048,6 +1054,12 @@ class Gatekeeper:
             risk_level=RiskLevel.RED,
             original_action=action,
             policy_name="path_validation",
+            # TRUST-2: structured explanation for the receipt + UI.
+            explanation=DecisionExplanation(
+                rule_id="path_outside_allowed",
+                rule_source="cognithor.core.gatekeeper:_check_path",
+                matched_pattern=path_str[:200],
+            ),
         )
 
     # Compiled patterns for dangerous Python code (class-level, compiled once)
@@ -1134,6 +1146,12 @@ class Gatekeeper:
                     risk_level=RiskLevel.RED,
                     original_action=action,
                     policy_name="blocked_python_ast",
+                    # TRUST-2: structured explanation for the receipt + UI.
+                    explanation=DecisionExplanation(
+                        rule_id="dangerous_python_ast",
+                        rule_source="cognithor.security.python_ast_guard:analyse_python",
+                        matched_pattern=details[:200],
+                    ),
                 )
         except SyntaxError:
             pass  # Unparseable code falls through to regex check
@@ -1149,6 +1167,12 @@ class Gatekeeper:
                     risk_level=RiskLevel.RED,
                     original_action=action,
                     policy_name="blocked_python_code",
+                    # TRUST-2: structured explanation for the receipt + UI.
+                    explanation=DecisionExplanation(
+                        rule_id="dangerous_python_regex",
+                        rule_source="cognithor.core.gatekeeper:_DANGEROUS_PYTHON_PATTERNS",
+                        matched_pattern=pattern.pattern[:200],
+                    ),
                 )
 
         return None

--- a/tests/test_core/test_gatekeeper.py
+++ b/tests/test_core/test_gatekeeper.py
@@ -578,3 +578,46 @@ class TestDecisionExplanation:
         assert " " not in decision.explanation.rule_id  # no whitespace = stable
         # rule_source points at code location (file:line or module:func)
         assert ":" in decision.explanation.rule_source
+
+    def test_dangerous_python_block_emits_explanation(
+        self, gatekeeper: Gatekeeper, session: SessionContext
+    ) -> None:
+        """``run_python`` with os.system() must emit a structured
+        TRUST-2 explanation pointing at the python_ast_guard / regex
+        site (the dangerous-Python-code check fires only for
+        ``run_python``, see gatekeeper.evaluate).
+        """
+        action = PlannedAction(
+            tool="run_python",
+            params={"code": "import os\nos.system('rm -rf /')"},
+        )
+        decision = gatekeeper.evaluate(action, session)
+        assert decision.is_blocked
+        assert decision.explanation is not None
+        assert decision.explanation.rule_id in {
+            "dangerous_python_ast",
+            "dangerous_python_regex",
+        }
+        assert decision.explanation.matched_pattern
+        assert ":" in decision.explanation.rule_source
+
+    def test_path_outside_allowed_emits_explanation(
+        self, gatekeeper: Gatekeeper, session: SessionContext
+    ) -> None:
+        """A read_file outside the allowed roots must emit a TRUST-2
+        explanation with rule_id=path_outside_allowed.
+        """
+        action = PlannedAction(tool="read_file", params={"path": "/etc/passwd"})
+        decision = gatekeeper.evaluate(action, session)
+        assert decision.is_blocked
+        # The block may come from path_validation OR an upstream rule.
+        # If path_validation fired, explanation must be the structured
+        # one we just added.
+        if decision.policy_name == "path_validation":
+            assert decision.explanation is not None
+            assert decision.explanation.rule_id in {
+                "path_outside_allowed",
+                "path_unparseable",
+            }
+            assert decision.explanation.matched_pattern
+            assert ":" in decision.explanation.rule_source


### PR DESCRIPTION
## Summary

Two more gatekeeper block paths now emit structured `DecisionExplanation`s on top of the existing shell-AST/regex coverage (#377). The TRUST-1 receipt + `GET /api/crew/trace/{id}/receipt?include_trust=true` now shows a stable `rule_id` + `rule_source` for every block on these paths, instead of free-text `reason` strings only.

## Sites enriched

| Where | rule_id | rule_source |
|---|---|---|
| `_check_python_code` AST | `dangerous_python_ast` | `cognithor.security.python_ast_guard:analyse_python` |
| `_check_python_code` regex fallback | `dangerous_python_regex` | `cognithor.core.gatekeeper:_DANGEROUS_PYTHON_PATTERNS` |
| `_check_path` unparseable | `path_unparseable` | `cognithor.core.gatekeeper:_check_path` |
| `_check_path` outside-allowed | `path_outside_allowed` | `cognithor.core.gatekeeper:_check_path` |

`matched_pattern` is truncated to 200 chars to keep the audit-log embed bounded (long pasted Python sources or pathological paths shouldn't bloat the chain).

## Test plan

- [x] `pytest tests/test_core/test_gatekeeper.py -x -q` — 92 passed (+2 new, 90 unchanged).
- [x] `mypy --strict src/cognithor/core/gatekeeper.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

2 new cases in `TestDecisionExplanation`:
- `test_dangerous_python_block_emits_explanation`: `run_python` with `os.system()` must produce a `DecisionExplanation` with rule_id in `{dangerous_python_ast, dangerous_python_regex}` and a non-empty `matched_pattern`.
- `test_path_outside_allowed_emits_explanation`: `read_file` targeting `/etc/passwd` must produce an explanation with rule_id in `{path_outside_allowed, path_unparseable}` when the block came from `path_validation`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)