### PR TITLE
feat(gatekeeper): TRUST-2 explanation on capability-matrix block path

### DIFF
--- a/src/cognithor/core/gatekeeper.py
+++ b/src/cognithor/core/gatekeeper.py
@@ -537,6 +537,18 @@ class Gatekeeper:
                             risk_level=RiskLevel.RED,
                             original_action=action,
                             policy_name="capability_matrix",
+                            # TRUST-2: structured explanation listing the violated
+                            # capabilities. Each violation comes from
+                            # CapabilityMatrix.get_violations and names a stable
+                            # capability label (NETWORK_HTTP, FILE_WRITE, etc.).
+                            explanation=DecisionExplanation(
+                                rule_id="capability_matrix",
+                                rule_source=(
+                                    "cognithor.security.capabilities:"
+                                    "CapabilityMatrix.get_violations"
+                                ),
+                                matched_pattern=",".join([action.tool, *violations])[:200],
+                            ),
                         )
                         self._write_audit(action, decision, context)
                         return decision


### PR DESCRIPTION
## Summary

Step 5 of `evaluate()` — the optional `CapabilityMatrix` violation check — now emits a structured `DecisionExplanation` alongside the free-text reason. Completes the TRUST-2 enrichment on every standard block path inside `evaluate()`.

```python
explanation=DecisionExplanation(
    rule_id="capability_matrix",
    rule_source="cognithor.security.capabilities:CapabilityMatrix.get_violations",
    matched_pattern=",".join([action.tool, *violations])[:200],
)
```

`matched_pattern` lists the tool name AND every violated capability label so the receipt + Trace-UI can show "blocked because tool X violates NETWORK_HTTP, FILE_WRITE" without parsing free text.

## Test plan

- [x] `pytest tests/test_core/test_gatekeeper.py -x -q` — 94 passed.
- [x] `mypy --strict` clean. `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)