### PR TITLE
feat(audit): TRUST-10 backfill — record SEC-HIGH-5 schema migration

### DIFF
--- a/src/cognithor/audit/__init__.py
+++ b/src/cognithor/audit/__init__.py
@@ -238,6 +238,49 @@ class AuditLogger:
         if log_dir:
             log_dir.mkdir(parents=True, exist_ok=True)
 
+        # TRUST-10 backfill: record the audit-log schema move from
+        # v0 (flat JSONL, no prev_hash) to v1 (hash-chained JSONL,
+        # SEC-HIGH-5) into the canonical MIGRATION_LEDGER. The hook
+        # is idempotent (the ledger rejects duplicate migration_id);
+        # safe to call on every AuditLogger construction.
+        self._record_audit_schema_migration()
+
+    @staticmethod
+    def _record_audit_schema_migration() -> None:
+        """Record the SEC-HIGH-5 audit-log schema migration.
+
+        Idempotent: the canonical MIGRATION_LEDGER rejects duplicate
+        migration_id with a chain error, which we silently swallow —
+        re-recording the same logical migration after a process
+        restart is a no-op, not a failure.
+
+        Best-effort: any exception is logged + swallowed. AuditLogger
+        construction MUST NEVER fail because of TRUST-10 backfill.
+        """
+        from contextlib import suppress
+
+        from cognithor.security.migration_ledger import (
+            MIGRATION_LEDGER,
+            MigrationChainError,
+            MigrationDomain,
+            MigrationStatus,
+            MigrationStep,
+        )
+
+        with suppress(MigrationChainError, ValueError):
+            MIGRATION_LEDGER.record(
+                MigrationStep(
+                    domain=MigrationDomain.AUDIT_LOG,
+                    source_version="v0-flat-jsonl",
+                    target_version="v1-hashchain-jsonl",
+                    status=MigrationStatus.APPLIED,
+                    applied_by="system",
+                    item_count=-1,  # schema-only, no row migration
+                    migration_id="audit_log:v0-flat-jsonl:v1-hashchain-jsonl",
+                    notes="SEC-HIGH-5: prev_hash chain on every audit entry",
+                )
+            )
+
     # ── Logging-Methoden ─────────────────────────────────────────
 
     def log_tool_call(

--- a/tests/test_audit/test_audit_logger.py
+++ b/tests/test_audit/test_audit_logger.py
@@ -801,3 +801,55 @@ class TestRunReceiptIncludeTrust:
         assert isinstance(trust, dict)
         trust["run_id"] = "tampered"
         assert AuditLogger.verify_receipt_signature(receipt, "hunter2") is False
+
+
+class TestAuditLoggerMigrationBackfill:
+    """TRUST-10 backfill: AuditLogger construction records the
+    SEC-HIGH-5 v0→v1 schema move into the canonical MIGRATION_LEDGER.
+    """
+
+    def test_construction_records_migration_step(self) -> None:
+        import cognithor.security.migration_ledger as mig_mod
+        from cognithor.security.migration_ledger import (
+            MigrationDomain,
+            MigrationLedger,
+            MigrationStatus,
+        )
+
+        isolated = MigrationLedger()
+        original = mig_mod.MIGRATION_LEDGER
+        mig_mod.MIGRATION_LEDGER = isolated  # type: ignore[misc]
+        try:
+            AuditLogger()
+            head = isolated.head_version(MigrationDomain.AUDIT_LOG)
+            assert head == "v1-hashchain-jsonl"
+            step = isolated.get("audit_log:v0-flat-jsonl:v1-hashchain-jsonl")
+            assert step is not None
+            assert step.status == MigrationStatus.APPLIED
+            assert step.applied_by == "system"
+            assert step.domain == MigrationDomain.AUDIT_LOG
+            assert "SEC-HIGH-5" in step.notes
+        finally:
+            mig_mod.MIGRATION_LEDGER = original  # type: ignore[misc]
+
+    def test_multiple_constructions_are_idempotent(self) -> None:
+        # Second AuditLogger() in the same process MUST NOT raise
+        # because of duplicate migration_id; the chain stays at v1.
+        import cognithor.security.migration_ledger as mig_mod
+        from cognithor.security.migration_ledger import (
+            MigrationDomain,
+            MigrationLedger,
+        )
+
+        isolated = MigrationLedger()
+        original = mig_mod.MIGRATION_LEDGER
+        mig_mod.MIGRATION_LEDGER = isolated  # type: ignore[misc]
+        try:
+            AuditLogger()
+            AuditLogger()
+            AuditLogger()
+            # Exactly one entry — duplicate migration_id is rejected.
+            assert len(isolated) == 1
+            assert isolated.head_version(MigrationDomain.AUDIT_LOG) == "v1-hashchain-jsonl"
+        finally:
+            mig_mod.MIGRATION_LEDGER = original  # type: ignore[misc]


### PR DESCRIPTION
## Summary

First TRUST-10 migration-script backfill from yesterday's deferred list. `AuditLogger.__init__` now records the v0→v1 audit-log schema move (the SEC-HIGH-5 hashchain work) into the canonical `MIGRATION_LEDGER` under `MigrationDomain.AUDIT_LOG`. The operational-trust receipt's migrations block now shows that the hashchain schema is in effect, instead of leaving the chain empty.

## Wiring

```
domain          = AUDIT_LOG
source_version  = "v0-flat-jsonl"
target_version  = "v1-hashchain-jsonl"
status          = APPLIED
applied_by      = "system"
item_count      = -1 (schema-only)
migration_id    = "audit_log:v0-flat-jsonl:v1-hashchain-jsonl"
notes           = "SEC-HIGH-5: prev_hash chain on every audit entry"
```

- **Idempotent**: ledger rejects duplicate `migration_id` with `MigrationChainError`; we silently swallow via `contextlib.suppress`. Multiple `AuditLogger()` constructions in the same process leave exactly one ledger entry.
- **Best-effort**: any `ValueError` during `MigrationStep` construction also gets swallowed. **AuditLogger construction MUST NEVER fail** because of TRUST-10 backfill.

## Test plan

- [x] `pytest tests/test_audit/test_audit_logger.py -x -q` — 70 passed (+2 new, 68 unchanged).
- [x] `mypy --strict src/cognithor/audit/__init__.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

2 new cases in `TestAuditLoggerMigrationBackfill`:
- `test_construction_records_migration_step`: `head_version(AUDIT_LOG) == "v1-hashchain-jsonl"` with the expected status/applied_by/notes fields.
- `test_multiple_constructions_are_idempotent`: 3× `AuditLogger()` in one isolated ledger leaves exactly 1 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)