### PR TITLE
feat(memory): TRUST-9 wiring into MemoryIndex.upsert_chunk

### DIFF
--- a/src/cognithor/memory/indexer.py
+++ b/src/cognithor/memory/indexer.py
@@ -186,14 +186,73 @@ class MemoryIndex:
 
     # ── Chunk Operations ─────────────────────────────────────────
 
-    def upsert_chunk(self, chunk: Chunk) -> None:
+    def upsert_chunk(
+        self,
+        chunk: Chunk,
+        *,
+        provenance_source_type: str | None = None,
+        provenance_source_id: str | None = None,
+        provenance_notes: str = "",
+    ) -> None:
         """Fuegt einen Chunk ein oder aktualisiert ihn und committet.
 
         Thread-safe: Geschuetzt ueber Write-Lock.
+
+        Optional TRUST-9 provenance: when both
+        ``provenance_source_type`` and ``provenance_source_id`` are
+        passed, a tag is written to the canonical
+        ``PROVENANCE_LEDGER`` keyed by ``chunk:<chunk.id>``. Lets
+        the operational-trust receipt answer "where did the
+        knowledge in this chunk come from?" — owner-uploaded PDF,
+        agent-fetched URL, scheduled cron import — for every chunk
+        that opted into provenance at indexing time.
         """
         with self._write_lock:
             self._upsert_chunk_impl(chunk)
             self.conn.commit()
+        if provenance_source_type and provenance_source_id:
+            self._tag_provenance(
+                item_id=f"chunk:{chunk.id}",
+                source_type_value=provenance_source_type,
+                source_id=provenance_source_id,
+                notes=provenance_notes,
+            )
+
+    @staticmethod
+    def _tag_provenance(
+        *,
+        item_id: str,
+        source_type_value: str,
+        source_id: str,
+        notes: str,
+    ) -> None:
+        """Best-effort TRUST-9 provenance tag — failures swallowed.
+
+        Unknown ``source_type_value`` is coerced to
+        :data:`SourceType.UNKNOWN`. Indexing NEVER fails because of
+        provenance tagging.
+        """
+        from cognithor.memory.provenance import (
+            PROVENANCE_LEDGER,
+            ProvenanceTag,
+            SourceType,
+        )
+
+        try:
+            try:
+                source_type = SourceType(source_type_value)
+            except ValueError:
+                source_type = SourceType.UNKNOWN
+            PROVENANCE_LEDGER.tag(
+                item_id,
+                ProvenanceTag(
+                    source_type=source_type,
+                    source_id=source_id,
+                    notes=notes,
+                ),
+            )
+        except ValueError:
+            pass
 
     def _upsert_chunk_impl(self, chunk: Chunk) -> None:
         """Internal: insert/update ohne Lock und ohne Commit (fuer Batch-Nutzung)."""

--- a/tests/test_memory/test_indexer.py
+++ b/tests/test_memory/test_indexer.py
@@ -308,3 +308,72 @@ class TestMaintenance:
         idx2 = MemoryIndex(db_path)
         assert idx2.count_chunks() == 1
         idx2.close()
+
+
+class TestMemoryIndexProvenance:
+    """TRUST-9 wiring: ``MemoryIndex.upsert_chunk(provenance_source_type=...,
+    provenance_source_id=...)`` writes a tag to the canonical
+    PROVENANCE_LEDGER keyed by ``chunk:<chunk.id>``.
+    """
+
+    def test_upsert_without_provenance_does_not_tag(
+        self, index: MemoryIndex, sample_chunk: Chunk
+    ) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            index.upsert_chunk(sample_chunk)
+            assert f"chunk:{sample_chunk.id}" not in isolated
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_upsert_with_provenance_tags_ledger(
+        self, index: MemoryIndex, sample_chunk: Chunk
+    ) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger, SourceType
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            index.upsert_chunk(
+                sample_chunk,
+                provenance_source_type="tool_output",
+                provenance_source_id="audit-77",
+                provenance_notes="indexed from web_fetch result",
+            )
+            tag = isolated.current(f"chunk:{sample_chunk.id}")
+            assert tag is not None
+            assert tag.source_type == SourceType.TOOL_OUTPUT
+            assert tag.source_id == "audit-77"
+            assert tag.notes == "indexed from web_fetch result"
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]
+
+    def test_partial_provenance_args_skip_tag(
+        self, index: MemoryIndex, sample_chunk: Chunk
+    ) -> None:
+        import cognithor.memory.provenance as prov_mod
+        from cognithor.memory.provenance import ProvenanceLedger
+
+        isolated = ProvenanceLedger()
+        original = prov_mod.PROVENANCE_LEDGER
+        prov_mod.PROVENANCE_LEDGER = isolated  # type: ignore[misc]
+        try:
+            index.upsert_chunk(
+                sample_chunk,
+                provenance_source_type="tool_output",
+            )
+            # Second upsert (overwrite) with only id — also skipped.
+            index.upsert_chunk(
+                sample_chunk,
+                provenance_source_id="audit-77",
+            )
+            assert len(isolated) == 0
+        finally:
+            prov_mod.PROVENANCE_LEDGER = original  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Eighth memory-tier wiring after #409-#412 + #425 + #426 + #433. Indexed chunks (the SQLite-backed primary memory store) now support opt-in provenance tagging keyed by `chunk:<chunk.id>`.

Lets the operational-trust receipt answer **"where did the knowledge in this chunk come from?"** for every chunk that opted into provenance at indexing time.

## Wiring

- New keyword-only params on `MemoryIndex.upsert_chunk`: `provenance_source_type`, `provenance_source_id`, `provenance_notes`. Identical contract to the other TRUST-9 hooks.
- Tag fires AFTER the SQLite commit succeeds — failed inserts don't leave stale provenance behind.
- Indexing **NEVER fails** because of provenance tagging.

## Test plan

- [x] `pytest tests/test_memory/test_indexer.py -x -q` — 30 passed (+3 new, 27 unchanged).
- [x] `mypy --strict` clean. `ruff check` + `ruff format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)