### PR TITLE
fix(cli): ruff format src/cognithor/__main__.py — Sprint-27 agent-cmd wiring

### DIFF
--- a/src/cognithor/__main__.py
+++ b/src/cognithor/__main__.py
@@ -669,9 +669,7 @@ def main() -> None:
                 agent_cmd.cmd_run(
                     plan_path=Path(args.agent_run_plan),
                     stream=getattr(args, "agent_run_stream", False),
-                    out=Path(args.agent_run_out)
-                    if getattr(args, "agent_run_out", None)
-                    else None,
+                    out=Path(args.agent_run_out) if getattr(args, "agent_run_out", None) else None,
                 ),
             )
         elif action == "ws":


### PR DESCRIPTION
## Format hotfix for Sprint-27 PR-B/PR-C agent-cmd wiring

### Why

Post-merge CI on #439 (PR-B) and #440 (PR-C) flagged \`Lint (Ruff)\` red. Locally I'd only run \`ruff format --check\` against my new files in \`src/cognithor/streaming/\`, \`src/cognithor/cli/agent_cmd.py\`, and \`tests/test_streaming/\` — not against the edited \`src/cognithor/__main__.py\`. CI runs the format check against the **full tree** (\`src/ tests/\`).

### What

Mechanical \`ruff format src/cognithor/__main__.py\` — 1 file, 3-line diff. Full-tree \`ruff format --check src/ tests/\` is now clean.

### Process lesson reinforced

The MEMORY.md feedback note "ruff pre-flight muss tests/ einschließen" applies to format too: I'll always run the full-tree format-check (not the path-scoped one) before push from here on.

### Sprint-27 Phase-1 status after this hotfix

PR-A (#438), PR-B (#439), PR-C (#440) functionality on main; lint goes green again with this PR. **Phase-1 truly final**, Phase-2 (PR-D extension scaffold) can start.