### PR TITLE
feat(security): TRUST-10 self-audit backfills for cost / escalation / scope ledgers

### DIFF
--- a/src/cognithor/security/cloud_escalation.py
+++ b/src/cognithor/security/cloud_escalation.py
@@ -307,3 +307,36 @@ class EscalationLedger:
 # ledger stays empty in production until that wiring lands. Tests
 # construct their own :class:`EscalationLedger` for isolation.
 ESCALATION_LEDGER: EscalationLedger = EscalationLedger()
+
+
+def _record_escalation_ledger_migration() -> None:
+    """TRUST-10 self-audit: announce the escalation-ledger schema."""
+    from contextlib import suppress
+
+    from cognithor.security.migration_ledger import (
+        MIGRATION_LEDGER,
+        MigrationChainError,
+        MigrationDomain,
+        MigrationStatus,
+        MigrationStep,
+    )
+
+    with suppress(MigrationChainError, ValueError):
+        MIGRATION_LEDGER.record(
+            MigrationStep(
+                domain=MigrationDomain.ESCALATION_LEDGER,
+                source_version="v0-no-ledger",
+                target_version="v1-metadata-only-ledger",
+                status=MigrationStatus.APPLIED,
+                applied_by="system",
+                item_count=-1,
+                migration_id="escalation_ledger:v0-no-ledger:v1-metadata-only-ledger",
+                notes=(
+                    "TRUST-8 EscalationLedger schema active "
+                    "(metadata-only privacy contract, EscalationReason enum)"
+                ),
+            )
+        )
+
+
+_record_escalation_ledger_migration()

--- a/src/cognithor/security/cost_ledger.py
+++ b/src/cognithor/security/cost_ledger.py
@@ -399,3 +399,37 @@ class CostLedger:
 # Production-wiring lands in a follow-up PR (PSE cost tracker,
 # TRUST-8 escalation, every billed tool). Tests use fresh ledgers.
 COST_LEDGER: CostLedger = CostLedger()
+
+
+def _record_cost_ledger_migration() -> None:
+    """TRUST-10 self-audit: announce the cost-ledger schema."""
+    from contextlib import suppress
+
+    from cognithor.security.migration_ledger import (
+        MIGRATION_LEDGER,
+        MigrationChainError,
+        MigrationDomain,
+        MigrationStatus,
+        MigrationStep,
+    )
+
+    with suppress(MigrationChainError, ValueError):
+        MIGRATION_LEDGER.record(
+            MigrationStep(
+                domain=MigrationDomain.COST_LEDGER,
+                source_version="v0-no-ledger",
+                target_version="v1-micro-usd-ledger",
+                status=MigrationStatus.APPLIED,
+                applied_by="system",
+                item_count=-1,
+                migration_id="cost_ledger:v0-no-ledger:v1-micro-usd-ledger",
+                notes=(
+                    "TRUST-6 CostLedger schema active "
+                    "(integer micro-USD cost unit, CostKind enum, "
+                    "BudgetReport status taxonomy)"
+                ),
+            )
+        )
+
+
+_record_cost_ledger_migration()

--- a/src/cognithor/security/migration_ledger.py
+++ b/src/cognithor/security/migration_ledger.py
@@ -66,6 +66,9 @@ class MigrationDomain(StrEnum):
     CONFIG_SCHEMA = "config_schema"
     PROVENANCE_LEDGER = "provenance_ledger"
     FINGERPRINT_LEDGER = "fingerprint_ledger"
+    COST_LEDGER = "cost_ledger"
+    ESCALATION_LEDGER = "escalation_ledger"
+    SCOPE_REGISTRY = "scope_registry"
 
 
 class MigrationStatus(StrEnum):

--- a/src/cognithor/security/permission_scope.py
+++ b/src/cognithor/security/permission_scope.py
@@ -370,3 +370,36 @@ class ScopeRegistry:
 # it from config / DB; tests construct fresh registries to keep state
 # out of globals.
 SCOPE_REGISTRY: ScopeRegistry = ScopeRegistry()
+
+
+def _record_scope_registry_migration() -> None:
+    """TRUST-10 self-audit: announce the scope-registry schema."""
+    from contextlib import suppress
+
+    from cognithor.security.migration_ledger import (
+        MIGRATION_LEDGER,
+        MigrationChainError,
+        MigrationDomain,
+        MigrationStatus,
+        MigrationStep,
+    )
+
+    with suppress(MigrationChainError, ValueError):
+        MIGRATION_LEDGER.record(
+            MigrationStep(
+                domain=MigrationDomain.SCOPE_REGISTRY,
+                source_version="v0-no-registry",
+                target_version="v1-axis-identity-registry",
+                status=MigrationStatus.APPLIED,
+                applied_by="system",
+                item_count=-1,
+                migration_id="scope_registry:v0-no-registry:v1-axis-identity-registry",
+                notes=(
+                    "TRUST-5 ScopeRegistry schema active "
+                    "(ScopeAxis enum, allow/deny/max_risk evaluation)"
+                ),
+            )
+        )
+
+
+_record_scope_registry_migration()

--- a/tests/test_security/test_cloud_escalation.py
+++ b/tests/test_security/test_cloud_escalation.py
@@ -376,3 +376,33 @@ class TestEscalationLedgerSnapshot:
 class TestProcessLocalLedger:
     def test_default_ledger_is_an_escalation_ledger(self) -> None:
         assert isinstance(ESCALATION_LEDGER, EscalationLedger)
+
+
+class TestEscalationLedgerSelfAuditMigration:
+    """TRUST-10 self-audit: cloud_escalation module-import records
+    a v0→v1 step in the canonical MIGRATION_LEDGER.
+    """
+
+    def test_migration_step_landed(self) -> None:
+        from cognithor.security.migration_ledger import (
+            MIGRATION_LEDGER,
+            MigrationDomain,
+            MigrationStatus,
+        )
+
+        step = MIGRATION_LEDGER.get("escalation_ledger:v0-no-ledger:v1-metadata-only-ledger")
+        assert step is not None
+        assert step.status == MigrationStatus.APPLIED
+        assert step.domain == MigrationDomain.ESCALATION_LEDGER
+        assert (
+            MIGRATION_LEDGER.head_version(MigrationDomain.ESCALATION_LEDGER)
+            == "v1-metadata-only-ledger"
+        )
+
+    def test_repeated_calls_idempotent(self) -> None:
+        from cognithor.security.cloud_escalation import (
+            _record_escalation_ledger_migration,
+        )
+
+        _record_escalation_ledger_migration()
+        _record_escalation_ledger_migration()

--- a/tests/test_security/test_cost_ledger.py
+++ b/tests/test_security/test_cost_ledger.py
@@ -427,3 +427,29 @@ class TestCostLedgerSnapshot:
 class TestProcessLocalLedger:
     def test_default_is_a_cost_ledger(self) -> None:
         assert isinstance(COST_LEDGER, CostLedger)
+
+
+class TestCostLedgerSelfAuditMigration:
+    """TRUST-10 self-audit: cost_ledger module-import records a
+    v0→v1 step in the canonical MIGRATION_LEDGER.
+    """
+
+    def test_migration_step_landed(self) -> None:
+        from cognithor.security.migration_ledger import (
+            MIGRATION_LEDGER,
+            MigrationDomain,
+            MigrationStatus,
+        )
+
+        step = MIGRATION_LEDGER.get("cost_ledger:v0-no-ledger:v1-micro-usd-ledger")
+        assert step is not None
+        assert step.status == MigrationStatus.APPLIED
+        assert step.domain == MigrationDomain.COST_LEDGER
+        assert MIGRATION_LEDGER.head_version(MigrationDomain.COST_LEDGER) == "v1-micro-usd-ledger"
+
+    def test_repeated_calls_idempotent(self) -> None:
+        from cognithor.security.cost_ledger import _record_cost_ledger_migration
+
+        _record_cost_ledger_migration()
+        _record_cost_ledger_migration()
+        _record_cost_ledger_migration()

--- a/tests/test_security/test_permission_scope.py
+++ b/tests/test_security/test_permission_scope.py
@@ -254,3 +254,33 @@ class TestScopeViolation:
         assert "cron" in msg
         assert "shell" in msg
         assert "max_risk" in msg
+
+
+class TestScopeRegistrySelfAuditMigration:
+    """TRUST-10 self-audit: permission_scope module-import records
+    a v0→v1 step in the canonical MIGRATION_LEDGER.
+    """
+
+    def test_migration_step_landed(self) -> None:
+        from cognithor.security.migration_ledger import (
+            MIGRATION_LEDGER,
+            MigrationDomain,
+            MigrationStatus,
+        )
+
+        step = MIGRATION_LEDGER.get("scope_registry:v0-no-registry:v1-axis-identity-registry")
+        assert step is not None
+        assert step.status == MigrationStatus.APPLIED
+        assert step.domain == MigrationDomain.SCOPE_REGISTRY
+        assert (
+            MIGRATION_LEDGER.head_version(MigrationDomain.SCOPE_REGISTRY)
+            == "v1-axis-identity-registry"
+        )
+
+    def test_repeated_calls_idempotent(self) -> None:
+        from cognithor.security.permission_scope import (
+            _record_scope_registry_migration,
+        )
+
+        _record_scope_registry_migration()
+        _record_scope_registry_migration()


### PR DESCRIPTION
## Summary

Completes the TRUST-10 self-audit set after #432 (provenance + fingerprint). Adds three new `MigrationDomain` values + module-level recorders so all six TRUST-5..10 ledgers now appear in the canonical migration chain.

## New MigrationDomain values + recorders

| Domain | source → target |
|---|---|
| `COST_LEDGER` (TRUST-6) | `v0-no-ledger → v1-micro-usd-ledger` |
| `ESCALATION_LEDGER` (TRUST-8) | `v0-no-ledger → v1-metadata-only-ledger` |
| `SCOPE_REGISTRY` (TRUST-5) | `v0-no-registry → v1-axis-identity-registry` |

All wrapped in `suppress(MigrationChainError, ValueError)` so module imports NEVER raise.

## Test plan

- [x] `pytest tests/test_security/test_cost_ledger.py tests/test_security/test_cloud_escalation.py tests/test_security/test_permission_scope.py tests/test_security/test_migration_ledger.py -x -q` — 125 passed (+6 new, 119 unchanged).
- [x] `mypy --strict` clean. `ruff check` + `ruff format` clean.

## TRUST-10 self-audit coverage now

| Domain | PR |
|---|---|
| `AUDIT_LOG` | #416 |
| `PACK_MANIFEST` | #417 |
| `PROVENANCE_LEDGER` | #432 |
| `FINGERPRINT_LEDGER` | #432 |
| `COST_LEDGER` | this PR |
| `ESCALATION_LEDGER` | this PR |
| `SCOPE_REGISTRY` | this PR |

Every TRUST-5..10 foundation now announces its schema lineage in the migration chain. The trust bundle's `migrations.head_version` section shows exactly which schema versions are active per process — the receipt is self-describing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)