### PR TITLE
feat(packs): TRUST-7 SCHEMA-kind fingerprint of PackManifest

### DIFF
--- a/src/cognithor/packs/loader.py
+++ b/src/cognithor/packs/loader.py
@@ -151,6 +151,50 @@ class PackLoader:
                 )
             )
 
+        # TRUST-7: register a SCHEMA-kind fingerprint for the
+        # PackManifest pydantic schema itself. The content_hash is
+        # SHA-256 of PackManifest.model_json_schema() so any future
+        # change to the schema (added field, type tightening, etc.)
+        # produces a new fingerprint and divergent_names() can spot it.
+        PackLoader._fingerprint_pack_manifest_schema()
+
+    @staticmethod
+    def _fingerprint_pack_manifest_schema() -> None:
+        """Best-effort SCHEMA-kind fingerprint of ``PackManifest``.
+
+        Idempotent via the ledger's content-hash de-dup: same schema
+        bytes → same registration → no-op. Failures are silently
+        logged and swallowed; pack discovery NEVER fails because of
+        fingerprinting.
+        """
+        import hashlib
+        import json as _json
+
+        from cognithor.security.fingerprint import (
+            FINGERPRINT_LEDGER,
+            BinaryKind,
+            ToolFingerprint,
+        )
+
+        try:
+            schema = PackManifest.model_json_schema()
+            canonical = _json.dumps(schema, sort_keys=True, ensure_ascii=False)
+            digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+            FINGERPRINT_LEDGER.register(
+                ToolFingerprint(
+                    name="pack_manifest_schema",
+                    kind=BinaryKind.SCHEMA,
+                    content_hash=digest,
+                    version="v1",
+                    notes="PackManifest pydantic schema",
+                )
+            )
+        except (ValueError, TypeError, _json.JSONDecodeError) as exc:
+            _log.debug(
+                "pack.schema_fingerprint_skipped",
+                error=str(exc),
+            )
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------

--- a/tests/test_packs/test_loader.py
+++ b/tests/test_packs/test_loader.py
@@ -264,3 +264,43 @@ class TestPackLoaderMigrationBackfill:
             )
         finally:
             mig_mod.MIGRATION_LEDGER = original  # type: ignore[misc]
+
+
+class TestPackManifestSchemaFingerprint:
+    """TRUST-7 SCHEMA-kind capture: PackLoader construction registers
+    a SCHEMA fingerprint of PackManifest.model_json_schema().
+    """
+
+    def test_construction_registers_schema_fingerprint(self, packs_dir: Path) -> None:
+        import cognithor.security.fingerprint as fp_mod
+        from cognithor.security.fingerprint import BinaryKind, FingerprintLedger
+
+        isolated = FingerprintLedger()
+        original = fp_mod.FINGERPRINT_LEDGER
+        fp_mod.FINGERPRINT_LEDGER = isolated  # type: ignore[misc]
+        try:
+            PackLoader(packs_dir=packs_dir, cognithor_version="0.92.0")
+            history = isolated.history("pack_manifest_schema")
+            assert len(history) == 1
+            fp = history[0]
+            assert fp.kind == BinaryKind.SCHEMA
+            assert fp.version == "v1"
+            assert len(fp.content_hash) == 64
+        finally:
+            fp_mod.FINGERPRINT_LEDGER = original  # type: ignore[misc]
+
+    def test_multiple_constructions_share_one_fingerprint(self, packs_dir: Path) -> None:
+        import cognithor.security.fingerprint as fp_mod
+        from cognithor.security.fingerprint import FingerprintLedger
+
+        isolated = FingerprintLedger()
+        original = fp_mod.FINGERPRINT_LEDGER
+        fp_mod.FINGERPRINT_LEDGER = isolated  # type: ignore[misc]
+        try:
+            PackLoader(packs_dir=packs_dir, cognithor_version="0.92.0")
+            PackLoader(packs_dir=packs_dir, cognithor_version="0.92.0")
+            PackLoader(packs_dir=packs_dir, cognithor_version="0.92.0")
+            # Same content_hash → ledger de-dups, exactly one entry.
+            assert len(isolated.history("pack_manifest_schema")) == 1
+        finally:
+            fp_mod.FINGERPRINT_LEDGER = original  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Adds the SCHEMA-kind capture deferred from #413 (TOOL/MODEL/PACK covered, SCHEMA noted as "no obvious central call site"). PackLoader now registers a SCHEMA-kind `ToolFingerprint` of `PackManifest.model_json_schema()` at construction time.

```python
ToolFingerprint(
    name="pack_manifest_schema",
    kind=BinaryKind.SCHEMA,
    content_hash=sha256(json.dumps(schema, sort_keys=True)),
    version="v1",
)
```

Idempotent via content-hash de-dup; pack discovery NEVER fails because of fingerprinting.

## Test plan

- [x] `pytest tests/test_packs/test_loader.py -x -q` — 15 passed (+2 new, 13 unchanged).
- [x] `mypy --strict` clean. `ruff check` + `ruff format` clean.

## TRUST-7 capture coverage now

| Kind | Site | PR |
|---|---|---|
| `TOOL` | `JarvisMCPServer.register_tool` | #407 |
| `PACK` | `PackLoader._load_one` | #408 |
| `MODEL` | `OllamaBackend.fingerprint_model` | #413, auto-wired #414 |
| `SCHEMA` | `PackLoader._fingerprint_pack_manifest_schema` | this PR |
| `BINARY` | (still deferred — Ollama/vLLM server binaries) | — |

🤖 Generated with [Claude Code](https://claude.com/claude-code)