### PR TITLE
feat(gatekeeper): TRUST-2 explanation on OFFLINE-mode network blocks

### DIFF
--- a/src/cognithor/core/gatekeeper.py
+++ b/src/cognithor/core/gatekeeper.py
@@ -363,12 +363,30 @@ class Gatekeeper:
                     ToolCapability.NETWORK_HTTP in tool_caps.capabilities
                     or ToolCapability.NETWORK_WS in tool_caps.capabilities
                 ):
+                    # Surface which capability triggered the block —
+                    # NETWORK_HTTP, NETWORK_WS, or both.
+                    matched_caps = sorted(
+                        c.value
+                        for c in (
+                            ToolCapability.NETWORK_HTTP,
+                            ToolCapability.NETWORK_WS,
+                        )
+                        if c in tool_caps.capabilities
+                    )
                     decision = GateDecision(
                         status=GateStatus.BLOCK,
                         reason=t("gatekeeper.offline_network_blocked", tool=action.tool),
                         risk_level=RiskLevel.RED,
                         original_action=action,
                         policy_name="operation_mode_offline",
+                        # TRUST-2: structured explanation for the receipt + UI.
+                        explanation=DecisionExplanation(
+                            rule_id="operation_mode_offline_network",
+                            rule_source=(
+                                "cognithor.core.gatekeeper:_OFFLINE_ALLOWED_NETWORK_TOOLS"
+                            ),
+                            matched_pattern=",".join([action.tool, *matched_caps])[:200],
+                        ),
                     )
                     self._write_audit(action, decision, context)
                     return decision

--- a/tests/test_core/test_operation_mode.py
+++ b/tests/test_core/test_operation_mode.py
@@ -167,6 +167,12 @@ class TestGatekeeperOfflineEnforcement:
         assert decision.status == GateStatus.BLOCK
         assert "OFFLINE" in decision.reason
         assert decision.policy_name == "operation_mode_offline"
+        # TRUST-2: structured explanation with the matched capability.
+        assert decision.explanation is not None
+        assert decision.explanation.rule_id == "operation_mode_offline_network"
+        assert "_OFFLINE_ALLOWED_NETWORK_TOOLS" in decision.explanation.rule_source
+        assert "cloud_api_call" in decision.explanation.matched_pattern
+        assert "network_http" in decision.explanation.matched_pattern
 
     def test_offline_blocks_websocket_tool(
         self,


### PR DESCRIPTION
## Summary

Step 0 of `evaluate()` — the `OperationMode.OFFLINE` network-block path — now emits a structured `DecisionExplanation` alongside the free-text reason. After #415 (Python AST + path) and #418 (credential mask), this completes the TRUST-2 enrichment of every common block path in `evaluate()`.

## Wiring

```python
explanation=DecisionExplanation(
    rule_id="operation_mode_offline_network",
    rule_source="cognithor.core.gatekeeper:_OFFLINE_ALLOWED_NETWORK_TOOLS",
    matched_pattern=",".join([action.tool, *matched_caps])[:200],
)
```

`matched_pattern` surfaces both the tool name AND which capability (`NETWORK_HTTP` / `NETWORK_WS` / both) triggered the block, so the receipt + Trace-UI can answer "exactly why was this tool blocked in offline mode" without parsing the free-text reason.

## Test plan

- [x] `pytest tests/test_core/test_operation_mode.py -x -q` — 17 passed.
- [x] `pytest tests/test_core/test_gatekeeper.py -x -q` — 93 passed.
- [x] `mypy --strict src/cognithor/core/gatekeeper.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

Existing `test_offline_blocks_network_tool` extended with TRUST-2 assertions:
- `decision.explanation.rule_id == "operation_mode_offline_network"`
- `rule_source` mentions `_OFFLINE_ALLOWED_NETWORK_TOOLS`
- `matched_pattern` contains the tool name AND `"network_http"`

## TRUST-2 explanation coverage now

| Block path | rule_id | landed |
|---|---|---|
| destructive shell command (AST) | `dest_cmd_ast` | #377 |
| destructive shell command (regex) | `dest_cmd_regex` | #377 |
| dangerous Python (AST) | `dangerous_python_ast` | #415 |
| dangerous Python (regex) | `dangerous_python_regex` | #415 |
| path unparseable | `path_unparseable` | #415 |
| path outside allowed | `path_outside_allowed` | #415 |
| credential mask | `credential_scan` | #418 |
| OFFLINE network block | `operation_mode_offline_network` | this PR |
| permission scope | `scope:<axis>:<identity>` | #396 |
| explicit policy match | `policy:<rule_name>` | #377 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)