### PR TITLE
feat(learning): TRUST-9 wiring into KnowledgeIngestService.ingest_file

### DIFF
--- a/src/cognithor/learning/knowledge_ingest.py
+++ b/src/cognithor/learning/knowledge_ingest.py
@@ -134,8 +134,20 @@ class KnowledgeIngestService:
         filename: str,
         content: bytes,
         priority: Priority = Priority.NORMAL,
+        *,
+        provenance_source_type: str | None = None,
+        provenance_source_id: str | None = None,
+        provenance_notes: str = "",
     ) -> IngestResult:
-        """Ingest a file (PDF, DOCX, TXT, MD, images)."""
+        """Ingest a file (PDF, DOCX, TXT, MD, images).
+
+        Optional TRUST-9 provenance: when both
+        ``provenance_source_type`` and ``provenance_source_id`` are
+        passed, a tag is written to the canonical
+        ``PROVENANCE_LEDGER`` keyed by ``ingest:<result.id>``. Lets
+        the operational-trust receipt answer "which upload produced
+        this knowledge chunk?" without parsing the source URL.
+        """
         result = IngestResult(
             id=str(uuid4()),
             source_type="file",
@@ -183,8 +195,52 @@ class KnowledgeIngestService:
             result.error = str(exc)
             log.warning("ingest_file_failed", file=filename, error=str(exc))
 
+        if provenance_source_type and provenance_source_id:
+            self._tag_provenance(
+                item_id=f"ingest:{result.id}",
+                source_type_value=provenance_source_type,
+                source_id=provenance_source_id,
+                notes=provenance_notes,
+            )
+
         self._results.append(result)
         return result
+
+    @staticmethod
+    def _tag_provenance(
+        *,
+        item_id: str,
+        source_type_value: str,
+        source_id: str,
+        notes: str,
+    ) -> None:
+        """Best-effort TRUST-9 provenance tag — failures are swallowed.
+
+        Unknown ``source_type_value`` is coerced to
+        :data:`SourceType.UNKNOWN`. Ingest NEVER fails because of
+        provenance tagging.
+        """
+        from cognithor.memory.provenance import (
+            PROVENANCE_LEDGER,
+            ProvenanceTag,
+            SourceType,
+        )
+
+        try:
+            try:
+                source_type = SourceType(source_type_value)
+            except ValueError:
+                source_type = SourceType.UNKNOWN
+            PROVENANCE_LEDGER.tag(
+                item_id,
+                ProvenanceTag(
+                    source_type=source_type,
+                    source_id=source_id,
+                    notes=notes,
+                ),
+            )
+        except ValueError:
+            pass
 
     async def ingest_url(
         self,

--- a/tests/test_learning/test_knowledge_ingest.py
+++ b/tests/test_learning/test_knowledge_ingest.py
@@ -350,3 +350,92 @@ class TestYoutubeFrames:
         with patch("shutil.which", side_effect=_which):
             result = svc._extract_youtube_frames("dQw4w9WgXcQ")
             assert result == []
+
+
+class TestKnowledgeIngestProvenance:
+    """TRUST-9 wiring: ``ingest_file(provenance_source_type=...,
+    provenance_source_id=...)`` writes a tag to the canonical
+    PROVENANCE_LEDGER keyed by ``ingest:<result.id>``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_ingest_without_provenance_does_not_tag(self) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            memory = MagicMock()
+            memory.index_text = MagicMock(return_value=1)
+            svc = KnowledgeIngestService(memory=memory)
+            with pytest.MonkeyPatch.context() as mp:
+                mp.setattr(svc, "_extract_text", AsyncMock(return_value="content"))
+                mp.setattr(svc, "_ensure_worker", MagicMock())
+                result = await svc.ingest_file("a.txt", b"c", priority=Priority.LOW)
+            assert f"ingest:{result.id}" not in isolated
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    @pytest.mark.asyncio
+    async def test_ingest_with_provenance_tags_ledger(self) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger, SourceType
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            memory = MagicMock()
+            memory.index_text = MagicMock(return_value=1)
+            svc = KnowledgeIngestService(memory=memory)
+            with pytest.MonkeyPatch.context() as mp:
+                mp.setattr(svc, "_extract_text", AsyncMock(return_value="content"))
+                mp.setattr(svc, "_ensure_worker", MagicMock())
+                result = await svc.ingest_file(
+                    "a.pdf",
+                    b"content",
+                    priority=Priority.NORMAL,
+                    provenance_source_type="user_directive",
+                    provenance_source_id="upload-7",
+                    provenance_notes="owner-uploaded PDF",
+                )
+            tag = isolated.current(f"ingest:{result.id}")
+            assert tag is not None
+            assert tag.source_type == SourceType.USER_DIRECTIVE
+            assert tag.source_id == "upload-7"
+            assert tag.notes == "owner-uploaded PDF"
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    @pytest.mark.asyncio
+    async def test_partial_provenance_args_skip_tag(self) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            memory = MagicMock()
+            memory.index_text = MagicMock(return_value=1)
+            svc = KnowledgeIngestService(memory=memory)
+            with pytest.MonkeyPatch.context() as mp:
+                mp.setattr(svc, "_extract_text", AsyncMock(return_value="c"))
+                mp.setattr(svc, "_ensure_worker", MagicMock())
+                await svc.ingest_file(
+                    "a.txt",
+                    b"c",
+                    priority=Priority.LOW,
+                    provenance_source_type="user_directive",
+                )
+                await svc.ingest_file(
+                    "b.txt",
+                    b"c",
+                    priority=Priority.LOW,
+                    provenance_source_id="upload-7",
+                )
+            assert len(isolated) == 0
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Seventh memory-tier wiring (the deep-learning upload pipeline) after #409-#412 + #425 + #426. Pasted/uploaded files flowing through the ingest queue now support opt-in provenance tagging keyed by `ingest:<result_id>`.

Lets the operational-trust receipt answer **"which upload produced this knowledge chunk?"** for every ingest that opted into provenance.

## Wiring

- New keyword-only params on `ingest_file`: `provenance_source_type`, `provenance_source_id`, `provenance_notes`. Identical contract to the other TRUST-9 hooks.
- Tag fires AFTER the ingest completes (success OR failure path), so even failed ingests carry a provenance record.
- Ingest **NEVER fails** because of provenance tagging.

## Test plan

- [x] `pytest tests/test_learning/test_knowledge_ingest.py -x -q` — 38 passed (+3 new, 35 unchanged).
- [x] `mypy --strict` clean. `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)