### PR TITLE
feat(cli): cognithor receipt diff — surface trust-ledger deltas

### DIFF
--- a/src/cognithor/__main__.py
+++ b/src/cognithor/__main__.py
@@ -326,6 +326,12 @@ def parse_args() -> argparse.Namespace:
         default=50,
         help="Max sessions to print, newest-first (default: 50)",
     )
+    diff_p = receipt_sub.add_parser(
+        "diff",
+        help="Diff two receipt JSON files — surface trust-ledger deltas",
+    )
+    diff_p.add_argument("a", help="Path to the first receipt JSON file")
+    diff_p.add_argument("b", help="Path to the second receipt JSON file")
     export_p = receipt_sub.add_parser(
         "export-all",
         help="Bulk-export one receipt JSON per session_id",
@@ -644,9 +650,16 @@ def main() -> None:
                     signing_key=getattr(args, "receipt_export_signing_key", None),
                 )
             )
+        elif action == "diff":
+            sys.exit(
+                receipt_cmd.cmd_diff(
+                    a_path=Path(args.a),
+                    b_path=Path(args.b),
+                )
+            )
         else:
             print(
-                "Usage: cognithor receipt <show|verify|list|export-all>",
+                "Usage: cognithor receipt <show|verify|list|export-all|diff>",
                 file=sys.stderr,
             )
             sys.exit(2)

--- a/src/cognithor/cli/receipt_cmd.py
+++ b/src/cognithor/cli/receipt_cmd.py
@@ -284,4 +284,153 @@ def cmd_list(
     return 0
 
 
-__all__ = ["cmd_export_all", "cmd_list", "cmd_show", "cmd_verify"]
+def cmd_diff(*, a_path: Path, b_path: Path) -> int:
+    """Diff two TRUST-1 receipt bundles.
+
+    Surfaces the operationally-meaningful differences between two
+    receipts: per-section entry-count delta, total-cost delta,
+    escalation-count delta, fingerprint-divergence, new permission
+    scopes, and migration-chain head movement. Designed for "we ran
+    the same workflow twice — what changed?" post-mortems.
+
+    Output is human-readable, not JSON: one section per kind of
+    delta, blank when no changes. Returns:
+
+    * 0 — receipts loaded successfully (regardless of whether they
+      differ; an unchanged-pair still returns 0).
+    * 2 — bad arguments / unreadable / non-JSON / non-object bundle.
+    """
+    bundles: list[dict[str, Any]] = []
+    for label, path in (("a", a_path), ("b", b_path)):
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except (OSError, FileNotFoundError) as exc:
+            print(f"error: cannot read {label}={path}: {exc}", file=sys.stderr)
+            return 2
+        try:
+            bundle = json.loads(raw)
+        except json.JSONDecodeError as exc:
+            print(f"error: invalid JSON in {label}={path}: {exc}", file=sys.stderr)
+            return 2
+        if not isinstance(bundle, dict):
+            print(
+                f"error: bundle at {label}={path} is not a JSON object",
+                file=sys.stderr,
+            )
+            return 2
+        bundles.append(bundle)
+    a_bundle, b_bundle = bundles[0], bundles[1]
+
+    a_sid = a_bundle.get("session_id", "?")
+    b_sid = b_bundle.get("session_id", "?")
+    print(f"diff: a={a_sid!r} → b={b_sid!r}")
+
+    # ── Audit-aggregate deltas ─────────────────────────────────────
+    a_count = int(a_bundle.get("entry_count", 0))
+    b_count = int(b_bundle.get("entry_count", 0))
+    if a_count != b_count:
+        print(f"  entry_count: {a_count} → {b_count}  (delta {b_count - a_count:+d})")
+
+    a_agg = _safe_dict(a_bundle.get("aggregate"))
+    b_agg = _safe_dict(b_bundle.get("aggregate"))
+    for key in ("success_count", "failure_count", "pii_count"):
+        av = int(a_agg.get(key, 0))
+        bv = int(b_agg.get(key, 0))
+        if av != bv:
+            print(f"  aggregate.{key}: {av} → {bv}  (delta {bv - av:+d})")
+
+    # ── Trust-bundle deltas (only if BOTH receipts have one) ───────
+    a_has_trust = "trust" in a_bundle
+    b_has_trust = "trust" in b_bundle
+    if not a_has_trust and not b_has_trust:
+        return 0
+    if a_has_trust != b_has_trust:
+        print(
+            f"  trust block: {'present' if a_has_trust else 'absent'} → "
+            f"{'present' if b_has_trust else 'absent'}"
+        )
+        return 0
+    a_trust = _safe_dict(a_bundle.get("trust"))
+    b_trust = _safe_dict(b_bundle.get("trust"))
+
+    # Cost delta (USD micro on the summary).
+    a_cost = _safe_dict(_safe_dict(a_trust.get("cost")).get("summary"))
+    b_cost = _safe_dict(_safe_dict(b_trust.get("cost")).get("summary"))
+    a_micro = int(a_cost.get("total_cost_usd_micro", 0))
+    b_micro = int(b_cost.get("total_cost_usd_micro", 0))
+    if a_micro != b_micro:
+        delta = b_micro - a_micro
+        print(
+            f"  trust.cost: {a_micro / 1_000_000:.6f} → {b_micro / 1_000_000:.6f} USD "
+            f"(delta {delta / 1_000_000:+.6f})"
+        )
+
+    # Escalation event-count delta.
+    a_esc = _safe_dict(_safe_dict(a_trust.get("escalations")).get("summary"))
+    b_esc = _safe_dict(_safe_dict(b_trust.get("escalations")).get("summary"))
+    a_ev = int(a_esc.get("event_count", 0))
+    b_ev = int(b_esc.get("event_count", 0))
+    if a_ev != b_ev:
+        print(f"  trust.escalations.event_count: {a_ev} → {b_ev}  (delta {b_ev - a_ev:+d})")
+
+    # Fingerprint divergence.
+    a_fps = _safe_list(_safe_dict(a_trust.get("fingerprints")).get("all"))
+    b_fps = _safe_list(_safe_dict(b_trust.get("fingerprints")).get("all"))
+    a_hashes = {str(fp.get("content_hash", "")) for fp in a_fps if isinstance(fp, dict)}
+    b_hashes = {str(fp.get("content_hash", "")) for fp in b_fps if isinstance(fp, dict)}
+    new_in_b = sorted(b_hashes - a_hashes)
+    gone_from_a = sorted(a_hashes - b_hashes)
+    if new_in_b or gone_from_a:
+        print(f"  trust.fingerprints: +{len(new_in_b)} -{len(gone_from_a)}")
+        for h in new_in_b[:3]:
+            print(f"    + {h[:12]}…")
+        for h in gone_from_a[:3]:
+            print(f"    - {h[:12]}…")
+
+    # Permission-scope diff.
+    a_scopes = {
+        f"{s.get('axis')}:{s.get('identity')}"
+        for s in _safe_list(a_trust.get("permission_scopes"))
+        if isinstance(s, dict)
+    }
+    b_scopes = {
+        f"{s.get('axis')}:{s.get('identity')}"
+        for s in _safe_list(b_trust.get("permission_scopes"))
+        if isinstance(s, dict)
+    }
+    if a_scopes != b_scopes:
+        added = sorted(b_scopes - a_scopes)
+        removed = sorted(a_scopes - b_scopes)
+        print(f"  trust.permission_scopes: +{len(added)} -{len(removed)}")
+        for s in added:
+            print(f"    + {s}")
+        for s in removed:
+            print(f"    - {s}")
+
+    # Migration-head movement per domain.
+    a_heads = _safe_dict(_safe_dict(a_trust.get("migrations")).get("head_version"))
+    b_heads = _safe_dict(_safe_dict(b_trust.get("migrations")).get("head_version"))
+    domains = sorted(set(a_heads) | set(b_heads))
+    for domain in domains:
+        a_head = a_heads.get(domain)
+        b_head = b_heads.get(domain)
+        if a_head != b_head:
+            print(f"  trust.migrations.{domain}: {a_head!r} → {b_head!r}")
+    return 0
+
+
+def _safe_dict(obj: object) -> dict[str, Any]:
+    return obj if isinstance(obj, dict) else {}
+
+
+def _safe_list(obj: object) -> list[Any]:
+    return obj if isinstance(obj, list) else []
+
+
+__all__ = [
+    "cmd_diff",
+    "cmd_export_all",
+    "cmd_list",
+    "cmd_show",
+    "cmd_verify",
+]

--- a/tests/test_receipt_cmd.py
+++ b/tests/test_receipt_cmd.py
@@ -8,7 +8,13 @@ from typing import TYPE_CHECKING
 import pytest
 
 from cognithor.audit import AuditLogger
-from cognithor.cli.receipt_cmd import cmd_export_all, cmd_list, cmd_show, cmd_verify
+from cognithor.cli.receipt_cmd import (
+    cmd_diff,
+    cmd_export_all,
+    cmd_list,
+    cmd_show,
+    cmd_verify,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -379,3 +385,203 @@ class TestCmdExportAll:
         manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
         assert manifest["count"] == 0
         assert manifest["sessions"] == []
+
+
+def _write_receipt(path: Path, bundle: dict[str, object]) -> None:
+    path.write_text(json.dumps(bundle, indent=2), encoding="utf-8")
+
+
+class TestCmdDiff:
+    def test_missing_file_returns_2(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        b = tmp_path / "b.json"
+        b.write_text("{}", encoding="utf-8")
+        rc = cmd_diff(a_path=tmp_path / "no_such.json", b_path=b)
+        assert rc == 2
+        assert "cannot read" in capsys.readouterr().err
+
+    def test_invalid_json_returns_2(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        a.write_text("not json {", encoding="utf-8")
+        b.write_text("{}", encoding="utf-8")
+        rc = cmd_diff(a_path=a, b_path=b)
+        assert rc == 2
+        assert "invalid JSON" in capsys.readouterr().err
+
+    def test_non_object_returns_2(self, tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        a.write_text("[1, 2, 3]", encoding="utf-8")
+        b.write_text("{}", encoding="utf-8")
+        rc = cmd_diff(a_path=a, b_path=b)
+        assert rc == 2
+        assert "not a JSON object" in capsys.readouterr().err
+
+    def test_identical_receipts_only_print_header(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        bundle = {"session_id": "run-A", "entry_count": 3}
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write_receipt(a, bundle)
+        _write_receipt(b, bundle)
+        rc = cmd_diff(a_path=a, b_path=b)
+        assert rc == 0
+        out = capsys.readouterr().out
+        # Only the diff header line, no delta lines.
+        assert "diff: a='run-A' → b='run-A'" in out
+        assert "delta" not in out
+
+    def test_entry_count_delta_surfaced(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write_receipt(a, {"session_id": "x", "entry_count": 3})
+        _write_receipt(b, {"session_id": "x", "entry_count": 7})
+        rc = cmd_diff(a_path=a, b_path=b)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "entry_count: 3 → 7" in out
+        assert "delta +4" in out
+
+    def test_failure_count_delta_surfaced(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write_receipt(
+            a,
+            {
+                "session_id": "x",
+                "entry_count": 5,
+                "aggregate": {"success_count": 5, "failure_count": 0},
+            },
+        )
+        _write_receipt(
+            b,
+            {
+                "session_id": "x",
+                "entry_count": 5,
+                "aggregate": {"success_count": 3, "failure_count": 2},
+            },
+        )
+        rc = cmd_diff(a_path=a, b_path=b)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "aggregate.success_count: 5 → 3" in out
+        assert "aggregate.failure_count: 0 → 2" in out
+
+    def test_trust_cost_delta_surfaced(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write_receipt(
+            a,
+            {
+                "session_id": "x",
+                "entry_count": 1,
+                "trust": {
+                    "cost": {"summary": {"total_cost_usd_micro": 10_000}},
+                },
+            },
+        )
+        _write_receipt(
+            b,
+            {
+                "session_id": "x",
+                "entry_count": 1,
+                "trust": {
+                    "cost": {"summary": {"total_cost_usd_micro": 35_000}},
+                },
+            },
+        )
+        rc = cmd_diff(a_path=a, b_path=b)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "trust.cost: 0.010000 → 0.035000 USD" in out
+        assert "+0.025000" in out
+
+    def test_trust_fingerprint_diff_surfaced(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write_receipt(
+            a,
+            {
+                "session_id": "x",
+                "entry_count": 1,
+                "trust": {
+                    "fingerprints": {
+                        "all": [{"content_hash": "a" * 64}],
+                    },
+                },
+            },
+        )
+        _write_receipt(
+            b,
+            {
+                "session_id": "x",
+                "entry_count": 1,
+                "trust": {
+                    "fingerprints": {
+                        "all": [{"content_hash": "b" * 64}, {"content_hash": "c" * 64}],
+                    },
+                },
+            },
+        )
+        rc = cmd_diff(a_path=a, b_path=b)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "trust.fingerprints: +2 -1" in out
+
+    def test_trust_migration_head_movement(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write_receipt(
+            a,
+            {
+                "session_id": "x",
+                "entry_count": 1,
+                "trust": {
+                    "migrations": {"head_version": {"audit_log": "v1"}},
+                },
+            },
+        )
+        _write_receipt(
+            b,
+            {
+                "session_id": "x",
+                "entry_count": 1,
+                "trust": {
+                    "migrations": {
+                        "head_version": {"audit_log": "v1", "pack_manifest": "v2"},
+                    },
+                },
+            },
+        )
+        rc = cmd_diff(a_path=a, b_path=b)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "trust.migrations.pack_manifest: None → 'v2'" in out
+
+    def test_trust_block_presence_delta(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        # One side has a trust block, the other doesn't.
+        a = tmp_path / "a.json"
+        b = tmp_path / "b.json"
+        _write_receipt(a, {"session_id": "x", "entry_count": 1})
+        _write_receipt(b, {"session_id": "x", "entry_count": 1, "trust": {}})
+        rc = cmd_diff(a_path=a, b_path=b)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "trust block: absent → present" in out


### PR DESCRIPTION
## Summary

Fifth subcommand for the operator-facing TRUST-1 CLI after #404 (show + verify), #424 (list), #430 (export-all). Lets an operator answer **"we ran the same workflow twice — what changed?"** without diffing 10kB of JSON by hand.

```
cognithor receipt diff <a.json> <b.json>
```

```
diff: a='run-A' → b='run-A'
  entry_count: 5 → 7  (delta +2)
  aggregate.failure_count: 0 → 2  (delta +2)
  trust.cost: 0.010000 → 0.035000 USD (delta +0.025000)
  trust.escalations.event_count: 0 → 1  (delta +1)
  trust.fingerprints: +2 -1
    + bbbbbbbbbbbb…
    - aaaaaaaaaaaa…
  trust.permission_scopes: +0 -1
    - channel:telegram
  trust.migrations.pack_manifest: None → 'v2'
```

## Behaviour

- Identical receipts print only the header — no false-positive noise.
- Bad arguments / unreadable / non-JSON / non-object bundles → exit code 2.
- Loaded receipts always return 0 regardless of whether they differ (informational, not pass/fail).
- Trust-block presence delta short-circuits the rest of the trust diff (one side has bundle, other doesn't).

## Test plan

- [x] `pytest tests/test_receipt_cmd.py -x -q` — 36 passed (+10 new, 26 unchanged).
- [x] `mypy --strict` clean. `ruff check` + `ruff format` clean.

## TRUST-1 CLI now

| Subcommand | Purpose | PR |
|---|---|---|
| `show` | dump one receipt | #404 |
| `verify` | check HMAC signature | #404 |
| `list` | enumerate session_ids | #424 |
| `export-all` | bulk-dump every session | #430 |
| `diff` | compare two receipts | this PR |

🤖 Generated with [Claude Code](https://claude.com/claude-code)