### PR TITLE
feat(cli): cognithor receipt export-all — bulk-export per-session receipts

### DIFF
--- a/src/cognithor/__main__.py
+++ b/src/cognithor/__main__.py
@@ -326,6 +326,34 @@ def parse_args() -> argparse.Namespace:
         default=50,
         help="Max sessions to print, newest-first (default: 50)",
     )
+    export_p = receipt_sub.add_parser(
+        "export-all",
+        help="Bulk-export one receipt JSON per session_id",
+    )
+    export_p.add_argument(
+        "--log-dir",
+        dest="receipt_export_log_dir",
+        required=True,
+        help="Audit-log directory to scan",
+    )
+    export_p.add_argument(
+        "--out",
+        dest="receipt_export_out_dir",
+        required=True,
+        help="Target directory for receipt files",
+    )
+    export_p.add_argument(
+        "--include-trust",
+        dest="receipt_export_include_trust",
+        action="store_true",
+        help="Fold the TRUST-5..10 ledger bundle into each receipt",
+    )
+    export_p.add_argument(
+        "--key",
+        dest="receipt_export_signing_key",
+        default=None,
+        help="HMAC-SHA-256 signing key (omitted ⇒ unsigned)",
+    )
 
     return parser.parse_args()
 
@@ -607,8 +635,20 @@ def main() -> None:
                     limit=int(getattr(args, "receipt_list_limit", 50)),
                 )
             )
+        elif action == "export-all":
+            sys.exit(
+                receipt_cmd.cmd_export_all(
+                    log_dir=Path(args.receipt_export_log_dir),
+                    out_dir=Path(args.receipt_export_out_dir),
+                    include_trust=getattr(args, "receipt_export_include_trust", False),
+                    signing_key=getattr(args, "receipt_export_signing_key", None),
+                )
+            )
         else:
-            print("Usage: cognithor receipt <show|verify|list>", file=sys.stderr)
+            print(
+                "Usage: cognithor receipt <show|verify|list|export-all>",
+                file=sys.stderr,
+            )
             sys.exit(2)
 
     # 0a. Auto-migrate data from ~/.jarvis/ to ~/.cognithor/ (one-time, on upgrade)

--- a/src/cognithor/cli/receipt_cmd.py
+++ b/src/cognithor/cli/receipt_cmd.py
@@ -115,6 +115,97 @@ def cmd_verify(*, bundle_path: Path, signing_key: str) -> int:
     return 1
 
 
+def cmd_export_all(
+    *,
+    log_dir: Path,
+    out_dir: Path,
+    include_trust: bool = False,
+    signing_key: str | None = None,
+) -> int:
+    """Export one signed receipt JSON per session_id under ``out_dir``.
+
+    Walks the same audit_*.jsonl files :func:`cmd_list` enumerates,
+    then emits one ``<session_id>.json`` per session. Sessions
+    without an explicit ``session_id`` bucket under ``_unscoped.json``.
+    Files are written with deterministic JSON formatting so a later
+    diff can spot post-export tampering.
+
+    Parameters
+    ----------
+    log_dir:
+        Directory holding ``audit_*.jsonl``. Required.
+    out_dir:
+        Target directory for receipt files. Created if missing.
+        Existing files in the directory are overwritten without
+        prompt — this is a bulk-export, not an incremental sync.
+    include_trust:
+        Fold the TRUST-5..10 ledger bundle into each receipt.
+    signing_key:
+        Optional HMAC-SHA-256 signing key applied to every emitted
+        receipt.
+
+    Returns
+    -------
+    0 on success, 2 on bad arguments. Empty audit log writes a
+    ``manifest.json`` listing zero sessions and returns 0.
+    """
+    if not log_dir or not log_dir.exists():
+        print("error: --log-dir must point to an existing directory", file=sys.stderr)
+        return 2
+
+    sessions: set[str] = set()
+    for jsonl in sorted(log_dir.glob("audit_*.jsonl")):
+        try:
+            for raw in jsonl.read_text(encoding="utf-8").splitlines():
+                line = raw.strip()
+                if not line:
+                    continue
+                try:
+                    data = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(data, dict):
+                    sessions.add(str(data.get("session_id", "")))
+        except OSError:
+            continue
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    logger = AuditLogger(log_dir=log_dir)
+    manifest: list[dict[str, Any]] = []
+    for sid in sorted(sessions):
+        bundle = logger.run_receipt(
+            sid,
+            signing_key=signing_key,
+            include_trust=include_trust,
+        )
+        filename = (sid or "_unscoped").replace("/", "_").replace("\\", "_")
+        out_path = out_dir / f"{filename}.json"
+        payload = json.dumps(bundle, indent=2, ensure_ascii=False, sort_keys=True)
+        out_path.write_text(payload, encoding="utf-8")
+        manifest.append(
+            {
+                "session_id": sid,
+                "file": out_path.name,
+                "entry_count": int(bundle.get("entry_count", 0)),
+                "signed": bool(bundle.get("signature")),
+                "include_trust": include_trust,
+            }
+        )
+
+    manifest_path = out_dir / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {"sessions": manifest, "count": len(manifest)},
+            indent=2,
+            ensure_ascii=False,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    print(f"exported {len(manifest)} session(s) to {out_dir}")
+    return 0
+
+
 def cmd_list(
     *,
     log_dir: Path | None = None,
@@ -193,4 +284,4 @@ def cmd_list(
     return 0
 
 
-__all__ = ["cmd_list", "cmd_show", "cmd_verify"]
+__all__ = ["cmd_export_all", "cmd_list", "cmd_show", "cmd_verify"]

--- a/tests/test_receipt_cmd.py
+++ b/tests/test_receipt_cmd.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from cognithor.audit import AuditLogger
-from cognithor.cli.receipt_cmd import cmd_list, cmd_show, cmd_verify
+from cognithor.cli.receipt_cmd import cmd_export_all, cmd_list, cmd_show, cmd_verify
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -284,3 +284,98 @@ class TestCmdList:
         out = capsys.readouterr().out
         assert "run-A" in out
         assert "run-B" in out
+
+
+class TestCmdExportAll:
+    def test_missing_log_dir_returns_2(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        rc = cmd_export_all(
+            log_dir=tmp_path / "no_such_dir",
+            out_dir=tmp_path / "out",
+        )
+        assert rc == 2
+        assert "log-dir" in capsys.readouterr().err
+
+    def test_exports_one_file_per_session(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        log_dir = tmp_path / "audit"
+        out_dir = tmp_path / "out"
+        _write_audit_jsonl(
+            log_dir,
+            rows=[
+                {"session_id": "run-A", "timestamp": "2026-05-04T10:00:00Z"},
+                {"session_id": "run-B", "timestamp": "2026-05-04T11:00:00Z"},
+                {"session_id": "run-A", "timestamp": "2026-05-04T10:00:05Z"},
+            ],
+        )
+        rc = cmd_export_all(log_dir=log_dir, out_dir=out_dir)
+        assert rc == 0
+        # One JSON per session_id + manifest.json.
+        files = sorted(p.name for p in out_dir.iterdir())
+        assert "run-A.json" in files
+        assert "run-B.json" in files
+        assert "manifest.json" in files
+        # Manifest lists both sessions.
+        manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+        assert manifest["count"] == 2
+        sids = {entry["session_id"] for entry in manifest["sessions"]}
+        assert sids == {"run-A", "run-B"}
+        assert "exported 2 session" in capsys.readouterr().out
+
+    def test_unscoped_bucketed_under_filename(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "audit"
+        out_dir = tmp_path / "out"
+        _write_audit_jsonl(
+            log_dir,
+            rows=[
+                {"timestamp": "2026-05-04T10:00:00Z"},
+                {"session_id": "run-A", "timestamp": "2026-05-04T11:00:00Z"},
+            ],
+        )
+        rc = cmd_export_all(log_dir=log_dir, out_dir=out_dir)
+        assert rc == 0
+        assert (out_dir / "_unscoped.json").exists()
+        assert (out_dir / "run-A.json").exists()
+
+    def test_signing_key_signs_every_receipt(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "audit"
+        out_dir = tmp_path / "out"
+        _write_audit_jsonl(
+            log_dir,
+            rows=[
+                {"session_id": "run-A", "timestamp": "2026-05-04T10:00:00Z"},
+                {"session_id": "run-B", "timestamp": "2026-05-04T11:00:00Z"},
+            ],
+        )
+        rc = cmd_export_all(log_dir=log_dir, out_dir=out_dir, signing_key="hunter2")
+        assert rc == 0
+        for sid in ("run-A", "run-B"):
+            bundle = json.loads((out_dir / f"{sid}.json").read_text(encoding="utf-8"))
+            assert bundle["signature"]
+            assert AuditLogger.verify_receipt_signature(bundle, "hunter2") is True
+
+    def test_include_trust_folds_bundle(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "audit"
+        out_dir = tmp_path / "out"
+        _write_audit_jsonl(
+            log_dir,
+            rows=[
+                {"session_id": "run-A", "timestamp": "2026-05-04T10:00:00Z"},
+            ],
+        )
+        rc = cmd_export_all(log_dir=log_dir, out_dir=out_dir, include_trust=True)
+        assert rc == 0
+        bundle = json.loads((out_dir / "run-A.json").read_text(encoding="utf-8"))
+        assert "trust" in bundle
+
+    def test_empty_audit_log_writes_zero_session_manifest(self, tmp_path: Path) -> None:
+        log_dir = tmp_path / "audit"
+        log_dir.mkdir()
+        out_dir = tmp_path / "out"
+        rc = cmd_export_all(log_dir=log_dir, out_dir=out_dir)
+        assert rc == 0
+        manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+        assert manifest["count"] == 0
+        assert manifest["sessions"] == []


### PR DESCRIPTION
## Summary

Fourth subcommand for the operator-facing TRUST-1 CLI after #404 (show + verify) and #424 (list). Lets an operator dump **every** session's receipt to disk in one command — the right shape for external auditors / compliance archives / cold-storage migration.

```
cognithor receipt export-all --log-dir DIR --out OUT [--include-trust] [--key KEY]
```

Output:

```
OUT/<session_id>.json     # one signed receipt per session
OUT/_unscoped.json        # entries without an explicit session_id
OUT/manifest.json         # {"sessions": [...], "count": N}
```

Each receipt is written with `sort_keys=True` so a later diff spots post-export tampering. The manifest lists `session_id`, `file`, `entry_count`, `signed`, `include_trust`.

## Test plan

- [x] `pytest tests/test_receipt_cmd.py -x -q` — 26 passed (+6 new, 20 unchanged).
- [x] `mypy --strict` clean. `ruff check` + `ruff format` clean.

6 new cases: missing log-dir → 2, multi-session dump, `_unscoped` fallback, signing round-trip, `--include-trust` folds bundle, empty audit log writes zero-session manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)