### PR TITLE
feat(gatekeeper): TRUST-3 — derive failure_mode for new policy_names

### DIFF
--- a/src/cognithor/core/gatekeeper.py
+++ b/src/cognithor/core/gatekeeper.py
@@ -1485,6 +1485,17 @@ class Gatekeeper:
             return FailureMode.GATEKEEPER_BLOCK
         if policy == "credential_masking":
             return FailureMode.AUTH_ERROR
+        if policy == "tool_disabled_by_config":
+            # Tool group toggled off in config.tools — surfaces as a
+            # generic block in the failure-mode taxonomy. The
+            # rule_id="tool_disabled_by_config" carries the precise
+            # reason for the Trace-UI; the failure-mode aggregate
+            # only needs to know it was a gatekeeper block.
+            return FailureMode.GATEKEEPER_BLOCK
+        if policy == "capability_matrix":
+            # CapabilityMatrix violation — the violated capability
+            # labels are in decision.explanation.matched_pattern.
+            return FailureMode.GATEKEEPER_BLOCK
         return None
 
     def _flush_audit_buffer(self) -> None:


### PR DESCRIPTION
## Summary

Extends `Gatekeeper._derive_failure_mode` (#422) to cover the two policy_names added today: `tool_disabled_by_config` (#423) and `capability_matrix` (#428). Both map to `FailureMode.GATEKEEPER_BLOCK` so the receipt's `failures_by_mode` aggregator counts them under the right bucket; the precise context still lives in `decision.explanation.matched_pattern` (TRUST-2).

## Test plan

- [x] `pytest tests/test_core/test_gatekeeper.py tests/test_audit/test_audit_logger.py -x -q` — 172 passed.
- [x] `mypy --strict` clean. `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)