### PR TITLE
feat(memory): TRUST-9 wiring into ProceduralMemory.save_procedure

### DIFF
--- a/src/cognithor/memory/procedural.py
+++ b/src/cognithor/memory/procedural.py
@@ -72,6 +72,10 @@ class ProceduralMemory:
         name: str,
         body: str,
         metadata: ProcedureMetadata | None = None,
+        *,
+        provenance_source_type: str | None = None,
+        provenance_source_id: str | None = None,
+        provenance_notes: str = "",
     ) -> Path:
         """Save a procedure as a Markdown file.
 
@@ -79,6 +83,16 @@ class ProceduralMemory:
             name: Prozedur-Name (wird als Dateiname verwendet).
             body: Markdown-Body (ohne Frontmatter).
             metadata: Prozedur-Metadaten.
+            provenance_source_type: Optional TRUST-9 ``SourceType`` value
+                (``"agent_inference"``, ``"user_directive"``, etc.). When
+                set with ``provenance_source_id``, a tag is written to
+                the canonical ``PROVENANCE_LEDGER`` keyed by
+                ``procedure:<safe_name>``.
+            provenance_source_id: Stable upstream id (audit-log entry id,
+                message id, …). Required when ``provenance_source_type``
+                is set.
+            provenance_notes: Short audit-log breadcrumb. MUST NOT
+                contain prompt / response content.
 
         Returns:
             Pfad zur erstellten Datei.
@@ -101,7 +115,51 @@ class ProceduralMemory:
         else:
             file_path.write_text(content, encoding="utf-8")
         logger.info("Prozedur gespeichert: %s → %s", name, file_path)
+        if provenance_source_type and provenance_source_id:
+            self._tag_provenance(
+                item_id=f"procedure:{safe_name}",
+                source_type_value=provenance_source_type,
+                source_id=provenance_source_id,
+                notes=provenance_notes,
+            )
         return file_path
+
+    @staticmethod
+    def _tag_provenance(
+        *,
+        item_id: str,
+        source_type_value: str,
+        source_id: str,
+        notes: str,
+    ) -> None:
+        """Best-effort TRUST-9 provenance tag for a saved procedure.
+
+        Failures are silently swallowed — saving a procedure MUST
+        NEVER fail because of provenance tagging. Unknown
+        ``source_type_value`` is coerced to
+        :data:`SourceType.UNKNOWN`.
+        """
+        from cognithor.memory.provenance import (
+            PROVENANCE_LEDGER,
+            ProvenanceTag,
+            SourceType,
+        )
+
+        try:
+            try:
+                source_type = SourceType(source_type_value)
+            except ValueError:
+                source_type = SourceType.UNKNOWN
+            PROVENANCE_LEDGER.tag(
+                item_id,
+                ProvenanceTag(
+                    source_type=source_type,
+                    source_id=source_id,
+                    notes=notes,
+                ),
+            )
+        except ValueError:
+            pass
 
     def load_procedure(self, name: str) -> tuple[ProcedureMetadata, str] | None:
         """Laedt eine Prozedur.

--- a/tests/test_memory/test_procedural.py
+++ b/tests/test_memory/test_procedural.py
@@ -223,3 +223,81 @@ class TestFindByQuery:
         """Unbekannte Query findet nichts."""
         results = proc_with_data.find_by_query("Wetter in Nürnberg morgen")
         assert results == []
+
+
+class TestProceduralMemoryProvenance:
+    """TRUST-9 wiring: passing ``provenance_source_type`` +
+    ``provenance_source_id`` to ``save_procedure`` writes a tag to
+    the canonical PROVENANCE_LEDGER keyed by
+    ``procedure:<safe_name>``.
+    """
+
+    def test_save_without_provenance_does_not_tag(self, proc: ProceduralMemory) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            proc.save_procedure("Probe", "body")
+            assert "procedure:probe" not in isolated
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_save_with_provenance_tags_ledger(self, proc: ProceduralMemory) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger, SourceType
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            proc.save_procedure(
+                "Wetter Abfrage",
+                "body",
+                provenance_source_type="agent_inference",
+                provenance_source_id="run-77",
+                provenance_notes="learned from successful run",
+            )
+            tag = isolated.current("procedure:wetter-abfrage")
+            assert tag is not None
+            assert tag.source_type == SourceType.AGENT_INFERENCE
+            assert tag.source_id == "run-77"
+            assert tag.notes == "learned from successful run"
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_unknown_source_type_falls_back_to_unknown(self, proc: ProceduralMemory) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger, SourceType
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            proc.save_procedure(
+                "weird",
+                "body",
+                provenance_source_type="not_real",
+                provenance_source_id="x",
+            )
+            tag = isolated.current("procedure:weird")
+            assert tag is not None
+            assert tag.source_type == SourceType.UNKNOWN
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_partial_provenance_args_skip_tag(self, proc: ProceduralMemory) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            proc.save_procedure("OnlyType", "b", provenance_source_type="agent_inference")
+            proc.save_procedure("OnlyId", "b", provenance_source_id="run-77")
+            assert len(isolated) == 0
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Fifth memory-tier wiring after #409 (semantic entities), #410 (episodic logs), #411 (relations), #412 (vault). The procedural memory tier (tier 4 — saved skills / playbooks as Markdown procedures) now supports opt-in provenance tagging.

The TRUST-1 receipt + `GET /api/crew/trace/{id}/receipt?include_trust=true` can now answer **"where did this learned skill come from?"** — owner authoring, `agent_inference` from a successful run, `config_import`, etc. — for every procedure that opted into provenance at save time.

## Wiring

- New keyword-only params on `save_procedure`: `provenance_source_type`, `provenance_source_id`, `provenance_notes`. Identical contract to the other TRUST-9 hooks.
- Tag keyed by `f"procedure:{safe_name}"` so the receipt can cross-reference the on-disk Markdown file.
- Saving a procedure **NEVER fails** because of provenance tagging.

## Test plan

- [x] `pytest tests/test_memory/test_procedural.py -x -q` — 29 passed (+4 new, 25 unchanged).
- [x] `mypy --strict src/cognithor/memory/procedural.py` — clean.
- [x] `ruff check` + `ruff format` — clean.

4 new cases in `TestProceduralMemoryProvenance`: without args / with both / unknown coerced / partial args skip.

## Five memory tiers wired now

- ✅ #409 — SemanticMemory.add_entity
- ✅ #410 — EpisodicMemory.append_entry
- ✅ #411 — SemanticMemory.add_relation
- ✅ #412 — AgentVault.store
- ✅ this PR — ProceduralMemory.save_procedure

🤖 Generated with [Claude Code](https://claude.com/claude-code)