### PR TITLE
feat(core): multimodal helpers + VISION_TOKENS CostKind (Sprint-27 VLM-3)

### DIFF
--- a/src/cognithor/core/multimodal.py
+++ b/src/cognithor/core/multimodal.py
@@ -1,0 +1,156 @@
+"""Sprint-27 VLM-3 — multimodal-message helpers for the LLMBackend layer.
+
+The OpenAI / vLLM chat schema accepts a typed-content list per
+message:
+
+.. code-block:: json
+
+    {"role": "user", "content": [
+      {"type": "text", "text": "What is in this image?"},
+      {"type": "image_url",
+       "image_url": {"url": "data:image/jpeg;base64,..."}},
+      {"type": "video_url",
+       "video_url": {"url": "file:///path/to/video.mp4"}}
+    ]}
+
+This module is the central place every backend (OllamaBackend,
+OpenAIBackend, VLLMBackend, ...) consults to:
+
+* count multimodal parts per message — drives the
+  :data:`CostKind.VISION_TOKENS` ledger entry shipped in HF-2's
+  cost-ledger update;
+* validate the part structure before forwarding so a malformed
+  payload is rejected at the boundary rather than half-way
+  through the engine; and
+* expose typed accessors so type-checkers can audit every
+  multimodal-handling code path.
+
+All wire types stay JSON-serialisable so Gatekeeper, audit log,
+and telemetry can ride the same shapes without custom encoders.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Final
+
+
+@dataclass(frozen=True, slots=True)
+class MultimodalCounts:
+    """Per-request count of image + video parts across all messages."""
+
+    image_parts: int = 0
+    video_parts: int = 0
+    text_parts: int = 0
+
+    @property
+    def has_vision(self) -> bool:
+        return self.image_parts > 0 or self.video_parts > 0
+
+    @property
+    def total_vision_parts(self) -> int:
+        return self.image_parts + self.video_parts
+
+
+# Per the Qwen3-VL spike doc: 1 image ≈ 256 vision tokens at the
+# default ViT patch size; 1 video frame ≈ 256 vision tokens, with
+# the v0.92.7 ffprobe pipeline sampling fps=3 short / num_frames=32
+# long. Without a frame-count handle from the backend, we estimate
+# 32 frames per video to budget the cost ledger conservatively.
+_TOKENS_PER_IMAGE: Final[int] = 256
+_TOKENS_PER_VIDEO_DEFAULT_FRAMES: Final[int] = 32
+_TOKENS_PER_FRAME: Final[int] = 256
+
+
+def estimate_vision_tokens(counts: MultimodalCounts) -> int:
+    """Estimate the vision-token cost for a single chat request.
+
+    Coarse upper bound — the actual count depends on frame
+    sampling (fps=3 vs num_frames=32) which the backend
+    determines via ffprobe at request time. Operators can
+    reconcile this estimate against the engine's own usage
+    counter once vLLM exposes per-request vision-token
+    breakdowns (open feature request as of vLLM 0.6).
+    """
+
+    return (
+        counts.image_parts * _TOKENS_PER_IMAGE
+        + counts.video_parts * _TOKENS_PER_VIDEO_DEFAULT_FRAMES * _TOKENS_PER_FRAME
+    )
+
+
+def count_multimodal_parts(messages: list[dict[str, Any]]) -> MultimodalCounts:
+    """Walk a chat-messages list and tally every multimodal part.
+
+    Accepts both shapes:
+
+    * Plain string content: ``{"role": "user", "content": "hi"}``
+      — counts as one text part, no vision.
+    * Typed list content: see module docstring. Each part with
+      ``type == "image_url"`` or ``type == "video_url"`` counts
+      toward the corresponding tally; everything else counts
+      as text. Unknown types are ignored (forward-compat).
+
+    Tolerates malformed messages — never raises. Operators get
+    the best-effort tally and the backend is the source of truth
+    for hard validation.
+    """
+
+    images = 0
+    videos = 0
+    texts = 0
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            if content:
+                texts += 1
+            continue
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            ptype = part.get("type")
+            if ptype == "image_url":
+                if _is_valid_url_part(part.get("image_url")):
+                    images += 1
+            elif ptype == "video_url":
+                if _is_valid_url_part(part.get("video_url")):
+                    videos += 1
+            elif ptype == "text" and isinstance(part.get("text"), str) and part["text"]:
+                texts += 1
+            # Other/unknown types: silently ignored.
+
+    return MultimodalCounts(image_parts=images, video_parts=videos, text_parts=texts)
+
+
+def _is_valid_url_part(value: Any) -> bool:
+    """Return True for ``{"url": "..."}`` shapes used by image_url / video_url."""
+
+    if isinstance(value, dict):
+        url = value.get("url")
+        return isinstance(url, str) and bool(url)
+    if isinstance(value, str):
+        # Some clients send the URL directly without nesting.
+        return bool(value)
+    return False
+
+
+def is_multimodal_request(messages: list[dict[str, Any]]) -> bool:
+    """Cheap existential check — saves a full count when unused."""
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if not isinstance(content, list):
+            continue
+        for part in content:
+            if not isinstance(part, dict):
+                continue
+            if part.get("type") in ("image_url", "video_url"):
+                return True
+    return False

--- a/src/cognithor/security/cost_ledger.py
+++ b/src/cognithor/security/cost_ledger.py
@@ -55,6 +55,7 @@ class CostKind(StrEnum):
 
     LLM_INFERENCE = "llm_inference"  # tokens billed by an LLM provider
     EMBEDDING = "embedding"  # vector embedding API
+    VISION_TOKENS = "vision_tokens"  # image + video frame tokens (Sprint-27 VLM)
     TOOL_API = "tool_api"  # external tool API (search, scraping, …)
     STORAGE = "storage"  # persisted bytes-per-month
     NETWORK = "network"  # bandwidth / egress

--- a/tests/test_core/test_multimodal.py
+++ b/tests/test_core/test_multimodal.py
@@ -1,0 +1,258 @@
+"""Sprint-27 VLM-3 — multimodal-message helper tests."""
+
+from __future__ import annotations
+
+from cognithor.core.multimodal import (
+    MultimodalCounts,
+    count_multimodal_parts,
+    estimate_vision_tokens,
+    is_multimodal_request,
+)
+from cognithor.security.cost_ledger import CostKind
+
+# ---------------------------------------------------------------------------
+# CostKind extension
+# ---------------------------------------------------------------------------
+
+
+class TestCostKindHasVisionTokens:
+    def test_vision_tokens_value_in_enum(self) -> None:
+        # Spike-doc decision: VLM-3 adds VISION_TOKENS to the enum.
+        assert CostKind.VISION_TOKENS.value == "vision_tokens"
+        assert CostKind("vision_tokens") is CostKind.VISION_TOKENS
+
+
+# ---------------------------------------------------------------------------
+# count_multimodal_parts
+# ---------------------------------------------------------------------------
+
+
+class TestCountMultimodalParts:
+    def test_plain_string_content(self) -> None:
+        counts = count_multimodal_parts(
+            [{"role": "user", "content": "hello"}],
+        )
+        assert counts == MultimodalCounts(text_parts=1)
+
+    def test_typed_text_only(self) -> None:
+        counts = count_multimodal_parts(
+            [
+                {
+                    "role": "user",
+                    "content": [{"type": "text", "text": "describe"}],
+                },
+            ],
+        )
+        assert counts.text_parts == 1
+        assert counts.image_parts == 0
+        assert counts.video_parts == 0
+
+    def test_image_part(self) -> None:
+        counts = count_multimodal_parts(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "what is this?"},
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "data:image/png;base64,xyz"},
+                        },
+                    ],
+                },
+            ],
+        )
+        assert counts.image_parts == 1
+        assert counts.text_parts == 1
+        assert counts.has_vision is True
+
+    def test_video_part(self) -> None:
+        counts = count_multimodal_parts(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {
+                            "type": "video_url",
+                            "video_url": {"url": "file:///tmp/clip.mp4"},
+                        },
+                    ],
+                },
+            ],
+        )
+        assert counts.video_parts == 1
+        assert counts.has_vision is True
+        assert counts.total_vision_parts == 1
+
+    def test_mixed_multi_message(self) -> None:
+        counts = count_multimodal_parts(
+            [
+                {"role": "system", "content": "you are helpful"},
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "watch this"},
+                        {
+                            "type": "video_url",
+                            "video_url": {"url": "file:///clip1.mp4"},
+                        },
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "file:///shot.png"},
+                        },
+                        {
+                            "type": "image_url",
+                            "image_url": {"url": "file:///shot2.png"},
+                        },
+                    ],
+                },
+            ],
+        )
+        assert counts.image_parts == 2
+        assert counts.video_parts == 1
+        assert counts.text_parts == 2  # system string + user text part
+
+    def test_string_url_form_accepted(self) -> None:
+        # Some clients send {"image_url": "..."} without the {"url": ...} nesting.
+        counts = count_multimodal_parts(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": "file:///shot.png"},
+                    ],
+                },
+            ],
+        )
+        assert counts.image_parts == 1
+
+    def test_empty_url_dropped(self) -> None:
+        counts = count_multimodal_parts(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "image_url", "image_url": {"url": ""}},
+                        {"type": "video_url", "video_url": {}},
+                    ],
+                },
+            ],
+        )
+        assert counts.image_parts == 0
+        assert counts.video_parts == 0
+
+    def test_unknown_type_ignored(self) -> None:
+        counts = count_multimodal_parts(
+            [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "audio_url", "audio_url": {"url": "x"}},
+                        {"type": "text", "text": "hi"},
+                    ],
+                },
+            ],
+        )
+        assert counts.text_parts == 1
+        assert counts.image_parts == 0
+
+    def test_malformed_messages_ignored(self) -> None:
+        # Should not raise on garbage input.
+        counts = count_multimodal_parts(
+            [
+                None,  # type: ignore[list-item]
+                {"role": "user", "content": 42},  # type: ignore[dict-item]
+                "not a message",  # type: ignore[list-item]
+                {"role": "user", "content": [None, "string", 123]},  # type: ignore[list-item]
+            ],
+        )
+        assert counts == MultimodalCounts()
+
+    def test_empty_string_content_does_not_count_text(self) -> None:
+        counts = count_multimodal_parts([{"role": "user", "content": ""}])
+        assert counts.text_parts == 0
+
+
+# ---------------------------------------------------------------------------
+# estimate_vision_tokens
+# ---------------------------------------------------------------------------
+
+
+class TestEstimateVisionTokens:
+    def test_zero_when_no_vision(self) -> None:
+        assert estimate_vision_tokens(MultimodalCounts(text_parts=3)) == 0
+
+    def test_image_uses_256_tokens(self) -> None:
+        assert estimate_vision_tokens(MultimodalCounts(image_parts=1)) == 256
+
+    def test_video_uses_32_frames_x_256_tokens(self) -> None:
+        # Spike-doc default num_frames=32 for long clips.
+        assert estimate_vision_tokens(MultimodalCounts(video_parts=1)) == 32 * 256
+
+    def test_combined_estimate(self) -> None:
+        # 2 images + 1 video = 2*256 + 32*256
+        assert (
+            estimate_vision_tokens(
+                MultimodalCounts(image_parts=2, video_parts=1),
+            )
+            == 2 * 256 + 32 * 256
+        )
+
+
+# ---------------------------------------------------------------------------
+# is_multimodal_request
+# ---------------------------------------------------------------------------
+
+
+class TestIsMultimodal:
+    def test_plain_text_is_not_multimodal(self) -> None:
+        assert is_multimodal_request([{"role": "user", "content": "hi"}]) is False
+
+    def test_text_typed_only_is_not_multimodal(self) -> None:
+        assert (
+            is_multimodal_request(
+                [
+                    {
+                        "role": "user",
+                        "content": [{"type": "text", "text": "hi"}],
+                    },
+                ],
+            )
+            is False
+        )
+
+    def test_image_makes_multimodal(self) -> None:
+        assert (
+            is_multimodal_request(
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image_url",
+                                "image_url": {"url": "x"},
+                            },
+                        ],
+                    },
+                ],
+            )
+            is True
+        )
+
+    def test_video_makes_multimodal(self) -> None:
+        assert (
+            is_multimodal_request(
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "video_url",
+                                "video_url": {"url": "x"},
+                            },
+                        ],
+                    },
+                ],
+            )
+            is True
+        )


### PR DESCRIPTION
## Sprint-27 VLM-3 — multimodal-message helpers + cost-kind extension

Lays the central seam every backend (Ollama / OpenAI / vLLM / Anthropic / Gemini) consults to count `image_url` + `video_url` parts in a chat-messages list, plus the new TRUST-9 cost-ledger kind for vision-token billing.

## What ships

| File | Purpose |
|---|---|
| `cognithor/security/cost_ledger.py` | Adds `CostKind.VISION_TOKENS` per VLM-1 spike. Existing kinds unchanged (additive). |
| `cognithor/core/multimodal.py` | New module: `MultimodalCounts` frozen dataclass, `count_multimodal_parts()`, `estimate_vision_tokens()`, `is_multimodal_request()`. |
| `tests/test_core/test_multimodal.py` | 19 tests: enum membership, plain-string content, typed-list, mixed, string-url shorthand, empty-url drop, unknown-type ignore, malformed-input safety, token estimation. |

## Coverage

- **Plain-string + typed-list content** — both shapes counted correctly
- **Malformed input safety** — never raises (returns zero counts)
- **Forward-compat** — unknown part types silently ignored (audio_url, etc.)
- **Both URL shapes** — `{"image_url": {"url": "..."}}` and `{"image_url": "..."}` accepted
- **Token estimation** — image=256 tokens, video=32×256 tokens (matches v0.92.7 ffprobe default sampling)

## Quality

- ✅ mypy --strict on `cognithor/core/multimodal.py` — clean
- ✅ ruff check + ruff format --check (full src/ + tests/) — clean
- ✅ pytest tests/test_core/test_multimodal.py — **19/19 passing**

## Backend wiring (deferred to follow-up)

This PR ships the helpers + cost-kind. The actual per-backend wiring (emit `CostEntry(kind=VISION_TOKENS)` from `OpenAIBackend.chat()` / `VLLMBackend.chat()` / `OllamaBackend.chat()` whenever `is_multimodal_request(messages)` is True; YELLOW-classify in Gatekeeper) is the natural next step but lands in a separate, smaller PR to keep this one focused on the foundational seam.

## Refs

- VLM-1 spike (cost-kind decision): `docs/superpowers/spikes/2026-05-04-qwen3-vl-quant-spike.md`
- Builds on: VLM-2 (#445)
- Tasks: #134 (this PR), unblocks VLM-4 (#135 — end-to-end smoke)