### PR TITLE
feat(security): TRUST-10 self-audit backfills for provenance + fingerprint ledgers

### DIFF
--- a/src/cognithor/memory/provenance.py
+++ b/src/cognithor/memory/provenance.py
@@ -398,3 +398,43 @@ def make_ttl_tag(
 # ledger stays empty in production until that wiring lands. Tests
 # construct their own :class:`ProvenanceLedger` for isolation.
 PROVENANCE_LEDGER: ProvenanceLedger = ProvenanceLedger()
+
+
+def _record_provenance_ledger_migration() -> None:
+    """TRUST-10 self-audit: announce the provenance-ledger schema.
+
+    Idempotent via the canonical ``MigrationLedger``'s
+    ``MigrationChainError`` on duplicate ``migration_id``. Wrapped
+    in ``suppress`` so import-time side effects NEVER raise. Tests
+    that monkey-patch the canonical ledger for isolation see this
+    step as a no-op (the original singleton already has it).
+    """
+    from contextlib import suppress
+
+    from cognithor.security.migration_ledger import (
+        MIGRATION_LEDGER,
+        MigrationChainError,
+        MigrationDomain,
+        MigrationStatus,
+        MigrationStep,
+    )
+
+    with suppress(MigrationChainError, ValueError):
+        MIGRATION_LEDGER.record(
+            MigrationStep(
+                domain=MigrationDomain.PROVENANCE_LEDGER,
+                source_version="v0-no-ledger",
+                target_version="v1-append-only-ledger",
+                status=MigrationStatus.APPLIED,
+                applied_by="system",
+                item_count=-1,
+                migration_id="provenance_ledger:v0-no-ledger:v1-append-only-ledger",
+                notes=(
+                    "TRUST-9 ProvenanceLedger schema active "
+                    "(append-only chain per item_id, ExpiryPolicy enum)"
+                ),
+            )
+        )
+
+
+_record_provenance_ledger_migration()

--- a/src/cognithor/security/fingerprint.py
+++ b/src/cognithor/security/fingerprint.py
@@ -343,3 +343,43 @@ def fingerprint_python_tool(
 # follow-up PR; the ledger stays empty in production until that
 # wiring lands. Tests construct their own :class:`FingerprintLedger`.
 FINGERPRINT_LEDGER: FingerprintLedger = FingerprintLedger()
+
+
+def _record_fingerprint_ledger_migration() -> None:
+    """TRUST-10 self-audit: announce the fingerprint-ledger schema.
+
+    Idempotent via the canonical ``MigrationLedger``'s duplicate-id
+    check. Wrapped in ``suppress`` so import-time side effects NEVER
+    raise. Test isolation is unaffected — tests that monkey-patch
+    the canonical migration ledger see this step as a no-op since
+    it already landed at first import.
+    """
+    from contextlib import suppress
+
+    from cognithor.security.migration_ledger import (
+        MIGRATION_LEDGER,
+        MigrationChainError,
+        MigrationDomain,
+        MigrationStatus,
+        MigrationStep,
+    )
+
+    with suppress(MigrationChainError, ValueError):
+        MIGRATION_LEDGER.record(
+            MigrationStep(
+                domain=MigrationDomain.FINGERPRINT_LEDGER,
+                source_version="v0-no-ledger",
+                target_version="v1-dual-index-ledger",
+                status=MigrationStatus.APPLIED,
+                applied_by="system",
+                item_count=-1,
+                migration_id="fingerprint_ledger:v0-no-ledger:v1-dual-index-ledger",
+                notes=(
+                    "TRUST-7 FingerprintLedger schema active "
+                    "(by-hash + by-name dual index, BinaryKind enum)"
+                ),
+            )
+        )
+
+
+_record_fingerprint_ledger_migration()

--- a/tests/test_memory/test_provenance.py
+++ b/tests/test_memory/test_provenance.py
@@ -509,3 +509,39 @@ class TestMakeTtlTag:
 class TestProcessLocalLedger:
     def test_default_ledger_is_a_provenance_ledger(self) -> None:
         assert isinstance(PROVENANCE_LEDGER, ProvenanceLedger)
+
+
+class TestProvenanceLedgerSelfAuditMigration:
+    """TRUST-10 self-audit: importing the provenance module records
+    a v0→v1 migration step into the canonical MIGRATION_LEDGER.
+    """
+
+    def test_migration_step_landed(self) -> None:
+        from cognithor.security.migration_ledger import (
+            MIGRATION_LEDGER,
+            MigrationDomain,
+            MigrationStatus,
+        )
+
+        # The module-level _record_provenance_ledger_migration() ran
+        # at import time. Look the step up by its stable id.
+        step = MIGRATION_LEDGER.get("provenance_ledger:v0-no-ledger:v1-append-only-ledger")
+        assert step is not None
+        assert step.status == MigrationStatus.APPLIED
+        assert step.domain == MigrationDomain.PROVENANCE_LEDGER
+        assert step.applied_by == "system"
+        assert (
+            MIGRATION_LEDGER.head_version(MigrationDomain.PROVENANCE_LEDGER)
+            == "v1-append-only-ledger"
+        )
+
+    def test_repeated_calls_idempotent(self) -> None:
+        # Re-running the recorder must NOT raise — duplicate
+        # migration_id is suppressed.
+        from cognithor.memory.provenance import (
+            _record_provenance_ledger_migration,
+        )
+
+        _record_provenance_ledger_migration()
+        _record_provenance_ledger_migration()
+        _record_provenance_ledger_migration()

--- a/tests/test_security/test_fingerprint.py
+++ b/tests/test_security/test_fingerprint.py
@@ -358,3 +358,35 @@ class TestHashHelpers:
 class TestProcessLocalLedger:
     def test_default_ledger_is_a_fingerprint_ledger(self) -> None:
         assert isinstance(FINGERPRINT_LEDGER, FingerprintLedger)
+
+
+class TestFingerprintLedgerSelfAuditMigration:
+    """TRUST-10 self-audit: importing the fingerprint module records
+    a v0→v1 migration step into the canonical MIGRATION_LEDGER.
+    """
+
+    def test_migration_step_landed(self) -> None:
+        from cognithor.security.migration_ledger import (
+            MIGRATION_LEDGER,
+            MigrationDomain,
+            MigrationStatus,
+        )
+
+        step = MIGRATION_LEDGER.get("fingerprint_ledger:v0-no-ledger:v1-dual-index-ledger")
+        assert step is not None
+        assert step.status == MigrationStatus.APPLIED
+        assert step.domain == MigrationDomain.FINGERPRINT_LEDGER
+        assert step.applied_by == "system"
+        assert (
+            MIGRATION_LEDGER.head_version(MigrationDomain.FINGERPRINT_LEDGER)
+            == "v1-dual-index-ledger"
+        )
+
+    def test_repeated_calls_idempotent(self) -> None:
+        from cognithor.security.fingerprint import (
+            _record_fingerprint_ledger_migration,
+        )
+
+        _record_fingerprint_ledger_migration()
+        _record_fingerprint_ledger_migration()
+        _record_fingerprint_ledger_migration()


### PR DESCRIPTION
## Summary

After #416 (audit_log) and #417 (pack_manifest), the TRUST-9 `ProvenanceLedger` and TRUST-7 `FingerprintLedger` now also announce their schema lineage via TRUST-10. Closes the deferred "self-audit" gap from yesterday's roadmap.

## Wiring

```
provenance_ledger: v0-no-ledger → v1-append-only-ledger
fingerprint_ledger: v0-no-ledger → v1-dual-index-ledger
```

Both module-level recorders run at import time, wrapped in `suppress(MigrationChainError, ValueError)` so module imports NEVER raise.

## Test plan

- [x] `pytest tests/test_memory/test_provenance.py tests/test_security/test_fingerprint.py -x -q` — 72 passed (+4 new).
- [x] `mypy --strict` clean. `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)