### PR TITLE
feat(audit): TRUST-3 — classify TRUST-5..10 failure modes

### DIFF
--- a/src/cognithor/audit/__init__.py
+++ b/src/cognithor/audit/__init__.py
@@ -902,11 +902,38 @@ class AuditLogger:
 
         # Category-driven routing first — most reliable signal.
         if entry.category == AuditCategory.GATEKEEPER:
+            # TRUST-5..6 hooks: distinguish scope / budget blocks
+            # from generic gatekeeper blocks before falling through.
+            if (
+                "permission_scope" in description
+                or "scope=" in description
+                or "scope " in description
+            ):
+                return FailureMode.PERMISSION_SCOPE_DENIED
+            if (
+                "budget" in description
+                or "cost limit" in description
+                or "budget_exceeded" in description
+            ):
+                return FailureMode.BUDGET_EXCEEDED
             if "approve" in description or "approval" in description:
                 return FailureMode.GATEKEEPER_APPROVAL_DENIED
             return FailureMode.GATEKEEPER_BLOCK
 
         if entry.category == AuditCategory.SECURITY:
+            # TRUST-7..10 surfaces — match before the catch-all so a
+            # SECURITY-categorised entry with the right keyword gets
+            # the structured failure mode.
+            if "fingerprint" in description and (
+                "drift" in description or "diverg" in description or "mismatch" in description
+            ):
+                return FailureMode.FINGERPRINT_DRIFT
+            if "escalation" in description and ("reject" in description or "denied" in description):
+                return FailureMode.CLOUD_ESCALATION_REJECTED
+            if "provenance" in description and ("expired" in description or "stale" in description):
+                return FailureMode.PROVENANCE_EXPIRED
+            if "migration" in description and ("chain" in description or "mismatch" in description):
+                return FailureMode.MIGRATION_CHAIN_ERROR
             if "sandbox" in description:
                 return FailureMode.SANDBOX_REFUSED
             if "auth" in description or "credential" in description:

--- a/src/cognithor/models.py
+++ b/src/cognithor/models.py
@@ -157,6 +157,14 @@ class FailureMode(StrEnum):
     LLM_HALLUCINATION = "llm_hallucination"
     LLM_REFUSAL = "llm_refusal"
 
+    # Operational-trust failures (TRUST-5..10, added 2026-05-04)
+    PERMISSION_SCOPE_DENIED = "permission_scope_denied"  # TRUST-5
+    BUDGET_EXCEEDED = "budget_exceeded"  # TRUST-6
+    FINGERPRINT_DRIFT = "fingerprint_drift"  # TRUST-7 — same name, different SHA
+    CLOUD_ESCALATION_REJECTED = "cloud_escalation_rejected"  # TRUST-8
+    PROVENANCE_EXPIRED = "provenance_expired"  # TRUST-9 — TTL-tagged item past valid_until
+    MIGRATION_CHAIN_ERROR = "migration_chain_error"  # TRUST-10 — head/source mismatch
+
     # Catch-all — only when none of the above fits. Aggregator should
     # surface any non-trivial counts here as "needs new enum value".
     UNKNOWN = "unknown"

--- a/tests/test_audit/test_audit_logger.py
+++ b/tests/test_audit/test_audit_logger.py
@@ -576,6 +576,70 @@ class TestFailureModeClassification:
         d = entry.to_dict()
         assert d["failure_mode"] is None
 
+    # ── TRUST-5..10 failure-mode taxonomy ─────────────────────────
+
+    def test_permission_scope_denied_classified(self) -> None:
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger.log_gatekeeper(
+            "BLOCK",
+            "Scope channel='telegram' blocks 'shell': permission_scope denylist",
+            tool_name="shell",
+        )
+        assert AuditLogger.classify_failure(entry) == FailureMode.PERMISSION_SCOPE_DENIED
+
+    def test_budget_exceeded_classified(self) -> None:
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger.log_gatekeeper(
+            "BLOCK",
+            "budget_exceeded: cost limit 0.50 USD reached",
+            tool_name="anthropic:claude",
+        )
+        assert AuditLogger.classify_failure(entry) == FailureMode.BUDGET_EXCEEDED
+
+    def test_fingerprint_drift_classified(self) -> None:
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger.log_security(
+            "fingerprint drift detected: web_fetch has 2 distinct SHA-256 values",
+            blocked=True,
+        )
+        assert AuditLogger.classify_failure(entry) == FailureMode.FINGERPRINT_DRIFT
+
+    def test_cloud_escalation_rejected_classified(self) -> None:
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger.log_security(
+            "cloud escalation rejected: owner consent required for cross-region call",
+            blocked=True,
+        )
+        assert AuditLogger.classify_failure(entry) == FailureMode.CLOUD_ESCALATION_REJECTED
+
+    def test_provenance_expired_classified(self) -> None:
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger.log_security(
+            "provenance expired: TTL tag past valid_until on item-7",
+            blocked=True,
+        )
+        assert AuditLogger.classify_failure(entry) == FailureMode.PROVENANCE_EXPIRED
+
+    def test_migration_chain_error_classified(self) -> None:
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger.log_security(
+            "migration chain mismatch on audit_log: head v2 vs source v1",
+            blocked=True,
+        )
+        assert AuditLogger.classify_failure(entry) == FailureMode.MIGRATION_CHAIN_ERROR
+
 
 # ============================================================================
 # TRUST-1 — Run-Receipts (operational-trust audit, 2026-05-04)


### PR DESCRIPTION
## Summary

Extends the TRUST-3 failure-mode taxonomy + classifier to cover the six new failure surfaces introduced by TRUST-5..10. Previously, a permission-scope deny showed up as generic `GATEKEEPER_BLOCK`; a budget exceedance fell through to `UNKNOWN`. The TRUST-1 receipt's `failures_by_mode` aggregator now distinguishes them.

## New `FailureMode` enum values

| Value | Origin |
|---|---|
| `PERMISSION_SCOPE_DENIED` | TRUST-5 |
| `BUDGET_EXCEEDED` | TRUST-6 |
| `FINGERPRINT_DRIFT` | TRUST-7 |
| `CLOUD_ESCALATION_REJECTED` | TRUST-8 |
| `PROVENANCE_EXPIRED` | TRUST-9 |
| `MIGRATION_CHAIN_ERROR` | TRUST-10 |

## New classifier branches

- **GATEKEEPER** category: `permission_scope` / `scope=` / `scope ` → `PERMISSION_SCOPE_DENIED`. `budget` / `cost limit` / `budget_exceeded` → `BUDGET_EXCEEDED`. Both fire BEFORE the existing approval check so the TRUST modes win over generic approval-denied.
- **SECURITY** category: `fingerprint` + drift/diverg/mismatch → `FINGERPRINT_DRIFT`. `escalation` + reject/denied → `CLOUD_ESCALATION_REJECTED`. `provenance` + expired/stale → `PROVENANCE_EXPIRED`. `migration` + chain/mismatch → `MIGRATION_CHAIN_ERROR`. All match before the existing sandbox/auth/credential branches.

Pure-function classifier (no I/O), safe to call from the receipt aggregator's hot path.

## Test plan

- [x] `pytest tests/test_audit/test_audit_logger.py -x -q` — 76 passed (+6 new, 70 unchanged).
- [x] `mypy --strict src/cognithor/audit/__init__.py src/cognithor/models.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

6 new cases in `TestFailureModeClassification` covering each new mode by feeding a hand-crafted `log_security` or `log_gatekeeper` entry with a representative description string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)