### PR TITLE
feat(gatekeeper): TRUST-3 — explicit failure_mode on gatekeeper audit entries

### DIFF
--- a/src/cognithor/audit/__init__.py
+++ b/src/cognithor/audit/__init__.py
@@ -406,8 +406,16 @@ class AuditLogger:
         tool_name: str = "",
         agent_name: str = "",
         session_id: str = "",
+        failure_mode: FailureMode | None = None,
     ) -> AuditEntry:
-        """Logs a gatekeeper decision."""
+        """Logs a gatekeeper decision.
+
+        ``failure_mode``: optional TRUST-3 explicit classification. The
+        gatekeeper passes a structured value (e.g.
+        ``FailureMode.PERMISSION_SCOPE_DENIED``) so the receipt
+        aggregator no longer has to infer from the free-text reason.
+        Ignored for non-block decisions (success path).
+        """
         is_block = decision.upper() in ("BLOCK", "DENY")
         return self._log(
             category=AuditCategory.GATEKEEPER,
@@ -419,6 +427,7 @@ class AuditLogger:
             parameters={"decision": decision, "reason": reason},
             success=not is_block,
             session_id=session_id,
+            failure_mode=failure_mode if is_block else None,
         )
 
     def log_memory_op(

--- a/src/cognithor/core/gatekeeper.py
+++ b/src/cognithor/core/gatekeeper.py
@@ -30,6 +30,7 @@ from cognithor.i18n import t
 from cognithor.models import (
     AuditEntry,
     DecisionExplanation,
+    FailureMode,
     GateDecision,
     GateStatus,
     OperationMode,
@@ -1409,6 +1410,7 @@ class Gatekeeper:
                 decision.status.value,
                 decision.reason,
                 tool_name=action.tool,
+                failure_mode=self._derive_failure_mode(decision),
             )
 
         # Auch ins structlog
@@ -1421,6 +1423,39 @@ class Gatekeeper:
             policy=decision.policy_name,
             session=context.session_id[:8],
         )
+
+    @staticmethod
+    def _derive_failure_mode(decision: GateDecision) -> FailureMode | None:
+        """Map a :class:`GateDecision` to an explicit :class:`FailureMode`.
+
+        TRUST-3 enrichment: the gatekeeper knows exactly which rule
+        fired (it set ``decision.policy_name``), so the receipt no
+        longer has to infer the failure mode from the free-text
+        reason. Returns ``None`` for non-block decisions and for
+        block paths where the existing classifier-by-description
+        path is already accurate enough.
+        """
+        if not decision.is_blocked:
+            return None
+        policy = (decision.policy_name or "").lower()
+        if policy.startswith("permission_scope:"):
+            return FailureMode.PERMISSION_SCOPE_DENIED
+        if policy == "operation_mode_offline":
+            # Offline-mode block is a network-error in the failure-mode
+            # taxonomy (the request would have left the machine).
+            return FailureMode.NETWORK_ERROR
+        if policy in {
+            "blocked_command",
+            "blocked_command_ast",
+            "blocked_python_code",
+            "blocked_python_ast",
+        }:
+            return FailureMode.GATEKEEPER_BLOCK
+        if policy == "path_validation":
+            return FailureMode.GATEKEEPER_BLOCK
+        if policy == "credential_masking":
+            return FailureMode.AUTH_ERROR
+        return None
 
     def _flush_audit_buffer(self) -> None:
         """Schreibt den Audit-Buffer gesammelt auf Disk (batch I/O).

--- a/tests/test_audit/test_audit_logger.py
+++ b/tests/test_audit/test_audit_logger.py
@@ -640,6 +640,39 @@ class TestFailureModeClassification:
         )
         assert AuditLogger.classify_failure(entry) == FailureMode.MIGRATION_CHAIN_ERROR
 
+    def test_explicit_failure_mode_via_log_gatekeeper(self) -> None:
+        # log_gatekeeper now accepts an explicit failure_mode kwarg so
+        # the gatekeeper can stamp the structured value directly
+        # instead of relying on the description-pattern classifier.
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger.log_gatekeeper(
+            "BLOCK",
+            "scoped blocked",
+            tool_name="shell",
+            failure_mode=FailureMode.PERMISSION_SCOPE_DENIED,
+        )
+        # The classifier returns the explicit value unchanged.
+        assert AuditLogger.classify_failure(entry) == FailureMode.PERMISSION_SCOPE_DENIED
+        # And it serialises to the to_dict() shape.
+        assert entry.to_dict()["failure_mode"] == "permission_scope_denied"
+
+    def test_explicit_failure_mode_ignored_on_allow(self) -> None:
+        # ALLOW path: failure_mode kwarg is silently dropped because
+        # success entries don't carry one.
+        from cognithor.models import FailureMode
+
+        logger = AuditLogger()
+        entry = logger.log_gatekeeper(
+            "ALLOW",
+            "ok",
+            tool_name="read_file",
+            failure_mode=FailureMode.PERMISSION_SCOPE_DENIED,
+        )
+        assert entry.success is True
+        assert entry.failure_mode is None
+
 
 # ============================================================================
 # TRUST-1 — Run-Receipts (operational-trust audit, 2026-05-04)


### PR DESCRIPTION
## Summary

After #421 added the TRUST-5..10 failure-mode taxonomy + classifier, the gatekeeper now stamps the structured value **directly** on every gatekeeper audit entry instead of relying on the description-pattern classifier. The receipt's `failures_by_mode` aggregator gets the correct breakdown even when reasons are translated, truncated, or otherwise deviate from the classifier's regex assumptions.

## Wiring

- `log_gatekeeper(... failure_mode=FailureMode | None)` now accepts an optional explicit value. Forwarded to `AuditEntry.failure_mode` via the existing `_log()` path. Ignored on `ALLOW` decisions.
- New static helper `Gatekeeper._derive_failure_mode(decision)` maps `decision.policy_name` →
  | policy_name | failure_mode |
  |---|---|
  | `permission_scope:*` | `PERMISSION_SCOPE_DENIED` |
  | `operation_mode_offline` | `NETWORK_ERROR` |
  | `blocked_command` / `blocked_command_ast` / `blocked_python_code` / `blocked_python_ast` | `GATEKEEPER_BLOCK` |
  | `path_validation` | `GATEKEEPER_BLOCK` |
  | `credential_masking` | `AUTH_ERROR` |
- `_write_audit()` passes the derived value into `log_gatekeeper`.
- `classify_failure` already returns `entry.failure_mode` unchanged when set, so the explicit value wins over the inference path.

## Test plan

- [x] `pytest tests/test_audit/test_audit_logger.py tests/test_core/test_gatekeeper.py tests/test_core/test_operation_mode.py -x -q` — 188 passed (+2 new).
- [x] `mypy --strict src/cognithor/core/gatekeeper.py src/cognithor/audit/__init__.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

2 new cases in `TestFailureModeClassification`:
- `test_explicit_failure_mode_via_log_gatekeeper`: `log_gatekeeper(BLOCK, failure_mode=PERMISSION_SCOPE_DENIED)` produces an entry whose `classify_failure()` and `to_dict()["failure_mode"]` both surface the structured value.
- `test_explicit_failure_mode_ignored_on_allow`: ALLOW decisions silently drop the kwarg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)