### PR TITLE
feat(packs): TRUST-10 backfill — pack_manifest schema lineage

### DIFF
--- a/src/cognithor/packs/loader.py
+++ b/src/cognithor/packs/loader.py
@@ -105,6 +105,51 @@ class PackLoader:
         self._root = packs_dir
         self._cognithor_version = cognithor_version
         self._loaded: dict[str, AgentPack] = {}
+        # TRUST-10 backfill: record the pack-manifest schema lineage
+        # in the canonical MIGRATION_LEDGER. Idempotent + best-effort
+        # (see _record_pack_schema_migration). Pack loading MUST NEVER
+        # fail because of this hook.
+        self._record_pack_schema_migration()
+
+    @staticmethod
+    def _record_pack_schema_migration() -> None:
+        """Record the pack_manifest schema lineage (v0 implicit → v1).
+
+        v0 = pre-#395 era when packs shipped without an explicit
+        ``schema_version`` field. v1 = current ``schema_version: int = 1``
+        contract enforced by :class:`PackManifest`.
+
+        Idempotent: duplicate ``migration_id`` is silently swallowed
+        via :class:`MigrationChainError` suppression. Multiple
+        :class:`PackLoader` instances in the same process share one
+        ledger entry.
+        """
+        from contextlib import suppress
+
+        from cognithor.security.migration_ledger import (
+            MIGRATION_LEDGER,
+            MigrationChainError,
+            MigrationDomain,
+            MigrationStatus,
+            MigrationStep,
+        )
+
+        with suppress(MigrationChainError, ValueError):
+            MIGRATION_LEDGER.record(
+                MigrationStep(
+                    domain=MigrationDomain.PACK_MANIFEST,
+                    source_version="v0-implicit",
+                    target_version="v1-explicit-schema_version",
+                    status=MigrationStatus.APPLIED,
+                    applied_by="system",
+                    item_count=-1,
+                    migration_id=("pack_manifest:v0-implicit:v1-explicit-schema_version"),
+                    notes=(
+                        "PackManifest now requires an explicit schema_version "
+                        "field (default=1) and forbids extra keys"
+                    ),
+                )
+            )
 
     # ------------------------------------------------------------------
     # Public API

--- a/tests/test_packs/test_loader.py
+++ b/tests/test_packs/test_loader.py
@@ -214,3 +214,53 @@ class TestPackLoaderFingerprint:
             assert isolated.history("cognithor-official/exploding") == ()
         finally:
             fp_mod.FINGERPRINT_LEDGER = original  # type: ignore[misc]
+
+
+class TestPackLoaderMigrationBackfill:
+    """TRUST-10 backfill: PackLoader construction records the
+    pack_manifest schema lineage into the canonical MIGRATION_LEDGER.
+    """
+
+    def test_construction_records_migration_step(self, packs_dir: Path) -> None:
+        import cognithor.security.migration_ledger as mig_mod
+        from cognithor.security.migration_ledger import (
+            MigrationDomain,
+            MigrationLedger,
+            MigrationStatus,
+        )
+
+        isolated = MigrationLedger()
+        original = mig_mod.MIGRATION_LEDGER
+        mig_mod.MIGRATION_LEDGER = isolated  # type: ignore[misc]
+        try:
+            PackLoader(packs_dir=packs_dir, cognithor_version="0.92.0")
+            head = isolated.head_version(MigrationDomain.PACK_MANIFEST)
+            assert head == "v1-explicit-schema_version"
+            step = isolated.get("pack_manifest:v0-implicit:v1-explicit-schema_version")
+            assert step is not None
+            assert step.status == MigrationStatus.APPLIED
+            assert step.applied_by == "system"
+            assert step.domain == MigrationDomain.PACK_MANIFEST
+        finally:
+            mig_mod.MIGRATION_LEDGER = original  # type: ignore[misc]
+
+    def test_multiple_constructions_are_idempotent(self, packs_dir: Path) -> None:
+        import cognithor.security.migration_ledger as mig_mod
+        from cognithor.security.migration_ledger import (
+            MigrationDomain,
+            MigrationLedger,
+        )
+
+        isolated = MigrationLedger()
+        original = mig_mod.MIGRATION_LEDGER
+        mig_mod.MIGRATION_LEDGER = isolated  # type: ignore[misc]
+        try:
+            PackLoader(packs_dir=packs_dir, cognithor_version="0.92.0")
+            PackLoader(packs_dir=packs_dir, cognithor_version="0.92.0")
+            PackLoader(packs_dir=packs_dir, cognithor_version="0.92.0")
+            assert len(isolated) == 1
+            assert (
+                isolated.head_version(MigrationDomain.PACK_MANIFEST) == "v1-explicit-schema_version"
+            )
+        finally:
+            mig_mod.MIGRATION_LEDGER = original  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Second TRUST-10 migration-script backfill after #416 (audit-log hashchain). `PackLoader.__init__` now records the `pack_manifest` schema lineage from v0 (implicit pre-#395 era when packs shipped without explicit `schema_version`) to v1 (current `PackManifest.schema_version: int = 1` with `extra="forbid"`) into the canonical `MIGRATION_LEDGER` under `MigrationDomain.PACK_MANIFEST`.

## Wiring

```
domain          = PACK_MANIFEST
source_version  = "v0-implicit"
target_version  = "v1-explicit-schema_version"
status          = APPLIED
applied_by      = "system"
item_count      = -1
migration_id    = "pack_manifest:v0-implicit:v1-explicit-schema_version"
```

- **Idempotent**: `MigrationChainError` on duplicate id silently swallowed via `contextlib.suppress`.
- **Best-effort**: `ValueError` on construction also swallowed. **PackLoader construction MUST NEVER fail** because of backfill.

## Test plan

- [x] `pytest tests/test_packs/test_loader.py -x -q` — 13 passed (+2 new, 11 unchanged).
- [x] `mypy --strict src/cognithor/packs/loader.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

2 new cases in `TestPackLoaderMigrationBackfill`:
- construction records the v0→v1 step with the right status/applied_by fields.
- 3× `PackLoader()` in one isolated ledger leaves exactly 1 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)