### PR TITLE
feat(streaming+cli): JsonlSink + cognithor agent run --stream (Sprint-27 PR-B)

### DIFF
--- a/src/cognithor/__main__.py
+++ b/src/cognithor/__main__.py
@@ -361,6 +361,37 @@ def parse_args() -> argparse.Namespace:
         help="HMAC-SHA-256 signing key (omitted ⇒ unsigned)",
     )
 
+    # `cognithor agent run --plan FILE.json --stream` — Sprint-27
+    # PR-B headless runner that streams JSONL events to stdout for
+    # the VS-Code extension and other external orchestrators.
+    agent_parser = sub.add_parser(
+        "agent",
+        help="Headless agent runner (Sprint-27 streaming surface)",
+    )
+    agent_sub = agent_parser.add_subparsers(dest="agent_action")
+    agent_run_p = agent_sub.add_parser(
+        "run",
+        help="Execute an ActionPlan JSON file and stream events",
+    )
+    agent_run_p.add_argument(
+        "--plan",
+        dest="agent_run_plan",
+        required=True,
+        help="Path to the ActionPlan JSON file",
+    )
+    agent_run_p.add_argument(
+        "--stream",
+        dest="agent_run_stream",
+        action="store_true",
+        help="Emit one JSON event per line (currently required)",
+    )
+    agent_run_p.add_argument(
+        "--out",
+        dest="agent_run_out",
+        default=None,
+        help="Output file (omitted ⇒ stdout)",
+    )
+
     return parser.parse_args()
 
 
@@ -610,6 +641,27 @@ def main() -> None:
         from cognithor.crew.cli.run_cmd import run_project_crew
 
         sys.exit(run_project_crew())
+
+    if getattr(args, "command", None) == "agent":
+        from cognithor.cli import agent_cmd
+
+        action = getattr(args, "agent_action", None)
+        if action == "run":
+            sys.exit(
+                agent_cmd.cmd_run(
+                    plan_path=Path(args.agent_run_plan),
+                    stream=getattr(args, "agent_run_stream", False),
+                    out=Path(args.agent_run_out)
+                    if getattr(args, "agent_run_out", None)
+                    else None,
+                ),
+            )
+        else:
+            print(
+                "Usage: cognithor agent run --plan FILE.json --stream [--out FILE]",
+                file=sys.stderr,
+            )
+            sys.exit(2)
 
     if getattr(args, "command", None) == "receipt":
         from cognithor.cli import receipt_cmd

--- a/src/cognithor/cli/agent_cmd.py
+++ b/src/cognithor/cli/agent_cmd.py
@@ -1,0 +1,84 @@
+"""CLI dispatcher for ``cognithor agent run --plan FILE.json --stream``.
+
+Sprint-27 PR-B. Wires the streaming Producer (PR-A) into the
+existing ``__main__.py`` argparse surface. Kept thin — the real
+work lives in :mod:`cognithor.streaming.runner`. This module
+exists so the argparse handler in ``__main__.py`` does not have
+to import asyncio / streaming primitives directly.
+
+Exit codes:
+
+* ``0`` — run_complete emitted successfully
+* ``1`` — run_error (Gatekeeper block, tool exception, plan-file
+  validation failure, ...)
+* ``2`` — bad command-line arguments
+* ``130`` — KeyboardInterrupt (run_cancelled emitted)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import TYPE_CHECKING
+
+from cognithor.streaming import EventEmitter, JsonlSink
+from cognithor.streaming.runner import parse_plan_file, run_plan
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def cmd_run(
+    *,
+    plan_path: Path,
+    stream: bool = True,
+    out: Path | None = None,
+) -> int:
+    """Run the streaming agent CLI.
+
+    Parameters
+    ----------
+    plan_path:
+        Path to the JSON plan-file. See
+        :func:`cognithor.streaming.runner.parse_plan_file` for the
+        accepted shape.
+    stream:
+        Currently always required (for parity with the
+        plan-doc spec that called the flag ``--stream``). When
+        ``False``, the function returns 2 — callers must opt in
+        explicitly.
+    out:
+        Optional output path. Defaults to ``sys.stdout`` so the
+        VS-Code extension can subprocess-stream straight from the
+        pipe.
+    """
+
+    if not stream:
+        print(
+            "cognithor agent run currently requires --stream",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        plan = parse_plan_file(plan_path)
+    except (ValueError, OSError) as exc:
+        print(f"cognithor agent run: bad plan file: {exc}", file=sys.stderr)
+        return 2
+
+    sink = JsonlSink.to_path(out) if out is not None else JsonlSink()
+    emitter = EventEmitter()
+    emitter.add_sink(sink)
+
+    return asyncio.run(_run(plan, emitter))
+
+
+async def _run(plan: object, emitter: EventEmitter) -> int:
+    await emitter.start()
+    try:
+        # plan is a _ParsedPlan; runner accepts the unstructured
+        # type to avoid circular imports through the cognithor.cli
+        # layer.
+        return await run_plan(plan, emitter)  # type: ignore[arg-type]
+    finally:
+        await emitter.stop()

--- a/src/cognithor/streaming/__init__.py
+++ b/src/cognithor/streaming/__init__.py
@@ -45,7 +45,8 @@ from cognithor.streaming.events import (
     StreamEvent,
     ToolResult,
 )
-from cognithor.streaming.sinks.base import Sink
+from cognithor.streaming.sinks.base import Sink, SinkBufferConfig
+from cognithor.streaming.sinks.jsonl_sink import JsonlSink
 
 __all__ = [
     "SCHEMA_PATH",
@@ -53,12 +54,14 @@ __all__ = [
     "DecisionExplanation",
     "EventEmitter",
     "GateDecision",
+    "JsonlSink",
     "PlanStep",
     "RunCancelled",
     "RunComplete",
     "RunError",
     "RunStarted",
     "Sink",
+    "SinkBufferConfig",
     "SinkDropped",
     "StreamEvent",
     "ToolResult",

--- a/src/cognithor/streaming/runner.py
+++ b/src/cognithor/streaming/runner.py
@@ -1,0 +1,298 @@
+"""AgentRunner — execute a serialised :class:`ActionPlan` and stream events.
+
+The thin connector between Sprint-27's `cognithor agent run`
+subcommand and the existing Cognithor execution surface
+(:class:`Gatekeeper`, MCP dispatch). Loads a JSON plan file,
+walks the steps, and for each:
+
+1. emits a ``plan_step`` event,
+2. asks the :class:`Gatekeeper` for a decision (when wired) and
+   emits the corresponding ``gate_decision`` event,
+3. executes the tool (real dispatch when ``execute_tool`` is
+   provided; otherwise a deterministic mock that returns ``ok=true``
+   for the JSONL-stream contract demo) and emits ``tool_result``,
+4. on terminal exit, emits ``run_complete`` / ``run_error`` /
+   ``run_cancelled`` with an optional TRUST-1 receipt bundle.
+
+This module is intentionally NOT the place to plumb the full PGE
+loop — Gateway integration happens in Sprint-27 PR-K's end-to-end
+smoke. PR-B's contract is "given a plan file, produce a faithful
+event stream"; the streaming primitives are what the extension
+binds against.
+
+Plan-file shape (JSON, all fields top-level):
+
+.. code-block:: json
+
+    {
+      "run_id": "trace-2026-05-04-1234",
+      "agent_id": "planner-default",
+      "goal": "fetch the README",
+      "steps": [
+        {"tool": "read_file", "params": {"path": "README.md"}}
+      ]
+    }
+
+``run_id`` is required and is reused as the ``trace_id`` for the
+TRUST-1 receipt fetch (when wired).
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from cognithor.streaming.events import (
+    DecisionExplanation as StreamDecisionExplanation,
+)
+from cognithor.streaming.events import (
+    GateDecision,
+    PlanStep,
+    RunCancelled,
+    RunComplete,
+    RunError,
+    RunStarted,
+    ToolResult,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from cognithor.streaming.emitter import EventEmitter
+
+# Type alias for the optional real-dispatch callable. The extension
+# in PR-K (or external orchestrators) supply it; PR-B's tests rely
+# on the mock fallback so they don't need an MCP environment.
+ExecuteTool = Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]]
+
+# Type alias for the optional Gatekeeper-evaluate callable. Kept
+# loosely typed so callers can pass any function with the right
+# call shape — the runner doesn't import Gatekeeper directly to
+# keep PR-B isolated.
+EvaluateGate = Callable[
+    [str, dict[str, Any]],  # tool, params
+    "GateOutcome",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class GateOutcome:
+    """Provider-agnostic Gatekeeper decision shape consumed by the runner."""
+
+    status: str  # one of green / yellow / orange_approved / orange_blocked / red
+    rule_id: str | None = None
+    rule_source: str | None = None
+    matched_pattern: str | None = None
+    reason: str | None = None
+
+    @property
+    def is_block(self) -> bool:
+        return self.status in ("red", "orange_blocked")
+
+
+@dataclass(frozen=True, slots=True)
+class _ParsedPlan:
+    run_id: str
+    agent_id: str | None
+    plan_path: str
+    steps: list[dict[str, Any]]
+
+
+def parse_plan_file(path: Path) -> _ParsedPlan:
+    """Load + minimally validate a plan-file. Raises ``ValueError`` on bad shape.
+
+    The runner accepts a deliberately small slice of the
+    :class:`cognithor.models.ActionPlan` Pydantic model — enough
+    to drive the event stream without forcing every external
+    orchestrator to pull in the full Pydantic schema.
+    """
+
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        msg = "plan-file must decode to a JSON object"
+        raise ValueError(msg)
+
+    run_id = raw.get("run_id")
+    if not isinstance(run_id, str) or not run_id:
+        msg = "plan-file: 'run_id' must be a non-empty string"
+        raise ValueError(msg)
+
+    agent_id_raw = raw.get("agent_id")
+    agent_id: str | None = agent_id_raw if isinstance(agent_id_raw, str) and agent_id_raw else None
+
+    steps = raw.get("steps")
+    if not isinstance(steps, list):
+        msg = "plan-file: 'steps' must be a list"
+        raise ValueError(msg)
+
+    normalised: list[dict[str, Any]] = []
+    for i, step in enumerate(steps):
+        if not isinstance(step, dict):
+            msg = f"plan-file: step[{i}] must be a JSON object"
+            raise ValueError(msg)
+        tool = step.get("tool")
+        if not isinstance(tool, str) or not tool:
+            msg = f"plan-file: step[{i}].tool must be a non-empty string"
+            raise ValueError(msg)
+        params = step.get("params") or step.get("arguments") or {}
+        if not isinstance(params, dict):
+            msg = f"plan-file: step[{i}].params must be an object"
+            raise ValueError(msg)
+        rationale = step.get("rationale")
+        normalised.append(
+            {
+                "tool": tool,
+                "arguments": dict(params),
+                "rationale": rationale if isinstance(rationale, str) else None,
+            },
+        )
+
+    return _ParsedPlan(
+        run_id=run_id,
+        agent_id=agent_id,
+        plan_path=str(path),
+        steps=normalised,
+    )
+
+
+async def run_plan(
+    plan: _ParsedPlan,
+    emitter: EventEmitter,
+    *,
+    evaluate_gate: EvaluateGate | None = None,
+    execute_tool: ExecuteTool | None = None,
+    receipt_builder: Callable[[str], dict[str, Any]] | None = None,
+) -> int:
+    """Walk the plan, emit events, return process exit-code.
+
+    ``0`` on success, ``1`` on run_error, ``130`` on user-cancel.
+    The runner deliberately catches ``KeyboardInterrupt`` so the
+    extension reading a subprocess stream sees ``run_cancelled``
+    rather than a torn-off pipe.
+    """
+
+    started_at = time.monotonic()
+
+    emitter.emit(
+        RunStarted(
+            run_id=plan.run_id,
+            plan_path=plan.plan_path,
+            step_count=len(plan.steps),
+            agent_id=plan.agent_id,
+        ),
+    )
+
+    last_step_index: int | None = None
+    try:
+        for step_index, step in enumerate(plan.steps):
+            last_step_index = step_index
+            emitter.emit(
+                PlanStep(
+                    run_id=plan.run_id,
+                    step=step_index,
+                    action={k: v for k, v in step.items() if v is not None},
+                ),
+            )
+
+            outcome = (
+                evaluate_gate(step["tool"], step["arguments"])
+                if evaluate_gate is not None
+                else GateOutcome(status="green")
+            )
+            explanation: StreamDecisionExplanation | None = None
+            if outcome.rule_id is not None and outcome.rule_source is not None:
+                explanation = StreamDecisionExplanation(
+                    rule_id=outcome.rule_id,
+                    rule_source=outcome.rule_source,
+                    matched_pattern=outcome.matched_pattern,
+                )
+            emitter.emit(
+                GateDecision(
+                    run_id=plan.run_id,
+                    step=step_index,
+                    status=outcome.status,  # type: ignore[arg-type]
+                    explanation=explanation,
+                ),
+            )
+            if outcome.is_block:
+                # Blocked tools terminate the run with run_error so
+                # the extension can render the failure clearly.
+                emitter.emit(
+                    RunError(
+                        run_id=plan.run_id,
+                        failure_mode="policy_block",
+                        error=outcome.reason or "blocked by Gatekeeper",
+                        step=step_index,
+                        receipt=(
+                            receipt_builder(plan.run_id) if receipt_builder is not None else None
+                        ),
+                    ),
+                )
+                return 1
+
+            tool_started = time.monotonic()
+            try:
+                if execute_tool is not None:
+                    result = await execute_tool(step["tool"], step["arguments"])
+                    ok = bool(result.get("ok", True))
+                    error = result.get("error")
+                    chunks_raw = result.get("chunks")
+                    chunks = chunks_raw if isinstance(chunks_raw, int) and chunks_raw >= 0 else None
+                    preview_raw = result.get("preview")
+                    preview = preview_raw if isinstance(preview_raw, str) else None
+                else:
+                    # Mock execution — preserves the JSONL stream
+                    # contract for tests + extension demos without
+                    # requiring an MCP environment.
+                    ok = True
+                    error = None
+                    chunks = None
+                    preview = None
+            except Exception as exc:
+                emitter.emit(
+                    RunError(
+                        run_id=plan.run_id,
+                        failure_mode="internal_error",
+                        error=f"{type(exc).__name__}: {exc}",
+                        step=step_index,
+                        receipt=(
+                            receipt_builder(plan.run_id) if receipt_builder is not None else None
+                        ),
+                    ),
+                )
+                return 1
+
+            emitter.emit(
+                ToolResult(
+                    run_id=plan.run_id,
+                    step=step_index,
+                    ok=ok,
+                    duration_ms=int((time.monotonic() - tool_started) * 1000),
+                    chunks=chunks,
+                    preview=preview,
+                    error=str(error) if error else None,
+                ),
+            )
+
+        emitter.emit(
+            RunComplete(
+                run_id=plan.run_id,
+                duration_ms=int((time.monotonic() - started_at) * 1000),
+                receipt=(receipt_builder(plan.run_id) if receipt_builder is not None else {}),
+            ),
+        )
+        return 0
+
+    except KeyboardInterrupt:
+        emitter.emit(
+            RunCancelled(
+                run_id=plan.run_id,
+                reason="user-abort",
+                step=last_step_index,
+                receipt=(receipt_builder(plan.run_id) if receipt_builder is not None else None),
+            ),
+        )
+        return 130

--- a/src/cognithor/streaming/sinks/__init__.py
+++ b/src/cognithor/streaming/sinks/__init__.py
@@ -8,5 +8,6 @@ bypass machinery. Concrete sinks (:mod:`jsonl_sink`,
 from __future__ import annotations
 
 from cognithor.streaming.sinks.base import Sink, SinkBufferConfig
+from cognithor.streaming.sinks.jsonl_sink import JsonlSink
 
-__all__ = ["Sink", "SinkBufferConfig"]
+__all__ = ["JsonlSink", "Sink", "SinkBufferConfig"]

--- a/src/cognithor/streaming/sinks/base.py
+++ b/src/cognithor/streaming/sinks/base.py
@@ -6,28 +6,27 @@ or any future sink that lands in Sprint-28+) inherits from
 transport). Backpressure semantics are enforced by the base
 class so concrete sinks cannot drift away from them:
 
-* Each sink owns a bounded ``asyncio.Queue`` of capacity
-  ``SinkBufferConfig.normal_capacity`` (default 1000) plus a
-  reserved-slot pool of ``SinkBufferConfig.critical_reserve``
-  events (default 16). The reserve is for terminal events
-  (:data:`CRITICAL_EVENT_TYPES`).
-* :meth:`Sink.offer` is the producer-side entry point. Returns
-  ``True`` if the event was queued, ``False`` if the sink is full
-  AND the event is non-critical — in which case the sink emits a
-  :class:`SinkDropped` notice into its OWN stream the next time
+* Each sink owns a single bounded ``asyncio.Queue`` of capacity
+  ``normal_capacity + critical_reserve`` (defaults 1000 + 16).
+  Events are accepted in **strict insertion order**; the dual
+  capacity is enforced via two counters tracked at offer-time.
+* Non-critical events use ``normal_capacity`` slots. When full,
+  ``offer()`` returns ``False`` and the sink emits a
+  :class:`SinkDropped` notice into the same stream the next time
   it has slack.
-* Critical events bypass the normal-capacity gate by drawing from
-  the reserve pool. Reserve exhaustion is treated as a process-
-  level failure (the sink raises) rather than silently losing a
-  terminal event.
-* :meth:`Sink.run` is the consumer-side coroutine — pulls events
-  off the queue and calls :meth:`_write`. Concrete sinks override
-  ``_write`` only.
+* Critical events (terminal lifecycle + ``sink_dropped``) draw
+  from the ``critical_reserve`` pool; reserve exhaustion logs at
+  ERROR and ``offer()`` returns ``False``. Reserve exhaustion is
+  treated by the caller as a fatal fanout error.
+* Insertion order is preserved on the wire — critical events
+  emitted *after* a backlog of normal events still appear after
+  them in the output stream. This is what the JSONL extension
+  consumer needs (it switches on the LAST event to render the
+  terminal banner).
 
-All method-level errors in ``_write`` are caught and logged to
-``cognithor.streaming.sinks.base``'s logger; sinks self-quarantine
-(``self._faulted = True``) on the first exception so a runaway
-``_write`` failure cannot block the producer.
+All method-level errors in ``_write`` are caught and logged;
+sinks self-quarantine (``self._faulted = True``) on the first
+exception so a runaway transport can't block the producer.
 """
 
 from __future__ import annotations
@@ -83,15 +82,13 @@ class Sink(ABC):
 
     def __init__(self, *, buffer: SinkBufferConfig | None = None) -> None:
         self._buffer = buffer or SinkBufferConfig()
-        # Two queues: normal events use ``_queue``, critical events
-        # bypass into ``_critical_queue``. The consumer drains
-        # ``_critical_queue`` first on every iteration.
-        self._queue: asyncio.Queue[StreamEvent] = asyncio.Queue(
-            maxsize=self._buffer.normal_capacity,
-        )
-        self._critical_queue: asyncio.Queue[StreamEvent] = asyncio.Queue(
-            maxsize=self._buffer.critical_reserve,
-        )
+        # Single FIFO queue preserves insertion order. Capacity is
+        # ``normal_capacity + critical_reserve`` so a terminal event
+        # can still slot in when the normal pool is saturated.
+        max_size = self._buffer.normal_capacity + self._buffer.critical_reserve
+        self._queue: asyncio.Queue[StreamEvent] = asyncio.Queue(maxsize=max_size)
+        self._normal_occupancy = 0
+        self._critical_occupancy = 0
         self._dropped_count = 0
         self._faulted = False
         self._stop = asyncio.Event()
@@ -115,23 +112,31 @@ class Sink(ABC):
 
         is_critical = event.EVENT_TYPE in CRITICAL_EVENT_TYPES
         if is_critical:
-            try:
-                self._critical_queue.put_nowait(event)
-                return True
-            except asyncio.QueueFull:
+            if self._critical_occupancy >= self._buffer.critical_reserve:
                 log.error(
                     "sink %s: critical-event reserve exhausted, dropping %s",
                     self.name,
                     event.EVENT_TYPE,
                 )
                 return False
-
-        try:
-            self._queue.put_nowait(event)
+            try:
+                self._queue.put_nowait(event)
+            except asyncio.QueueFull:  # pragma: no cover — should not happen
+                log.error("sink %s: queue full when putting critical event", self.name)
+                return False
+            self._critical_occupancy += 1
             return True
-        except asyncio.QueueFull:
+
+        if self._normal_occupancy >= self._buffer.normal_capacity:
             self._dropped_count += 1
             return False
+        try:
+            self._queue.put_nowait(event)
+        except asyncio.QueueFull:  # pragma: no cover — should not happen
+            self._dropped_count += 1
+            return False
+        self._normal_occupancy += 1
+        return True
 
     # ------------------------------------------------------------------
     # Consumer-side surface
@@ -168,32 +173,40 @@ class Sink(ABC):
         await self._close()
 
     async def _run(self) -> None:
-        """Drain loop: critical queue first, then normal queue.
+        """Drain loop in strict insertion order.
 
-        On stop signal: drain whatever is already in both queues,
-        then exit. Does not block waiting for new events once the
-        stop signal is set.
+        On stop signal: drain whatever is already queued, then
+        exit. Does not block waiting for new events once the stop
+        signal is set.
         """
 
         while True:
             stopping = self._stop.is_set()
 
+            event: StreamEvent
             if stopping:
-                event = self._drain_one_nowait()
-                if event is None:
-                    return  # both queues empty + stop signalled → exit
+                if self._queue.empty():
+                    return
+                event = self._queue.get_nowait()
             else:
                 try:
-                    event = await self._next_event()
+                    next_event = await self._next_event()
                 except asyncio.CancelledError:
                     raise
                 except Exception:
                     log.exception("sink %s: drain loop error", self.name)
                     self._faulted = True
                     return
-                if event is None:
+                if next_event is None:
                     # _next_event woke us up because stop got set.
                     continue
+                event = next_event
+
+            # Decrement the occupancy counter that this event used.
+            if event.EVENT_TYPE in CRITICAL_EVENT_TYPES:
+                self._critical_occupancy = max(0, self._critical_occupancy - 1)
+            else:
+                self._normal_occupancy = max(0, self._normal_occupancy - 1)
 
             try:
                 await self._write(event)
@@ -209,8 +222,8 @@ class Sink(ABC):
                 return
 
             # Surface backpressure drops to the consumer next time
-            # the queues are quiet enough to accept the notice.
-            if self._dropped_count > 0 and self._queue.qsize() == 0:
+            # the queue is quiet enough to accept the notice.
+            if self._dropped_count > 0 and self._queue.empty():
                 dropped = self._dropped_count
                 self._dropped_count = 0
                 notice = SinkDropped(
@@ -218,34 +231,17 @@ class Sink(ABC):
                     sink=self.name,
                     dropped_count=dropped,
                 )
-                try:
-                    self._critical_queue.put_nowait(notice)
-                except asyncio.QueueFull:
-                    # Reserve is full; restore counter for next cycle.
+                if not self.offer(notice):
+                    # Reserve full; restore counter for next cycle.
                     self._dropped_count += dropped
 
-    def _drain_one_nowait(self) -> StreamEvent | None:
-        """Pull the next queued event without awaiting. ``None`` if both empty."""
-
-        if not self._critical_queue.empty():
-            return self._critical_queue.get_nowait()
-        if not self._queue.empty():
-            return self._queue.get_nowait()
-        return None
-
     async def _next_event(self) -> StreamEvent | None:
-        """Pull the next event, prioritising the critical queue.
+        """Pull the next event, racing the stop signal.
 
-        Returns ``None`` only on stop-signal-during-wait (so the
-        caller loops back to the ``self._stop.is_set()`` check).
+        Returns ``None`` if the stop signal fired before an event
+        arrived (caller loops back to the ``stopping`` branch).
         """
 
-        # Fast path: critical queue has work.
-        if not self._critical_queue.empty():
-            return await self._critical_queue.get()
-
-        # Race the normal queue against the stop signal so a quiet
-        # sink doesn't block forever on shutdown.
         get_task = asyncio.create_task(self._queue.get())
         stop_task = asyncio.create_task(self._stop.wait())
         try:

--- a/src/cognithor/streaming/sinks/jsonl_sink.py
+++ b/src/cognithor/streaming/sinks/jsonl_sink.py
@@ -1,0 +1,90 @@
+"""JsonlSink — newline-delimited JSON to stdout / file (Sprint-27 PR-B).
+
+First concrete consumer of :class:`Sink`. Writes one
+JSON-encoded event per line to a text stream. Defaults to
+:data:`sys.stdout` so an extension shelling out to
+``cognithor agent run --plan FILE.json --stream`` reads events
+straight from the subprocess pipe.
+
+The wire format is exactly the per-event ``to_dict()`` payload
+defined by the v1 JSON Schema — no extra envelope, no decoration,
+no batching. One event = one line. That makes the stream trivial
+to parse with ``readline()`` from any consumer language.
+
+Critical events still bypass the bounded buffer (H4); ``stop()``
+flushes anything queued before returning.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import sys
+from typing import IO, TYPE_CHECKING
+
+from cognithor.streaming.sinks.base import Sink, SinkBufferConfig
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from cognithor.streaming.events import StreamEvent
+
+
+class JsonlSink(Sink):
+    """Writes events as ``json.dumps(event.to_dict()) + "\\n"`` to a text stream.
+
+    Three construction patterns:
+
+    1. ``JsonlSink()`` — defaults to ``sys.stdout``.
+    2. ``JsonlSink(stream=open_text_handle)`` — wrap any text handle.
+       Caller owns the handle's lifecycle.
+    3. ``JsonlSink.to_path(Path("run.jsonl"))`` — convenience that
+       opens the path in append-binary mode and lets the sink own
+       its lifecycle (closed in ``_close``).
+    """
+
+    name = "jsonl"
+
+    def __init__(
+        self,
+        *,
+        stream: IO[str] | None = None,
+        buffer: SinkBufferConfig | None = None,
+        owns_stream: bool = False,
+    ) -> None:
+        super().__init__(buffer=buffer)
+        self._stream: IO[str] = stream if stream is not None else sys.stdout
+        self._owns_stream = owns_stream
+
+    @classmethod
+    def to_path(
+        cls,
+        path: Path,
+        *,
+        buffer: SinkBufferConfig | None = None,
+    ) -> JsonlSink:
+        """Open ``path`` in line-buffered append-text mode and own the handle."""
+
+        path.parent.mkdir(parents=True, exist_ok=True)
+        stream = path.open("a", encoding="utf-8", buffering=1)
+        return cls(stream=stream, buffer=buffer, owns_stream=True)
+
+    async def _write(self, event: StreamEvent) -> None:
+        line = json.dumps(event.to_dict(), ensure_ascii=False, sort_keys=True)
+        # Single write call so partially-buffered output stays
+        # line-aligned even if the consumer is reading concurrently.
+        self._stream.write(line + "\n")
+        # Stdout is line-buffered by default in CPython; explicit
+        # flush keeps the extension-side reader from blocking on
+        # idle producers (e.g. waiting on a slow LLM mid-step).
+        try:
+            self._stream.flush()
+        except (OSError, ValueError):
+            # Stream closed or detached mid-write. Quarantine
+            # ourselves rather than spinning on the same error.
+            self._faulted = True
+
+    async def _close(self) -> None:
+        if self._owns_stream:
+            with contextlib.suppress(OSError, ValueError):
+                self._stream.close()

--- a/tests/test_streaming/test_jsonl_sink.py
+++ b/tests/test_streaming/test_jsonl_sink.py
@@ -1,0 +1,125 @@
+"""Tests for `cognithor.streaming.sinks.jsonl_sink`."""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from cognithor.streaming import EventEmitter
+from cognithor.streaming.events import (
+    PlanStep,
+    RunComplete,
+    RunStarted,
+)
+from cognithor.streaming.sinks import JsonlSink, SinkBufferConfig
+
+
+class TestJsonlSinkBasic:
+    @pytest.mark.asyncio
+    async def test_writes_one_line_per_event(self) -> None:
+        buf = io.StringIO()
+        sink = JsonlSink(stream=buf)
+        emitter = EventEmitter()
+        emitter.add_sink(sink)
+        await emitter.start()
+        try:
+            emitter.emit(RunStarted(run_id="r", plan_path="p.json", step_count=1))
+            emitter.emit(PlanStep(run_id="r", step=0, action={"tool": "noop"}))
+            emitter.emit(RunComplete(run_id="r", receipt={"trace_id": "r"}))
+        finally:
+            await emitter.stop()
+
+        lines = [line for line in buf.getvalue().splitlines() if line]
+        assert len(lines) == 3
+        events = [json.loads(line) for line in lines]
+        assert events[0]["event"] == "run_started"
+        assert events[1]["event"] == "plan_step"
+        assert events[2]["event"] == "run_complete"
+        # Each line must be self-contained valid JSON.
+        for line, evt in zip(lines, events, strict=True):
+            assert json.loads(line) == evt
+
+    @pytest.mark.asyncio
+    async def test_keys_are_sorted_for_deterministic_diffs(self) -> None:
+        buf = io.StringIO()
+        sink = JsonlSink(stream=buf)
+        emitter = EventEmitter()
+        emitter.add_sink(sink)
+        await emitter.start()
+        try:
+            emitter.emit(RunStarted(run_id="r", plan_path="p", step_count=1))
+        finally:
+            await emitter.stop()
+        line = buf.getvalue().strip()
+        # sort_keys=True must produce a deterministic byte-stable
+        # representation. Re-encoding the parsed payload with the
+        # same flags must round-trip exactly.
+        payload = json.loads(line)
+        recompiled = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+        assert line == recompiled
+
+
+class TestJsonlSinkToPath:
+    @pytest.mark.asyncio
+    async def test_to_path_writes_to_file(self, tmp_path: Path) -> None:
+        out = tmp_path / "events.jsonl"
+        sink = JsonlSink.to_path(out)
+        emitter = EventEmitter()
+        emitter.add_sink(sink)
+        await emitter.start()
+        try:
+            emitter.emit(RunStarted(run_id="r", plan_path="p", step_count=0))
+            emitter.emit(RunComplete(run_id="r", receipt={}))
+        finally:
+            await emitter.stop()
+
+        content = out.read_text(encoding="utf-8").strip().splitlines()
+        assert len(content) == 2
+        first = json.loads(content[0])
+        assert first["event"] == "run_started"
+
+    @pytest.mark.asyncio
+    async def test_to_path_appends(self, tmp_path: Path) -> None:
+        out = tmp_path / "events.jsonl"
+        out.write_text('{"existing": true}\n', encoding="utf-8")
+        sink = JsonlSink.to_path(out)
+        emitter = EventEmitter()
+        emitter.add_sink(sink)
+        await emitter.start()
+        try:
+            emitter.emit(RunComplete(run_id="r", receipt={}))
+        finally:
+            await emitter.stop()
+        lines = out.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 2
+        assert json.loads(lines[0]) == {"existing": True}
+
+
+class TestJsonlSinkFaultHandling:
+    @pytest.mark.asyncio
+    async def test_closed_stream_quarantines_sink(self) -> None:
+        buf = io.StringIO()
+        buf.close()
+        sink = JsonlSink(
+            stream=buf,
+            buffer=SinkBufferConfig(normal_capacity=4, critical_reserve=4),
+        )
+        emitter = EventEmitter()
+        emitter.add_sink(sink)
+        await emitter.start()
+        try:
+            emitter.emit(RunStarted(run_id="r", plan_path="p", step_count=0))
+            # Give the consumer time to attempt the write and quarantine itself.
+            import asyncio
+
+            await asyncio.sleep(0.1)
+        finally:
+            await emitter.stop()
+
+        assert sink.is_faulted is True

--- a/tests/test_streaming/test_runner.py
+++ b/tests/test_streaming/test_runner.py
@@ -1,0 +1,215 @@
+"""Tests for `cognithor.streaming.runner` and the `agent run` CLI."""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from cognithor.streaming import EventEmitter
+from cognithor.streaming.runner import (
+    GateOutcome,
+    parse_plan_file,
+    run_plan,
+)
+from cognithor.streaming.sinks import JsonlSink
+
+
+def _write_plan(tmp_path: Path, **overrides: Any) -> Path:
+    plan = {
+        "run_id": "test-run-1",
+        "agent_id": "tester",
+        "goal": "smoke",
+        "steps": [
+            {"tool": "noop", "params": {"k": "v"}, "rationale": "demo"},
+            {"tool": "echo", "arguments": {"msg": "hi"}},
+        ],
+    }
+    plan.update(overrides)
+    p = tmp_path / "plan.json"
+    p.write_text(json.dumps(plan), encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# parse_plan_file
+# ---------------------------------------------------------------------------
+
+
+class TestParsePlanFile:
+    def test_happy_path(self, tmp_path: Path) -> None:
+        p = _write_plan(tmp_path)
+        plan = parse_plan_file(p)
+        assert plan.run_id == "test-run-1"
+        assert plan.agent_id == "tester"
+        assert len(plan.steps) == 2
+        # Both 'params' and 'arguments' map to the canonical 'arguments' key.
+        assert plan.steps[0]["arguments"] == {"k": "v"}
+        assert plan.steps[1]["arguments"] == {"msg": "hi"}
+
+    def test_missing_run_id(self, tmp_path: Path) -> None:
+        p = tmp_path / "p.json"
+        p.write_text(json.dumps({"steps": []}), encoding="utf-8")
+        with pytest.raises(ValueError, match="run_id"):
+            parse_plan_file(p)
+
+    def test_steps_must_be_list(self, tmp_path: Path) -> None:
+        p = tmp_path / "p.json"
+        p.write_text(json.dumps({"run_id": "r", "steps": "nope"}), encoding="utf-8")
+        with pytest.raises(ValueError, match="steps"):
+            parse_plan_file(p)
+
+    def test_step_tool_required(self, tmp_path: Path) -> None:
+        p = tmp_path / "p.json"
+        p.write_text(
+            json.dumps({"run_id": "r", "steps": [{"params": {}}]}),
+            encoding="utf-8",
+        )
+        with pytest.raises(ValueError, match="tool"):
+            parse_plan_file(p)
+
+
+# ---------------------------------------------------------------------------
+# run_plan — happy path with mock execution
+# ---------------------------------------------------------------------------
+
+
+class TestRunPlanMock:
+    @pytest.mark.asyncio
+    async def test_emits_full_lifecycle(self, tmp_path: Path) -> None:
+        plan = parse_plan_file(_write_plan(tmp_path))
+        buf = io.StringIO()
+        emitter = EventEmitter()
+        emitter.add_sink(JsonlSink(stream=buf))
+        await emitter.start()
+        try:
+            exit_code = await run_plan(plan, emitter)
+        finally:
+            await emitter.stop()
+
+        assert exit_code == 0
+        events = [json.loads(line) for line in buf.getvalue().splitlines() if line]
+        types = [e["event"] for e in events]
+        # 1 run_started + N×(plan_step + gate_decision + tool_result) + 1 run_complete
+        assert types[0] == "run_started"
+        assert types[-1] == "run_complete"
+        assert types.count("plan_step") == 2
+        assert types.count("gate_decision") == 2
+        assert types.count("tool_result") == 2
+        # Mock execution → all tool_results are ok
+        for evt in events:
+            if evt["event"] == "tool_result":
+                assert evt["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# run_plan — Gatekeeper block path
+# ---------------------------------------------------------------------------
+
+
+class TestRunPlanGateBlock:
+    @pytest.mark.asyncio
+    async def test_red_block_emits_run_error(self, tmp_path: Path) -> None:
+        plan = parse_plan_file(_write_plan(tmp_path))
+        buf = io.StringIO()
+        emitter = EventEmitter()
+        emitter.add_sink(JsonlSink(stream=buf))
+        await emitter.start()
+        try:
+            exit_code = await run_plan(
+                plan,
+                emitter,
+                evaluate_gate=lambda _t, _p: GateOutcome(
+                    status="red",
+                    rule_id="exec.shell.block",
+                    rule_source="cognithor.core.gatekeeper",
+                    matched_pattern="rm -rf /",
+                    reason="destructive shell pattern",
+                ),
+            )
+        finally:
+            await emitter.stop()
+
+        assert exit_code == 1
+        events = [json.loads(line) for line in buf.getvalue().splitlines() if line]
+        types = [e["event"] for e in events]
+        # Must terminate with run_error, NOT run_complete.
+        assert types[-1] == "run_error"
+        assert "run_complete" not in types
+        # The gate_decision before run_error must carry the explanation.
+        gate_evt = next(e for e in events if e["event"] == "gate_decision")
+        assert gate_evt["status"] == "red"
+        assert gate_evt["explanation"]["rule_id"] == "exec.shell.block"
+        # FailureMode is policy_block per TRUST-3 contract.
+        run_error = events[-1]
+        assert run_error["failure_mode"] == "policy_block"
+
+
+# ---------------------------------------------------------------------------
+# run_plan — real execute_tool callable
+# ---------------------------------------------------------------------------
+
+
+class TestRunPlanRealExecute:
+    @pytest.mark.asyncio
+    async def test_execute_tool_callable_drives_tool_result(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        plan = parse_plan_file(_write_plan(tmp_path))
+        buf = io.StringIO()
+        emitter = EventEmitter()
+        emitter.add_sink(JsonlSink(stream=buf))
+
+        async def execute(tool: str, params: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "ok": True,
+                "preview": f"ran {tool} with {params}",
+                "chunks": 3,
+            }
+
+        await emitter.start()
+        try:
+            exit_code = await run_plan(plan, emitter, execute_tool=execute)
+        finally:
+            await emitter.stop()
+
+        assert exit_code == 0
+        events = [json.loads(line) for line in buf.getvalue().splitlines() if line]
+        tool_evts = [e for e in events if e["event"] == "tool_result"]
+        assert len(tool_evts) == 2
+        for evt in tool_evts:
+            assert evt["ok"] is True
+            assert evt["chunks"] == 3
+            assert "ran" in evt["preview"]
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_raise_emits_run_error(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        plan = parse_plan_file(_write_plan(tmp_path))
+        buf = io.StringIO()
+        emitter = EventEmitter()
+        emitter.add_sink(JsonlSink(stream=buf))
+
+        async def execute(_tool: str, _params: dict[str, Any]) -> dict[str, Any]:
+            raise RuntimeError("network down")
+
+        await emitter.start()
+        try:
+            exit_code = await run_plan(plan, emitter, execute_tool=execute)
+        finally:
+            await emitter.stop()
+
+        assert exit_code == 1
+        events = [json.loads(line) for line in buf.getvalue().splitlines() if line]
+        run_error = events[-1]
+        assert run_error["event"] == "run_error"
+        assert run_error["failure_mode"] == "internal_error"
+        assert "RuntimeError" in run_error["error"]


### PR DESCRIPTION
## Sprint-27 Phase-1 PR-B — first concrete sink + headless CLI

First consumer of the EventEmitter shipped in #438 (PR-A). Wires
the JSONL transport, the headless CLI subcommand, and a runner
that walks an ActionPlan JSON file through the standard PGE hooks
and emits the full event lifecycle.

## What ships

| File | Purpose |
|---|---|
| \`cognithor/streaming/sinks/jsonl_sink.py\` | One JSON event per line, stdout default + \`to_path()\` for files. \`sort_keys=True\` for byte-stable diffs. Closed-stream → self-quarantine. |
| \`cognithor/streaming/runner.py\` | \`parse_plan_file()\` + \`run_plan()\`. Optional \`evaluate_gate\` and \`execute_tool\` callables; mock execution for CI / extension demos. Emits all 7 lifecycle events. |
| \`cognithor/cli/agent_cmd.py\` | Glue between argparse and the runner. |
| \`cognithor/__main__.py\` | New subcommand \`cognithor agent run --plan FILE.json --stream [--out FILE]\`. |
| \`tests/test_streaming/test_jsonl_sink.py\` | Happy path, append, sort_keys, quarantine. |
| \`tests/test_streaming/test_runner.py\` | Parse validation, full-lifecycle mock, Gatekeeper-block → run_error, execute_tool raise → run_error. |

## Backpressure refactor (caught while writing tests)

PR-A's two-queue design had critical events bypassing the normal
queue — but that bypass also **reordered events on the wire**: a
\`run_complete\` could land *before* the preceding
\`gate_decision\` because the consumer drained the critical queue
first. Breaks the JSONL contract; the extension switches on the
LAST event to render the terminal banner.

Refactored \`Sink\` to a **single FIFO queue** of capacity
\`normal_capacity + critical_reserve\` (default 1000 + 16) with
two occupancy counters tracked at offer-time. Critical events
still bypass the *capacity* gate (they use the reserve when the
normal pool is saturated) but no longer bypass *ordering*. PR-A's
H4 hardening still holds; the implementation just got correct.

## End-to-end CLI smoke

\`\`\`bash
\$ cognithor agent run --plan plan.json --stream
{\"agent_id\": \"smoke\", \"event\": \"run_started\", \"plan_path\": \"plan.json\", \"run_id\": \"r\", \"schema_version\": 1, \"step_count\": 2, \"ts\": \"...\"}
{\"action\": {\"arguments\": {\"x\": 1}, \"rationale\": \"first\", \"tool\": \"a\"}, \"event\": \"plan_step\", \"run_id\": \"r\", \"schema_version\": 1, \"step\": 0, \"ts\": \"...\"}
{\"event\": \"gate_decision\", \"run_id\": \"r\", \"schema_version\": 1, \"status\": \"green\", \"step\": 0, \"ts\": \"...\"}
{\"duration_ms\": 0, \"event\": \"tool_result\", \"ok\": true, \"run_id\": \"r\", \"schema_version\": 1, \"step\": 0, \"ts\": \"...\"}
... (steps repeated)
{\"duration_ms\": 0, \"event\": \"run_complete\", \"receipt\": {}, \"run_id\": \"r\", \"schema_version\": 1, \"status\": \"success\", \"ts\": \"...\"}
\`\`\`

## Quality gates

- ✅ \`mypy --strict\` — clean across 8 source files
- ✅ \`ruff check\` — clean
- ✅ \`ruff format --check\` — clean
- ✅ \`pytest tests/test_streaming/\` — **46/46 passing (+13 new)**
- ✅ End-to-end CLI smoke — exit 0, valid JSONL, all 8 events present

## Refs

- Plan: \`docs/superpowers/plans/2026-05-04-sprint27-ide-integration.md\`
- Decisions memo (D5 + H4): \`docs/superpowers/plans/2026-05-04-sprint27-ide-integration-decisions.md\`
- Builds on: #438 (PR-A — EventEmitter foundation)
- Tasks: #116 (this PR), unblocks #117 (PR-C WebSocketSink), #119 (PR-D extension scaffold)