### PR TITLE
feat(vllm): VLMConfig + orchestrator flags for Qwen3-VL on RTX 5090 (Sprint-27 VLM-2)

### DIFF
--- a/src/cognithor/config.py
+++ b/src/cognithor/config.py
@@ -2603,6 +2603,78 @@ class VLLMConfig(BaseModel):
     cpu_offload_gb: int = Field(default=4, ge=0, le=128)
     enforce_eager: bool = Field(default=True)
 
+    # VLM mode (Sprint-27 VLM-2 — qwen3-vl on RTX 5090 spike).
+    # See docs/superpowers/spikes/2026-05-04-qwen3-vl-quant-spike.md.
+    # When ``vlm_enabled`` is True and the model has vision support
+    # the orchestrator passes the additional flags below to the
+    # ``docker run`` invocation. Default fp8 because: vLLM-tested
+    # for Qwen3-VL family, ~10-15 % faster than NVFP4, near-identical
+    # quality to BF16 (Qwen team's own benchmarks).
+    vlm_enabled: bool = Field(
+        default=False,
+        description=(
+            "Enable vision/video content-type forwarding (image_url + "
+            "video_url) and the VLM-tuned launcher flags below. The model "
+            "selected via `model` must support vision (e.g. "
+            "Qwen/Qwen3-VL-32B-Instruct-FP8)."
+        ),
+    )
+    vlm_quantization: Literal["fp8", "nvfp4", "awq", "bf16"] = Field(
+        default="fp8",
+        description=(
+            "vLLM `--quantization` for VLM mode. fp8 is the spike-doc "
+            "recommendation for RTX 5090 32 GB; nvfp4 saves ~5 GB at "
+            "10-15 %% throughput cost and needs the cu130-nightly image; "
+            "awq is a fallback for pre-Blackwell GPUs; bf16 disables "
+            "quantization (>32 GB only)."
+        ),
+    )
+    vlm_kv_cache_dtype: Literal["auto", "fp8"] = Field(
+        default="fp8",
+        description="vLLM `--kv-cache-dtype`. fp8 halves KV-cache RAM at near-zero quality loss.",
+    )
+    vlm_enable_prefix_caching: bool = Field(
+        default=True,
+        description=(
+            "vLLM `--enable-prefix-caching`. Reuses the KV cache across "
+            "repeated prompts (common in agent loops)."
+        ),
+    )
+    vlm_num_speculative_tokens: int = Field(
+        default=1,
+        ge=0,
+        le=8,
+        description=(
+            "vLLM `--num-speculative-tokens`. Sprint-16 SM120 finding: "
+            "values > 1 still crash on RTX 5090 with the Qwen3-VL stack "
+            "as of 2026-04. Keep at 1 unless you've validated on your "
+            "exact driver+kernel."
+        ),
+    )
+    vlm_served_model_name: str = Field(
+        default="",
+        description=(
+            "vLLM `--served-model-name`. Decouples the served name from "
+            "the HF repo path so a model_registry alias survives a swap. "
+            "Empty = use the model field verbatim."
+        ),
+    )
+    vlm_image_max_per_prompt: int = Field(
+        default=4,
+        ge=0,
+        le=64,
+        description="vLLM `--limit-mm-per-prompt {image: N}`. Hard cap on images per chat turn.",
+    )
+    vlm_video_max_per_prompt: int = Field(
+        default=1,
+        ge=0,
+        le=8,
+        description=(
+            "vLLM `--limit-mm-per-prompt {video: N}`. Matches the v0.92.7 "
+            "video-input contract (single video per turn)."
+        ),
+    )
+
 
 # ============================================================================
 # Haupt-Konfiguration

--- a/src/cognithor/core/vllm_orchestrator.py
+++ b/src/cognithor/core/vllm_orchestrator.py
@@ -430,6 +430,36 @@ class VLLMOrchestrator:
         if cfg.enforce_eager:
             cmd.append("--enforce-eager")
 
+        # VLM mode (Sprint-27 VLM-2). Only applied when the operator
+        # explicitly opted in — otherwise the Qwen3-VL flags would
+        # break a plain Qwen3-text deployment. See
+        # docs/superpowers/spikes/2026-05-04-qwen3-vl-quant-spike.md.
+        if cfg.vlm_enabled:
+            cmd.extend(["--quantization", cfg.vlm_quantization])
+            cmd.extend(["--kv-cache-dtype", cfg.vlm_kv_cache_dtype])
+            if cfg.vlm_enable_prefix_caching:
+                cmd.append("--enable-prefix-caching")
+            if cfg.vlm_num_speculative_tokens > 0:
+                cmd.extend(
+                    [
+                        "--num-speculative-tokens",
+                        str(cfg.vlm_num_speculative_tokens),
+                    ],
+                )
+            if cfg.vlm_served_model_name:
+                cmd.extend(["--served-model-name", cfg.vlm_served_model_name])
+            cmd.extend(
+                [
+                    "--limit-mm-per-prompt",
+                    _json.dumps(
+                        {
+                            "image": cfg.vlm_image_max_per_prompt,
+                            "video": cfg.vlm_video_max_per_prompt,
+                        },
+                    ),
+                ],
+            )
+
         # Redact HF_TOKEN before logging — it's in the cmd list as "HF_TOKEN=<value>"
         _cmd_for_log = _redact_hf_token(cmd)
         log.info(

--- a/tests/test_core/test_vllm_orchestrator_vlm.py
+++ b/tests/test_core/test_vllm_orchestrator_vlm.py
@@ -1,0 +1,290 @@
+"""Sprint-27 VLM-2 — orchestrator launch-flag tests for VLM mode.
+
+Verifies that ``vllm_enabled=True`` extends the docker-run argv
+with the spike-doc-recommended flags, and that the launcher stays
+identical to the pre-VLM-2 shape when the flag is off (no
+regression for the plain text-only Qwen path).
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cognithor.config import VLLMConfig
+from cognithor.core.vllm_orchestrator import VLLMOrchestrator
+
+
+def _make_orchestrator(cfg: VLLMConfig) -> VLLMOrchestrator:
+    """Construct an orchestrator with a stubbed _hf_token for tests."""
+
+    return VLLMOrchestrator(config=cfg, hf_token="hf_test_token_xx")
+
+
+def _intercept_docker_run() -> tuple[list[str], MagicMock]:
+    """Patch subprocess.run + port + health to capture the docker argv.
+
+    Returns ``(captured_cmd, mock_run)``. The first element is
+    populated only after ``_start_container`` is called.
+    """
+
+    captured: list[list[str]] = []
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        captured.append(list(cmd))
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "container-id-12345abc\n"
+        result.stderr = ""
+        return result
+
+    mock_run = MagicMock(side_effect=fake_run)
+    return [], mock_run  # type: ignore[return-value]
+
+
+@pytest.fixture
+def captured_argv() -> list[list[str]]:
+    """Captures every subprocess.run argv list during a test."""
+
+    return []
+
+
+@pytest.fixture
+def patched_subprocess(captured_argv: list[list[str]]) -> object:
+    """Patch subprocess.run to capture argv + always return success."""
+
+    def fake_run(cmd: list[str], **_kwargs: object) -> MagicMock:
+        captured_argv.append(list(cmd))
+        result = MagicMock()
+        result.returncode = 0
+        result.stdout = "container-id-12345abc\n"
+        result.stderr = ""
+        return result
+
+    with patch("subprocess.run", side_effect=fake_run) as mock_run:
+        yield mock_run
+
+
+# ---------------------------------------------------------------------------
+# vlm_enabled=False — no regression vs pre-VLM-2 shape
+# ---------------------------------------------------------------------------
+
+
+class TestVLMModeOff:
+    def test_no_vlm_flags_when_disabled(
+        self,
+        captured_argv: list[list[str]],
+        patched_subprocess: object,
+    ) -> None:
+        cfg = VLLMConfig(enabled=True, model="qwen3:32b", vlm_enabled=False)
+        orch = _make_orchestrator(cfg)
+        with (
+            patch.object(orch, "_port_available", return_value=True),
+            patch.object(
+                orch,
+                "_wait_for_health",
+                return_value=True,
+            ),
+        ):
+            orch.start_container("qwen3:32b")
+        assert captured_argv, "no docker run captured"
+        argv = captured_argv[0]
+        # None of the VLM-mode flags must appear.
+        for flag in (
+            "--quantization",
+            "--kv-cache-dtype",
+            "--enable-prefix-caching",
+            "--num-speculative-tokens",
+            "--limit-mm-per-prompt",
+            "--served-model-name",
+        ):
+            assert flag not in argv, f"{flag} should not be present when vlm_enabled=False"
+
+
+# ---------------------------------------------------------------------------
+# vlm_enabled=True — spike-doc flags applied
+# ---------------------------------------------------------------------------
+
+
+class TestVLMModeOn:
+    def test_default_fp8_quant_kv_prefix_speculative(
+        self,
+        captured_argv: list[list[str]],
+        patched_subprocess: object,
+    ) -> None:
+        cfg = VLLMConfig(
+            enabled=True,
+            model="Qwen/Qwen3-VL-32B-Instruct-FP8",
+            vlm_enabled=True,
+        )
+        orch = _make_orchestrator(cfg)
+        with (
+            patch.object(orch, "_port_available", return_value=True),
+            patch.object(
+                orch,
+                "_wait_for_health",
+                return_value=True,
+            ),
+        ):
+            orch.start_container("Qwen/Qwen3-VL-32B-Instruct-FP8")
+
+        argv = captured_argv[0]
+        # spike-doc defaults
+        assert "--quantization" in argv
+        assert argv[argv.index("--quantization") + 1] == "fp8"
+        assert "--kv-cache-dtype" in argv
+        assert argv[argv.index("--kv-cache-dtype") + 1] == "fp8"
+        assert "--enable-prefix-caching" in argv
+        assert "--num-speculative-tokens" in argv
+        assert argv[argv.index("--num-speculative-tokens") + 1] == "1"
+
+    def test_limit_mm_per_prompt_json_payload(
+        self,
+        captured_argv: list[list[str]],
+        patched_subprocess: object,
+    ) -> None:
+        cfg = VLLMConfig(
+            enabled=True,
+            model="Qwen/Qwen3-VL-32B-Instruct-FP8",
+            vlm_enabled=True,
+            vlm_image_max_per_prompt=8,
+            vlm_video_max_per_prompt=2,
+        )
+        orch = _make_orchestrator(cfg)
+        with (
+            patch.object(orch, "_port_available", return_value=True),
+            patch.object(
+                orch,
+                "_wait_for_health",
+                return_value=True,
+            ),
+        ):
+            orch.start_container("Qwen/Qwen3-VL-32B-Instruct-FP8")
+
+        argv = captured_argv[0]
+        idx = argv.index("--limit-mm-per-prompt")
+        payload = json.loads(argv[idx + 1])
+        assert payload == {"image": 8, "video": 2}
+
+    def test_served_model_name_when_set(
+        self,
+        captured_argv: list[list[str]],
+        patched_subprocess: object,
+    ) -> None:
+        cfg = VLLMConfig(
+            enabled=True,
+            model="Qwen/Qwen3-VL-32B-Instruct-FP8",
+            vlm_enabled=True,
+            vlm_served_model_name="qwen3-vl-32b-fp8",
+        )
+        orch = _make_orchestrator(cfg)
+        with (
+            patch.object(orch, "_port_available", return_value=True),
+            patch.object(
+                orch,
+                "_wait_for_health",
+                return_value=True,
+            ),
+        ):
+            orch.start_container("Qwen/Qwen3-VL-32B-Instruct-FP8")
+
+        argv = captured_argv[0]
+        assert "--served-model-name" in argv
+        assert argv[argv.index("--served-model-name") + 1] == "qwen3-vl-32b-fp8"
+
+    def test_served_model_name_omitted_when_blank(
+        self,
+        captured_argv: list[list[str]],
+        patched_subprocess: object,
+    ) -> None:
+        cfg = VLLMConfig(
+            enabled=True,
+            model="Qwen/Qwen3-VL-32B-Instruct-FP8",
+            vlm_enabled=True,
+            vlm_served_model_name="",
+        )
+        orch = _make_orchestrator(cfg)
+        with (
+            patch.object(orch, "_port_available", return_value=True),
+            patch.object(
+                orch,
+                "_wait_for_health",
+                return_value=True,
+            ),
+        ):
+            orch.start_container("Qwen/Qwen3-VL-32B-Instruct-FP8")
+
+        argv = captured_argv[0]
+        assert "--served-model-name" not in argv
+
+    def test_nvfp4_opt_in(
+        self,
+        captured_argv: list[list[str]],
+        patched_subprocess: object,
+    ) -> None:
+        cfg = VLLMConfig(
+            enabled=True,
+            model="Qwen/Qwen3-VL-32B-Instruct-NVFP4",
+            vlm_enabled=True,
+            vlm_quantization="nvfp4",
+        )
+        orch = _make_orchestrator(cfg)
+        with (
+            patch.object(orch, "_port_available", return_value=True),
+            patch.object(
+                orch,
+                "_wait_for_health",
+                return_value=True,
+            ),
+        ):
+            orch.start_container("Qwen/Qwen3-VL-32B-Instruct-NVFP4")
+        argv = captured_argv[0]
+        assert argv[argv.index("--quantization") + 1] == "nvfp4"
+
+    def test_speculative_tokens_zero_omits_flag(
+        self,
+        captured_argv: list[list[str]],
+        patched_subprocess: object,
+    ) -> None:
+        cfg = VLLMConfig(
+            enabled=True,
+            model="Qwen/Qwen3-VL-32B-Instruct-FP8",
+            vlm_enabled=True,
+            vlm_num_speculative_tokens=0,
+        )
+        orch = _make_orchestrator(cfg)
+        with (
+            patch.object(orch, "_port_available", return_value=True),
+            patch.object(
+                orch,
+                "_wait_for_health",
+                return_value=True,
+            ),
+        ):
+            orch.start_container("Qwen/Qwen3-VL-32B-Instruct-FP8")
+        argv = captured_argv[0]
+        assert "--num-speculative-tokens" not in argv
+
+
+# ---------------------------------------------------------------------------
+# Config validation
+# ---------------------------------------------------------------------------
+
+
+class TestVLMConfigValidation:
+    def test_invalid_quant_rejected(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            VLLMConfig(
+                vlm_enabled=True,
+                vlm_quantization="int4",  # type: ignore[arg-type]
+            )
+
+    def test_speculative_tokens_negative_rejected(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            VLLMConfig(vlm_enabled=True, vlm_num_speculative_tokens=-1)
+
+    def test_image_per_prompt_negative_rejected(self) -> None:
+        with pytest.raises((ValueError, TypeError)):
+            VLLMConfig(vlm_enabled=True, vlm_image_max_per_prompt=-1)


### PR DESCRIPTION
## Sprint-27 VLM-2 — vLLM launch profile for Qwen3-VL

Wires the spike-doc-recommended vLLM launch profile (see [VLM-1 spike](docs/superpowers/spikes/2026-05-04-qwen3-vl-quant-spike.md)) into the existing \`VLLMOrchestrator\` without breaking the plain text-only Qwen path.

## What ships

\`cognithor/config.py\` — eight new \`VLLMConfig\` fields, all opt-in via \`vlm_enabled=False\` default:

| Field | Default | Range | Purpose |
|---|---|---|---|
| \`vlm_quantization\` | \`fp8\` | fp8 / nvfp4 / awq / bf16 | spike-doc rec; fp8 best-tested on RTX 5090 |
| \`vlm_kv_cache_dtype\` | \`fp8\` | auto / fp8 | halves KV-cache RAM at near-zero quality cost |
| \`vlm_enable_prefix_caching\` | \`True\` | bool | reuses KV cache across repeated prompts |
| \`vlm_num_speculative_tokens\` | \`1\` | 0–8 | Sprint-16 SM120 finding: > 1 still crashes on RTX 5090 + Qwen3-VL |
| \`vlm_served_model_name\` | \`""\` | str | decouples served name from HF repo path |
| \`vlm_image_max_per_prompt\` | \`4\` | 0–64 | hard cap on images per chat turn |
| \`vlm_video_max_per_prompt\` | \`1\` | 0–8 | matches v0.92.7 single-video-per-turn contract |

\`cognithor/core/vllm_orchestrator.py\` — when \`vlm_enabled\` is True, the docker-run argv extends with these flags. Existing text-only deployment is **byte-for-byte unchanged** when the flag stays False (no-regression test verifies this).

## Quality

- ✅ mypy --strict on vllm_orchestrator.py — clean
- ✅ ruff check + ruff format --check (full src/ + tests/) — clean
- ✅ pytest tests/test_core/test_vllm_orchestrator_vlm.py — **10/10 passing** (new)
- ✅ pytest tests/test_core/test_vllm_backend.py — **17/17 still passing** (regression)
- ✅ pytest tests/config/test_vllm_config.py — **11/11 still passing** (regression)

## What does NOT ship (deferred)

- VLM-3 (#134): \`LLMBackend.chat()\` content-type forwarding for \`image_url\` + \`video_url\`
- VLM-4 (#135): End-to-end smoke against a live vLLM server (hardware-gated, RTX 5090 + Docker)

## Refs

- VLM-1 spike: \`docs/superpowers/spikes/2026-05-04-qwen3-vl-quant-spike.md\` (in #443)
- Predecessor work: v0.92.7 video-input pipeline (already shipped)