### PR TITLE
feat(video): RendererABC + HyperFramesRenderer (Sprint-27 HF-2)

### DIFF
--- a/src/cognithor/video/__init__.py
+++ b/src/cognithor/video/__init__.py
@@ -1,0 +1,45 @@
+"""Cognithor video-rendering surface (Sprint-27 HF track).
+
+Owner-decision Option C (see
+``docs/superpowers/spikes/2026-05-04-hyperframes-spike.md``):
+ship a thin :class:`RendererABC` abstraction with HyperFrames as
+the default backend, so future renderers (Remotion, homegrown,
+cloud) can be swapped in without touching the MCP-tool layer.
+
+Public surface:
+
+* :class:`RendererABC` — base contract every renderer implements.
+* :class:`RenderRequest` / :class:`RenderResult` / :class:`RenderError`
+  — the wire types between the MCP tools (HF-3) and a renderer.
+* :class:`HyperFramesRenderer` — default Apache-2.0 backend
+  (HF-2 ships this).
+* :class:`OutputFormat` / :class:`FrameAdapter` — taxonomies the
+  Gatekeeper + skill layer (HF-5) consume.
+* :data:`renderer_registry` — ``{name: factory}`` lookup the
+  ``video_render`` MCP tool dispatches against.
+"""
+
+from __future__ import annotations
+
+from cognithor.video.renderer_base import (
+    DEFAULT_ALLOWED_ADAPTERS,
+    FrameAdapter,
+    OutputFormat,
+    RendererABC,
+    RenderError,
+    RenderRequest,
+    RenderResult,
+)
+from cognithor.video.renderers import HyperFramesRenderer, renderer_registry
+
+__all__ = [
+    "DEFAULT_ALLOWED_ADAPTERS",
+    "FrameAdapter",
+    "HyperFramesRenderer",
+    "OutputFormat",
+    "RenderError",
+    "RenderRequest",
+    "RenderResult",
+    "RendererABC",
+    "renderer_registry",
+]

--- a/src/cognithor/video/renderer_base.py
+++ b/src/cognithor/video/renderer_base.py
@@ -1,0 +1,226 @@
+"""Renderer ABC + wire types for the Cognithor video surface (HF-2).
+
+Decision per ``docs/superpowers/spikes/2026-05-04-hyperframes-spike.md``:
+the rendering layer is renderer-agnostic. Every backend (HyperFrames
+default, future Remotion, future homegrown) implements
+:class:`RendererABC`. The MCP tools (``video_compose`` / ``video_render``)
+shipped in HF-3 talk only to this contract — never to a concrete
+renderer — so a swap is a one-file change.
+
+Frozen dataclass + ``StrEnum`` taxonomy mirrors the rest of the
+TRUST stack (see ``cognithor.security.permission_scope``,
+``cognithor.security.cost_ledger``). All wire types are
+JSON-serialisable so they can ride the MCP transport without
+custom encoders.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any, Final
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class OutputFormat(StrEnum):
+    """Supported render-output container formats."""
+
+    MP4 = "mp4"
+    MOV = "mov"
+    WEBM = "webm"
+
+
+class FrameAdapter(StrEnum):
+    """Animation runtimes a renderer may load when rendering a composition.
+
+    Mirrors the HyperFrames adapter taxonomy (CSS, WAAPI, Anime.js,
+    Lottie, Three.js, GSAP) so other renderers can opt into the same
+    name space. Not every renderer supports every adapter — the
+    ``RendererABC.supported_adapters()`` introspection lets callers
+    discover what is available.
+    """
+
+    CSS = "css"
+    WAAPI = "waapi"
+    ANIME = "anime"
+    LOTTIE = "lottie"
+    THREE = "three"
+    GSAP = "gsap"
+
+
+# Default adapter allowlist for paid-pack render paths (HF-1 spike
+# doc — GreenSock license risk excludes GSAP from the default).
+# Free-pack / core paths can opt in to GSAP via an explicit flag.
+DEFAULT_ALLOWED_ADAPTERS: Final[frozenset[FrameAdapter]] = frozenset(
+    {
+        FrameAdapter.CSS,
+        FrameAdapter.WAAPI,
+        FrameAdapter.ANIME,
+        FrameAdapter.LOTTIE,
+        FrameAdapter.THREE,
+    },
+)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RenderRequest:
+    """A renderer-agnostic render request.
+
+    Either ``html_path`` (a path to a self-contained composition
+    HTML file) OR ``html_text`` (the inline composition string)
+    must be set, never both. The renderer-agnostic Gatekeeper
+    rule in HF-3 enforces this invariant — repeated here as a
+    construction-time validation so accidental misuse is caught
+    before it reaches the renderer.
+
+    ``run_id`` is the same identifier used by the streaming
+    EventEmitter (PR-A) and TRUST-1 receipt API, so a single video
+    render can be cross-referenced from the agent run that
+    produced it.
+    """
+
+    run_id: str
+    html_path: Path | None = None
+    html_text: str | None = None
+    output_format: OutputFormat = OutputFormat.MP4
+    output_dir: Path | None = None
+    width: int = 1920
+    height: int = 1080
+    fps: int = 30
+    duration_seconds: float | None = None
+    allowed_adapters: frozenset[FrameAdapter] = DEFAULT_ALLOWED_ADAPTERS
+    timeout_seconds: float = 300.0
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.run_id:
+            msg = "RenderRequest.run_id must be a non-empty string"
+            raise ValueError(msg)
+        if self.html_path is None and self.html_text is None:
+            msg = "RenderRequest needs either html_path or html_text"
+            raise ValueError(msg)
+        if self.html_path is not None and self.html_text is not None:
+            msg = "RenderRequest cannot carry both html_path and html_text"
+            raise ValueError(msg)
+        if self.width < 16 or self.height < 16:
+            msg = "RenderRequest width / height must be >= 16"
+            raise ValueError(msg)
+        if self.fps < 1 or self.fps > 240:
+            msg = "RenderRequest fps must be in [1, 240]"
+            raise ValueError(msg)
+        if self.timeout_seconds <= 0:
+            msg = "RenderRequest timeout_seconds must be > 0"
+            raise ValueError(msg)
+        if self.duration_seconds is not None and self.duration_seconds <= 0:
+            msg = "RenderRequest duration_seconds must be > 0 when set"
+            raise ValueError(msg)
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RenderResult:
+    """Successful render output."""
+
+    run_id: str
+    output_path: Path
+    output_format: OutputFormat
+    duration_ms: int
+    width: int
+    height: int
+    fps: int
+    bytes_written: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """JSON-serialisable wire shape for MCP responses + audit entries."""
+
+        return {
+            "run_id": self.run_id,
+            "output_path": str(self.output_path),
+            "output_format": self.output_format.value,
+            "duration_ms": self.duration_ms,
+            "width": self.width,
+            "height": self.height,
+            "fps": self.fps,
+            "bytes_written": self.bytes_written,
+        }
+
+
+class RenderError(RuntimeError):
+    """Raised by every renderer when a render cannot complete.
+
+    Carries the same ``run_id`` the request did so the caller can
+    correlate the failure with the originating agent run / TRUST-1
+    receipt, plus an optional ``stderr_excerpt`` (truncated to 500
+    chars) for the audit trail.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        run_id: str,
+        stderr_excerpt: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.run_id = run_id
+        self.stderr_excerpt = (stderr_excerpt or "")[:500] or None
+
+    def __str__(self) -> str:
+        base = super().__str__()
+        if self.stderr_excerpt:
+            return f"{base}\n--- stderr (truncated) ---\n{self.stderr_excerpt}"
+        return base
+
+
+class RendererABC(ABC):
+    """Base class every renderer (HyperFrames, future Remotion, ...) implements.
+
+    Subclasses override :meth:`render` to do the actual work and
+    :meth:`supported_adapters` / :meth:`name` for introspection.
+    They MUST NOT mutate the input :class:`RenderRequest` — any
+    transformation is the renderer's own internal state.
+    """
+
+    #: Short-and-stable identifier — used in the MCP tools'
+    #: ``--renderer NAME`` flag and in the registry dict below.
+    NAME: str = "abstract"
+
+    @property
+    def name(self) -> str:
+        """Convenience accessor for the class-level ``NAME``."""
+
+        return self.NAME
+
+    @abstractmethod
+    async def is_available(self) -> bool:
+        """``True`` when this renderer can satisfy requests right now.
+
+        Implementations probe whatever they need (e.g. ``npx`` on
+        PATH, a writable temp dir, a running browser pool) and
+        return a bool. Must not raise.
+        """
+
+    @abstractmethod
+    def supported_adapters(self) -> frozenset[FrameAdapter]:
+        """Adapters this renderer can load. Static — describes the binary."""
+
+    @abstractmethod
+    async def render(self, request: RenderRequest) -> RenderResult:
+        """Run the render. Raises :class:`RenderError` on any failure."""
+
+    def reject_disallowed_adapters(self, request: RenderRequest) -> None:
+        """Validate the request's adapter allowlist against the renderer's support set.
+
+        Called by concrete renderers at the top of :meth:`render` so
+        every backend uses the same enforcement. Mismatches raise
+        :class:`RenderError` so the Planner sees a single typed
+        failure rather than a renderer-specific shell error.
+        """
+
+        unsupported = request.allowed_adapters - self.supported_adapters()
+        if unsupported:
+            names = sorted(a.value for a in unsupported)
+            msg = f"renderer {self.name!r} does not support adapter(s): " + ", ".join(names)
+            raise RenderError(msg, run_id=request.run_id)

--- a/src/cognithor/video/renderers/__init__.py
+++ b/src/cognithor/video/renderers/__init__.py
@@ -1,0 +1,27 @@
+"""Concrete renderers + dispatch registry (HF-2).
+
+The MCP tools shipped in HF-3 dispatch to a renderer by string
+name, so we keep a single source-of-truth registry here. Future
+renderers (Remotion, homegrown, cloud) add a single line to
+:data:`renderer_registry`.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from cognithor.video.renderers.hyperframes import HyperFramesRenderer
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from cognithor.video.renderer_base import RendererABC
+
+#: Registry of available renderer factories, keyed by short
+#: identifier. Stays a plain dict so callers can introspect /
+#: extend it for tests without touching production code.
+renderer_registry: Final[dict[str, Callable[[], RendererABC]]] = {
+    HyperFramesRenderer.NAME: HyperFramesRenderer,
+}
+
+__all__ = ["HyperFramesRenderer", "renderer_registry"]

--- a/src/cognithor/video/renderers/hyperframes.py
+++ b/src/cognithor/video/renderers/hyperframes.py
@@ -1,0 +1,251 @@
+"""HyperFrames default renderer (HF-2).
+
+Apache-2.0 (per HF-1 spike). Spawns ``npx hyperframes render``
+against a sandboxed temp directory under
+``~/.cognithor/render/<run_id>/``. The Python side is intentionally
+thin — composition / scene authoring lives in the skill layer
+(HF-5); this class only takes a finished HTML and produces a
+finished MP4.
+
+Default adapter allowlist (per :data:`DEFAULT_ALLOWED_ADAPTERS`) is
+MIT-clean. GSAP is NOT in the support set unless the caller
+explicitly opts in via the request — protects paid-pack render
+paths from the GreenSock paid-tier trigger.
+
+The subprocess contract:
+
+* ``npx --yes hyperframes render <composition.html> --out <output.<fmt>>``
+* cwd = the sandbox dir
+* env = inherit
+* timeout from ``RenderRequest.timeout_seconds`` (default 300 s)
+* stdout / stderr captured; stderr (truncated) is folded into
+  :class:`RenderError` on non-zero exit.
+
+This module imports nothing renderer-specific from elsewhere in
+Cognithor — the only coupling is the ``cognithor.video.renderer_base``
+contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import shutil
+import time
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+from cognithor.video.renderer_base import (
+    FrameAdapter,
+    RendererABC,
+    RenderError,
+    RenderResult,
+)
+
+if TYPE_CHECKING:
+    from cognithor.video.renderer_base import RenderRequest
+
+log = logging.getLogger(__name__)
+
+
+# Where renders write under the user-home. Overridden in tests via
+# the ``COGNITHOR_HOME`` env var (the same convention the rest of
+# the codebase uses).
+def _render_root() -> Path:
+    """Return the canonical render-output root directory."""
+
+    home_override = os.environ.get("COGNITHOR_HOME")
+    base = Path(home_override).expanduser() if home_override else Path.home() / ".cognithor"
+    return base / "render"
+
+
+# Set of adapters this renderer is willing to load. GSAP is in the
+# *support* set (HyperFrames bundles it) but not in
+# :data:`DEFAULT_ALLOWED_ADAPTERS` — the caller still has to opt in.
+_HYPERFRAMES_SUPPORTED: Final[frozenset[FrameAdapter]] = frozenset(
+    {
+        FrameAdapter.CSS,
+        FrameAdapter.WAAPI,
+        FrameAdapter.ANIME,
+        FrameAdapter.LOTTIE,
+        FrameAdapter.THREE,
+        FrameAdapter.GSAP,
+    },
+)
+
+
+class HyperFramesRenderer(RendererABC):
+    """Default renderer — HeyGen HyperFrames via ``npx``."""
+
+    NAME = "hyperframes"
+
+    def __init__(
+        self,
+        *,
+        npx_command: str = "npx",
+        node_command: str = "node",
+    ) -> None:
+        self._npx_command = npx_command
+        self._node_command = node_command
+
+    # ------------------------------------------------------------------
+    # Renderer contract
+    # ------------------------------------------------------------------
+
+    async def is_available(self) -> bool:
+        """Probe Node 22+ + npx. Returns ``False`` on any failure."""
+
+        # First — `npx` and `node` must be on PATH.
+        if shutil.which(self._npx_command) is None:
+            return False
+        if shutil.which(self._node_command) is None:
+            return False
+
+        # Second — Node major must be 22+ (HF spec).
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self._node_command,
+                "--version",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout_b, _ = await asyncio.wait_for(proc.communicate(), timeout=10.0)
+        except (OSError, TimeoutError):
+            return False
+
+        version = stdout_b.decode("utf-8", errors="replace").strip().lstrip("v")
+        major_part = version.split(".", 1)[0]
+        try:
+            major = int(major_part)
+        except ValueError:
+            return False
+        return major >= 22
+
+    def supported_adapters(self) -> frozenset[FrameAdapter]:
+        return _HYPERFRAMES_SUPPORTED
+
+    async def render(self, request: RenderRequest) -> RenderResult:
+        # Adapter-allowlist gate (default disables GSAP for paid
+        # paths; caller-supplied allowlist still has to be a subset
+        # of what HyperFrames itself supports).
+        self.reject_disallowed_adapters(request)
+
+        sandbox = self._prepare_sandbox(request.run_id)
+        try:
+            html_path = self._materialize_html(request, sandbox)
+            output_path = self._resolve_output_path(request, sandbox)
+            started = time.monotonic()
+            await self._spawn_render(
+                html_path=html_path,
+                output_path=output_path,
+                request=request,
+            )
+            duration_ms = int((time.monotonic() - started) * 1000)
+            return RenderResult(
+                run_id=request.run_id,
+                output_path=output_path,
+                output_format=request.output_format,
+                duration_ms=duration_ms,
+                width=request.width,
+                height=request.height,
+                fps=request.fps,
+                bytes_written=output_path.stat().st_size,
+            )
+        except RenderError:
+            raise
+        except (OSError, TimeoutError) as exc:
+            msg = f"hyperframes render: {type(exc).__name__}: {exc}"
+            raise RenderError(msg, run_id=request.run_id) from exc
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _prepare_sandbox(self, run_id: str) -> Path:
+        """Create + return ``~/.cognithor/render/<run_id>/`` cleanly."""
+
+        sandbox = _render_root() / run_id
+        sandbox.mkdir(parents=True, exist_ok=True)
+        return sandbox
+
+    def _materialize_html(self, request: RenderRequest, sandbox: Path) -> Path:
+        """Return a path to the composition HTML inside the sandbox.
+
+        When ``html_path`` is supplied, it is copied into the
+        sandbox so the renderer's cwd contains a stable filename
+        the operator can find later. When ``html_text`` is supplied,
+        it is written to ``composition.html``.
+        """
+
+        target = sandbox / "composition.html"
+        if request.html_path is not None:
+            target.write_text(
+                Path(request.html_path).read_text(encoding="utf-8"),
+                encoding="utf-8",
+            )
+        else:
+            assert request.html_text is not None  # invariant from RenderRequest
+            target.write_text(request.html_text, encoding="utf-8")
+        return target
+
+    def _resolve_output_path(self, request: RenderRequest, sandbox: Path) -> Path:
+        """Where the renderer should write the MP4 / MOV / WebM."""
+
+        out_dir = request.output_dir or sandbox
+        out_dir.mkdir(parents=True, exist_ok=True)
+        return out_dir / f"render.{request.output_format.value}"
+
+    async def _spawn_render(
+        self,
+        *,
+        html_path: Path,
+        output_path: Path,
+        request: RenderRequest,
+    ) -> None:
+        """Run ``npx hyperframes render``. Raises :class:`RenderError` on failure."""
+
+        argv = [
+            self._npx_command,
+            "--yes",
+            "hyperframes",
+            "render",
+            str(html_path),
+            "--out",
+            str(output_path),
+        ]
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=html_path.parent,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        try:
+            stdout_b, stderr_b = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=request.timeout_seconds,
+            )
+        except TimeoutError as exc:
+            with contextlib.suppress(ProcessLookupError):
+                proc.kill()
+            msg = f"hyperframes render timed out after {request.timeout_seconds}s"
+            raise RenderError(msg, run_id=request.run_id) from exc
+
+        if proc.returncode != 0:
+            stderr_text = stderr_b.decode("utf-8", errors="replace")
+            msg = f"hyperframes render exited with code {proc.returncode}"
+            raise RenderError(
+                msg,
+                run_id=request.run_id,
+                stderr_excerpt=stderr_text,
+            )
+
+        if not output_path.exists():
+            stdout_text = stdout_b.decode("utf-8", errors="replace")
+            msg = f"hyperframes render claimed success but {output_path} is missing"
+            raise RenderError(
+                msg,
+                run_id=request.run_id,
+                stderr_excerpt=stdout_text,
+            )

--- a/tests/test_video/test_hyperframes_renderer.py
+++ b/tests/test_video/test_hyperframes_renderer.py
@@ -1,0 +1,277 @@
+"""Tests for the default :class:`HyperFramesRenderer`.
+
+The real ``npx hyperframes render`` is not invoked in CI. These
+tests pin the subprocess contract via a tiny shim binary written
+into ``tmp_path`` and used as a stand-in for ``npx``. The shim
+simulates HyperFrames by writing a fake MP4 byte sequence to the
+``--out`` path, then exits 0. Failure paths swap in a shim that
+exits non-zero.
+"""
+
+from __future__ import annotations
+
+import platform
+import stat
+import sys
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cognithor.video.renderer_base import (
+    FrameAdapter,
+    OutputFormat,
+    RenderError,
+    RenderRequest,
+)
+from cognithor.video.renderers.hyperframes import HyperFramesRenderer
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_fake_npx_shim(
+    tmp_path: Path,
+    *,
+    exit_code: int = 0,
+    write_output: bool = True,
+    stderr_text: str = "",
+) -> Path:
+    """Write a minimal Python script + thin wrapper that mimics ``npx``.
+
+    The shim parses ``hyperframes render <html> --out <output>``
+    from sys.argv, writes a tiny fake MP4 to the output path (or
+    skips it to test the missing-output failure mode), and exits
+    with the requested code.
+    """
+
+    py_path = tmp_path / "fake_npx.py"
+    py_path.write_text(
+        textwrap.dedent(
+            f"""
+            import sys, pathlib
+            argv = sys.argv[1:]
+            try:
+                out_idx = argv.index("--out")
+                out_path = pathlib.Path(argv[out_idx + 1])
+            except (ValueError, IndexError):
+                sys.stderr.write("fake_npx: missing --out\\n")
+                sys.exit(2)
+            if {write_output!r}:
+                out_path.parent.mkdir(parents=True, exist_ok=True)
+                out_path.write_bytes(b"fake-mp4-bytes")
+            if {stderr_text!r}:
+                sys.stderr.write({stderr_text!r})
+            sys.exit({exit_code})
+            """,
+        ).strip(),
+        encoding="utf-8",
+    )
+    if platform.system() == "Windows":
+        wrapper = tmp_path / "fake_npx.cmd"
+        wrapper.write_text(
+            f'@echo off\r\n"{sys.executable}" "{py_path}" %*\r\n',
+            encoding="utf-8",
+        )
+        return wrapper
+    wrapper = tmp_path / "fake_npx"
+    wrapper.write_text(
+        f'#!/bin/sh\nexec "{sys.executable}" "{py_path}" "$@"\n',
+        encoding="utf-8",
+    )
+    wrapper.chmod(wrapper.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return wrapper
+
+
+@pytest.fixture
+def cognithor_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Sandbox the render-output root under tmp_path."""
+
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("COGNITHOR_HOME", str(home))
+    return home
+
+
+# ---------------------------------------------------------------------------
+# render() happy-path
+# ---------------------------------------------------------------------------
+
+
+class TestRenderHappy:
+    @pytest.mark.asyncio
+    async def test_inline_html_renders_to_mp4(
+        self,
+        tmp_path: Path,
+        cognithor_home: Path,
+    ) -> None:
+        shim = _write_fake_npx_shim(tmp_path)
+        renderer = HyperFramesRenderer(npx_command=str(shim))
+
+        req = RenderRequest(
+            run_id="run-A",
+            html_text='<div data-composition-id="x"></div>',
+            output_format=OutputFormat.MP4,
+            timeout_seconds=10.0,
+        )
+        result = await renderer.render(req)
+
+        assert result.run_id == "run-A"
+        assert result.output_format == OutputFormat.MP4
+        assert result.bytes_written == len(b"fake-mp4-bytes")
+        assert result.output_path.exists()
+        # Sandbox lives under ~/.cognithor/render/<run_id>/
+        assert "run-A" in str(result.output_path)
+        assert result.output_path.parent.is_relative_to(cognithor_home)
+
+    @pytest.mark.asyncio
+    async def test_html_path_input_is_copied_into_sandbox(
+        self,
+        tmp_path: Path,
+        cognithor_home: Path,
+    ) -> None:
+        shim = _write_fake_npx_shim(tmp_path)
+        external_html = tmp_path / "external.html"
+        external_html.write_text('<div data-composition-id="ext"></div>', encoding="utf-8")
+
+        renderer = HyperFramesRenderer(npx_command=str(shim))
+        req = RenderRequest(
+            run_id="run-B",
+            html_path=external_html,
+            timeout_seconds=10.0,
+        )
+        result = await renderer.render(req)
+        # Sandboxed composition.html must exist with the original content.
+        sandbox = cognithor_home / "render" / "run-B"
+        assert (sandbox / "composition.html").exists()
+        assert (sandbox / "composition.html").read_text(
+            encoding="utf-8"
+        ) == '<div data-composition-id="ext"></div>'
+        assert result.output_path.exists()
+
+
+# ---------------------------------------------------------------------------
+# render() failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestRenderFailure:
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_raises_render_error(
+        self,
+        tmp_path: Path,
+        cognithor_home: Path,
+    ) -> None:
+        shim = _write_fake_npx_shim(
+            tmp_path,
+            exit_code=3,
+            write_output=False,
+            stderr_text="boom from fake_npx\n",
+        )
+        renderer = HyperFramesRenderer(npx_command=str(shim))
+        req = RenderRequest(run_id="run-C", html_text="<div/>", timeout_seconds=10.0)
+        with pytest.raises(RenderError) as exc_info:
+            await renderer.render(req)
+        err = exc_info.value
+        assert err.run_id == "run-C"
+        assert err.stderr_excerpt is not None
+        assert "boom" in err.stderr_excerpt
+
+    @pytest.mark.asyncio
+    async def test_missing_output_raises_even_on_zero_exit(
+        self,
+        tmp_path: Path,
+        cognithor_home: Path,
+    ) -> None:
+        shim = _write_fake_npx_shim(tmp_path, exit_code=0, write_output=False)
+        renderer = HyperFramesRenderer(npx_command=str(shim))
+        req = RenderRequest(run_id="run-D", html_text="<div/>", timeout_seconds=10.0)
+        with pytest.raises(RenderError, match="missing"):
+            await renderer.render(req)
+
+    @pytest.mark.asyncio
+    async def test_disallowed_gsap_adapter_rejected(
+        self,
+        tmp_path: Path,
+        cognithor_home: Path,
+    ) -> None:
+        shim = _write_fake_npx_shim(tmp_path)
+        renderer = HyperFramesRenderer(npx_command=str(shim))
+        # Caller asks for an adapter HyperFrames *can* support
+        # (GSAP) but it's not in the request's allowlist — should
+        # still pass since the request is the source-of-truth for
+        # allowlist. To trigger rejection, ask for something the
+        # *renderer* cannot support.
+        # Inject a non-existent adapter to simulate that case.
+        # FrameAdapter is closed StrEnum; use an existing adapter
+        # not in the renderer's support set by patching support.
+        renderer._supported_override = frozenset({FrameAdapter.CSS})  # type: ignore[attr-defined]
+
+        # Replace supported_adapters via subclass-style monkey:
+        original = HyperFramesRenderer.supported_adapters
+
+        def restricted(self: HyperFramesRenderer) -> frozenset[FrameAdapter]:
+            return frozenset({FrameAdapter.CSS})
+
+        HyperFramesRenderer.supported_adapters = restricted  # type: ignore[method-assign]
+        try:
+            req = RenderRequest(
+                run_id="run-E",
+                html_text="<div/>",
+                timeout_seconds=10.0,
+                allowed_adapters=frozenset({FrameAdapter.CSS, FrameAdapter.LOTTIE}),
+            )
+            with pytest.raises(RenderError, match="lottie"):
+                await renderer.render(req)
+        finally:
+            HyperFramesRenderer.supported_adapters = original  # type: ignore[method-assign]
+
+
+# ---------------------------------------------------------------------------
+# is_available probing
+# ---------------------------------------------------------------------------
+
+
+class TestAvailability:
+    @pytest.mark.asyncio
+    async def test_npx_missing_returns_false(self) -> None:
+        renderer = HyperFramesRenderer(
+            npx_command="this-binary-does-not-exist-zxqv",
+            node_command="this-binary-does-not-exist-zxqv",
+        )
+        assert (await renderer.is_available()) is False
+
+    @pytest.mark.asyncio
+    async def test_node_below_22_returns_false(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Fake `node --version` outputting v20.x → treated as unavailable."""
+
+        # Simple shim that prints v20.10.0 and exits 0.
+        py_path = tmp_path / "fake_node.py"
+        py_path.write_text('print("v20.10.0")\n', encoding="utf-8")
+        if platform.system() == "Windows":
+            wrap = tmp_path / "fake_node.cmd"
+            wrap.write_text(
+                f'@echo off\r\n"{sys.executable}" "{py_path}" %*\r\n',
+                encoding="utf-8",
+            )
+        else:
+            wrap = tmp_path / "fake_node"
+            wrap.write_text(
+                f'#!/bin/sh\nexec "{sys.executable}" "{py_path}"\n',
+                encoding="utf-8",
+            )
+            wrap.chmod(
+                wrap.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH,
+            )
+
+        # We also need an existing `npx` for the check to even reach
+        # the node-version branch — reuse the same fake_node as a stand-in
+        # since `which` only looks for existence.
+        renderer = HyperFramesRenderer(
+            npx_command=str(wrap),
+            node_command=str(wrap),
+        )
+        assert (await renderer.is_available()) is False

--- a/tests/test_video/test_renderer_base.py
+++ b/tests/test_video/test_renderer_base.py
@@ -1,0 +1,205 @@
+"""Tests for `cognithor.video.renderer_base` — wire-types + ABC contract."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cognithor.video.renderer_base import (
+    DEFAULT_ALLOWED_ADAPTERS,
+    FrameAdapter,
+    OutputFormat,
+    RendererABC,
+    RenderError,
+    RenderRequest,
+    RenderResult,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# RenderRequest validation
+# ---------------------------------------------------------------------------
+
+
+class TestRenderRequest:
+    def test_html_path_only_is_valid(self, tmp_path: Path) -> None:
+        html = tmp_path / "comp.html"
+        html.write_text("<div></div>", encoding="utf-8")
+        req = RenderRequest(run_id="r1", html_path=html)
+        assert req.html_path == html
+        assert req.html_text is None
+        assert req.output_format == OutputFormat.MP4
+        assert req.allowed_adapters == DEFAULT_ALLOWED_ADAPTERS
+
+    def test_html_text_only_is_valid(self) -> None:
+        req = RenderRequest(run_id="r1", html_text="<div></div>")
+        assert req.html_text == "<div></div>"
+
+    def test_run_id_required(self) -> None:
+        with pytest.raises(ValueError, match="run_id"):
+            RenderRequest(run_id="", html_text="<div></div>")
+
+    def test_must_have_html_source(self) -> None:
+        with pytest.raises(ValueError, match="html_path or html_text"):
+            RenderRequest(run_id="r1")
+
+    def test_cannot_have_both_html_sources(self, tmp_path: Path) -> None:
+        html = tmp_path / "comp.html"
+        html.write_text("x", encoding="utf-8")
+        with pytest.raises(ValueError, match="cannot carry both"):
+            RenderRequest(run_id="r1", html_path=html, html_text="<div/>")
+
+    def test_dimensions_floor(self) -> None:
+        with pytest.raises(ValueError, match=">= 16"):
+            RenderRequest(run_id="r1", html_text="<div/>", width=4, height=4)
+
+    def test_fps_range(self) -> None:
+        with pytest.raises(ValueError, match=r"\[1, 240\]"):
+            RenderRequest(run_id="r1", html_text="<div/>", fps=0)
+        with pytest.raises(ValueError, match=r"\[1, 240\]"):
+            RenderRequest(run_id="r1", html_text="<div/>", fps=300)
+
+    def test_timeout_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="timeout_seconds"):
+            RenderRequest(run_id="r1", html_text="<div/>", timeout_seconds=0)
+
+    def test_duration_when_set_must_be_positive(self) -> None:
+        with pytest.raises(ValueError, match="duration_seconds"):
+            RenderRequest(
+                run_id="r1",
+                html_text="<div/>",
+                duration_seconds=-1.0,
+            )
+
+    def test_default_adapters_excludes_gsap(self) -> None:
+        # HF-1 spike decision — GSAP off by default.
+        assert FrameAdapter.GSAP not in DEFAULT_ALLOWED_ADAPTERS
+        # MIT adapters are on by default.
+        for adapter in (
+            FrameAdapter.CSS,
+            FrameAdapter.WAAPI,
+            FrameAdapter.ANIME,
+            FrameAdapter.LOTTIE,
+            FrameAdapter.THREE,
+        ):
+            assert adapter in DEFAULT_ALLOWED_ADAPTERS
+
+
+# ---------------------------------------------------------------------------
+# RenderResult.to_dict round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestRenderResult:
+    def test_to_dict_shape(self, tmp_path: Path) -> None:
+        out = tmp_path / "render.mp4"
+        out.write_bytes(b"fake")
+        result = RenderResult(
+            run_id="r1",
+            output_path=out,
+            output_format=OutputFormat.MP4,
+            duration_ms=4321,
+            width=1920,
+            height=1080,
+            fps=30,
+            bytes_written=4,
+        )
+        d = result.to_dict()
+        assert d == {
+            "run_id": "r1",
+            "output_path": str(out),
+            "output_format": "mp4",
+            "duration_ms": 4321,
+            "width": 1920,
+            "height": 1080,
+            "fps": 30,
+            "bytes_written": 4,
+        }
+
+
+# ---------------------------------------------------------------------------
+# RenderError carries run_id + truncates stderr
+# ---------------------------------------------------------------------------
+
+
+class TestRenderError:
+    def test_str_without_stderr(self) -> None:
+        err = RenderError("boom", run_id="r1")
+        s = str(err)
+        assert "boom" in s
+        assert "stderr" not in s
+
+    def test_str_with_stderr(self) -> None:
+        err = RenderError("boom", run_id="r1", stderr_excerpt="oh no")
+        assert "stderr" in str(err)
+        assert "oh no" in str(err)
+
+    def test_stderr_truncated_to_500(self) -> None:
+        long = "x" * 1000
+        err = RenderError("boom", run_id="r1", stderr_excerpt=long)
+        assert err.stderr_excerpt is not None
+        assert len(err.stderr_excerpt) == 500
+
+    def test_empty_stderr_becomes_none(self) -> None:
+        err = RenderError("boom", run_id="r1", stderr_excerpt="")
+        assert err.stderr_excerpt is None
+
+
+# ---------------------------------------------------------------------------
+# RendererABC.reject_disallowed_adapters helper
+# ---------------------------------------------------------------------------
+
+
+class _StubRenderer(RendererABC):
+    NAME = "stub"
+
+    def __init__(self, supported: frozenset[FrameAdapter]) -> None:
+        self._supported = supported
+
+    async def is_available(self) -> bool:
+        return True
+
+    def supported_adapters(self) -> frozenset[FrameAdapter]:
+        return self._supported
+
+    async def render(self, request: RenderRequest) -> RenderResult:  # pragma: no cover
+        msg = "stub does not actually render"
+        raise NotImplementedError(msg)
+
+
+class TestAdapterEnforcement:
+    def test_allowed_subset_passes(self) -> None:
+        renderer = _StubRenderer(supported=DEFAULT_ALLOWED_ADAPTERS)
+        req = RenderRequest(
+            run_id="r1",
+            html_text="<div/>",
+            allowed_adapters=DEFAULT_ALLOWED_ADAPTERS,
+        )
+        # Should NOT raise.
+        renderer.reject_disallowed_adapters(req)
+
+    def test_disallowed_adapter_raises(self) -> None:
+        renderer = _StubRenderer(
+            supported=frozenset({FrameAdapter.CSS}),
+        )
+        req = RenderRequest(
+            run_id="r1",
+            html_text="<div/>",
+            allowed_adapters=frozenset({FrameAdapter.CSS, FrameAdapter.GSAP}),
+        )
+        with pytest.raises(RenderError, match="gsap"):
+            renderer.reject_disallowed_adapters(req)
+
+    def test_render_error_carries_run_id(self) -> None:
+        renderer = _StubRenderer(supported=frozenset())
+        req = RenderRequest(
+            run_id="some-run-id",
+            html_text="<div/>",
+            allowed_adapters=frozenset({FrameAdapter.CSS}),
+        )
+        with pytest.raises(RenderError) as exc_info:
+            renderer.reject_disallowed_adapters(req)
+        assert exc_info.value.run_id == "some-run-id"


### PR DESCRIPTION
## Sprint-27 HF-2 — \`cognithor.video\` package

First Python-side track of the HyperFrames integration kicked off 2026-05-04 evening. Per Option C in the [HF-1 spike doc](docs/superpowers/spikes/2026-05-04-hyperframes-spike.md), ships a thin renderer-agnostic abstraction with HyperFrames as the default backend so future renderers (Remotion, homegrown, cloud) can be swapped in via a single registry-line change without touching the MCP-tool layer that lands in HF-3.

## What ships

| File | Purpose |
|---|---|
| \`cognithor/video/renderer_base.py\` | \`RendererABC\`, \`RenderRequest\`/\`RenderResult\`/\`RenderError\`, \`OutputFormat\`+\`FrameAdapter\` enums, \`DEFAULT_ALLOWED_ADAPTERS\` (GSAP-excluded by default — GreenSock-paid-tier dodge per HF-1 spike) |
| \`cognithor/video/renderers/hyperframes.py\` | \`HyperFramesRenderer\` — \`npx --yes hyperframes render\` subprocess, sandboxed under \`~/.cognithor/render/<run_id>/\`, Node 22+ probe, timeout-aware, post-success file-existence check |
| \`cognithor/video/renderers/__init__.py\` | \`renderer_registry\` dict for HF-3's MCP-tool dispatch |
| \`tests/test_video/test_renderer_base.py\` | wire-type validation, adapter enforcement, RenderError truncation |
| \`tests/test_video/test_hyperframes_renderer.py\` | fake-npx shim for happy + failure paths (Linux + Windows), is_available probe |

## Quality

- ✅ mypy --strict — clean (4 source files)
- ✅ ruff check + ruff format --check — clean (full src/ + tests/)
- ✅ pytest tests/test_video/ — **25/25 passing**

## What does NOT ship in this PR (deferred to HF-3..HF-5)

- \`video_compose\` + \`video_render\` MCP tools (#129)
- TRUST-9 provenance + cost-ledger wiring (#130)
- Skill layer with explainer / social-cut / caption-overlay templates (#131)

## Refs

- HF-1 spike: \`docs/superpowers/spikes/2026-05-04-hyperframes-spike.md\`
- Sprint-27 plan + decisions memo: see Phase-1 PRs (#438, #439, #440)
- Builds on Phase-1 — no runtime coupling, just convention parity (frozen-dataclass + StrEnum + JSON-serialisable wire types).