### PR TITLE
feat(gatekeeper): TRUST-2 explanation on disabled-tool block path

### DIFF
--- a/src/cognithor/core/gatekeeper.py
+++ b/src/cognithor/core/gatekeeper.py
@@ -603,13 +603,31 @@ class Gatekeeper:
             except Exception:
                 log.debug("confidence_check_failed", exc_info=True)
 
+        # TRUST-2: when the default-classification path lands on a
+        # disabled tool (config.tools toggle off → forced RED), surface
+        # a structured explanation so the receipt can show "this was
+        # blocked because the tool group is disabled in config" without
+        # parsing free text.
+        disabled_explanation: DecisionExplanation | None = None
+        if action.tool.lower() in self._disabled_tools:
+            disabled_explanation = DecisionExplanation(
+                rule_id="tool_disabled_by_config",
+                rule_source="cognithor.core.gatekeeper:_disabled_tools",
+                matched_pattern=action.tool[:200],
+            )
+
         decision = GateDecision(
             status=status,
             reason=t("gatekeeper.default_classification", risk=risk.name),
             risk_level=risk,
             original_action=action,
-            policy_name="default_classification",
+            policy_name=(
+                "tool_disabled_by_config"
+                if disabled_explanation is not None
+                else "default_classification"
+            ),
             confidence_score=confidence_score,
+            explanation=disabled_explanation,
         )
         self._write_audit(action, decision, context)
         return decision

--- a/tests/test_core/test_gatekeeper.py
+++ b/tests/test_core/test_gatekeeper.py
@@ -622,6 +622,25 @@ class TestDecisionExplanation:
             assert decision.explanation.matched_pattern
             assert ":" in decision.explanation.rule_source
 
+    def test_disabled_tool_emits_explanation(
+        self, gk_config: CognithorConfig, session: SessionContext
+    ) -> None:
+        """Tool disabled by ``config.tools`` toggle must emit a TRUST-2
+        explanation pointing at the disabled-tools set.
+        """
+        # Build a gatekeeper with computer_use disabled — that group's
+        # tools land in self._disabled_tools.
+        gk_config.tools.computer_use_enabled = False
+        gk = Gatekeeper(gk_config)
+        gk.initialize()
+        action = PlannedAction(tool="computer_screenshot", params={})
+        decision = gk.evaluate(action, session)
+        assert decision.policy_name == "tool_disabled_by_config"
+        assert decision.explanation is not None
+        assert decision.explanation.rule_id == "tool_disabled_by_config"
+        assert "_disabled_tools" in decision.explanation.rule_source
+        assert decision.explanation.matched_pattern == "computer_screenshot"
+
     def test_credential_mask_emits_explanation(
         self, gatekeeper: Gatekeeper, session: SessionContext
     ) -> None:


### PR DESCRIPTION
## Summary

Tool blocked because its `config.tools` toggle was off used to land in `default_classification` with only a generic "Default-Klassifizierung: RED" reason. The Trace-UI could not distinguish "computer_use disabled in config" from "unknown tool defaulted to RED".

## Wiring

When `action.tool.lower() in self._disabled_tools` the default-classification decision emits:

```python
policy_name="tool_disabled_by_config"
explanation=DecisionExplanation(
    rule_id="tool_disabled_by_config",
    rule_source="cognithor.core.gatekeeper:_disabled_tools",
    matched_pattern=action.tool[:200],
)
```

## Test plan

- [x] `pytest tests/test_core/test_gatekeeper.py -x -q` — 94 passed (+1 new, 93 unchanged).
- [x] `mypy --strict` clean. `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)