### PR TITLE
feat(streaming+cli): WebSocketSink + cognithor agent ws (Sprint-27 PR-C)

### DIFF
--- a/src/cognithor/__main__.py
+++ b/src/cognithor/__main__.py
@@ -392,6 +392,24 @@ def parse_args() -> argparse.Namespace:
         help="Output file (omitted ⇒ stdout)",
     )
 
+    agent_ws_p = agent_sub.add_parser(
+        "ws",
+        help="WebSocket variant of the streaming protocol",
+    )
+    agent_ws_p.add_argument(
+        "--port",
+        dest="agent_ws_port",
+        type=int,
+        default=8742,
+        help="TCP port to listen on (default 8742)",
+    )
+    agent_ws_p.add_argument(
+        "--bind",
+        dest="agent_ws_bind",
+        default="127.0.0.1",
+        help="Bind address (default 127.0.0.1; 0.0.0.0 still requires the token)",
+    )
+
     return parser.parse_args()
 
 
@@ -656,9 +674,16 @@ def main() -> None:
                     else None,
                 ),
             )
+        elif action == "ws":
+            sys.exit(
+                agent_cmd.cmd_ws(
+                    bind=getattr(args, "agent_ws_bind", "127.0.0.1"),
+                    port=int(getattr(args, "agent_ws_port", 8742)),
+                ),
+            )
         else:
             print(
-                "Usage: cognithor agent run --plan FILE.json --stream [--out FILE]",
+                "Usage: cognithor agent <run|ws> ...",
                 file=sys.stderr,
             )
             sys.exit(2)

--- a/src/cognithor/cli/agent_cmd.py
+++ b/src/cognithor/cli/agent_cmd.py
@@ -82,3 +82,30 @@ async def _run(plan: object, emitter: EventEmitter) -> int:
         return await run_plan(plan, emitter)  # type: ignore[arg-type]
     finally:
         await emitter.stop()
+
+
+def cmd_ws(*, bind: str, port: int) -> int:
+    """Run ``cognithor agent ws`` until SIGINT.
+
+    Reads the bearer token (creating it if missing), starts the
+    WebSocket server, and runs forever. Exit codes:
+
+    * ``0`` — clean shutdown via SIGINT/Ctrl-C
+    * ``1`` — server-level startup failure
+    * ``2`` — bad command-line arguments
+    """
+
+    if port < 1 or port > 65535:
+        print(f"cognithor agent ws: invalid port {port}", file=sys.stderr)
+        return 2
+
+    from cognithor.streaming.server import serve
+
+    try:
+        asyncio.run(serve(bind=bind, port=port))
+    except KeyboardInterrupt:
+        return 0
+    except OSError as exc:
+        print(f"cognithor agent ws: bind failed: {exc}", file=sys.stderr)
+        return 1
+    return 0

--- a/src/cognithor/streaming/auth.py
+++ b/src/cognithor/streaming/auth.py
@@ -1,0 +1,71 @@
+"""WebSocket bearer-token loading + creation (Sprint-27 H3).
+
+Single source of truth for the PSK that ``cognithor agent ws``
+requires from clients. The token lives at
+``~/.cognithor/auth.token`` (override via the
+``COGNITHOR_HOME`` environment variable, the same convention the
+rest of the codebase uses). On first run the file is generated
+with 32 bytes of cryptographically random hex (64 hex chars) and
+mode ``0o600`` so other users on a shared workstation cannot
+read it. Best-effort on Windows where ``chmod`` is a no-op for
+the file-permission bit (the file still resides under the
+user-profile, which is access-controlled by the OS).
+
+The token is **the only auth surface for the local WS server**.
+Lose it = compromise the surface. The companion
+``docs/superpowers/plans/2026-05-04-sprint27-ide-integration-decisions.md``
+H3 hardening explicitly forbids unauthenticated binds.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import secrets
+from pathlib import Path
+
+# 32 bytes → 64 hex chars. Conservative entropy for a localhost
+# PSK that lives in a file on the same machine the server runs
+# on; rotation is a follow-up.
+_TOKEN_BYTES = 32
+
+
+def _home_dir() -> Path:
+    """Resolve the cognithor home directory (matches config.py convention)."""
+
+    override = os.environ.get("COGNITHOR_HOME")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".cognithor"
+
+
+def auth_token_path() -> Path:
+    """Where the token lives on disk."""
+
+    return _home_dir() / "auth.token"
+
+
+def load_or_create_token(*, path: Path | None = None) -> str:
+    """Return the bearer token, generating it on first call.
+
+    Returns the existing token verbatim if the file exists and
+    contains a non-empty single-line value (with whitespace
+    stripped). Otherwise generates a new 64-char hex token,
+    writes it to disk with mode 0o600, and returns it.
+    """
+
+    target = path or auth_token_path()
+    if target.exists():
+        existing = target.read_text(encoding="utf-8").strip()
+        if existing:
+            return existing
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    token = secrets.token_hex(_TOKEN_BYTES)
+    target.write_text(token + "\n", encoding="utf-8")
+    # Windows: chmod is a best-effort no-op for the user permission
+    # bit; the file still lives under the user-profile so it inherits
+    # NTFS ACLs anyway.
+    with contextlib.suppress(OSError, NotImplementedError):
+        target.chmod(0o600)
+    return token

--- a/src/cognithor/streaming/server.py
+++ b/src/cognithor/streaming/server.py
@@ -1,0 +1,205 @@
+"""WebSocket server backing ``cognithor agent ws`` (Sprint-27 PR-C).
+
+H3 security defaults locked in:
+
+* Bind ``127.0.0.1`` by default. ``--bind 0.0.0.0`` is allowed
+  but emits an explicit warning AND **still requires the token**
+  — no auth-bypass-on-bind escape hatch. Port defaults to 8742.
+* Bearer-token auth via ``Authorization: Bearer <token>`` header
+  on the WS upgrade. Token from
+  :func:`cognithor.streaming.auth.load_or_create_token`. Mismatch
+  closes the connection with code ``1008`` (policy violation).
+* Per-connection request schema (newline-or-frame-delimited JSON):
+
+  .. code-block:: json
+
+      {"type": "run_plan", "plan": <ActionPlan-shape>}
+      {"type": "run_plan", "plan_path": "/abs/or/cwd-relative/path.json"}
+
+  After the request lands, the server runs the plan, streams
+  events through a :class:`WebSocketSink` for that single
+  connection, then closes the connection cleanly.
+
+The server is intentionally simple — Phase-2's VS-Code
+extension is the primary consumer; external orchestrators that
+want long-lived connections can be added in Sprint-28+.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from cognithor.streaming.auth import load_or_create_token
+from cognithor.streaming.emitter import EventEmitter
+from cognithor.streaming.runner import parse_plan_file, run_plan
+from cognithor.streaming.sinks.ws_sink import WebSocketSink
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+log = logging.getLogger(__name__)
+
+DEFAULT_PORT = 8742
+DEFAULT_BIND = "127.0.0.1"
+
+WS_CLOSE_POLICY_VIOLATION = 1008
+WS_CLOSE_INTERNAL_ERROR = 1011
+
+
+def _extract_bearer_token(headers: Iterable[tuple[str, str]] | object) -> str | None:
+    """Pull ``Authorization: Bearer <token>`` from a websockets request.
+
+    The websockets library exposes request headers as a mapping-
+    or list-like object depending on version; we duck-type both.
+    """
+
+    auth_header: str | None = None
+
+    get_attr = getattr(headers, "get", None)
+    if callable(get_attr):
+        auth_header = get_attr("Authorization")
+    if auth_header is None and hasattr(headers, "__iter__"):
+        for k, v in headers:
+            if k.lower() == "authorization":
+                auth_header = v
+                break
+
+    if not auth_header:
+        return None
+    parts = auth_header.split(None, 1)
+    if len(parts) != 2 or parts[0].lower() != "bearer":
+        return None
+    return parts[1].strip() or None
+
+
+async def _handle_request_payload(payload: str) -> tuple[object, str]:
+    """Parse the first message a client sends. Returns ``(plan, kind)``.
+
+    ``plan`` is a parsed :class:`_ParsedPlan` from
+    :mod:`cognithor.streaming.runner`. ``kind`` reports how the
+    plan was supplied ("inline" or "path") for the
+    ``run_started`` event's ``plan_path`` field.
+    """
+
+    msg = json.loads(payload)
+    if not isinstance(msg, dict) or msg.get("type") != "run_plan":
+        msg_text = "first frame must be a JSON object with type='run_plan'"
+        raise ValueError(msg_text)
+
+    plan_path = msg.get("plan_path")
+    inline = msg.get("plan")
+
+    if plan_path:
+        return parse_plan_file(Path(plan_path)), "path"
+    if isinstance(inline, dict):
+        # Marshal the inline plan dict through the same parser so
+        # validation + canonicalisation are consistent.
+        from tempfile import NamedTemporaryFile
+
+        with NamedTemporaryFile(
+            mode="w",
+            suffix=".json",
+            delete=False,
+            encoding="utf-8",
+        ) as tmp:
+            json.dump(inline, tmp)
+            tmp_path = Path(tmp.name)
+        try:
+            plan = parse_plan_file(tmp_path)
+            # Replace the synthetic temp-path with a sentinel for
+            # the run_started event so consumers know the source
+            # was inline.
+            return dataclasses.replace(plan, plan_path="<inline>"), "inline"
+        finally:
+            tmp_path.unlink(missing_ok=True)
+
+    msg_text = "run_plan request must carry either 'plan' (inline) or 'plan_path'"
+    raise ValueError(msg_text)
+
+
+async def _serve_connection(
+    ws: object,
+    *,
+    expected_token: str,
+) -> None:
+    """Per-connection handler. Auth + parse + run + close."""
+
+    # Extract Authorization header from whichever websockets API
+    # version we're running against.
+    headers = getattr(ws, "request_headers", None) or getattr(
+        getattr(ws, "request", None),
+        "headers",
+        None,
+    )
+    supplied = _extract_bearer_token(headers) if headers is not None else None
+    if supplied != expected_token:
+        log.warning("ws: rejecting connection — invalid or missing bearer token")
+        close = getattr(ws, "close", None)
+        if callable(close):
+            await close(code=WS_CLOSE_POLICY_VIOLATION, reason="invalid token")
+        return
+
+    # First frame must be the run_plan request.
+    recv = getattr(ws, "recv", None)
+    if not callable(recv):
+        log.error("ws: connection object has no recv()")
+        return
+    payload = await recv()
+    if isinstance(payload, bytes):
+        payload = payload.decode("utf-8", errors="replace")
+
+    try:
+        plan, _kind = await _handle_request_payload(payload)
+    except (ValueError, OSError, json.JSONDecodeError) as exc:
+        log.warning("ws: bad run_plan request: %s", exc)
+        close = getattr(ws, "close", None)
+        if callable(close):
+            await close(code=WS_CLOSE_POLICY_VIOLATION, reason=str(exc)[:120])
+        return
+
+    sink = WebSocketSink(ws)  # type: ignore[arg-type]
+    emitter = EventEmitter()
+    emitter.add_sink(sink)
+    await emitter.start()
+    try:
+        await run_plan(plan, emitter)  # type: ignore[arg-type]
+    finally:
+        await emitter.stop()
+        close = getattr(ws, "close", None)
+        if callable(close):
+            await close()
+
+
+async def serve(
+    *,
+    bind: str = DEFAULT_BIND,
+    port: int = DEFAULT_PORT,
+    token: str | None = None,
+) -> None:
+    """Start the WebSocket server and run forever (Ctrl-C to stop)."""
+
+    expected = token or load_or_create_token()
+    if bind != DEFAULT_BIND:
+        log.warning(
+            "cognithor agent ws: binding to %s (NOT localhost). "
+            "The bearer-token check is still enforced, but a "
+            "mis-rotated token here is a worse exposure than on "
+            "127.0.0.1. Make sure that's what you want.",
+            bind,
+        )
+
+    # Late import so unit tests don't pay the websockets dep cost
+    # unless they exercise the server path.
+    from websockets.asyncio.server import serve as ws_serve
+
+    async def handler(ws: object) -> None:
+        await _serve_connection(ws, expected_token=expected)
+
+    log.info("cognithor agent ws: listening on ws://%s:%d", bind, port)
+    async with ws_serve(handler, bind, port):
+        await asyncio.Future()  # run forever

--- a/src/cognithor/streaming/sinks/__init__.py
+++ b/src/cognithor/streaming/sinks/__init__.py
@@ -9,5 +9,12 @@ from __future__ import annotations
 
 from cognithor.streaming.sinks.base import Sink, SinkBufferConfig
 from cognithor.streaming.sinks.jsonl_sink import JsonlSink
+from cognithor.streaming.sinks.ws_sink import WebSocketSink, encode_event_frame
 
-__all__ = ["JsonlSink", "Sink", "SinkBufferConfig"]
+__all__ = [
+    "JsonlSink",
+    "Sink",
+    "SinkBufferConfig",
+    "WebSocketSink",
+    "encode_event_frame",
+]

--- a/src/cognithor/streaming/sinks/ws_sink.py
+++ b/src/cognithor/streaming/sinks/ws_sink.py
@@ -1,0 +1,77 @@
+"""WebSocketSink — stream events as JSON frames over WebSocket (Sprint-27 PR-C).
+
+Second concrete consumer of :class:`Sink`. Wraps an open
+WebSocket connection (``websockets.asyncio.server.ServerConnection``
+or any compatible duck-typed object that supports ``await
+ws.send(text)`` and a ``close()`` coroutine). One sink ↔ one
+connection is the standard usage from ``cognithor agent ws``,
+but the class is happy to be reused once another part of the
+codebase wants to broadcast to many clients.
+
+Wire format: each event is ``json.dumps(event.to_dict()) + "\\n"``
+sent as a single text frame. The trailing newline is intentional
+so a client that buffers frame text into a stream-style reader
+can still split on ``"\\n"`` like the JSONL transport. Frame-level
+boundaries also work — clients are free to use either.
+
+Auth is handled at the server layer (see
+:mod:`cognithor.streaming.auth` and the ``cognithor agent ws``
+command in ``__main__.py``); this sink trusts that the caller
+supplied an already-authenticated connection.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any, Protocol
+
+from cognithor.streaming.sinks.base import Sink, SinkBufferConfig
+
+if TYPE_CHECKING:
+    from cognithor.streaming.events import StreamEvent
+
+log = logging.getLogger(__name__)
+
+
+class _SendableWebSocket(Protocol):
+    """Minimal duck-typing for the WS connection object.
+
+    Both the modern ``websockets.asyncio.server.ServerConnection``
+    and the legacy ``WebSocketServerProtocol`` satisfy this. Tests
+    use a small in-process fake.
+    """
+
+    async def send(self, message: str) -> None: ...
+
+
+class WebSocketSink(Sink):
+    """Sink that pushes JSON events to one WebSocket connection.
+
+    The connection lifecycle (accept, auth, close) is owned by
+    the calling server — this sink only writes. On a send-side
+    failure (socket closed mid-stream, peer reset, etc.) the sink
+    self-quarantines so subsequent events are not retried; the
+    server typically tears the connection down at that point.
+    """
+
+    name = "websocket"
+
+    def __init__(
+        self,
+        ws: _SendableWebSocket,
+        *,
+        buffer: SinkBufferConfig | None = None,
+    ) -> None:
+        super().__init__(buffer=buffer)
+        self._ws = ws
+
+    async def _write(self, event: StreamEvent) -> None:
+        line = json.dumps(event.to_dict(), ensure_ascii=False, sort_keys=True)
+        await self._ws.send(line + "\n")
+
+
+def encode_event_frame(event_dict: dict[str, Any]) -> str:
+    """Public helper for tests + non-Sink callers that need the wire shape."""
+
+    return json.dumps(event_dict, ensure_ascii=False, sort_keys=True) + "\n"

--- a/tests/test_streaming/test_server.py
+++ b/tests/test_streaming/test_server.py
@@ -1,0 +1,182 @@
+"""Tests for the WebSocket server in `cognithor.streaming.server`.
+
+H3 — auth header parsing, bad-token rejection, run_plan request
+parsing (path + inline). Full async-server boot/connect E2E is
+covered in PR-K's smoke test; these tests exercise the
+unit-level seams.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from cognithor.streaming.server import (
+    WS_CLOSE_POLICY_VIOLATION,
+    _extract_bearer_token,
+    _handle_request_payload,
+    _serve_connection,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Bearer-token header extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractBearerToken:
+    def test_dict_like_headers(self) -> None:
+        headers = {"Authorization": "Bearer abc123"}
+        assert _extract_bearer_token(headers) == "abc123"
+
+    def test_iterable_headers(self) -> None:
+        headers = [("X-Other", "y"), ("Authorization", "Bearer xyz789")]
+        assert _extract_bearer_token(headers) == "xyz789"
+
+    def test_iterable_headers_case_insensitive(self) -> None:
+        headers = [("authorization", "Bearer secret-lower")]
+        assert _extract_bearer_token(headers) == "secret-lower"
+
+    def test_missing_header(self) -> None:
+        assert _extract_bearer_token({}) is None
+
+    def test_non_bearer_scheme(self) -> None:
+        assert _extract_bearer_token({"Authorization": "Basic dXNlcjpwYXNz"}) is None
+
+    def test_empty_token(self) -> None:
+        assert _extract_bearer_token({"Authorization": "Bearer "}) is None
+
+
+# ---------------------------------------------------------------------------
+# run_plan request payload parsing
+# ---------------------------------------------------------------------------
+
+
+class TestHandleRequestPayload:
+    @pytest.mark.asyncio
+    async def test_path_form(self, tmp_path: Path) -> None:
+        plan_path = tmp_path / "plan.json"
+        plan_path.write_text(
+            json.dumps(
+                {
+                    "run_id": "r1",
+                    "steps": [{"tool": "noop", "params": {}}],
+                },
+            ),
+            encoding="utf-8",
+        )
+        msg = json.dumps({"type": "run_plan", "plan_path": str(plan_path)})
+        plan, kind = await _handle_request_payload(msg)
+        assert kind == "path"
+        assert plan.run_id == "r1"  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_inline_form(self) -> None:
+        msg = json.dumps(
+            {
+                "type": "run_plan",
+                "plan": {
+                    "run_id": "inline-r",
+                    "steps": [{"tool": "noop", "params": {}}],
+                },
+            },
+        )
+        plan, kind = await _handle_request_payload(msg)
+        assert kind == "inline"
+        assert plan.plan_path == "<inline>"  # type: ignore[attr-defined]
+        assert plan.run_id == "inline-r"  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_wrong_type_raises(self) -> None:
+        msg = json.dumps({"type": "wrong"})
+        with pytest.raises(ValueError, match="run_plan"):
+            await _handle_request_payload(msg)
+
+    @pytest.mark.asyncio
+    async def test_neither_path_nor_inline(self) -> None:
+        msg = json.dumps({"type": "run_plan"})
+        with pytest.raises(ValueError, match="plan"):
+            await _handle_request_payload(msg)
+
+
+# ---------------------------------------------------------------------------
+# _serve_connection — bad-token and happy-path
+# ---------------------------------------------------------------------------
+
+
+class _FakeWSConnection:
+    """In-process double for `websockets.asyncio.server.ServerConnection`."""
+
+    def __init__(self, *, token: str | None, first_message: str | None = None) -> None:
+        if token is None:
+            self.request_headers: dict[str, str] = {}
+        else:
+            self.request_headers = {"Authorization": f"Bearer {token}"}
+        self._first_message = first_message
+        self.sent: list[str] = []
+        self.closed_with: tuple[int | None, str | None] = (None, None)
+        self._first_consumed = False
+
+    async def recv(self) -> str:
+        if self._first_consumed or self._first_message is None:
+            await asyncio.sleep(3600)  # never returns; tests timeout instead
+            raise RuntimeError("recv called twice")
+        self._first_consumed = True
+        return self._first_message
+
+    async def send(self, message: str) -> None:
+        self.sent.append(message)
+
+    async def close(
+        self,
+        code: int | None = None,
+        reason: str | None = None,
+    ) -> None:
+        self.closed_with = (code, reason)
+
+
+class TestServeConnection:
+    @pytest.mark.asyncio
+    async def test_rejects_missing_token(self) -> None:
+        ws = _FakeWSConnection(token=None)
+        await _serve_connection(ws, expected_token="server-secret")  # type: ignore[arg-type]
+        assert ws.closed_with[0] == WS_CLOSE_POLICY_VIOLATION
+        assert ws.sent == []
+
+    @pytest.mark.asyncio
+    async def test_rejects_wrong_token(self) -> None:
+        ws = _FakeWSConnection(token="client-wrong-secret")
+        await _serve_connection(ws, expected_token="server-secret")  # type: ignore[arg-type]
+        assert ws.closed_with[0] == WS_CLOSE_POLICY_VIOLATION
+
+    @pytest.mark.asyncio
+    async def test_accepts_correct_token_and_runs_plan(self) -> None:
+        plan_msg: dict[str, Any] = {
+            "type": "run_plan",
+            "plan": {
+                "run_id": "ws-r",
+                "steps": [{"tool": "noop", "params": {}}],
+            },
+        }
+        ws = _FakeWSConnection(token="shared", first_message=json.dumps(plan_msg))
+        await _serve_connection(ws, expected_token="shared")  # type: ignore[arg-type]
+
+        # Streamed events landed.
+        assert len(ws.sent) > 0
+        types = [json.loads(f.rstrip("\n"))["event"] for f in ws.sent]
+        assert types[0] == "run_started"
+        assert types[-1] == "run_complete"
+        # Connection closed cleanly after run.
+        assert ws.closed_with[0] is None or ws.closed_with[0] != WS_CLOSE_POLICY_VIOLATION
+
+    @pytest.mark.asyncio
+    async def test_rejects_bad_first_frame(self) -> None:
+        ws = _FakeWSConnection(token="shared", first_message="not json at all")
+        await _serve_connection(ws, expected_token="shared")  # type: ignore[arg-type]
+        assert ws.closed_with[0] == WS_CLOSE_POLICY_VIOLATION

--- a/tests/test_streaming/test_ws_sink_and_auth.py
+++ b/tests/test_streaming/test_ws_sink_and_auth.py
@@ -1,0 +1,176 @@
+"""Tests for `cognithor.streaming.sinks.ws_sink` + `cognithor.streaming.auth`.
+
+H3 — token auto-gen + 0o600, frame format stability, multi-event
+ordering on the wire, sink quarantine on send-failure.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cognithor.streaming import EventEmitter
+from cognithor.streaming.auth import auth_token_path, load_or_create_token
+from cognithor.streaming.events import (
+    PlanStep,
+    RunComplete,
+    RunStarted,
+)
+from cognithor.streaming.sinks import WebSocketSink, encode_event_frame
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Auth — load_or_create_token
+# ---------------------------------------------------------------------------
+
+
+class TestAuthToken:
+    def test_creates_token_with_64_hex_chars(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("COGNITHOR_HOME", str(tmp_path))
+        token = load_or_create_token()
+        assert re.fullmatch(r"[0-9a-f]{64}", token)
+        # File written.
+        assert auth_token_path().exists()
+
+    def test_preserves_existing_token(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("COGNITHOR_HOME", str(tmp_path))
+        first = load_or_create_token()
+        second = load_or_create_token()
+        assert first == second
+
+    def test_strips_whitespace_from_existing_file(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("COGNITHOR_HOME", str(tmp_path))
+        path = auth_token_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("  abc123\n  ", encoding="utf-8")
+        assert load_or_create_token() == "abc123"
+
+    def test_regenerates_when_file_is_blank(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        monkeypatch.setenv("COGNITHOR_HOME", str(tmp_path))
+        path = auth_token_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("\n", encoding="utf-8")
+        token = load_or_create_token()
+        assert token  # non-empty
+        assert path.read_text(encoding="utf-8").strip() == token
+
+
+# ---------------------------------------------------------------------------
+# WebSocketSink
+# ---------------------------------------------------------------------------
+
+
+class _FakeWS:
+    """In-process recording WebSocket double."""
+
+    def __init__(self) -> None:
+        self.sent: list[str] = []
+        self.fail_after: int | None = None
+
+    async def send(self, message: str) -> None:
+        if self.fail_after is not None and len(self.sent) >= self.fail_after:
+            raise ConnectionError("peer reset")
+        self.sent.append(message)
+
+
+class TestWebSocketSink:
+    @pytest.mark.asyncio
+    async def test_sends_one_frame_per_event(self) -> None:
+        ws = _FakeWS()
+        sink = WebSocketSink(ws)
+        emitter = EventEmitter()
+        emitter.add_sink(sink)
+        await emitter.start()
+        try:
+            emitter.emit(RunStarted(run_id="r", plan_path="p", step_count=1))
+            emitter.emit(PlanStep(run_id="r", step=0, action={"tool": "noop"}))
+            emitter.emit(RunComplete(run_id="r", receipt={}))
+        finally:
+            await emitter.stop()
+
+        assert len(ws.sent) == 3
+        # Each frame is exactly one JSON line + trailing newline.
+        for frame in ws.sent:
+            assert frame.endswith("\n")
+            payload = json.loads(frame.rstrip("\n"))
+            assert "event" in payload
+
+    @pytest.mark.asyncio
+    async def test_preserves_event_order(self) -> None:
+        ws = _FakeWS()
+        sink = WebSocketSink(ws)
+        emitter = EventEmitter()
+        emitter.add_sink(sink)
+        await emitter.start()
+        try:
+            for i in range(5):
+                emitter.emit(PlanStep(run_id="r", step=i, action={"tool": f"t{i}"}))
+            emitter.emit(RunComplete(run_id="r", receipt={}))
+        finally:
+            await emitter.stop()
+
+        types = [json.loads(f.rstrip("\n"))["event"] for f in ws.sent]
+        # 5 plan_step in order, then run_complete LAST.
+        assert types == ["plan_step"] * 5 + ["run_complete"]
+        steps = [
+            json.loads(f.rstrip("\n")).get("step")
+            for f in ws.sent
+            if json.loads(f.rstrip("\n"))["event"] == "plan_step"
+        ]
+        assert steps == [0, 1, 2, 3, 4]
+
+    @pytest.mark.asyncio
+    async def test_send_failure_quarantines_sink(self) -> None:
+        ws = _FakeWS()
+        ws.fail_after = 1  # accept one event, then raise.
+        sink = WebSocketSink(ws)
+        emitter = EventEmitter()
+        emitter.add_sink(sink)
+        await emitter.start()
+        try:
+            emitter.emit(RunStarted(run_id="r", plan_path="p", step_count=2))
+            emitter.emit(PlanStep(run_id="r", step=0, action={"tool": "noop"}))
+            import asyncio as _a
+
+            await _a.sleep(0.1)  # let consumer catch the raise
+        finally:
+            await emitter.stop()
+        assert sink.is_faulted is True
+
+
+# ---------------------------------------------------------------------------
+# encode_event_frame helper
+# ---------------------------------------------------------------------------
+
+
+class TestEncodeEventFrame:
+    def test_appends_newline(self) -> None:
+        frame = encode_event_frame({"event": "noop", "schema_version": 1})
+        assert frame.endswith("\n")
+
+    def test_sort_keys_for_determinism(self) -> None:
+        a = encode_event_frame({"b": 2, "a": 1})
+        b = encode_event_frame({"a": 1, "b": 2})
+        assert a == b


### PR DESCRIPTION
## Sprint-27 Phase-1 PR-C — WebSocket transport + H3 security

Second concrete consumer of the EventEmitter shipped in #438. Adds
the WebSocket transport, the \`cognithor agent ws\` subcommand,
and the H3 security defaults locked in by the [decisions memo](docs/superpowers/plans/2026-05-04-sprint27-ide-integration-decisions.md).

**Phase-1 is complete with this PR** (PR-A + PR-B + PR-C).
Phase-2 (\`extensions/vscode/\` scaffold) unblocks next.

## What ships

| File | Purpose |
|---|---|
| \`cognithor/streaming/auth.py\` | \`load_or_create_token()\` — auto-gen 64-hex PSK at \`~/.cognithor/auth.token\`, mode 0o600 |
| \`cognithor/streaming/sinks/ws_sink.py\` | \`WebSocketSink\` — one event per text frame (JSON + newline), self-quarantine on send-failure |
| \`cognithor/streaming/server.py\` | \`serve()\` — H3 defaults: bind 127.0.0.1, \`--bind 0.0.0.0\` warns + still requires token, mismatch closes with code 1008 |
| \`cognithor/cli/agent_cmd.py\` | \`cmd_ws()\` glue with KeyboardInterrupt + OSError handling |
| \`cognithor/__main__.py\` | \`cognithor agent ws --port 8742 --bind 127.0.0.1\` |
| \`tests/test_streaming/test_ws_sink_and_auth.py\` | Token gen + sink format + ordering + quarantine |
| \`tests/test_streaming/test_server.py\` | Bearer-header parsing + run_plan request parsing + auth pass/fail |

## H3 security contract

Per the decisions memo:

\`\`\`python
# Default — localhost only:
serve(bind=\"127.0.0.1\", port=8742)

# Explicit external bind — STILL requires token, just emits warning:
serve(bind=\"0.0.0.0\", port=8742)
\`\`\`

Client must supply \`Authorization: Bearer <token>\` on the WS upgrade.
Token mismatch → \`close(code=1008, reason=\"invalid token\")\`.

The SEC-CRIT-1 bootstrap-endpoint CVSS-9.8 incident (closed via
PR #173) was the same class of error — exposed network surface
with no auth. H3 ensures we don't repeat it.

## Live end-to-end smoke

\`\`\`
events received: ['run_started', 'plan_step', 'gate_decision', 'tool_result',
                  'plan_step', 'gate_decision', 'tool_result', 'run_complete']
PASS
bad-token close code: 1008 (expected 1008)
AUTH-PASS
\`\`\`

(Real \`websockets.asyncio.server.serve()\` listener + real \`websockets.connect()\` client subprocess; not a mock.)

## Quality gates

- ✅ \`mypy --strict\` — clean across 11 source files
- ✅ \`ruff check\` + \`ruff format --check\` — clean
- ✅ \`pytest tests/test_streaming/\` — **69/69 passing (+23 new)**
- ✅ End-to-end smoke (live WS server + client) — happy path + auth-reject both verified

## Refs

- Plan: \`docs/superpowers/plans/2026-05-04-sprint27-ide-integration.md\`
- Decisions memo (D5 + H3 + H4): \`docs/superpowers/plans/2026-05-04-sprint27-ide-integration-decisions.md\`
- Builds on: #438 (PR-A — Producer), #439 (PR-B — JsonlSink)
- Tasks: #117 (this PR), Phase-1 complete; unblocks #119 (PR-D extension scaffold) + #121 (PR-F WS client in extension)