### PR TITLE
feat(security): TRUST-9 wiring into IsolatedSessionStore.create_session

### DIFF
--- a/src/cognithor/security/agent_vault.py
+++ b/src/cognithor/security/agent_vault.py
@@ -474,9 +474,30 @@ class IsolatedSessionStore:
         self._counter = 0
 
     def create_session(
-        self, agent_id: str, tenant_id: str = "", data: dict[str, Any] | None = None
+        self,
+        agent_id: str,
+        tenant_id: str = "",
+        data: dict[str, Any] | None = None,
+        *,
+        provenance_source_type: str | None = None,
+        provenance_source_id: str | None = None,
+        provenance_notes: str = "",
     ) -> AgentSession:
-        """Creates a new session for an agent."""
+        """Creates a new session for an agent.
+
+        Optional TRUST-9 provenance: when both
+        ``provenance_source_type`` and ``provenance_source_id`` are
+        passed, a tag is written to the canonical
+        ``PROVENANCE_LEDGER`` keyed by the new ``session_id``. Lets
+        the operational-trust receipt answer "where did this session
+        come from?" — channel onboarding, IDE plugin handshake,
+        cron-spawned worker, etc.
+
+        Privacy contract carried over from :meth:`AgentVault.store`:
+        only metadata flows. The session's ``data`` payload is NOT
+        introspected; the caller must avoid putting credentials into
+        ``provenance_notes``.
+        """
         self._counter += 1
         session = AgentSession(
             session_id=f"SESS-{agent_id[:6]}-{self._counter:04d}",
@@ -489,6 +510,13 @@ class IsolatedSessionStore:
         if agent_id not in self._stores:
             self._stores[agent_id] = {}
         self._stores[agent_id][session.session_id] = session
+        if provenance_source_type and provenance_source_id:
+            _tag_vault_provenance(
+                item_id=session.session_id,
+                source_type_value=provenance_source_type,
+                source_id=provenance_source_id,
+                notes=provenance_notes,
+            )
         return session
 
     def get_session(self, agent_id: str, session_id: str) -> AgentSession | None:

--- a/tests/test_security/test_vault_provenance.py
+++ b/tests/test_security/test_vault_provenance.py
@@ -1,8 +1,13 @@
-"""Tests for the TRUST-9 wiring into AgentVault.store (#412)."""
+"""Tests for the TRUST-9 wiring into AgentVault.store (#412) and
+IsolatedSessionStore.create_session (this PR)."""
 
 from __future__ import annotations
 
-from cognithor.security.agent_vault import AgentVault, SecretType
+from cognithor.security.agent_vault import (
+    AgentVault,
+    IsolatedSessionStore,
+    SecretType,
+)
 
 
 class TestAgentVaultProvenance:
@@ -119,5 +124,87 @@ class TestAgentVaultProvenance:
             # Round-trip retrieval still works (secret was stored).
             assert vault.retrieve(secret.secret_id) == "v"
             assert len(isolated) == 0
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+
+class TestIsolatedSessionStoreProvenance:
+    """``IsolatedSessionStore.create_session(provenance_source_type=...,
+    provenance_source_id=...)`` writes a tag to the canonical
+    PROVENANCE_LEDGER keyed by the new session_id.
+    """
+
+    def test_create_session_without_provenance_does_not_tag(self) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            store = IsolatedSessionStore()
+            session = store.create_session("agent-1")
+            assert session.session_id not in isolated
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_create_session_with_provenance_tags_ledger(self) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger, SourceType
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            store = IsolatedSessionStore()
+            session = store.create_session(
+                "agent-1",
+                tenant_id="tenant-x",
+                data={"role": "user"},
+                provenance_source_type="chat_utterance",
+                provenance_source_id="msg-42",
+                provenance_notes="onboarded via telegram",
+            )
+            tag = isolated.current(session.session_id)
+            assert tag is not None
+            assert tag.source_type == SourceType.CHAT_UTTERANCE
+            assert tag.source_id == "msg-42"
+            assert tag.notes == "onboarded via telegram"
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_partial_provenance_args_skip_tag(self) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            store = IsolatedSessionStore()
+            s1 = store.create_session("agent-a", provenance_source_type="chat_utterance")
+            s2 = store.create_session("agent-b", provenance_source_id="msg-7")
+            assert s1.session_id not in isolated
+            assert s2.session_id not in isolated
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_unknown_source_type_falls_back_to_unknown(self) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger, SourceType
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            store = IsolatedSessionStore()
+            session = store.create_session(
+                "agent-1",
+                provenance_source_type="not_real",
+                provenance_source_id="x",
+            )
+            tag = isolated.current(session.session_id)
+            assert tag is not None
+            assert tag.source_type == SourceType.UNKNOWN
         finally:
             prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Companion to #412 (vault.store provenance). Sessions tracked in `IsolatedSessionStore` now also accept opt-in provenance tagging: `provenance_source_type` + `provenance_source_id` keyword-only args write a `ProvenanceTag` to the canonical `PROVENANCE_LEDGER` keyed by the new `session_id`.

The TRUST-1 receipt + `GET /api/crew/trace/{id}/receipt?include_trust=true` can now answer **"where did this session come from?"** — channel onboarding (`chat_utterance`), IDE plugin handshake (`config_import`), cron-spawned worker (`scheduled_ingest`), owner /reset (`user_directive`), etc. — for every session that opted into provenance at creation.

## Wiring

- New keyword-only params on `create_session`: `provenance_source_type`, `provenance_source_id`, `provenance_notes`.
- Identical contract to `AgentVault.store` (#412): both required to tag, partial args silently skip, unknown values coerce to `SourceType.UNKNOWN`.
- Reuses the existing `_tag_vault_provenance()` module-level helper from #412 — no new code path.
- Tag keyed by `session_id` (the `SESS-*` identifier the store generates).

## Privacy contract

Only metadata flows. The session's `data` payload is NOT introspected. Caller responsible for not putting credentials into `notes`.

## Test plan

- [x] `pytest tests/test_security/ -k vault -x -q` — 105 passed (+4 new, 101 unchanged).
- [x] `mypy --strict src/cognithor/security/agent_vault.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

4 new cases in `TestIsolatedSessionStoreProvenance`:
- without provenance args: no ledger entry.
- with both args: tag written, source_type/source_id/notes match.
- partial args: no tag.
- unknown source_type string falls back to `UNKNOWN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)