### PR TITLE
feat(extensions/vscode): MCP-stdio bridge auto-spawn (Sprint-27 PR-E)

### DIFF
--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -34,7 +34,8 @@
   "icon": "media/icon.png",
   "main": "./dist/extension.js",
   "activationEvents": [
-    "onCommand:cognithor.runPlan"
+    "onCommand:cognithor.runPlan",
+    "onStartupFinished"
   ],
   "contributes": {
     "commands": [

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,30 +1,71 @@
 /**
  * Cognithor VS Code extension — entry point.
  *
- * PR-D ships only the scaffold + activation skeleton + the
- * "Run Plan" command stub. The real wiring lands in:
+ * PR-D shipped the scaffold. PR-E (this file's update) wires the
+ * MCP-stdio bridge so the extension auto-spawns
+ * `cognithor mcp --stdio` on activation, heartbeats it every
+ * 30 s, and restarts on no-pong within 5 s. Mitigates plan-doc
+ * §6 risk-1 (MCP-stdio handshake instability for VS-Code's
+ * activate/deactivate cycle).
  *
- *   - PR-E (#120): MCP-stdio bridge auto-spawned on activation
- *   - PR-F (#121): WebSocket client + plan picker
+ * Subsequent wiring lands in:
+ *
+ *   - PR-F (#121): WebSocket client + plan picker (uses bridge
+ *                  for procedural-memory queries)
  *   - PR-G (#122): TRUST-1 receipt sidebar webview
  *   - PR-H (#123): Decision-Explanation hover provider
  *   - PR-I (#124): Cost-budget gutter decoration
- *
- * The streaming-event types under ./types/events.ts are
- * generated from src/cognithor/streaming/schemas/v1/events.json
- * via `npm run codegen:events` (per H5 of the decisions memo).
  */
 
 import * as vscode from "vscode";
+import { McpBridge, readBridgeConfig } from "./mcp_bridge";
 
-export function activate(context: vscode.ExtensionContext): void {
-  console.log("[cognithor] extension activated");
+let bridge: McpBridge | null = null;
+let outputChannel: vscode.OutputChannel | null = null;
 
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
+  outputChannel = vscode.window.createOutputChannel("Cognithor");
+  context.subscriptions.push(outputChannel);
+  outputChannel.appendLine("[cognithor] extension activated");
+
+  // --------------------------------------------------------------------
+  // MCP-stdio bridge (PR-E)
+  // --------------------------------------------------------------------
+  bridge = new McpBridge(readBridgeConfig());
+  context.subscriptions.push(bridge);
+
+  bridge.onLog((line) => outputChannel?.appendLine(`[mcp] ${line}`));
+  bridge.onReady(() => {
+    outputChannel?.appendLine("[mcp] bridge ready");
+  });
+  bridge.onCrash(({ code, restartCount }) => {
+    outputChannel?.appendLine(
+      `[mcp] crashed (exit code ${code}); restart attempt ${restartCount}`,
+    );
+  });
+
+  // Best-effort start. If `cognithor` is not on PATH, the bridge
+  // surfaces the spawn error via onLog + onCrash and the
+  // extension keeps the user in a degraded-but-not-broken state
+  // (the "Run Plan" command stub still works).
+  try {
+    await bridge.start();
+  } catch (err) {
+    const message = (err as Error).message;
+    outputChannel?.appendLine(`[mcp] start failed: ${message}`);
+    void vscode.window.showWarningMessage(
+      `Cognithor MCP bridge failed to start: ${message}. ` +
+        "Set cognithor.cliPath in settings to point at your cognithor executable.",
+    );
+  }
+
+  // --------------------------------------------------------------------
+  // Palette command stub (PR-F replaces this with the real flow)
+  // --------------------------------------------------------------------
   const runPlan = vscode.commands.registerCommand(
     "cognithor.runPlan",
     async () => {
-      // PR-F will replace this stub with the WebSocket-backed plan picker.
-      vscode.window.showInformationMessage(
+      void vscode.window.showInformationMessage(
         "Cognithor: Run Plan — wiring lands in Sprint-27 PR-F (#121).",
       );
     },
@@ -33,5 +74,7 @@ export function activate(context: vscode.ExtensionContext): void {
 }
 
 export function deactivate(): void {
-  console.log("[cognithor] extension deactivated");
+  outputChannel?.appendLine("[cognithor] extension deactivated");
+  void bridge?.stop();
+  bridge = null;
 }

--- a/extensions/vscode/src/mcp_bridge.ts
+++ b/extensions/vscode/src/mcp_bridge.ts
@@ -1,0 +1,313 @@
+/**
+ * Sprint-27 PR-E — MCP-stdio bridge.
+ *
+ * Auto-spawns `cognithor mcp --stdio` on workspace activation,
+ * heartbeats every 30 s, and restarts the subprocess on no-pong
+ * within 5 s. Mitigates plan-doc §6 risk-1 (MCP-stdio handshake
+ * instability for VS-Code's activate/deactivate cycle).
+ *
+ * The bridge speaks JSON-RPC over the spawned process's stdin /
+ * stdout. The Cognithor side ships 138+ MCP tools (per
+ * `docs/integrations/catalog.json`), so once the bridge is up
+ * the rest of the extension can call any of them via
+ * `bridge.call("video_render", { run_id: ..., html_text: ... })`.
+ *
+ * Lifecycle hooks:
+ *
+ *   - `activate(context)` → constructs the bridge, registers
+ *     dispose-on-deactivate.
+ *   - `bridge.start()` → spawns the subprocess + handshake.
+ *   - `bridge.stop()` → graceful shutdown (SIGTERM → 2 s grace
+ *     → SIGKILL).
+ *
+ * Exposed events (via `vscode.EventEmitter`):
+ *
+ *   - `onReady`   — fired after successful handshake.
+ *   - `onCrash`   — fired on unexpected exit (with restart
+ *                   attempt count).
+ *   - `onLog`     — child-process stderr lines (debug surface).
+ */
+
+import { spawn, type ChildProcess } from "child_process";
+import * as readline from "readline";
+import * as vscode from "vscode";
+
+/** A pending in-flight JSON-RPC request awaiting its response. */
+interface Pending {
+  resolve: (result: unknown) => void;
+  reject: (error: Error) => void;
+  /** Wall-clock deadline for the request (epoch ms). */
+  deadlineMs: number;
+}
+
+/** JSON-RPC 2.0 minimal message shape. */
+interface JsonRpcMessage {
+  jsonrpc: "2.0";
+  id?: number | string | null;
+  method?: string;
+  params?: unknown;
+  result?: unknown;
+  error?: { code: number; message: string; data?: unknown };
+}
+
+/** Configuration — pulled from the workspace `cognithor.*` settings. */
+export interface BridgeConfig {
+  cliPath: string;
+  heartbeatMs: number;
+  pongTimeoutMs: number;
+  restartBackoffMs: number;
+  maxRestarts: number;
+  requestTimeoutMs: number;
+}
+
+export const DEFAULT_BRIDGE_CONFIG: BridgeConfig = {
+  cliPath: "cognithor",
+  heartbeatMs: 30_000,
+  pongTimeoutMs: 5_000,
+  restartBackoffMs: 2_000,
+  maxRestarts: 5,
+  requestTimeoutMs: 30_000,
+};
+
+export class McpBridge implements vscode.Disposable {
+  private child: ChildProcess | null = null;
+  private rl: readline.Interface | null = null;
+  private nextId = 1;
+  private readonly pending = new Map<number, Pending>();
+
+  private heartbeatTimer: NodeJS.Timeout | null = null;
+  private restartCount = 0;
+  private stopped = false;
+
+  private readonly readyEmitter = new vscode.EventEmitter<void>();
+  private readonly crashEmitter = new vscode.EventEmitter<{
+    code: number | null;
+    restartCount: number;
+  }>();
+  private readonly logEmitter = new vscode.EventEmitter<string>();
+
+  readonly onReady: vscode.Event<void> = this.readyEmitter.event;
+  readonly onCrash: vscode.Event<{ code: number | null; restartCount: number }> =
+    this.crashEmitter.event;
+  readonly onLog: vscode.Event<string> = this.logEmitter.event;
+
+  constructor(private readonly config: BridgeConfig = DEFAULT_BRIDGE_CONFIG) {}
+
+  /** Spawn the subprocess + run the JSON-RPC initialise handshake. */
+  async start(): Promise<void> {
+    if (this.child !== null) {
+      return; // idempotent
+    }
+    this.stopped = false;
+    this.spawnChild();
+    await this.handshake();
+    this.startHeartbeat();
+    this.readyEmitter.fire();
+  }
+
+  /** Graceful shutdown — SIGTERM, 2 s grace, then SIGKILL. */
+  async stop(): Promise<void> {
+    this.stopped = true;
+    this.stopHeartbeat();
+    if (this.child === null) {
+      return;
+    }
+    const child = this.child;
+    this.child = null;
+    this.rl?.close();
+    this.rl = null;
+    // Reject any in-flight requests so the caller doesn't hang.
+    for (const [id, pending] of this.pending) {
+      pending.reject(new Error("MCP bridge stopped"));
+      this.pending.delete(id);
+    }
+    if (!child.killed) {
+      child.kill("SIGTERM");
+      await new Promise<void>((resolve) => {
+        const timer = setTimeout(() => {
+          if (!child.killed) {
+            child.kill("SIGKILL");
+          }
+          resolve();
+        }, 2_000);
+        child.once("exit", () => {
+          clearTimeout(timer);
+          resolve();
+        });
+      });
+    }
+  }
+
+  /** Send a JSON-RPC request and await the response. */
+  async call(method: string, params?: unknown): Promise<unknown> {
+    if (this.child === null) {
+      throw new Error("MCP bridge is not running");
+    }
+    const id = this.nextId++;
+    const message: JsonRpcMessage = { jsonrpc: "2.0", id, method, params };
+    return new Promise<unknown>((resolve, reject) => {
+      const deadlineMs = Date.now() + this.config.requestTimeoutMs;
+      this.pending.set(id, { resolve, reject, deadlineMs });
+      this.writeMessage(message);
+      // Per-request deadline guard (cleared on response).
+      setTimeout(() => {
+        const pending = this.pending.get(id);
+        if (pending !== undefined) {
+          this.pending.delete(id);
+          pending.reject(new Error(`MCP request ${method} timed out`));
+        }
+      }, this.config.requestTimeoutMs);
+    });
+  }
+
+  dispose(): void {
+    void this.stop();
+    this.readyEmitter.dispose();
+    this.crashEmitter.dispose();
+    this.logEmitter.dispose();
+  }
+
+  // ------------------------------------------------------------------
+  // Internals
+  // ------------------------------------------------------------------
+
+  private spawnChild(): void {
+    const child = spawn(this.config.cliPath, ["mcp", "--stdio"], {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: process.env,
+    });
+    this.child = child;
+    if (child.stdout !== null) {
+      this.rl = readline.createInterface({ input: child.stdout });
+      this.rl.on("line", (line) => this.onStdoutLine(line));
+    }
+    if (child.stderr !== null) {
+      const errRl = readline.createInterface({ input: child.stderr });
+      errRl.on("line", (line) => this.logEmitter.fire(`stderr: ${line}`));
+    }
+    child.on("exit", (code) => this.onChildExit(code));
+    child.on("error", (err) => this.logEmitter.fire(`spawn error: ${err.message}`));
+  }
+
+  private async handshake(): Promise<void> {
+    // Minimal MCP `initialize` per the spec — name + version of
+    // the client. The Cognithor server responds with its own
+    // capability set; we don't need to inspect it here, but the
+    // round-trip proves the subprocess is alive and parsing.
+    await this.call("initialize", {
+      protocolVersion: "2025-06-18",
+      capabilities: {},
+      clientInfo: { name: "cognithor-vscode", version: "0.97.0" },
+    });
+  }
+
+  private writeMessage(message: JsonRpcMessage): void {
+    if (this.child === null || this.child.stdin === null) {
+      throw new Error("MCP bridge: child stdin unavailable");
+    }
+    this.child.stdin.write(JSON.stringify(message) + "\n");
+  }
+
+  private onStdoutLine(line: string): void {
+    if (line.trim() === "") {
+      return;
+    }
+    let message: JsonRpcMessage;
+    try {
+      message = JSON.parse(line) as JsonRpcMessage;
+    } catch (_err) {
+      this.logEmitter.fire(`malformed stdout line: ${line.slice(0, 200)}`);
+      return;
+    }
+    if (typeof message.id === "number") {
+      const pending = this.pending.get(message.id);
+      if (pending !== undefined) {
+        this.pending.delete(message.id);
+        if (message.error !== undefined) {
+          pending.reject(new Error(message.error.message));
+        } else {
+          pending.resolve(message.result);
+        }
+      }
+      return;
+    }
+    // Notifications + server-initiated messages — ignored for
+    // PR-E's scope. PR-F and PR-G will subscribe to crew lifecycle
+    // notifications for the receipt sidebar.
+  }
+
+  private onChildExit(code: number | null): void {
+    this.child = null;
+    this.rl?.close();
+    this.rl = null;
+    this.stopHeartbeat();
+    if (this.stopped) {
+      return; // intentional shutdown
+    }
+    this.restartCount += 1;
+    this.crashEmitter.fire({ code, restartCount: this.restartCount });
+    if (this.restartCount > this.config.maxRestarts) {
+      this.logEmitter.fire(
+        `MCP bridge: max restart count (${this.config.maxRestarts}) exceeded`,
+      );
+      return;
+    }
+    setTimeout(() => {
+      if (!this.stopped) {
+        // Best-effort restart. Failures will surface via the log
+        // event + a subsequent crash event.
+        void this.start().catch((err) => {
+          this.logEmitter.fire(`restart failed: ${(err as Error).message}`);
+        });
+      }
+    }, this.config.restartBackoffMs);
+  }
+
+  private startHeartbeat(): void {
+    this.heartbeatTimer = setInterval(() => {
+      void this.tick();
+    }, this.config.heartbeatMs);
+  }
+
+  private stopHeartbeat(): void {
+    if (this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
+  }
+
+  private async tick(): Promise<void> {
+    if (this.child === null) {
+      return;
+    }
+    // The MCP spec defines a `ping` request that returns an empty
+    // result. Use that as our heartbeat; if the subprocess fails
+    // to respond within `pongTimeoutMs`, treat it as crashed.
+    try {
+      await Promise.race([
+        this.call("ping"),
+        new Promise<never>((_resolve, reject) => {
+          setTimeout(
+            () => reject(new Error("ping timeout")),
+            this.config.pongTimeoutMs,
+          );
+        }),
+      ]);
+    } catch (_err) {
+      this.logEmitter.fire(
+        `heartbeat: no pong within ${this.config.pongTimeoutMs}ms — restarting`,
+      );
+      // Synthesise a crash so the existing restart logic kicks in.
+      this.child?.kill("SIGTERM");
+    }
+  }
+}
+
+/** Read the bridge config from VS Code workspace settings. */
+export function readBridgeConfig(): BridgeConfig {
+  const cfg = vscode.workspace.getConfiguration("cognithor");
+  return {
+    ...DEFAULT_BRIDGE_CONFIG,
+    cliPath: cfg.get<string>("cliPath") ?? DEFAULT_BRIDGE_CONFIG.cliPath,
+  };
+}


### PR DESCRIPTION
## Sprint-27 PR-E — MCP-stdio bridge

Wires the extension to spawn `cognithor mcp --stdio` on activation, heartbeat it every 30 s, and restart on no-pong within 5 s. Mitigates Sprint-27 plan-doc §6 risk-1 (MCP-stdio handshake instability for VS-Code's activate/deactivate cycle).

## What ships

| File | Purpose |
|---|---|
| `src/mcp_bridge.ts` | `McpBridge` class — subprocess lifecycle, JSON-RPC 2.0 client, ping heartbeat, onExit restart |
| `src/extension.ts` | wires bridge into `activate()`, output channel for logs, non-fatal warning toast if `cognithor` missing |
| `package.json` | adds `onStartupFinished` activation so bridge boots before user runs palette command |

## McpBridge contract

- `start()` — spawn `cognithor mcp --stdio` + MCP `initialize` handshake + heartbeat-timer kickoff
- `call(method, params)` — JSON-RPC 2.0 request with 30 s deadline
- `tick()` — ping → 5 s pong-timeout → SIGTERM the child so onExit restart logic kicks in
- `onExit` restart — 2 s back-off, max 5 attempts, then surface via `onCrash` event
- `stop()` / `dispose()` — graceful: SIGTERM + 2 s grace + SIGKILL fallback. Rejects in-flight requests so callers don't hang.

## Quality

- ✅ `npm run typecheck` — clean (strict tsconfig)
- ✅ `npm run package` — clean (esbuild production, 5.2 KB output)
- No new runtime deps; uses Node `child_process` + `readline`. The `ws` dep already in package.json is reserved for PR-F's WebSocket client.

## What does NOT ship (deferred)

- PR-F (#121): palette command actually does something (today it still falls through to a toast)
- PR-G (#122): receipt sidebar webview + crew-lifecycle subscribe on the bridge
- PR-H/I (#123/#124): hover + gutter

## Refs

- Plan: `docs/superpowers/plans/2026-05-04-sprint27-ide-integration.md` §2 Track A task #2
- Decisions memo: D1 (monorepo) + D5 (MCP-stdio is for tool calls; the EventEmitter rides WebSocket separately)
- Builds on: PR-D #442 (extension scaffold)