### PR TITLE
feat(streaming): EventEmitter foundation + JSON Schema v1 (Sprint-27 PR-A)

### DIFF
--- a/docs/superpowers/plans/2026-05-04-sprint27-ide-integration-decisions.md
+++ b/docs/superpowers/plans/2026-05-04-sprint27-ide-integration-decisions.md
@@ -1,0 +1,336 @@
+# Sprint-27 — IDE-Integration: Owner Decisions (Companion Doc)
+
+**Date:** 2026-05-04
+**Status:** Decisions locked. Phase-1 unblocked. Companion to
+[`2026-05-04-sprint27-ide-integration.md`](./2026-05-04-sprint27-ide-integration.md).
+**Owner:** Alexander Söllner
+
+This document records the five decisions made before Sprint-27 kicks
+off, and the architectural / process refinements derived from owner
+review of the original plan-doc. The plan-doc itself stays the
+canonical scope reference; this companion holds the *binding*
+choices and the *why* behind them.
+
+---
+
+## D1 — Repo Layout: **Monorepo, `extensions/vscode/` subdirectory**
+
+The original plan-doc proposed a separate `cognithor-vscode/` repo.
+Decision: **NO**. Use a `extensions/vscode/` subdirectory inside
+the main `cognithor` repo.
+
+**Why:**
+- Separate repo is *convention*, not a Marketplace requirement.
+  Marketplace cares about the `.vsix` artifact, not the source repo
+  layout.
+- Phase-1 will iterate on the streaming-protocol; backend changes
+  and extension-side parser changes ship best in atomic PRs (single
+  PR touches both `src/cognithor/streaming/` and
+  `extensions/vscode/src/`). A two-repo split fragments that.
+- One CI, one issue tracker, one place where Apache-2.0 contributors
+  see the work — better discoverability for a solo-dev project with
+  one core contributor.
+- JetBrains plugin (when it lands in Sprint-28+) goes under
+  `extensions/jetbrains/` for the same reason.
+
+**Consequences:**
+- The Microsoft Marketplace publisher identity is still its own thing
+  (Azure-DevOps PAT) — that's orthogonal to repo layout.
+- The `.gitignore` and CI must be careful that `extensions/vscode/`
+  doesn't break Python-side test collection.
+- Versioning: extension's `package.json` version stays in lockstep
+  with `pyproject.toml` and the four other version-canonical files.
+
+---
+
+## D2 — Marketplace Publishing: **Azure-DevOps PAT, NO code-signing cert**
+
+The original plan-doc claimed publishing a VS-Code extension required
+a code-signing certificate with ~1 week lead time. **That claim was
+wrong** and would have created a phantom blocker for Phase-2.
+
+The actual VS-Code Marketplace requirements:
+- Microsoft account (already exists)
+- Azure DevOps organization (free, ~5 minutes to create)
+- Personal Access Token with scope **Marketplace (Manage)**
+- `vsce create-publisher <name>` to claim a publisher identity
+- `vsce publish` to upload the `.vsix`
+
+Total realistic setup: **30 minutes**, not one week. Microsoft signs
+extensions on upload; publisher-side signing is an in-progress
+initiative, currently mandatory only for Microsoft-owned extensions.
+
+**Owner-side action**: 30-minute Azure-DevOps + PAT + `vsce
+create-publisher cognithor` whenever convenient — does not block
+Phase-1.
+
+**Note for future**: Authenticode (Windows binary signing,
+DigiCert ~$500/year) is *unrelated* to VS-Code Marketplace
+publishing. Cognithor already has Authenticode for the
+`CognithorSetup-*.exe` Inno-Setup installer; it has nothing to do
+with the `.vsix` flow.
+
+### Anti-pattern lesson (META — applies beyond this sprint)
+
+**When a future Claude session claims a technical requirement that
+introduces lead-time risk** — "you need a cert", "this requires an
+external review", "hardware procurement needed", "approval cycle from
+upstream", etc. — **verify the claim against current vendor docs
+before accepting it as a sprint constraint.** The wrong assumption
+here would have padded Sprint-27 by an entire week of fake
+parallelism. The cost of asking "is this still true today?" is
+seconds; the cost of letting it through is days.
+
+This is the more valuable lesson than the specific cert correction.
+The same shape of error returns in different costumes:
+"compliance review takes 6 weeks", "legal sign-off required for X",
+"vendor needs an NDA before they answer". Verify each one.
+
+---
+
+## D3 — JetBrains Plugin: **Defer to Sprint-28+**
+
+The original plan-doc had a JetBrains plugin scaffold (Track C, task
+#10) inside Sprint-27. Decision: **DEFER**.
+
+**Why:**
+- IntelliJ Platform is a different stack (Kotlin/Java + Gradle, own
+  Marketplace pipeline). Building both plugins in parallel means
+  debugging both at the same time, with each fix possibly reflecting
+  back into the other.
+- Smaller DACH dev userbase for IntelliJ vs VS-Code.
+- Sprint-27 will surface lessons about what the streaming-protocol
+  actually needs (vs what the plan-doc *thinks* it needs). Those
+  lessons go straight into the JetBrains spec, instead of being
+  paid for twice.
+- Cursor and Windsurf are VS-Code forks — the same `.vsix` is very
+  likely to install and work there without separate distribution.
+  A *Compat smoke test* (load the extension in Cursor, click
+  "Run Plan", verify receipt sidebar populates) replaces the
+  Cursor/Windsurf section of the plan-doc cheaper.
+
+**Consequences:**
+- Plan-doc tasks #10 (JetBrains scaffold) → Sprint-28+
+- Plan-doc task #11 (Cursor + Claude-Desktop docs) → still in
+  Sprint-27, but downgraded from "build a plugin" to "smoke-test
+  the .vsix in each host + write a 1-page integration note"
+- Sprint-27 effective scope: Track A + Track B only.
+
+---
+
+## D4 — Pricing: **Extension fully free, including Receipt-Sidebar + Cost-Gutter**
+
+The original plan-doc left this as an open decision: extension
+free, but require a paid pack to unlock advanced features
+(Receipt-Sidebar, Cost-Gutter)?
+
+Decision: **NO paywall on the extension itself or on the
+trust-visualization features.** Apache-2.0, the whole thing.
+
+**Why:**
+- Receipt-Sidebar and Cost-Gutter are exactly the features that
+  *prove* Cognithor's differentiation against CrewAI / AutoGen /
+  LangGraph. Putting them behind a paywall kills the showcase —
+  reviewers writing comparison posts (Reddit, HN) need to see them
+  in their default Marketplace install.
+- The Anti-Enshittification Promise (`/promise` page on
+  cognithor.ai) commits to: tooling free, packs add but never
+  subtract. A paywall on Receipt-Sidebar would violate the spirit
+  of that promise even if not the letter.
+- The correct paywall surface is **domain-specific knowledge**:
+  insurance pre-advisory templates (Versicherungs-Pack), bAV
+  workflows, content-marketing prompt libraries, etc. That's where
+  Cognithor's commercial wedge actually lives.
+- Paid packs unlock new *capabilities*, not visibility into existing
+  capabilities.
+
+**Consequences:**
+- `extensions/vscode/` ships under Apache-2.0
+- All six features from plan-doc §2 Track A are in the free tier
+- Marketplace listing copy emphasizes the trust-receipt + decision-
+  explanation features as core differentiators, not as upsell hooks
+
+---
+
+## D5 — Architecture: **Single EventEmitter + multiple Sinks, NOT separate impls**
+
+The original plan-doc treated JSONL-stdout streaming (task #4) and
+WebSocket streaming (task #5) as separate implementations.
+Decision: **single producer, two encoders/sinks.**
+
+**Layout:**
+- `cognithor/streaming/event_emitter.py` — the Producer. Emits
+  schema-versioned `StreamEvent` instances.
+- `cognithor/streaming/sinks/jsonl_sink.py` — `JsonlSink` writes
+  one event per line to stdout (or a file).
+- `cognithor/streaming/sinks/ws_sink.py` — `WebSocketSink` pushes
+  events as JSON frames to all connected clients.
+- `cognithor/streaming/schemas/v1/events.json` — JSON Schema for
+  every event type, machine-readable.
+- `cognithor/streaming/schemas/v1/events.md` — Markdown companion,
+  human-readable.
+
+**Why:**
+- One producer means one source of truth for event shapes. No
+  drift between transports.
+- A schema bug found in Sprint-28 is fixed in *one place*, not two.
+- Adding a third sink later (e.g. a SQLite-backed sink for
+  post-mortem replay, or a Prometheus pushgateway sink) becomes a
+  ~50-LOC addition instead of a fork-the-CLI affair.
+- The JSON Schema at `schemas/v1/events.json` lets us run
+  `npx json-schema-to-typescript` in the extension build to generate
+  TS types, instead of hand-maintaining them in two languages.
+
+**Refactored task split for Sprint-27 Phase-1:**
+- **PR-A**: `EventEmitter` + event types + JSON Schema + Markdown
+  companion + the five hardening points below (~250-300 LOC)
+- **PR-B**: `JsonlSink` + `cognithor agent run --plan FILE.json
+  --stream` (~250 LOC)
+- **PR-C**: `WebSocketSink` + `cognithor agent ws --port 8742` +
+  security defaults (~250 LOC)
+
+Total ~750-800 LOC, single coherent architecture.
+
+---
+
+## PR-A non-retrofittable hardening (must ship in PR-A, not later)
+
+Five things that become breaking-change migrations if we punt them
+to a later PR. All five locked in before PR-A merge:
+
+### H1 — Per-event `schema_version`, NOT envelope-level
+
+Bad: `{"schema_version": 1, "events": [...]}` at the top.
+Good: `{"event":"plan_step", "schema_version":1, "step":N, ...}`
+on every event.
+
+Reason: in Sprint-29 we'll want to upgrade *one* event type
+without rev'ing the entire stream. Per-event versioning costs
+nothing and preserves that flexibility.
+
+### H2 — `run_started`, `run_error`, `run_cancelled` defined from day 1
+
+The original plan-doc listed only happy-path events:
+`plan_step`, `gate_decision`, `tool_result`, `run_complete`.
+
+That's not enough:
+- **`run_started`**: lets the extension show "this run is now
+  active" before any plan step lands. Also lets the extension
+  reconnect mid-run and learn what's currently running (handshake
+  reply).
+- **`run_error`**: distinct from `run_complete`. The receipt
+  bundle for a failed run is shaped differently (carries the
+  `FailureMode`); the UI needs to know to render the red banner
+  instead of the green checkmark.
+- **`run_cancelled`**: user-initiated abort. Different telemetry
+  bucket, different UI affordance, different audit shape.
+
+If these arrive in Sprint-28, every existing client breaks because
+their event-type discriminator is now incomplete. Ship all seven
+event types in v1 of the schema.
+
+### H3 — WebSocket security defaults: localhost-only + token auth
+
+`cognithor agent ws` defaults:
+- **Bind to `127.0.0.1` only.** Never `0.0.0.0` by default.
+- **Require token auth.** Simple pre-shared key from
+  `~/.cognithor/auth.token` (auto-generated on first start, 32-byte
+  random hex, mode 0600). Client supplies it via `Authorization:
+  Bearer <token>` header on the WebSocket upgrade request.
+- **`--bind 0.0.0.0`** flag exists but emits a security warning,
+  and *still* requires the token (no auth-bypass-with-bind).
+- Token-mismatch closes the WS with code 1008 (policy violation)
+  before the upgrade completes.
+
+Reason: the SEC-CRIT-1 bootstrap-endpoint-CVSS-9.8 incident
+(audit-fixed in PR #173) was the same class of error — exposed
+network surface with no auth. Don't repeat it. The VS-Code
+extension only needs localhost; making `0.0.0.0` the default would
+gain nothing and lose the security default.
+
+### H4 — Backpressure semantics defined in PR-A, async fan-out
+
+The Producer-Sink relationship needs explicit backpressure rules
+*before* multiple sinks ship, not after.
+
+Spec:
+- Each Sink has its own bounded buffer (default 1000 events).
+- Producer fans out async to all sinks in parallel.
+- Producer **only blocks** when *all* sinks are full.
+- A Sink falling behind drops events (oldest-first) and emits a
+  one-time `sink_dropped` warning into its own stream so the
+  consumer knows it's seen partial data.
+- **Critical events bypass the drop mechanism:** `run_complete`,
+  `run_error`, `run_cancelled` are always delivered, even if the
+  buffer is at limit (these get a small reserved-slot pool of 16
+  events per sink).
+
+Cost: ~30-50 LOC more in PR-A. Saves a full architecture migration
+later. Without this, PR-C ships and somebody's WebSocket client
+disconnects mid-run; current behavior is undefined; that's an
+ugly bug to discover in production.
+
+### H5 — JSON Schema in machine-readable path, not just prose
+
+`cognithor/streaming/schemas/v1/events.json` ships as a real JSON
+Schema (Draft 2020-12). The Markdown companion at
+`cognithor/streaming/schemas/v1/events.md` documents the human
+side, but the schema file is the source of truth.
+
+Phase-2 then runs `npx json-schema-to-typescript
+cognithor/streaming/schemas/v1/events.json -o
+extensions/vscode/src/types/events.ts` as part of the extension
+build. TS types are auto-generated; no hand-maintenance, no drift.
+
+Schema validation in PR-A's tests: every emitted event round-trips
+through `jsonschema.validate()` against the schema file. A test
+failure means either the schema needs updating *or* the producer
+is emitting an off-spec event — either way, blocking error.
+
+---
+
+## Sprint-26 → Sprint-27 transition
+
+Sprint-26 closed 2026-05-04 (PRs #389-#392, all four cut-offs
+delivered ahead of the 4-week calendar plan). Real-Score-Validation
+for Spider/HumanEval-Plus is hardware-gated and runs separately
+from the codebase work — not a Sprint-27 dependency.
+
+**Cadence override (2026-05-04):** Owner-direktive *"wir machen
+keinerlei pausen! maximaler fokus … vollautonom go"*. The
+Wednesday-pause rule from the Sprint-26 memo is **suspended for
+Sprint-27**. PR-A starts immediately after this memo lands. PR-B
+and PR-C follow without a calendar gap as soon as PR-A is merged.
+
+---
+
+## What this Memo locks in
+
+- **D1**: Monorepo, `extensions/vscode/`
+- **D2**: Azure-DevOps PAT, no signing cert needed (30-min owner task)
+- **D3**: JetBrains deferred to Sprint-28+
+- **D4**: Extension + Receipt-Sidebar + Cost-Gutter all free, Apache-2.0
+- **D5**: Single EventEmitter + multiple Sinks (PR-A / PR-B / PR-C structure)
+- **H1-H5**: Five PR-A hardening points, all non-retrofittable
+
+## What this Memo does NOT cover
+
+- Concrete wire-format examples for each event type — those land
+  in PR-A itself, generated from the JSON Schema.
+- Extension-side architecture (webview vs tree-view, etc.) —
+  Phase-2 / Phase-3 concern.
+- JetBrains plugin design — Sprint-28+.
+
+## Cross-references
+
+- Plan-doc: [`2026-05-04-sprint27-ide-integration.md`](./2026-05-04-sprint27-ide-integration.md)
+- TRUST-1 receipt API consumed by Receipt-Sidebar:
+  `src/cognithor/api/crew_traces.py:305` — `GET /api/crew/trace/{trace_id}/receipt?include_trust=true`
+- Receipt CLI consumed by extension shell-out:
+  `src/cognithor/cli/receipt_cmd.py` — `cognithor receipt show / verify / list / export-all / diff`
+- MCP-stdio entry consumed by extension MCP-bridge:
+  `src/cognithor/__main__.py:389` — `_run_mcp_server_mode`
+- SEC-CRIT-1 bootstrap-endpoint CVSS-9.8 incident (referenced in H3):
+  closed via PR #173.
+- Anti-Enshittification Promise (referenced in D4):
+  https://cognithor.ai/promise

--- a/src/cognithor/streaming/__init__.py
+++ b/src/cognithor/streaming/__init__.py
@@ -1,0 +1,65 @@
+"""Sprint-27 streaming package — `cognithor agent run --stream` / `cognithor agent ws`.
+
+Public surface for the IDE-Integration runtime: a single
+:class:`EventEmitter` Producer fans out schema-versioned
+:class:`StreamEvent` instances to one-or-more :class:`Sink`
+consumers. The two ship-with-the-CLI sinks are
+:class:`JsonlSink` (PR-B) and :class:`WebSocketSink` (PR-C);
+PR-A (this PR) only ships the Producer, the Sink ABC, the
+event taxonomy, and the JSON Schema.
+
+Owner-decision D5 (`docs/superpowers/plans/2026-05-04-sprint27-ide-integration-decisions.md`)
+locks "single Producer + multiple Sinks" as the architecture so
+neither the JSONL nor WebSocket transport drifts in shape.
+
+Hardening points H1-H5 (same companion doc):
+
+H1  Per-event ``schema_version`` so single events upgrade independently.
+H2  Seven event types from day 1 (run_started / plan_step /
+    gate_decision / tool_result / run_complete / run_error /
+    run_cancelled), plus the producer-emitted ``sink_dropped``.
+H3  WebSocket security defaults — see ``cognithor.streaming.sinks.ws_sink``
+    (PR-C).
+H4  Backpressure: each sink owns a bounded buffer; producer fans out
+    async; critical events bypass the drop mechanism via a reserved
+    16-slot pool per sink.
+H5  Machine-readable JSON Schema at
+    :data:`SCHEMA_PATH` — ``cognithor/streaming/schemas/v1/events.json``
+    (Draft 2020-12). Phase-2 codegens TypeScript types from it.
+"""
+
+from __future__ import annotations
+
+from cognithor.streaming.emitter import EventEmitter
+from cognithor.streaming.events import (
+    SCHEMA_PATH,
+    SCHEMA_VERSION,
+    DecisionExplanation,
+    GateDecision,
+    PlanStep,
+    RunCancelled,
+    RunComplete,
+    RunError,
+    RunStarted,
+    SinkDropped,
+    StreamEvent,
+    ToolResult,
+)
+from cognithor.streaming.sinks.base import Sink
+
+__all__ = [
+    "SCHEMA_PATH",
+    "SCHEMA_VERSION",
+    "DecisionExplanation",
+    "EventEmitter",
+    "GateDecision",
+    "PlanStep",
+    "RunCancelled",
+    "RunComplete",
+    "RunError",
+    "RunStarted",
+    "Sink",
+    "SinkDropped",
+    "StreamEvent",
+    "ToolResult",
+]

--- a/src/cognithor/streaming/emitter.py
+++ b/src/cognithor/streaming/emitter.py
@@ -1,0 +1,103 @@
+"""EventEmitter — single Producer fanning out to multiple Sinks (D5 + H4).
+
+The Producer side of Sprint-27's streaming architecture. Knows
+nothing about the transport (JSONL, WebSocket, future SQLite
+sink, etc.) — it just calls :meth:`Sink.offer` on every
+registered sink and reports aggregate fanout success.
+
+Per H4 backpressure semantics, ``EventEmitter.emit`` blocks
+*only* when:
+
+* The event is critical (terminal or ``sink_dropped``) AND
+  every sink's reserve pool is exhausted.
+
+For non-critical events, ``emit`` is non-blocking — slow sinks
+simply drop and surface a :class:`SinkDropped` notice next time
+they catch up. This keeps the agent loop's hot path free of
+sink-side latency.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from cognithor.streaming.events import (
+    CRITICAL_EVENT_TYPES,
+    StreamEvent,
+)
+
+if TYPE_CHECKING:
+    from cognithor.streaming.sinks.base import Sink
+
+log = logging.getLogger(__name__)
+
+
+class EventEmitter:
+    """Producer that fans an event out to a fixed set of sinks.
+
+    Sinks are added once at startup (typically by the agent-run
+    CLI bootstrapping a :class:`JsonlSink` and/or
+    :class:`WebSocketSink`) and remain for the lifetime of the
+    emitter. There is no removal API in PR-A — Sprint-28+ may add
+    one if a use case appears.
+    """
+
+    def __init__(self) -> None:
+        self._sinks: list[Sink] = []
+
+    def add_sink(self, sink: Sink) -> None:
+        """Register a sink for fanout. Order is preserved for tests."""
+
+        self._sinks.append(sink)
+
+    @property
+    def sinks(self) -> tuple[Sink, ...]:
+        """Read-only view of registered sinks."""
+
+        return tuple(self._sinks)
+
+    def emit(self, event: StreamEvent) -> int:
+        """Fan ``event`` out to every registered sink.
+
+        Returns the number of sinks that successfully accepted the
+        event. For critical events, a return value < ``len(sinks)``
+        is logged at ERROR level — the caller can decide whether
+        to surface it as a process-level failure.
+        """
+
+        accepted = 0
+        for sink in self._sinks:
+            if sink.is_faulted:
+                continue
+            if sink.offer(event):
+                accepted += 1
+
+        if event.EVENT_TYPE in CRITICAL_EVENT_TYPES and accepted < len(self._sinks):
+            # Don't include faulted sinks in the "missed" count —
+            # they're a separate already-logged failure mode.
+            live = sum(1 for s in self._sinks if not s.is_faulted)
+            if accepted < live:
+                log.error(
+                    "emitter: critical event %s dropped by %d/%d live sinks",
+                    event.EVENT_TYPE,
+                    live - accepted,
+                    live,
+                )
+
+        return accepted
+
+    async def start(self) -> None:
+        """Spin up every registered sink's consumer task."""
+
+        for sink in self._sinks:
+            await sink.start()
+
+    async def stop(self) -> None:
+        """Drain + close every sink. Best-effort across all sinks."""
+
+        for sink in self._sinks:
+            try:
+                await sink.stop()
+            except Exception:
+                log.exception("emitter: sink %s failed to stop cleanly", sink.name)

--- a/src/cognithor/streaming/events.py
+++ b/src/cognithor/streaming/events.py
@@ -1,0 +1,312 @@
+"""Sprint-27 streaming-event taxonomy + envelope.
+
+Frozen, JSON-serialisable dataclasses for the eight event types
+defined by the v1 JSON Schema at
+``cognithor/streaming/schemas/v1/events.json``.
+
+**H1 (per-event schema_version):** every concrete event class
+exposes a class-level ``SCHEMA_VERSION`` constant and embeds it
+into the wire payload via :meth:`StreamEvent.to_dict`. The
+envelope-level schema version is intentionally absent — bumping
+``RunComplete``'s schema in v2 must NOT force every other event to
+revision.
+
+**H2 (run_started / run_error / run_cancelled defined day 1):**
+all seven happy-and-sad-path events are first-class types; the
+extension's discriminator switch can rely on a closed set.
+
+**H4 critical bypass:** :data:`CRITICAL_EVENT_TYPES` is the
+authoritative set of events that bypass the bounded-buffer drop
+mechanism (terminal events, plus :class:`SinkDropped` itself so
+operators never lose the "I dropped events" signal).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, ClassVar, Final, Literal
+
+# Absolute path to the v1 JSON Schema. Tests round-trip every
+# emitted event through ``jsonschema.validate`` against this file.
+SCHEMA_PATH: Final[Path] = Path(__file__).parent / "schemas" / "v1" / "events.json"
+
+# Top-level schema-version label exposed for telemetry (e.g. the
+# "Cognithor streaming v1" footer in the extension status bar).
+# NOT mixed into the wire payload — per H1, individual event
+# classes carry their own ``schema_version`` field.
+SCHEMA_VERSION: Final[str] = "v1"
+
+# Producer-side truncation cap for ``DecisionExplanation.matched_pattern``.
+# Mirrors the cap baked into the JSON Schema and into
+# ``cognithor.security.permission_scope`` — keep them in sync.
+_MATCHED_PATTERN_MAX_LEN: Final[int] = 200
+
+
+def _utcnow_iso() -> str:
+    """ISO 8601 UTC timestamp with explicit ``Z`` suffix."""
+
+    return datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+@dataclass(frozen=True, slots=True)
+class DecisionExplanation:
+    """TRUST-2 structured 'why' attached to Gatekeeper block paths.
+
+    Mirrors the runtime ``DecisionExplanation`` in
+    :mod:`cognithor.core.gatekeeper`. Producer-side truncates
+    ``matched_pattern`` to 200 chars before emission.
+    """
+
+    rule_id: str
+    rule_source: str
+    matched_pattern: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out: dict[str, Any] = {
+            "rule_id": self.rule_id,
+            "rule_source": self.rule_source,
+        }
+        if self.matched_pattern is not None:
+            out["matched_pattern"] = self.matched_pattern[:_MATCHED_PATTERN_MAX_LEN]
+        return out
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class StreamEvent:
+    """Abstract envelope shared by every emitted event.
+
+    Concrete subclasses MUST set the class-var ``EVENT_TYPE`` to
+    the wire-format discriminator string and ``SCHEMA_VERSION`` to
+    the current per-event schema number (H1).
+    """
+
+    EVENT_TYPE: ClassVar[str] = ""
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    run_id: str
+    ts: str = field(default_factory=_utcnow_iso)
+
+    def __post_init__(self) -> None:
+        if not self.EVENT_TYPE:
+            msg = (
+                f"{type(self).__name__}.EVENT_TYPE is unset — concrete "
+                "StreamEvent subclasses must define EVENT_TYPE"
+            )
+            raise TypeError(msg)
+        if not self.run_id:
+            msg = "StreamEvent.run_id must be a non-empty string"
+            raise ValueError(msg)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Wire-format payload. Subclasses override + chain via super()."""
+
+        return {
+            "event": self.EVENT_TYPE,
+            "schema_version": self.SCHEMA_VERSION,
+            "run_id": self.run_id,
+            "ts": self.ts,
+        }
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RunStarted(StreamEvent):
+    """First event for any run — always precedes plan_step / gate_decision."""
+
+    EVENT_TYPE: ClassVar[str] = "run_started"
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    plan_path: str
+    step_count: int
+    agent_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out = StreamEvent.to_dict(self)
+        out["plan_path"] = self.plan_path
+        out["step_count"] = self.step_count
+        if self.agent_id is not None:
+            out["agent_id"] = self.agent_id
+        return out
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class PlanStep(StreamEvent):
+    """Per-step Planner-output event."""
+
+    EVENT_TYPE: ClassVar[str] = "plan_step"
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    step: int
+    action: dict[str, Any]
+
+    def to_dict(self) -> dict[str, Any]:
+        out = StreamEvent.to_dict(self)
+        out["step"] = self.step
+        out["action"] = dict(self.action)
+        return out
+
+
+GateStatus = Literal[
+    "green",
+    "yellow",
+    "orange_approved",
+    "orange_blocked",
+    "red",
+]
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class GateDecision(StreamEvent):
+    """TRUST-2 Gatekeeper outcome event with optional structured explanation."""
+
+    EVENT_TYPE: ClassVar[str] = "gate_decision"
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    step: int
+    status: GateStatus
+    explanation: DecisionExplanation | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out = StreamEvent.to_dict(self)
+        out["step"] = self.step
+        out["status"] = self.status
+        if self.explanation is not None:
+            out["explanation"] = self.explanation.to_dict()
+        return out
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class ToolResult(StreamEvent):
+    """Per-tool invocation result event."""
+
+    EVENT_TYPE: ClassVar[str] = "tool_result"
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    step: int
+    ok: bool
+    duration_ms: int | None = None
+    chunks: int | None = None
+    preview: str | None = None
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        out = StreamEvent.to_dict(self)
+        out["step"] = self.step
+        out["ok"] = self.ok
+        if self.duration_ms is not None:
+            out["duration_ms"] = self.duration_ms
+        if self.chunks is not None:
+            out["chunks"] = self.chunks
+        if self.preview is not None:
+            out["preview"] = self.preview[:500]
+        if self.error is not None:
+            out["error"] = self.error
+        return out
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RunComplete(StreamEvent):
+    """Terminal happy-path event — always carries the TRUST-1 receipt bundle."""
+
+    EVENT_TYPE: ClassVar[str] = "run_complete"
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    receipt: dict[str, Any]
+    duration_ms: int | None = None
+    status: Literal["success"] = "success"
+
+    def to_dict(self) -> dict[str, Any]:
+        out = StreamEvent.to_dict(self)
+        out["status"] = self.status
+        if self.duration_ms is not None:
+            out["duration_ms"] = self.duration_ms
+        out["receipt"] = dict(self.receipt)
+        return out
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RunError(StreamEvent):
+    """Terminal failure event — always carries a FailureMode (TRUST-3)."""
+
+    EVENT_TYPE: ClassVar[str] = "run_error"
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    failure_mode: str
+    error: str | None = None
+    step: int | None = None
+    receipt: dict[str, Any] | None = None
+    status: Literal["error"] = "error"
+
+    def to_dict(self) -> dict[str, Any]:
+        out = StreamEvent.to_dict(self)
+        out["status"] = self.status
+        out["failure_mode"] = self.failure_mode
+        if self.error is not None:
+            out["error"] = self.error
+        if self.step is not None:
+            out["step"] = self.step
+        if self.receipt is not None:
+            out["receipt"] = dict(self.receipt)
+        return out
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RunCancelled(StreamEvent):
+    """Terminal user-cancellation event."""
+
+    EVENT_TYPE: ClassVar[str] = "run_cancelled"
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    reason: str | None = None
+    step: int | None = None
+    receipt: dict[str, Any] | None = None
+    status: Literal["cancelled"] = "cancelled"
+
+    def to_dict(self) -> dict[str, Any]:
+        out = StreamEvent.to_dict(self)
+        out["status"] = self.status
+        if self.reason is not None:
+            out["reason"] = self.reason
+        if self.step is not None:
+            out["step"] = self.step
+        if self.receipt is not None:
+            out["receipt"] = dict(self.receipt)
+        return out
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class SinkDropped(StreamEvent):
+    """Producer-emitted notice that a Sink dropped buffered events.
+
+    Sinks emit this *into their own stream* only — operators must
+    learn that their consumer fell behind, even if no other channel
+    survives. Counted as a critical event so it never gets dropped
+    by the same backpressure mechanism it warns about (H4).
+    """
+
+    EVENT_TYPE: ClassVar[str] = "sink_dropped"
+    SCHEMA_VERSION: ClassVar[int] = 1
+
+    sink: str
+    dropped_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        out = StreamEvent.to_dict(self)
+        out["sink"] = self.sink
+        out["dropped_count"] = self.dropped_count
+        return out
+
+
+# H4 — critical events bypass the bounded-buffer drop mechanism.
+# Terminal lifecycle events MUST always be delivered; the
+# ``sink_dropped`` notification MUST always be delivered for the
+# operator to know they have an incomplete picture.
+CRITICAL_EVENT_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        RunComplete.EVENT_TYPE,
+        RunError.EVENT_TYPE,
+        RunCancelled.EVENT_TYPE,
+        SinkDropped.EVENT_TYPE,
+    }
+)

--- a/src/cognithor/streaming/schemas/v1/events.json
+++ b/src/cognithor/streaming/schemas/v1/events.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://cognithor.ai/schemas/streaming/v1/events.json",
+  "title": "Cognithor Streaming Events v1",
+  "description": "Schema for the per-line JSON / WebSocket event stream emitted by `cognithor agent run --stream` and `cognithor agent ws`. Each event carries its own `schema_version` so individual events can evolve independently. Consumed by the VS Code extension (Sprint-27) and by external orchestrators wrapping the headless CLI.",
+  "oneOf": [
+    {"$ref": "#/$defs/run_started"},
+    {"$ref": "#/$defs/plan_step"},
+    {"$ref": "#/$defs/gate_decision"},
+    {"$ref": "#/$defs/tool_result"},
+    {"$ref": "#/$defs/run_complete"},
+    {"$ref": "#/$defs/run_error"},
+    {"$ref": "#/$defs/run_cancelled"},
+    {"$ref": "#/$defs/sink_dropped"}
+  ],
+  "$defs": {
+    "EnvelopeFields": {
+      "type": "object",
+      "description": "Fields every event carries. Per-event `schema_version` (NOT envelope-level) so single events can evolve independently.",
+      "required": ["event", "schema_version", "run_id", "ts"],
+      "properties": {
+        "event": {
+          "type": "string",
+          "description": "Discriminator: one of run_started / plan_step / gate_decision / tool_result / run_complete / run_error / run_cancelled / sink_dropped."
+        },
+        "schema_version": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "run_id": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Stable identifier for the run / trace. Matches the trace_id used by GET /api/crew/trace/{trace_id}/receipt."
+        },
+        "ts": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 UTC timestamp."
+        }
+      }
+    },
+    "FailureMode": {
+      "type": "string",
+      "description": "Mirrors cognithor.models.FailureMode StrEnum.",
+      "enum": [
+        "unknown",
+        "tool_not_found",
+        "tool_argument_invalid",
+        "internal_error",
+        "user_cancelled",
+        "rate_limited",
+        "permission_denied",
+        "external_service_unavailable",
+        "validation_failure",
+        "policy_block",
+        "quota_exceeded",
+        "tool_timeout",
+        "parse_error",
+        "dependency_missing",
+        "pack_eula_missing"
+      ]
+    },
+    "DecisionExplanation": {
+      "type": "object",
+      "description": "TRUST-2 structured 'why' attached to every Gatekeeper block path.",
+      "required": ["rule_id", "rule_source"],
+      "properties": {
+        "rule_id": {"type": "string"},
+        "rule_source": {"type": "string"},
+        "matched_pattern": {
+          "type": "string",
+          "maxLength": 200,
+          "description": "Producer-side truncated to 200 chars."
+        }
+      }
+    },
+    "run_started": {
+      "type": "object",
+      "allOf": [{"$ref": "#/$defs/EnvelopeFields"}],
+      "required": ["plan_path", "step_count"],
+      "properties": {
+        "event": {"const": "run_started"},
+        "schema_version": {"const": 1},
+        "plan_path": {
+          "type": "string",
+          "description": "Path to the ActionPlan JSON file, or '<inline>' if supplied as JSON literal."
+        },
+        "step_count": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of steps the planner produced. Final per-step events may be fewer (early exit) or more (REPLAN)."
+        },
+        "agent_id": {"type": "string"}
+      }
+    },
+    "plan_step": {
+      "type": "object",
+      "allOf": [{"$ref": "#/$defs/EnvelopeFields"}],
+      "required": ["step", "action"],
+      "properties": {
+        "event": {"const": "plan_step"},
+        "schema_version": {"const": 1},
+        "step": {"type": "integer", "minimum": 0},
+        "action": {
+          "type": "object",
+          "required": ["tool"],
+          "properties": {
+            "tool": {"type": "string"},
+            "arguments": {"type": "object"},
+            "rationale": {"type": "string"}
+          }
+        }
+      }
+    },
+    "gate_decision": {
+      "type": "object",
+      "allOf": [{"$ref": "#/$defs/EnvelopeFields"}],
+      "required": ["step", "status"],
+      "properties": {
+        "event": {"const": "gate_decision"},
+        "schema_version": {"const": 1},
+        "step": {"type": "integer", "minimum": 0},
+        "status": {
+          "type": "string",
+          "enum": ["green", "yellow", "orange_approved", "orange_blocked", "red"]
+        },
+        "explanation": {"$ref": "#/$defs/DecisionExplanation"}
+      }
+    },
+    "tool_result": {
+      "type": "object",
+      "allOf": [{"$ref": "#/$defs/EnvelopeFields"}],
+      "required": ["step", "ok"],
+      "properties": {
+        "event": {"const": "tool_result"},
+        "schema_version": {"const": 1},
+        "step": {"type": "integer", "minimum": 0},
+        "ok": {"type": "boolean"},
+        "duration_ms": {"type": "integer", "minimum": 0},
+        "chunks": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Count of chunks for chunked results (file writes, searches). Omitted for scalar results."
+        },
+        "preview": {
+          "type": "string",
+          "description": "Optional truncated preview of tool output (<=500 chars) for UI; full output stays in audit log."
+        },
+        "error": {
+          "type": "string",
+          "description": "Single-line error summary; set when ok=false."
+        }
+      }
+    },
+    "run_complete": {
+      "type": "object",
+      "allOf": [{"$ref": "#/$defs/EnvelopeFields"}],
+      "required": ["status", "receipt"],
+      "properties": {
+        "event": {"const": "run_complete"},
+        "schema_version": {"const": 1},
+        "status": {"type": "string", "enum": ["success"]},
+        "duration_ms": {"type": "integer", "minimum": 0},
+        "receipt": {
+          "type": "object",
+          "description": "TRUST-1 receipt bundle as returned by AuditLogger.run_receipt(). Same shape as GET /api/crew/trace/{trace_id}/receipt?include_trust=true."
+        }
+      }
+    },
+    "run_error": {
+      "type": "object",
+      "allOf": [{"$ref": "#/$defs/EnvelopeFields"}],
+      "required": ["status", "failure_mode"],
+      "properties": {
+        "event": {"const": "run_error"},
+        "schema_version": {"const": 1},
+        "status": {"type": "string", "enum": ["error"]},
+        "failure_mode": {"$ref": "#/$defs/FailureMode"},
+        "error": {"type": "string"},
+        "step": {"type": "integer", "minimum": 0},
+        "receipt": {
+          "type": "object",
+          "description": "TRUST-1 receipt bundle for the partial run, when available."
+        }
+      }
+    },
+    "run_cancelled": {
+      "type": "object",
+      "allOf": [{"$ref": "#/$defs/EnvelopeFields"}],
+      "required": ["status"],
+      "properties": {
+        "event": {"const": "run_cancelled"},
+        "schema_version": {"const": 1},
+        "status": {"type": "string", "enum": ["cancelled"]},
+        "reason": {"type": "string"},
+        "step": {"type": "integer", "minimum": 0},
+        "receipt": {
+          "type": "object",
+          "description": "TRUST-1 receipt bundle for the partial run, when available."
+        }
+      }
+    },
+    "sink_dropped": {
+      "type": "object",
+      "allOf": [{"$ref": "#/$defs/EnvelopeFields"}],
+      "required": ["sink", "dropped_count"],
+      "properties": {
+        "event": {"const": "sink_dropped"},
+        "schema_version": {"const": 1},
+        "sink": {
+          "type": "string",
+          "description": "Name of the sink that dropped events (e.g. 'jsonl', 'websocket')."
+        },
+        "dropped_count": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Number of events dropped since the sink started, OR since the previous sink_dropped notification."
+        }
+      }
+    }
+  }
+}

--- a/src/cognithor/streaming/schemas/v1/events.md
+++ b/src/cognithor/streaming/schemas/v1/events.md
@@ -1,0 +1,189 @@
+# Cognithor Streaming Events — v1
+
+This is the human-readable companion to
+[`events.json`](./events.json). The JSON Schema is the source of
+truth; this Markdown documents intent, reasoning, and consumer-side
+expectations.
+
+**Source-of-truth path:** `src/cognithor/streaming/schemas/v1/events.json`
+(JSON Schema Draft 2020-12).
+
+**Producer:** `cognithor.streaming.EventEmitter` (`src/cognithor/streaming/emitter.py`)
+fans events out to one-or-more `Sink` consumers (`base.py` ABC,
+concrete `JsonlSink` in PR-B, `WebSocketSink` in PR-C).
+
+**Consumers:**
+- `cognithor agent run --plan FILE.json --stream` (PR-B) writes JSONL to stdout.
+- `cognithor agent ws --port 8742` (PR-C) serves frames over WebSocket.
+- The VS Code extension (Phase-2) parses these events to drive UI.
+- External orchestrators wrapping the headless CLI rely on the same shapes.
+
+## Envelope
+
+Every event carries:
+
+| field | type | notes |
+|---|---|---|
+| `event` | string | Discriminator; one of the eight types below |
+| `schema_version` | integer ≥ 1 | **Per-event, NOT envelope-level** (H1) |
+| `run_id` | non-empty string | Matches the `trace_id` used by `GET /api/crew/trace/{trace_id}/receipt` |
+| `ts` | RFC 3339 / ISO 8601 UTC | Producer-side timestamp |
+
+### H1 — per-event `schema_version`
+
+Per-event versioning means a Sprint-29 schema bump on, say,
+`run_complete` does NOT force every other event type to revision.
+Consumers MUST switch on the pair `(event, schema_version)` rather
+than a top-level stream version.
+
+## Event types
+
+### `run_started`
+
+Emitted exactly once per run, before any `plan_step`.
+Lets a late-connecting consumer know what's currently running and
+how long the run is expected to be.
+
+| field | type | required |
+|---|---|---|
+| `plan_path` | string | yes — path to the ActionPlan JSON file (or `"<inline>"`) |
+| `step_count` | int ≥ 0 | yes — Planner-reported step count |
+| `agent_id` | string | optional |
+
+### `plan_step`
+
+Emitted per Planner-output step, before the corresponding
+`gate_decision`.
+
+| field | type | required |
+|---|---|---|
+| `step` | int ≥ 0 | yes |
+| `action` | object with `tool` (string), optional `arguments` and `rationale` | yes |
+
+### `gate_decision`
+
+TRUST-2 — the Gatekeeper outcome for this step. Emitted after
+`plan_step`, before `tool_result`.
+
+| field | type | required |
+|---|---|---|
+| `step` | int ≥ 0 | yes |
+| `status` | one of `green`, `yellow`, `orange_approved`, `orange_blocked`, `red` | yes |
+| `explanation` | `DecisionExplanation` (`rule_id` + `rule_source` + optional truncated `matched_pattern`) | optional, but always present for block paths (status ∈ `{red, orange_blocked}`) |
+
+`matched_pattern` is producer-side truncated to 200 characters.
+
+### `tool_result`
+
+Per-tool-invocation result.
+
+| field | type | required |
+|---|---|---|
+| `step` | int ≥ 0 | yes |
+| `ok` | bool | yes |
+| `duration_ms` | int ≥ 0 | optional |
+| `chunks` | int ≥ 0 | optional — count of chunks for chunked results |
+| `preview` | string ≤ 500 chars | optional — UI-friendly preview |
+| `error` | string | optional — set when `ok=false` |
+
+### `run_complete` *(critical, terminal — H2 + H4)*
+
+Emitted exactly once at the end of a successful run.
+
+| field | type | required |
+|---|---|---|
+| `status` | const `"success"` | yes |
+| `duration_ms` | int ≥ 0 | optional |
+| `receipt` | object | yes — TRUST-1 bundle, same shape as `GET /api/crew/trace/{trace_id}/receipt?include_trust=true` |
+
+### `run_error` *(critical, terminal — H2 + H4)*
+
+Emitted exactly once when a run fails.
+
+| field | type | required |
+|---|---|---|
+| `status` | const `"error"` | yes |
+| `failure_mode` | one of the 15 `FailureMode` values | yes |
+| `error` | string | optional — short summary |
+| `step` | int ≥ 0 | optional — step where the error occurred |
+| `receipt` | object | optional — partial TRUST-1 bundle |
+
+### `run_cancelled` *(critical, terminal — H2 + H4)*
+
+Emitted exactly once on user-initiated abort.
+
+| field | type | required |
+|---|---|---|
+| `status` | const `"cancelled"` | yes |
+| `reason` | string | optional |
+| `step` | int ≥ 0 | optional |
+| `receipt` | object | optional |
+
+### `sink_dropped` *(critical — H4)*
+
+Producer-emitted notice that a sink dropped buffered non-critical
+events. Always delivered (cannot itself be dropped).
+
+| field | type | required |
+|---|---|---|
+| `sink` | string | yes — sink name (`jsonl`, `websocket`, ...) |
+| `dropped_count` | int ≥ 1 | yes |
+
+## H4 — Backpressure semantics
+
+Each sink owns:
+
+1. A bounded `asyncio.Queue` of normal events (default capacity **1000**).
+2. A reserved-slot pool for critical events (default capacity **16**).
+
+Producer fans an event out to all sinks via `Sink.offer`, which
+returns `True` on success and `False` on full-queue. **Producer
+does NOT block** on slow sinks for non-critical events — slow
+sinks drop, then surface the loss as a `sink_dropped` event the
+next time they catch up.
+
+Critical events (`run_complete`, `run_error`, `run_cancelled`,
+`sink_dropped`) always bypass the normal-capacity gate and draw
+from the reserve pool. Reserve exhaustion logs at ERROR level —
+that's a real failure that operators should investigate (sink is
+chronically slow or hung).
+
+## H3 — WebSocket security defaults (preview, lands in PR-C)
+
+The `WebSocketSink` in PR-C will:
+
+- Bind `127.0.0.1` by default. `--bind 0.0.0.0` requires explicit warning + still requires the token.
+- Require a `Bearer` token from `~/.cognithor/auth.token` (auto-generated 32-byte hex, mode 0600).
+- Close with code `1008` (policy violation) on auth mismatch.
+
+This is documented here in v1 so consumers (the extension client,
+external orchestrators) build against it from day one.
+
+## H5 — TypeScript codegen
+
+Phase-2 will generate TS types from `events.json` via:
+
+```bash
+npx json-schema-to-typescript src/cognithor/streaming/schemas/v1/events.json \
+  -o extensions/vscode/src/types/events.ts
+```
+
+The Markdown above is for humans; the JSON Schema is for both
+humans and machines. Hand-maintained TS types in two languages
+were explicitly rejected as a maintenance pattern (see decisions
+memo D5 and H5).
+
+## Versioning policy
+
+A schema version bump on event `X` means at least one of:
+
+- A required field was added.
+- A field's type narrowed in a non-backward-compatible way.
+- A field's semantics changed.
+
+Adding an *optional* field does NOT bump the schema version.
+
+A new event type is added by adding it to the top-level `oneOf`
+in `events.json` and to the `EVENT_TYPE` constants in `events.py`,
+with `SCHEMA_VERSION: ClassVar[int] = 1` for the new type. Other
+event types are unaffected.

--- a/src/cognithor/streaming/sinks/__init__.py
+++ b/src/cognithor/streaming/sinks/__init__.py
@@ -1,0 +1,12 @@
+"""Sprint-27 streaming sinks.
+
+PR-A ships the :class:`Sink` ABC + bounded-buffer + critical-event
+bypass machinery. Concrete sinks (:mod:`jsonl_sink`,
+:mod:`ws_sink`) land in PR-B and PR-C.
+"""
+
+from __future__ import annotations
+
+from cognithor.streaming.sinks.base import Sink, SinkBufferConfig
+
+__all__ = ["Sink", "SinkBufferConfig"]

--- a/src/cognithor/streaming/sinks/base.py
+++ b/src/cognithor/streaming/sinks/base.py
@@ -1,0 +1,293 @@
+"""Sink ABC + bounded-buffer + critical-event-bypass machinery (H4).
+
+Every concrete sink (:class:`JsonlSink`, :class:`WebSocketSink`,
+or any future sink that lands in Sprint-28+) inherits from
+:class:`Sink` and implements :meth:`Sink._write` (the actual
+transport). Backpressure semantics are enforced by the base
+class so concrete sinks cannot drift away from them:
+
+* Each sink owns a bounded ``asyncio.Queue`` of capacity
+  ``SinkBufferConfig.normal_capacity`` (default 1000) plus a
+  reserved-slot pool of ``SinkBufferConfig.critical_reserve``
+  events (default 16). The reserve is for terminal events
+  (:data:`CRITICAL_EVENT_TYPES`).
+* :meth:`Sink.offer` is the producer-side entry point. Returns
+  ``True`` if the event was queued, ``False`` if the sink is full
+  AND the event is non-critical — in which case the sink emits a
+  :class:`SinkDropped` notice into its OWN stream the next time
+  it has slack.
+* Critical events bypass the normal-capacity gate by drawing from
+  the reserve pool. Reserve exhaustion is treated as a process-
+  level failure (the sink raises) rather than silently losing a
+  terminal event.
+* :meth:`Sink.run` is the consumer-side coroutine — pulls events
+  off the queue and calls :meth:`_write`. Concrete sinks override
+  ``_write`` only.
+
+All method-level errors in ``_write`` are caught and logged to
+``cognithor.streaming.sinks.base``'s logger; sinks self-quarantine
+(``self._faulted = True``) on the first exception so a runaway
+``_write`` failure cannot block the producer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Final
+
+from cognithor.streaming.events import (
+    CRITICAL_EVENT_TYPES,
+    SinkDropped,
+    StreamEvent,
+)
+
+log = logging.getLogger(__name__)
+
+# Default buffer dimensions. Sinks may override via SinkBufferConfig.
+_DEFAULT_NORMAL_CAPACITY: Final[int] = 1000
+_DEFAULT_CRITICAL_RESERVE: Final[int] = 16
+
+
+@dataclass(frozen=True, slots=True)
+class SinkBufferConfig:
+    """Per-sink buffer parameters."""
+
+    normal_capacity: int = _DEFAULT_NORMAL_CAPACITY
+    critical_reserve: int = _DEFAULT_CRITICAL_RESERVE
+
+    def __post_init__(self) -> None:
+        if self.normal_capacity < 1:
+            msg = "normal_capacity must be >= 1"
+            raise ValueError(msg)
+        if self.critical_reserve < 1:
+            msg = "critical_reserve must be >= 1"
+            raise ValueError(msg)
+
+
+class Sink(ABC):
+    """Base class for every streaming sink (JSONL, WebSocket, ...).
+
+    Concrete sinks override :meth:`_write` and pick a unique
+    :attr:`name` (used in :class:`SinkDropped` notices and logs).
+    The producer fans out to multiple sinks via
+    :meth:`EventEmitter.emit`; each call invokes :meth:`offer` on
+    every registered sink.
+    """
+
+    #: Short identifier surfaced in ``sink_dropped`` events and logs.
+    name: str = "sink"
+
+    def __init__(self, *, buffer: SinkBufferConfig | None = None) -> None:
+        self._buffer = buffer or SinkBufferConfig()
+        # Two queues: normal events use ``_queue``, critical events
+        # bypass into ``_critical_queue``. The consumer drains
+        # ``_critical_queue`` first on every iteration.
+        self._queue: asyncio.Queue[StreamEvent] = asyncio.Queue(
+            maxsize=self._buffer.normal_capacity,
+        )
+        self._critical_queue: asyncio.Queue[StreamEvent] = asyncio.Queue(
+            maxsize=self._buffer.critical_reserve,
+        )
+        self._dropped_count = 0
+        self._faulted = False
+        self._stop = asyncio.Event()
+        self._consumer_task: asyncio.Task[None] | None = None
+
+    # ------------------------------------------------------------------
+    # Producer-side surface
+    # ------------------------------------------------------------------
+
+    def offer(self, event: StreamEvent) -> bool:
+        """Best-effort enqueue. Returns ``True`` on success.
+
+        Critical events (terminal lifecycle + ``sink_dropped``) are
+        admitted to the reserved-slot pool and ``offer`` only
+        returns ``False`` if the reserve is also exhausted, which
+        is treated by the caller as a fatal fanout error.
+        """
+
+        if self._faulted:
+            return False
+
+        is_critical = event.EVENT_TYPE in CRITICAL_EVENT_TYPES
+        if is_critical:
+            try:
+                self._critical_queue.put_nowait(event)
+                return True
+            except asyncio.QueueFull:
+                log.error(
+                    "sink %s: critical-event reserve exhausted, dropping %s",
+                    self.name,
+                    event.EVENT_TYPE,
+                )
+                return False
+
+        try:
+            self._queue.put_nowait(event)
+            return True
+        except asyncio.QueueFull:
+            self._dropped_count += 1
+            return False
+
+    # ------------------------------------------------------------------
+    # Consumer-side surface
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Spin up the consumer task. Idempotent."""
+
+        if self._consumer_task is not None and not self._consumer_task.done():
+            return
+        await self._open()
+        self._consumer_task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        """Signal the consumer to drain everything queued + exit.
+
+        Graceful-drain semantics: every event already enqueued at
+        the moment ``stop()`` is called is delivered before the
+        consumer exits. New events offered after ``stop()`` may or
+        may not make it depending on the race with the consumer
+        loop, but they are explicitly best-effort.
+        """
+
+        self._stop.set()
+        if self._consumer_task is not None:
+            try:
+                await asyncio.wait_for(self._consumer_task, timeout=5.0)
+            except TimeoutError:
+                log.warning("sink %s: consumer did not stop within 5s", self.name)
+                self._consumer_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError, Exception):
+                    await self._consumer_task
+            self._consumer_task = None
+        await self._close()
+
+    async def _run(self) -> None:
+        """Drain loop: critical queue first, then normal queue.
+
+        On stop signal: drain whatever is already in both queues,
+        then exit. Does not block waiting for new events once the
+        stop signal is set.
+        """
+
+        while True:
+            stopping = self._stop.is_set()
+
+            if stopping:
+                event = self._drain_one_nowait()
+                if event is None:
+                    return  # both queues empty + stop signalled → exit
+            else:
+                try:
+                    event = await self._next_event()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    log.exception("sink %s: drain loop error", self.name)
+                    self._faulted = True
+                    return
+                if event is None:
+                    # _next_event woke us up because stop got set.
+                    continue
+
+            try:
+                await self._write(event)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                log.exception(
+                    "sink %s: _write raised on event %s — quarantining sink",
+                    self.name,
+                    event.EVENT_TYPE,
+                )
+                self._faulted = True
+                return
+
+            # Surface backpressure drops to the consumer next time
+            # the queues are quiet enough to accept the notice.
+            if self._dropped_count > 0 and self._queue.qsize() == 0:
+                dropped = self._dropped_count
+                self._dropped_count = 0
+                notice = SinkDropped(
+                    run_id=event.run_id,
+                    sink=self.name,
+                    dropped_count=dropped,
+                )
+                try:
+                    self._critical_queue.put_nowait(notice)
+                except asyncio.QueueFull:
+                    # Reserve is full; restore counter for next cycle.
+                    self._dropped_count += dropped
+
+    def _drain_one_nowait(self) -> StreamEvent | None:
+        """Pull the next queued event without awaiting. ``None`` if both empty."""
+
+        if not self._critical_queue.empty():
+            return self._critical_queue.get_nowait()
+        if not self._queue.empty():
+            return self._queue.get_nowait()
+        return None
+
+    async def _next_event(self) -> StreamEvent | None:
+        """Pull the next event, prioritising the critical queue.
+
+        Returns ``None`` only on stop-signal-during-wait (so the
+        caller loops back to the ``self._stop.is_set()`` check).
+        """
+
+        # Fast path: critical queue has work.
+        if not self._critical_queue.empty():
+            return await self._critical_queue.get()
+
+        # Race the normal queue against the stop signal so a quiet
+        # sink doesn't block forever on shutdown.
+        get_task = asyncio.create_task(self._queue.get())
+        stop_task = asyncio.create_task(self._stop.wait())
+        try:
+            done, _pending = await asyncio.wait(
+                {get_task, stop_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            for t in (get_task, stop_task):
+                if not t.done():
+                    t.cancel()
+
+        if get_task in done:
+            return get_task.result()
+        return None
+
+    # ------------------------------------------------------------------
+    # Concrete-sink hooks
+    # ------------------------------------------------------------------
+
+    @abstractmethod
+    async def _write(self, event: StreamEvent) -> None:
+        """Transport-level write. Concrete sinks implement only this."""
+
+    async def _open(self) -> None:
+        """Hook for transport-level setup (open file, bind socket)."""
+
+    async def _close(self) -> None:
+        """Hook for transport-level teardown."""
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+
+    @property
+    def is_faulted(self) -> bool:
+        """``True`` iff a previous ``_write`` raised and the sink quarantined itself."""
+
+        return self._faulted
+
+    @property
+    def dropped_count(self) -> int:
+        """Pending un-reported drops, for tests + telemetry."""
+
+        return self._dropped_count

--- a/tests/test_streaming/test_emitter_and_sinks.py
+++ b/tests/test_streaming/test_emitter_and_sinks.py
@@ -1,0 +1,218 @@
+"""Tests for `cognithor.streaming.emitter` + `sinks.base`.
+
+Covers H4 (backpressure: bounded buffer per sink, fan-out async,
+critical events bypass drop) end-to-end with a small recording
+:class:`_RecordingSink` that lets us assert ordering and counts.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from cognithor.streaming.emitter import EventEmitter
+from cognithor.streaming.events import (
+    PlanStep,
+    RunComplete,
+    RunStarted,
+    SinkDropped,
+    StreamEvent,
+)
+from cognithor.streaming.sinks.base import Sink, SinkBufferConfig
+
+
+class _RecordingSink(Sink):
+    """In-process sink that records every event ``_write`` receives."""
+
+    name = "recording"
+
+    def __init__(
+        self,
+        *,
+        buffer: SinkBufferConfig | None = None,
+        write_delay: float = 0.0,
+    ) -> None:
+        super().__init__(buffer=buffer)
+        self.received: list[StreamEvent] = []
+        self._write_delay = write_delay
+
+    async def _write(self, event: StreamEvent) -> None:
+        if self._write_delay > 0:
+            await asyncio.sleep(self._write_delay)
+        self.received.append(event)
+
+
+class _ExplodingSink(Sink):
+    """Sink whose ``_write`` always raises; used to test self-quarantine."""
+
+    name = "exploding"
+
+    async def _write(self, event: StreamEvent) -> None:
+        raise RuntimeError("boom")
+
+
+# ---------------------------------------------------------------------------
+# Basic fanout
+# ---------------------------------------------------------------------------
+
+
+class TestFanout:
+    @pytest.mark.asyncio
+    async def test_emit_to_two_sinks(self) -> None:
+        a = _RecordingSink()
+        b = _RecordingSink()
+        emitter = EventEmitter()
+        emitter.add_sink(a)
+        emitter.add_sink(b)
+        await emitter.start()
+        try:
+            evt = RunStarted(run_id="r1", plan_path="plan.json", step_count=1)
+            accepted = emitter.emit(evt)
+            assert accepted == 2
+            await asyncio.sleep(0.05)
+            assert len(a.received) == 1
+            assert len(b.received) == 1
+            assert a.received[0].run_id == "r1"
+        finally:
+            await emitter.stop()
+
+    @pytest.mark.asyncio
+    async def test_emit_returns_zero_with_no_sinks(self) -> None:
+        emitter = EventEmitter()
+        evt = PlanStep(run_id="r", step=0, action={"tool": "noop"})
+        assert emitter.emit(evt) == 0
+
+    @pytest.mark.asyncio
+    async def test_sinks_property_is_readonly_view(self) -> None:
+        emitter = EventEmitter()
+        emitter.add_sink(_RecordingSink())
+        view = emitter.sinks
+        assert isinstance(view, tuple)
+        assert len(view) == 1
+
+
+# ---------------------------------------------------------------------------
+# H4 — backpressure: non-critical events drop, critical events bypass
+# ---------------------------------------------------------------------------
+
+
+class TestBackpressure:
+    @pytest.mark.asyncio
+    async def test_non_critical_drops_when_buffer_full(self) -> None:
+        # Tiny buffer + slow consumer → producer fills and drops.
+        sink = _RecordingSink(
+            buffer=SinkBufferConfig(normal_capacity=2, critical_reserve=4),
+            write_delay=0.05,
+        )
+        emitter = EventEmitter()
+        emitter.add_sink(sink)
+        await emitter.start()
+        try:
+            for i in range(20):
+                evt = PlanStep(run_id="r", step=i, action={"tool": "x"})
+                emitter.emit(evt)
+            await asyncio.sleep(2.0)  # let consumer drain whatever it can
+        finally:
+            await emitter.stop()
+
+        # Some non-critical events MUST have been dropped.
+        assert len(sink.received) < 20
+        # And the sink must have noticed (sink_dropped is in received
+        # because the consumer drains it from the critical queue).
+        drops = [e for e in sink.received if isinstance(e, SinkDropped)]
+        assert drops, "sink must surface a SinkDropped notice"
+        assert drops[0].sink == "recording"
+        assert drops[0].dropped_count >= 1
+
+    @pytest.mark.asyncio
+    async def test_critical_event_bypasses_normal_capacity(self) -> None:
+        # Fill the normal queue to its limit with the consumer paused
+        # (we never call ``start``), then enqueue a terminal event —
+        # it MUST land in the reserve, not drop.
+        sink = _RecordingSink(
+            buffer=SinkBufferConfig(normal_capacity=2, critical_reserve=4),
+        )
+        # Manually fill the normal queue (no consumer running yet).
+        for i in range(2):
+            assert sink.offer(PlanStep(run_id="r", step=i, action={"tool": "x"}))
+        # 3rd non-critical → drop.
+        assert sink.offer(PlanStep(run_id="r", step=99, action={"tool": "x"})) is False
+        # Critical event bypasses → still accepted.
+        assert sink.offer(
+            RunComplete(run_id="r", receipt={}),
+        )
+
+    @pytest.mark.asyncio
+    async def test_critical_reserve_exhausted_returns_false_and_logs(
+        self,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        sink = _RecordingSink(
+            buffer=SinkBufferConfig(normal_capacity=1, critical_reserve=1),
+        )
+        # Fill the reserve.
+        assert sink.offer(RunComplete(run_id="r", receipt={}))
+        # Reserve is now full.
+        with caplog.at_level("ERROR", logger="cognithor.streaming.sinks.base"):
+            ok = sink.offer(RunComplete(run_id="r", receipt={}))
+        assert ok is False
+        assert any("reserve exhausted" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Sink quarantine on _write failure
+# ---------------------------------------------------------------------------
+
+
+class TestQuarantine:
+    @pytest.mark.asyncio
+    async def test_exploding_sink_quarantines_after_first_write(self) -> None:
+        bad = _ExplodingSink()
+        good = _RecordingSink()
+        emitter = EventEmitter()
+        emitter.add_sink(bad)
+        emitter.add_sink(good)
+        await emitter.start()
+        try:
+            emitter.emit(RunStarted(run_id="r", plan_path="p", step_count=0))
+            # Give the consumer task time to fail + quarantine itself.
+            await asyncio.sleep(0.2)
+            # After quarantine, further emits must skip the bad sink.
+            emitter.emit(PlanStep(run_id="r", step=0, action={"tool": "noop"}))
+            await asyncio.sleep(0.1)
+            assert bad.is_faulted is True
+            # Good sink keeps receiving.
+            assert len(good.received) == 2
+        finally:
+            await emitter.stop()
+
+
+# ---------------------------------------------------------------------------
+# Stop semantics
+# ---------------------------------------------------------------------------
+
+
+class TestStop:
+    @pytest.mark.asyncio
+    async def test_stop_drains_critical_events(self) -> None:
+        sink = _RecordingSink()
+        emitter = EventEmitter()
+        emitter.add_sink(sink)
+        await emitter.start()
+        emitter.emit(RunStarted(run_id="r", plan_path="p", step_count=0))
+        emitter.emit(RunComplete(run_id="r", receipt={}))
+        await emitter.stop()
+        # Both events must have been delivered before stop returned.
+        types = [e.EVENT_TYPE for e in sink.received]
+        assert "run_started" in types
+        assert "run_complete" in types
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self) -> None:
+        sink = _RecordingSink()
+        emitter = EventEmitter()
+        emitter.add_sink(sink)
+        await emitter.start()
+        await emitter.start()
+        await emitter.stop()

--- a/tests/test_streaming/test_events.py
+++ b/tests/test_streaming/test_events.py
@@ -1,0 +1,247 @@
+"""Tests for `cognithor.streaming.events` — schema round-trip + envelope invariants.
+
+Covers H1 (per-event schema_version), H2 (all 7 lifecycle event
+types defined day 1), and H5 (events round-trip through the
+machine-readable JSON Schema at
+``src/cognithor/streaming/schemas/v1/events.json``).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import jsonschema
+import pytest
+
+from cognithor.streaming.events import (
+    CRITICAL_EVENT_TYPES,
+    SCHEMA_PATH,
+    SCHEMA_VERSION,
+    DecisionExplanation,
+    GateDecision,
+    PlanStep,
+    RunCancelled,
+    RunComplete,
+    RunError,
+    RunStarted,
+    SinkDropped,
+    StreamEvent,
+    ToolResult,
+)
+
+# --- Schema fixtures ---------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def schema() -> dict[str, object]:
+    """Load the v1 JSON Schema once per test module."""
+
+    return json.loads(SCHEMA_PATH.read_text(encoding="utf-8"))
+
+
+def _validate(schema: dict[str, object], payload: dict[str, object]) -> None:
+    jsonschema.validate(instance=payload, schema=schema)
+
+
+# --- Envelope invariants -----------------------------------------------------
+
+
+class TestEnvelope:
+    def test_schema_path_exists(self) -> None:
+        assert SCHEMA_PATH.exists(), f"events schema missing at {SCHEMA_PATH}"
+
+    def test_schema_version_label(self) -> None:
+        assert SCHEMA_VERSION == "v1"
+
+    def test_run_id_required(self) -> None:
+        with pytest.raises(ValueError, match="run_id"):
+            RunStarted(run_id="", plan_path="plan.json", step_count=3)
+
+    def test_subclass_must_set_event_type(self) -> None:
+        # Bare StreamEvent has empty EVENT_TYPE → must raise.
+        with pytest.raises(TypeError, match="EVENT_TYPE"):
+            StreamEvent(run_id="abc")
+
+    def test_ts_is_iso8601_utc(self) -> None:
+        evt = RunStarted(run_id="abc", plan_path="plan.json", step_count=0)
+        # Pattern: 2026-05-04T18:30:42.123Z
+        assert re.match(
+            r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$",
+            evt.ts,
+        ), evt.ts
+
+    def test_per_event_schema_version_not_envelope(self, schema: dict) -> None:
+        """H1 — schema_version is per-event, NOT envelope-level.
+
+        We assert this by checking that no envelope-level
+        ``schema_version`` exists in the top-level schema, while
+        every event variant has its own ``schema_version`` const.
+        """
+
+        assert "schema_version" not in schema.get("properties", {}), (
+            "envelope must NOT carry a top-level schema_version (H1)"
+        )
+        # Each event def must require schema_version
+        for name in (
+            "run_started",
+            "plan_step",
+            "gate_decision",
+            "tool_result",
+            "run_complete",
+            "run_error",
+            "run_cancelled",
+            "sink_dropped",
+        ):
+            event_schema = schema["$defs"][name]
+            sv = event_schema["properties"]["schema_version"]
+            assert "const" in sv, f"{name}.schema_version must be const for H1"
+
+
+# --- H2 — all seven lifecycle event types defined ----------------------------
+
+
+class TestLifecycleEventsAllDefined:
+    """H2 — run_started, run_error, run_cancelled MUST exist day 1.
+
+    If these are missing, any client that switches on a closed set
+    of event types breaks the moment they're added later. Adding
+    them in v1 prevents that.
+    """
+
+    def test_run_started_exists(self) -> None:
+        assert RunStarted.EVENT_TYPE == "run_started"
+
+    def test_run_error_exists(self) -> None:
+        assert RunError.EVENT_TYPE == "run_error"
+
+    def test_run_cancelled_exists(self) -> None:
+        assert RunCancelled.EVENT_TYPE == "run_cancelled"
+
+    def test_critical_set_includes_terminals_and_drop_notice(self) -> None:
+        # H4 — critical events bypass the bounded-buffer drop path.
+        assert (
+            frozenset({"run_complete", "run_error", "run_cancelled", "sink_dropped"})
+            == CRITICAL_EVENT_TYPES
+        )
+
+
+# --- Round-trip every event type through the schema -------------------------
+
+
+class TestSchemaRoundTrip:
+    def test_run_started_minimal(self, schema: dict) -> None:
+        evt = RunStarted(run_id="r1", plan_path="plan.json", step_count=3)
+        _validate(schema, evt.to_dict())
+
+    def test_run_started_with_agent_id(self, schema: dict) -> None:
+        evt = RunStarted(
+            run_id="r1",
+            plan_path="plan.json",
+            step_count=3,
+            agent_id="planner-1",
+        )
+        _validate(schema, evt.to_dict())
+
+    def test_plan_step_full(self, schema: dict) -> None:
+        evt = PlanStep(
+            run_id="r1",
+            step=0,
+            action={
+                "tool": "web_search",
+                "arguments": {"query": "TRUST-7"},
+                "rationale": "user asked",
+            },
+        )
+        _validate(schema, evt.to_dict())
+
+    def test_gate_decision_block_with_explanation(self, schema: dict) -> None:
+        evt = GateDecision(
+            run_id="r1",
+            step=0,
+            status="red",
+            explanation=DecisionExplanation(
+                rule_id="exec.shell.path-traversal",
+                rule_source="cognithor.core.gatekeeper._classify_risk",
+                matched_pattern="rm -rf /",
+            ),
+        )
+        _validate(schema, evt.to_dict())
+
+    def test_gate_decision_green_no_explanation(self, schema: dict) -> None:
+        evt = GateDecision(run_id="r1", step=1, status="green")
+        _validate(schema, evt.to_dict())
+
+    def test_tool_result_ok(self, schema: dict) -> None:
+        evt = ToolResult(
+            run_id="r1",
+            step=1,
+            ok=True,
+            duration_ms=42,
+            chunks=4,
+            preview="result preview",
+        )
+        _validate(schema, evt.to_dict())
+
+    def test_tool_result_error(self, schema: dict) -> None:
+        evt = ToolResult(
+            run_id="r1",
+            step=1,
+            ok=False,
+            duration_ms=10,
+            error="ConnectionRefusedError",
+        )
+        _validate(schema, evt.to_dict())
+
+    def test_run_complete_with_receipt(self, schema: dict) -> None:
+        evt = RunComplete(
+            run_id="r1",
+            duration_ms=1234,
+            receipt={"trace_id": "r1", "trust": {"cost": {"micro_usd": 17}}},
+        )
+        _validate(schema, evt.to_dict())
+
+    def test_run_error_with_failure_mode(self, schema: dict) -> None:
+        evt = RunError(
+            run_id="r1",
+            failure_mode="policy_block",
+            error="GREEN risk floor",
+            step=2,
+        )
+        _validate(schema, evt.to_dict())
+
+    def test_run_cancelled(self, schema: dict) -> None:
+        evt = RunCancelled(run_id="r1", reason="user-abort", step=2)
+        _validate(schema, evt.to_dict())
+
+    def test_sink_dropped(self, schema: dict) -> None:
+        evt = SinkDropped(run_id="r1", sink="websocket", dropped_count=42)
+        _validate(schema, evt.to_dict())
+
+
+# --- Producer-side invariants ------------------------------------------------
+
+
+class TestProducerInvariants:
+    def test_decision_explanation_truncates_matched_pattern(self) -> None:
+        long_pattern = "x" * 500
+        d = DecisionExplanation(
+            rule_id="r",
+            rule_source="s",
+            matched_pattern=long_pattern,
+        )
+        out = d.to_dict()
+        assert len(out["matched_pattern"]) == 200
+
+    def test_tool_result_truncates_preview_to_500(self, schema: dict) -> None:
+        evt = ToolResult(run_id="r", step=0, ok=True, preview="x" * 1000)
+        payload = evt.to_dict()
+        assert len(payload["preview"]) == 500
+        _validate(schema, payload)
+
+    def test_emitted_event_is_dict_not_str(self) -> None:
+        evt = PlanStep(run_id="r", step=0, action={"tool": "noop"})
+        out = evt.to_dict()
+        assert isinstance(out, dict)
+        # Must be JSON-serialisable.
+        json.dumps(out)


### PR DESCRIPTION
## Sprint-27 Phase-1 PR-A — Producer foundation

Producer-side foundation for the IDE-Integration sprint. Adds the
\`cognithor.streaming\` package with the **single Producer + multiple Sinks** architecture (D5 of the [Sprint-27 decisions memo](docs/superpowers/plans/2026-05-04-sprint27-ide-integration-decisions.md)).

PR-B (\`JsonlSink\` + \`cognithor agent run --stream\`) and PR-C (\`WebSocketSink\` + \`cognithor agent ws\`) consume this surface without re-implementing the event taxonomy or backpressure logic.

## What ships

| File | Purpose |
|---|---|
| \`cognithor/streaming/events.py\` | 8 frozen+slot dataclass event types; per-event \`SCHEMA_VERSION\` (H1); H2 closed-set incl. \`run_started\`/\`run_error\`/\`run_cancelled\` from day 1 |
| \`cognithor/streaming/sinks/base.py\` | \`Sink\` ABC, bounded buffer (1000) + critical-reserve pool (16), graceful-drain \`stop()\`, self-quarantine on \`_write\` raise (H4) |
| \`cognithor/streaming/emitter.py\` | \`EventEmitter\` Producer fanning out to N sinks |
| \`schemas/v1/events.json\` | JSON Schema Draft 2020-12 — source of truth for the wire format (H5). Phase-2 codegens TS types for the extension via \`npx json-schema-to-typescript\` |
| \`schemas/v1/events.md\` | Human-readable companion |
| \`tests/test_streaming/\` | 33 tests: schema round-trip per event type, producer truncation, fanout, drop-on-full, sink_dropped notice, critical bypass, reserve exhaustion, quarantine, graceful stop |

## Hardening points landed in this PR (per decisions memo H1-H5)

- **H1** Per-event \`schema_version\`, NOT envelope-level
- **H2** \`run_started\` + \`run_error\` + \`run_cancelled\` defined day 1 (closed discriminator set)
- **H3** WebSocket security contract documented in \`events.md\` (PR-C will implement: localhost bind, PSK from \`~/.cognithor/auth.token\`, Bearer header, code 1008 on mismatch)
- **H4** Async fan-out, bounded per-sink buffer, drop on full for non-critical, reserved 16-slot pool for terminals, \`SinkDropped\` notice surfaces drops
- **H5** Machine-readable JSON Schema; Phase-2 will codegen TS types

## Quality gates

- ✅ \`mypy --strict src/cognithor/streaming/\` — 5 source files, no issues
- ✅ \`ruff check\` — clean
- ✅ \`ruff format --check\` — clean
- ✅ \`pytest tests/test_streaming/\` — **33/33 passing**

## Refs

- Plan: \`docs/superpowers/plans/2026-05-04-sprint27-ide-integration.md\`
- Decisions memo: \`docs/superpowers/plans/2026-05-04-sprint27-ide-integration-decisions.md\`
- Tasks: #115 (this PR), unblocks #116 (PR-B JsonlSink), #117 (PR-C WebSocketSink), #119 (PR-D extension scaffold)