### PR TITLE
feat(memory): TRUST-9 wiring into CoreMemory.save

### DIFF
--- a/src/cognithor/memory/core_memory.py
+++ b/src/cognithor/memory/core_memory.py
@@ -90,11 +90,28 @@ class CoreMemory:
     # If it grows beyond this, something is appending in a loop.
     _MAX_CORE_BYTES = 1_000_000  # 1 MB
 
-    def save(self, content: str | None = None) -> None:
+    def save(
+        self,
+        content: str | None = None,
+        *,
+        provenance_source_type: str | None = None,
+        provenance_source_id: str | None = None,
+        provenance_notes: str = "",
+    ) -> None:
         """Save CORE.md to disk.
 
         Args:
             content: New content. If None, current content is saved.
+            provenance_source_type: Optional TRUST-9 ``SourceType``
+                value. When set together with ``provenance_source_id``,
+                a tag is written to the canonical
+                ``PROVENANCE_LEDGER`` keyed by
+                ``"core_memory:" + path.name``.
+            provenance_source_id: Stable upstream id (audit-log entry
+                id, message id, …). Required when
+                ``provenance_source_type`` is set.
+            provenance_notes: Short audit-log breadcrumb. MUST NOT
+                contain prompt / response content.
         """
         if content is not None:
             self._content = content
@@ -116,6 +133,51 @@ class CoreMemory:
             _efile.write(self._path, self._content)
         else:
             self._path.write_text(self._content, encoding="utf-8")
+
+        if provenance_source_type and provenance_source_id:
+            self._tag_provenance(
+                item_id=f"core_memory:{self._path.name}",
+                source_type_value=provenance_source_type,
+                source_id=provenance_source_id,
+                notes=provenance_notes,
+            )
+
+    @staticmethod
+    def _tag_provenance(
+        *,
+        item_id: str,
+        source_type_value: str,
+        source_id: str,
+        notes: str,
+    ) -> None:
+        """Best-effort TRUST-9 provenance tag for a CORE.md write.
+
+        Failures are silently swallowed — saving CORE.md MUST NEVER
+        fail because of provenance tagging. Unknown
+        ``source_type_value`` is coerced to
+        :data:`SourceType.UNKNOWN`.
+        """
+        from cognithor.memory.provenance import (
+            PROVENANCE_LEDGER,
+            ProvenanceTag,
+            SourceType,
+        )
+
+        try:
+            try:
+                source_type = SourceType(source_type_value)
+            except ValueError:
+                source_type = SourceType.UNKNOWN
+            PROVENANCE_LEDGER.tag(
+                item_id,
+                ProvenanceTag(
+                    source_type=source_type,
+                    source_id=source_id,
+                    notes=notes,
+                ),
+            )
+        except ValueError:
+            pass
 
     def create_default(self) -> str:
         """Create a default CORE.md and return its content."""

--- a/tests/test_memory/test_core_memory.py
+++ b/tests/test_memory/test_core_memory.py
@@ -86,3 +86,74 @@ class TestCoreMemory:
 
     def test_path_property(self, core: CoreMemory, core_file: Path):
         assert core.path == core_file
+
+
+class TestCoreMemoryProvenance:
+    """TRUST-9 wiring: ``CoreMemory.save(provenance_source_type=...,
+    provenance_source_id=...)`` writes a tag to the canonical
+    PROVENANCE_LEDGER keyed by ``core_memory:<filename>``.
+    """
+
+    def test_save_without_provenance_does_not_tag(self, core: CoreMemory) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            core.save("# Identität\nfoo\n")
+            assert len(isolated) == 0
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_save_with_provenance_tags_ledger(self, core: CoreMemory, core_file: Path) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger, SourceType
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            core.save(
+                "# Identität\nupdated\n",
+                provenance_source_type="user_directive",
+                provenance_source_id="owner-msg-3",
+                provenance_notes="owner edited",
+            )
+            tag = isolated.current(f"core_memory:{core_file.name}")
+            assert tag is not None
+            assert tag.source_type == SourceType.USER_DIRECTIVE
+            assert tag.source_id == "owner-msg-3"
+            assert tag.notes == "owner edited"
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_partial_provenance_args_skip_tag(self, core: CoreMemory) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            core.save("foo", provenance_source_type="user_directive")
+            core.save("bar", provenance_source_id="owner-msg-3")
+            assert len(isolated) == 0
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_unknown_source_type_falls_back(self, core: CoreMemory, core_file: Path) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger, SourceType
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            core.save("x", provenance_source_type="not_real", provenance_source_id="x")
+            tag = isolated.current(f"core_memory:{core_file.name}")
+            assert tag is not None
+            assert tag.source_type == SourceType.UNKNOWN
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Sixth memory-tier wiring (Tier 1 — `CORE.md` identity/rules/preferences) after #409-#412 + #425. Saving CORE.md now supports opt-in provenance tagging keyed by `core_memory:<filename>`.

Identical contract to the other TRUST-9 hooks: both `provenance_source_type` AND `provenance_source_id` required to tag, partial args silently skip, unknown values coerce to `UNKNOWN`. **Saving CORE.md NEVER fails** because of provenance tagging.

## Test plan

- [x] `pytest tests/test_memory/test_core_memory.py -x -q` — 16 passed (+4 new, 12 unchanged).
- [x] `mypy --strict` clean. `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)