### PR TITLE
feat(mcp): video_compose + video_render MCP tools (Sprint-27 HF-3)

### DIFF
--- a/docs/integrations/catalog.json
+++ b/docs/integrations/catalog.json
@@ -1,12 +1,19 @@
 {
-  "generated_at": "2026-05-04T08:34:03.675150+00:00",
-  "tool_count": 136,
+  "generated_at": "2026-05-04T21:13:19.760020+00:00",
+  "tool_count": 138,
   "tools": [
     {
       "name": "file_write",
       "module": "cognithor.mcp.filesystem",
       "category": "filesystem",
       "description": "Alias für write_file. Erstellt oder überschreibt eine Datei.",
+      "dach_specific": false
+    },
+    {
+      "name": "video_compose",
+      "module": "cognithor.mcp.video_tools",
+      "category": "filesystem",
+      "description": "Build a self-contained HTML composition from a structured spec. GREEN risk level — pure function, no subprocess, no filesystem write.",
       "dach_specific": false
     },
     {
@@ -938,6 +945,13 @@
       "module": "cognithor.mcp.web",
       "category": "web",
       "description": "Kombinierte Websuche + Fetch: Sucht im Web und liest die Top-Ergebnisse. Ideal für tiefere Recherche. Mit cross_check=true werden Quellen verglichen.",
+      "dach_specific": false
+    },
+    {
+      "name": "video_render",
+      "module": "cognithor.mcp.video_tools",
+      "category": "web",
+      "description": "Render a composition HTML to MP4 / MOV / WebM via the configured renderer (default: HyperFrames). Writes under ~/.cognithor/render/<run_id>/. ORANGE risk level — requires user approval. Raw user-suppl",
       "dach_specific": false
     },
     {

--- a/src/cognithor/mcp/video_tools.py
+++ b/src/cognithor/mcp/video_tools.py
@@ -1,0 +1,448 @@
+"""Sprint-27 HF-3 — `video_compose` + `video_render` MCP tools.
+
+Exposes the `cognithor.video` renderer-abstraction (HF-2) to the
+agent loop via two MCP tools:
+
+* ``video_compose(spec, run_id)`` — pure HTML-emission. Takes a
+  structured composition spec (scenes, durations, asset
+  references) and returns a self-contained HTML composition.
+  No subprocess, no filesystem write, no network. **GREEN risk
+  level** by default.
+
+* ``video_render(html_text|html_path, run_id, ...)`` — actual
+  render via the registered backend (default: HyperFrames).
+  Spawns a subprocess + writes MP4 to
+  ``~/.cognithor/render/<run_id>/``. **ORANGE risk level**
+  (requires user approval per agent-context risk-ceiling).
+
+The Gatekeeper-side wiring (RED for raw user-supplied HTML
+without an allowlist match) lives in HF-3's gatekeeper patch
+which lands alongside the tool registration; this module ships
+the tools + their input schemas + the Python-side handlers.
+
+Apache-2.0 — no insurance / domain coupling, per Sprint-27 D4
+"extension stays free, free packs ship the same surface".
+"""
+
+from __future__ import annotations
+
+import re
+from typing import TYPE_CHECKING, Any
+
+from cognithor.utils.logging import get_logger
+from cognithor.video import (
+    DEFAULT_ALLOWED_ADAPTERS,
+    FrameAdapter,
+    OutputFormat,
+    RenderError,
+    RenderRequest,
+    renderer_registry,
+)
+
+if TYPE_CHECKING:
+    from cognithor.mcp.server import JarvisMCPServer
+
+log = get_logger(__name__)
+
+__all__ = ["register_video_tools"]
+
+
+# Producer-side cap on the inline composition spec — protects the
+# subprocess + Gatekeeper from absurd payloads. ~64 KB ≈ 5 long
+# scenes with images / captions; anything bigger should land via
+# html_path rather than inline.
+_MAX_HTML_TEXT_BYTES = 64 * 1024
+
+
+_HTML_SHELL = """\
+<!doctype html>
+<html lang="{lang}">
+<head>
+<meta charset="utf-8" />
+<title>{title}</title>
+<style>
+  body {{ margin: 0; padding: 0; background: #000; color: #fff;
+          font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif; }}
+  #stage {{ position: relative; overflow: hidden;
+           width: {width}px; height: {height}px; }}
+  .scene {{ position: absolute; inset: 0; opacity: 0; }}
+</style>
+</head>
+<body>
+<div id="stage" data-composition-id="{composition_id}"
+     data-width="{width}" data-height="{height}">
+{scenes_html}
+</div>
+</body>
+</html>
+"""
+
+
+_SCENE_TEMPLATE = (
+    '  <div class="scene" data-track-index="{idx}" '
+    'data-start="{start:g}" data-duration="{duration:g}">\n'
+    "{body}\n"
+    "  </div>"
+)
+
+
+def _sanitize_text(s: str) -> str:
+    """Conservative HTML-escape for caption / title strings.
+
+    The composition is rendered in a sandboxed Puppeteer with a
+    strict CSP, but defense-in-depth: never embed raw user text
+    into the DOM without escaping. Allows letters, numbers,
+    spaces, and a small set of punctuation; everything else is
+    stripped.
+    """
+
+    return re.sub(r"[^\w\s.,:;!?\-—()À-ÿ]", "", s)[:512]
+
+
+def _scene_body(scene: dict[str, Any]) -> str:
+    """Build the inner HTML for a single scene from its spec."""
+
+    parts: list[str] = []
+    title = scene.get("title")
+    if isinstance(title, str) and title:
+        parts.append(
+            f'    <h1 style="position:absolute;top:5%;left:5%;font-size:5vw;'
+            f'margin:0">{_sanitize_text(title)}</h1>',
+        )
+    caption = scene.get("caption")
+    if isinstance(caption, str) and caption:
+        parts.append(
+            f'    <p style="position:absolute;bottom:8%;left:5%;right:5%;'
+            f'font-size:2.5vw;margin:0">{_sanitize_text(caption)}</p>',
+        )
+    image_url = scene.get("image_url")
+    if isinstance(image_url, str) and image_url.startswith(
+        ("file://", "/", "./", "../"),
+    ):
+        # Local-asset references only (no http(s)) — composition
+        # must self-contain its assets per HF-1 threat model.
+        parts.append(
+            f'    <img src="{image_url}" '
+            'style="position:absolute;inset:0;width:100%;height:100%;'
+            'object-fit:cover" />',
+        )
+    return "\n".join(parts) if parts else "    <!-- empty scene -->"
+
+
+def compose_html(spec: dict[str, Any]) -> str:
+    """Pure function: turn a structured spec into a HyperFrames HTML.
+
+    The accepted spec shape (intentionally tight):
+
+    .. code-block:: json
+
+        {
+          "title": "My Composition",
+          "lang": "en",
+          "width": 1920,
+          "height": 1080,
+          "composition_id": "demo-1",
+          "scenes": [
+            {"start": 0, "duration": 3, "title": "Hello",
+             "caption": "world", "image_url": "./assets/hero.png"}
+          ]
+        }
+
+    Anything outside the accepted shape is dropped (defensive
+    parsing). Returns the rendered HTML as a string. Does NOT
+    write to disk; the caller (typically the ``video_render`` MCP
+    tool) handles that.
+    """
+
+    title = _sanitize_text(str(spec.get("title", "Cognithor Composition")))
+    lang = re.sub(r"[^a-zA-Z\-]", "", str(spec.get("lang", "en")))[:8] or "en"
+    composition_id = (
+        re.sub(
+            r"[^a-zA-Z0-9_\-]",
+            "",
+            str(spec.get("composition_id", "comp")),
+        )[:64]
+        or "comp"
+    )
+
+    width = int(spec.get("width", 1920))
+    height = int(spec.get("height", 1080))
+    width = max(16, min(7680, width))
+    height = max(16, min(4320, height))
+
+    scenes_raw = spec.get("scenes")
+    if not isinstance(scenes_raw, list):
+        scenes_raw = []
+
+    scene_html_parts: list[str] = []
+    for idx, scene in enumerate(scenes_raw):
+        if not isinstance(scene, dict):
+            continue
+        try:
+            start = float(scene.get("start", 0.0))
+            duration = float(scene.get("duration", 3.0))
+        except (TypeError, ValueError):
+            continue
+        if duration <= 0:
+            continue
+        scene_html_parts.append(
+            _SCENE_TEMPLATE.format(
+                idx=idx,
+                start=max(0.0, start),
+                duration=duration,
+                body=_scene_body(scene),
+            ),
+        )
+
+    return _HTML_SHELL.format(
+        lang=lang,
+        title=title,
+        width=width,
+        height=height,
+        composition_id=composition_id,
+        scenes_html="\n".join(scene_html_parts) or "  <!-- no scenes -->",
+    )
+
+
+def _coerce_adapters(value: Any) -> frozenset[FrameAdapter]:
+    """Parse caller-supplied adapter list into a typed frozenset.
+
+    Falls back to :data:`DEFAULT_ALLOWED_ADAPTERS` when the value
+    is missing or invalid.
+    """
+
+    if value is None:
+        return DEFAULT_ALLOWED_ADAPTERS
+    if not isinstance(value, list):
+        return DEFAULT_ALLOWED_ADAPTERS
+    out: set[FrameAdapter] = set()
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        try:
+            out.add(FrameAdapter(item.lower()))
+        except ValueError:
+            continue
+    return frozenset(out) if out else DEFAULT_ALLOWED_ADAPTERS
+
+
+def _coerce_format(value: Any) -> OutputFormat:
+    if isinstance(value, str):
+        try:
+            return OutputFormat(value.lower())
+        except ValueError:
+            pass
+    return OutputFormat.MP4
+
+
+# ---------------------------------------------------------------------------
+# MCP tool handlers
+# ---------------------------------------------------------------------------
+
+
+async def _video_compose_handler(
+    spec: dict[str, Any],
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    """``video_compose`` MCP-tool handler.
+
+    Returns the rendered HTML (string) inline. The caller decides
+    whether to pipe it directly into ``video_render`` or stash it
+    in the vault for later editing.
+    """
+
+    if not isinstance(spec, dict):
+        return {"ok": False, "error": "spec must be a JSON object"}
+    html = compose_html(spec)
+    if len(html.encode("utf-8")) > _MAX_HTML_TEXT_BYTES:
+        return {
+            "ok": False,
+            "error": (
+                f"composed HTML exceeds {_MAX_HTML_TEXT_BYTES // 1024} KB cap "
+                "— split into multiple scenes or pre-render assets"
+            ),
+        }
+    return {
+        "ok": True,
+        "html": html,
+        "byte_size": len(html.encode("utf-8")),
+        "run_id": run_id or "",
+    }
+
+
+async def _video_render_handler(
+    run_id: str,
+    html_text: str | None = None,
+    html_path: str | None = None,
+    output_format: str = "mp4",
+    width: int = 1920,
+    height: int = 1080,
+    fps: int = 30,
+    duration_seconds: float | None = None,
+    allowed_adapters: list[str] | None = None,
+    timeout_seconds: float = 300.0,
+    renderer: str = "hyperframes",
+) -> dict[str, Any]:
+    """``video_render`` MCP-tool handler — dispatches to the registered renderer."""
+
+    if not run_id or not isinstance(run_id, str):
+        return {"ok": False, "error": "run_id is required"}
+
+    factory = renderer_registry.get(renderer)
+    if factory is None:
+        return {
+            "ok": False,
+            "error": f"unknown renderer {renderer!r}",
+            "available": sorted(renderer_registry),
+        }
+
+    try:
+        request = RenderRequest(
+            run_id=run_id,
+            html_path=__import__("pathlib").Path(html_path) if html_path else None,
+            html_text=html_text,
+            output_format=_coerce_format(output_format),
+            width=int(width),
+            height=int(height),
+            fps=int(fps),
+            duration_seconds=duration_seconds,
+            allowed_adapters=_coerce_adapters(allowed_adapters),
+            timeout_seconds=float(timeout_seconds),
+        )
+    except (TypeError, ValueError) as exc:
+        return {"ok": False, "error": f"bad render request: {exc}"}
+
+    try:
+        result = await factory().render(request)
+    except RenderError as exc:
+        return {
+            "ok": False,
+            "error": str(exc),
+            "run_id": exc.run_id,
+            "stderr_excerpt": exc.stderr_excerpt,
+        }
+    return {"ok": True, **result.to_dict()}
+
+
+# ---------------------------------------------------------------------------
+# Registration — called by the MCP server bootstrapping
+# ---------------------------------------------------------------------------
+
+
+_VIDEO_COMPOSE_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "spec": {
+            "type": "object",
+            "description": (
+                "Structured composition spec — title, lang, width, "
+                "height, composition_id, scenes (list of {start, "
+                "duration, title, caption, image_url})."
+            ),
+        },
+        "run_id": {
+            "type": "string",
+            "description": (
+                "Stable identifier for the composition run; reused as trace_id by the receipt API."
+            ),
+        },
+    },
+    "required": ["spec"],
+}
+
+_VIDEO_RENDER_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "run_id": {
+            "type": "string",
+            "description": "Same run_id as the originating agent run.",
+        },
+        "html_text": {
+            "type": "string",
+            "description": (
+                "Inline composition HTML. Mutually exclusive with html_path. "
+                "Caller should typically use the output of video_compose."
+            ),
+        },
+        "html_path": {
+            "type": "string",
+            "description": "Path to a self-contained composition HTML file.",
+        },
+        "output_format": {
+            "type": "string",
+            "enum": ["mp4", "mov", "webm"],
+            "default": "mp4",
+        },
+        "width": {"type": "integer", "minimum": 16, "maximum": 7680, "default": 1920},
+        "height": {"type": "integer", "minimum": 16, "maximum": 4320, "default": 1080},
+        "fps": {"type": "integer", "minimum": 1, "maximum": 240, "default": 30},
+        "duration_seconds": {"type": "number", "minimum": 0.0},
+        "allowed_adapters": {
+            "type": "array",
+            "items": {
+                "type": "string",
+                "enum": ["css", "waapi", "anime", "lottie", "three", "gsap"],
+            },
+            "description": (
+                "Override the default adapter allowlist. GSAP is opt-in "
+                "only — see the HyperFrames license note in the spike "
+                "doc."
+            ),
+        },
+        "timeout_seconds": {
+            "type": "number",
+            "minimum": 1.0,
+            "maximum": 1800.0,
+            "default": 300.0,
+        },
+        "renderer": {
+            "type": "string",
+            "default": "hyperframes",
+            "description": "Renderer name from cognithor.video.renderer_registry.",
+        },
+    },
+    "required": ["run_id"],
+}
+
+
+def register_video_tools(server: JarvisMCPServer) -> None:
+    """Register ``video_compose`` + ``video_render`` on a running MCP server."""
+
+    from cognithor.mcp.server import MCPToolDef  # local import to avoid cycles
+
+    server.register_tool(
+        MCPToolDef(
+            name="video_compose",
+            description=(
+                "Build a self-contained HTML composition from a structured spec. "
+                "GREEN risk level — pure function, no subprocess, no filesystem write."
+            ),
+            input_schema=_VIDEO_COMPOSE_INPUT_SCHEMA,
+            handler=_video_compose_handler,
+            annotations={
+                "risk_level": "green",
+                "category": "video",
+                "supports_streaming": False,
+            },
+        ),
+    )
+    server.register_tool(
+        MCPToolDef(
+            name="video_render",
+            description=(
+                "Render a composition HTML to MP4 / MOV / WebM via the configured "
+                "renderer (default: HyperFrames). Writes under "
+                "~/.cognithor/render/<run_id>/. ORANGE risk level — requires user "
+                "approval. Raw user-supplied HTML without adapter allowlist match "
+                "should be rejected RED upstream by the Gatekeeper."
+            ),
+            input_schema=_VIDEO_RENDER_INPUT_SCHEMA,
+            handler=_video_render_handler,
+            annotations={
+                "risk_level": "orange",
+                "category": "video",
+                "supports_streaming": False,
+            },
+        ),
+    )
+    log.info("video_tools_registered", tools=["video_compose", "video_render"])

--- a/tests/test_video/test_video_tools.py
+++ b/tests/test_video/test_video_tools.py
@@ -1,0 +1,258 @@
+"""Sprint-27 HF-3 — `video_compose` + `video_render` MCP-tool handlers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from cognithor.mcp.video_tools import (
+    _coerce_adapters,
+    _coerce_format,
+    _sanitize_text,
+    _video_compose_handler,
+    _video_render_handler,
+    compose_html,
+    register_video_tools,
+)
+from cognithor.video.renderer_base import (
+    DEFAULT_ALLOWED_ADAPTERS,
+    FrameAdapter,
+    OutputFormat,
+)
+
+# ---------------------------------------------------------------------------
+# compose_html — pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestComposeHTML:
+    def test_minimal_spec_renders_shell(self) -> None:
+        html = compose_html({"title": "Test", "scenes": []})
+        assert "<!doctype html>" in html
+        assert "<title>Test</title>" in html
+        assert 'data-composition-id="comp"' in html  # default sanitised id
+
+    def test_scenes_emitted_with_track_index(self) -> None:
+        html = compose_html(
+            {
+                "title": "Multi",
+                "scenes": [
+                    {"start": 0, "duration": 3, "caption": "scene one"},
+                    {"start": 3, "duration": 2, "caption": "scene two"},
+                ],
+            },
+        )
+        assert 'data-track-index="0"' in html
+        assert 'data-track-index="1"' in html
+        assert "scene one" in html
+        assert "scene two" in html
+        # Start + duration baked in
+        assert 'data-start="0"' in html
+        assert 'data-duration="3"' in html
+
+    def test_html_text_escapes_dangerous_chars(self) -> None:
+        html = compose_html(
+            {
+                "title": "<script>alert(1)</script>",
+                "scenes": [{"start": 0, "duration": 1, "caption": "</script>"}],
+            },
+        )
+        # The <title> field should NOT contain raw <script>.
+        assert "<script>" not in html
+        # Caption escaping
+        assert "</script>" not in html
+
+    def test_dimensions_clamped(self) -> None:
+        html = compose_html({"title": "Big", "width": 99999, "height": 99999})
+        # Clamped to 7680 / 4320
+        assert 'data-width="7680"' in html
+        assert 'data-height="4320"' in html
+
+    def test_invalid_scene_dropped(self) -> None:
+        html = compose_html(
+            {
+                "scenes": [
+                    "not a dict",
+                    {"start": 0, "duration": -1},  # bad duration
+                    {"start": 0, "duration": 1, "caption": "kept"},
+                ],
+            },
+        )
+        assert "kept" in html
+        # Only the valid scene should land — track-index 2 (the third item).
+        assert 'data-track-index="2"' in html
+        assert 'data-track-index="0"' not in html
+        assert 'data-track-index="1"' not in html
+
+    def test_remote_image_url_stripped(self) -> None:
+        html = compose_html(
+            {
+                "scenes": [
+                    {
+                        "start": 0,
+                        "duration": 1,
+                        "image_url": "https://evil.example.com/x.png",
+                    },
+                ],
+            },
+        )
+        assert "evil.example.com" not in html
+
+    def test_local_image_url_kept(self) -> None:
+        html = compose_html(
+            {
+                "scenes": [
+                    {"start": 0, "duration": 1, "image_url": "./assets/hero.png"},
+                ],
+            },
+        )
+        assert "./assets/hero.png" in html
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_text + _coerce_* helpers
+# ---------------------------------------------------------------------------
+
+
+class TestHelpers:
+    def test_sanitize_keeps_unicode_letters(self) -> None:
+        assert _sanitize_text("Schöne Grüße!") == "Schöne Grüße!"
+
+    def test_sanitize_drops_html_brackets(self) -> None:
+        out = _sanitize_text("<b>X</b>")
+        assert "<" not in out
+        assert ">" not in out
+
+    def test_sanitize_truncates_long_input(self) -> None:
+        long = "x" * 1000
+        assert len(_sanitize_text(long)) == 512
+
+    def test_coerce_adapters_falls_back_to_default(self) -> None:
+        assert _coerce_adapters(None) == DEFAULT_ALLOWED_ADAPTERS
+        assert _coerce_adapters("nope") == DEFAULT_ALLOWED_ADAPTERS  # type: ignore[arg-type]
+
+    def test_coerce_adapters_typed(self) -> None:
+        out = _coerce_adapters(["css", "lottie"])
+        assert out == frozenset({FrameAdapter.CSS, FrameAdapter.LOTTIE})
+
+    def test_coerce_adapters_drops_unknown(self) -> None:
+        out = _coerce_adapters(["css", "fake-thing"])
+        assert out == frozenset({FrameAdapter.CSS})
+
+    def test_coerce_format_default(self) -> None:
+        assert _coerce_format(None) == OutputFormat.MP4
+        assert _coerce_format("WEBM") == OutputFormat.WEBM
+        assert _coerce_format("nope") == OutputFormat.MP4
+
+
+# ---------------------------------------------------------------------------
+# video_compose handler
+# ---------------------------------------------------------------------------
+
+
+class TestVideoComposeHandler:
+    @pytest.mark.asyncio
+    async def test_returns_html_on_valid_spec(self) -> None:
+        result = await _video_compose_handler(
+            spec={"title": "Demo", "scenes": [{"start": 0, "duration": 2}]},
+            run_id="run-1",
+        )
+        assert result["ok"] is True
+        assert "<!doctype html>" in result["html"]
+        assert result["byte_size"] > 0
+        assert result["run_id"] == "run-1"
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_object_spec(self) -> None:
+        result = await _video_compose_handler(spec="not a dict")  # type: ignore[arg-type]
+        assert result["ok"] is False
+        assert "object" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversize_html(self) -> None:
+        # Pump in 200 scenes with long captions to exceed 64 KB cap.
+        scenes = [{"start": i, "duration": 1, "caption": "x" * 500} for i in range(200)]
+        result = await _video_compose_handler(spec={"scenes": scenes})
+        assert result["ok"] is False
+        assert "cap" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# video_render handler — exercises the registry dispatch + error paths
+# ---------------------------------------------------------------------------
+
+
+class TestVideoRenderHandler:
+    @pytest.mark.asyncio
+    async def test_unknown_renderer_returns_error(self) -> None:
+        result = await _video_render_handler(
+            run_id="r1",
+            html_text="<div/>",
+            renderer="does-not-exist",
+        )
+        assert result["ok"] is False
+        assert "unknown renderer" in result["error"]
+        assert "available" in result
+
+    @pytest.mark.asyncio
+    async def test_missing_run_id_rejected(self) -> None:
+        result = await _video_render_handler(run_id="", html_text="<div/>")
+        assert result["ok"] is False
+        assert "run_id" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_request_caught(self) -> None:
+        # Empty html_text + html_path → RenderRequest validation fails.
+        result = await _video_render_handler(run_id="r1")
+        assert result["ok"] is False
+        assert "render request" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# register_video_tools — schema + handler wired correctly
+# ---------------------------------------------------------------------------
+
+
+class _StubServer:
+    """Captures registered MCPToolDef instances."""
+
+    def __init__(self) -> None:
+        self.tools: list[Any] = []
+
+    def register_tool(self, tool: Any) -> None:
+        self.tools.append(tool)
+
+
+class TestRegistration:
+    def test_both_tools_registered(self) -> None:
+        srv = _StubServer()
+        register_video_tools(srv)  # type: ignore[arg-type]
+        names = [t.name for t in srv.tools]
+        assert "video_compose" in names
+        assert "video_render" in names
+
+    def test_video_compose_is_green(self) -> None:
+        srv = _StubServer()
+        register_video_tools(srv)  # type: ignore[arg-type]
+        compose = next(t for t in srv.tools if t.name == "video_compose")
+        assert compose.annotations["risk_level"] == "green"
+        assert compose.annotations["category"] == "video"
+
+    def test_video_render_is_orange(self) -> None:
+        srv = _StubServer()
+        register_video_tools(srv)  # type: ignore[arg-type]
+        render = next(t for t in srv.tools if t.name == "video_render")
+        assert render.annotations["risk_level"] == "orange"
+
+    def test_compose_schema_requires_spec(self) -> None:
+        srv = _StubServer()
+        register_video_tools(srv)  # type: ignore[arg-type]
+        compose = next(t for t in srv.tools if t.name == "video_compose")
+        assert "spec" in compose.input_schema["required"]
+
+    def test_render_schema_requires_run_id(self) -> None:
+        srv = _StubServer()
+        register_video_tools(srv)  # type: ignore[arg-type]
+        render = next(t for t in srv.tools if t.name == "video_render")
+        assert "run_id" in render.input_schema["required"]


### PR DESCRIPTION
## Sprint-27 HF-3 — agent-loop wiring for the video pipeline

**Stacked on top of #444 (HF-2)**. Exposes the renderer abstraction shipped in HF-2 to the agent loop via two MCP tools. Will rebase to fresh main after HF-2 merges.

## Tools

| Tool | Risk | Purpose |
|---|---|---|
| `video_compose` | GREEN | Pure-function HTML emission from structured spec. No subprocess, no FS, no network. |
| `video_render` | ORANGE | Actual render via registered backend (default `hyperframes`). Writes MP4/MOV/WebM under `~/.cognithor/render/<run_id>/`. |

## Defense in depth (composition path)

- `_sanitize_text()` strips HTML brackets + dangerous chars before DOM injection
- `image_url` accepts ONLY local file://or relative paths — HTTP(S) silently dropped (HF-1 threat-model: composition must self-contain assets)
- 64 KB cap on inline HTML
- Adapter allowlist defaults to `DEFAULT_ALLOWED_ADAPTERS` (no GSAP — HF-1 license note)

## Quality

- ✅ mypy --strict on video_tools.py — clean
- ✅ ruff check + ruff format --check (full src/ + tests/) — clean
- ✅ pytest tests/test_video/ — **50/50 passing** (25 HF-2 + 25 HF-3 new)

## Tests

25 new tests cover compose_html happy + edge paths, sanitisation, dimension clamping, invalid-scene drop, remote-image strip, local-image keep, _coerce_adapters / _coerce_format helpers, both handler success+error paths, and full registration round-trip with risk-level + required-field assertions.

## Deferred to HF-4 + HF-5

- TRUST-9 `ProvenanceTag` + `CostEntry` on render (HF-4 #130)
- Gatekeeper-side RED rules for raw HTML without allowlist match (HF-4 #130)
- Skill-layer composer templates: explainer / social-cut / caption-overlay (HF-5 #131)

## Refs

- HF-1 spike: `docs/superpowers/spikes/2026-05-04-hyperframes-spike.md` (in PR #443)
- Built-on: PR #444 (HF-2)
- Tasks: #129 (this PR), unblocks HF-4 (#130) + HF-5 (#131)