### PR TITLE
feat(mcp): TRUST-9 wiring for video_render — provenance + cost (Sprint-27 HF-4)

### DIFF
--- a/src/cognithor/mcp/video_tools.py
+++ b/src/cognithor/mcp/video_tools.py
@@ -26,6 +26,8 @@ Apache-2.0 — no insurance / domain coupling, per Sprint-27 D4
 
 from __future__ import annotations
 
+import contextlib
+import hashlib
 import re
 from typing import TYPE_CHECKING, Any
 
@@ -41,6 +43,7 @@ from cognithor.video import (
 
 if TYPE_CHECKING:
     from cognithor.mcp.server import JarvisMCPServer
+    from cognithor.video.renderer_base import RenderResult
 
 log = get_logger(__name__)
 
@@ -321,7 +324,93 @@ async def _video_render_handler(
             "run_id": exc.run_id,
             "stderr_excerpt": exc.stderr_excerpt,
         }
+
+    # HF-4: TRUST wiring. Best-effort emission to canonical
+    # ledgers — never raise into the caller. Each tier is wrapped
+    # in suppress() per the established TRUST-stack pattern.
+    _emit_trust_entries(request=request, result=result, html_text=html_text)
+
     return {"ok": True, **result.to_dict()}
+
+
+def _hash_html_source(html_text: str | None, html_path: str | None) -> str:
+    """Stable identifier for the rendered composition.
+
+    Used as the ``ProvenanceTag.source_id`` for the rendered MP4
+    so downstream tools can correlate the binary with the exact
+    HTML that produced it.
+    """
+
+    if html_text is not None:
+        digest = hashlib.sha256(html_text.encode("utf-8")).hexdigest()
+        return f"html-text:{digest[:16]}"
+    if html_path is not None:
+        return f"html-path:{html_path}"
+    return "html:unknown"
+
+
+def _emit_trust_entries(
+    *,
+    request: RenderRequest,
+    result: RenderResult,
+    html_text: str | None,
+) -> None:
+    """HF-4 — emit ProvenanceTag + CostEntry for a successful video render.
+
+    All three sub-emissions are individually wrapped in
+    :func:`contextlib.suppress` so a TRUST-tier fault cannot
+    surface into the MCP-tool caller. The pattern matches the
+    Sprint-26 TRUST-stack rollout: best-effort capture, never
+    block the calling tier.
+    """
+
+    html_path_str = str(request.html_path) if request.html_path is not None else None
+    source_id = _hash_html_source(html_text, html_path_str)
+    output_path_str = str(result.output_path)
+
+    # TRUST-9 ProvenanceTag for the rendered MP4 file.
+    with contextlib.suppress(Exception):
+        from cognithor.memory.provenance import (
+            PROVENANCE_LEDGER,
+            ExpiryPolicy,
+            ProvenanceTag,
+            SourceType,
+        )
+
+        PROVENANCE_LEDGER.tag(
+            output_path_str,
+            ProvenanceTag(
+                source_type=SourceType.TOOL_OUTPUT,
+                source_id=source_id,
+                expiry_policy=ExpiryPolicy.PERMANENT,
+                notes=(
+                    f"video_render run_id={request.run_id} "
+                    f"format={result.output_format.value} "
+                    f"{result.width}x{result.height}@{result.fps}fps"
+                ),
+            ),
+        )
+
+    # TRUST-9 CostEntry. Local renders carry zero monetary cost
+    # but the entry exists so the operator's per-run accounting
+    # surfaces "this run rendered N MP4s" in the cost-summary
+    # tile alongside text-token costs. cost_usd_micro=0 — the
+    # subprocess runtime in milliseconds rides ``unit_count`` so
+    # the Trace-UI can render a duration histogram.
+    with contextlib.suppress(Exception):
+        from cognithor.security.cost_ledger import COST_LEDGER, CostEntry, CostKind
+
+        COST_LEDGER.record(
+            CostEntry(
+                kind=CostKind.OTHER,
+                tool="video_render",
+                cost_usd_micro=0,
+                backend=(request.allowed_adapters and "hyperframes") or "",
+                run_id=request.run_id,
+                unit_count=result.duration_ms,
+                notes=(f"render={result.output_format.value} bytes={result.bytes_written}"),
+            ),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_video/test_hf4_trust_wiring.py
+++ b/tests/test_video/test_hf4_trust_wiring.py
@@ -1,0 +1,222 @@
+"""Sprint-27 HF-4 — TRUST wiring tests for the video pipeline.
+
+Verifies that a successful ``video_render`` call emits both a
+:class:`ProvenanceTag` (TRUST-9) and a :class:`CostEntry`
+(TRUST-9 cost-ledger) into the canonical ledgers, AND that the
+emission is best-effort: if either ledger raises, the MCP tool
+still returns the render result to the caller.
+
+Tests use the canonical singletons (``PROVENANCE_LEDGER``,
+``COST_LEDGER``) and clear them inside fixtures so they don't
+contaminate other test files.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from cognithor.mcp.video_tools import _video_render_handler
+from cognithor.memory.provenance import (
+    PROVENANCE_LEDGER,
+    SourceType,
+)
+from cognithor.security.cost_ledger import COST_LEDGER, CostKind
+from cognithor.video.renderer_base import (
+    OutputFormat,
+    RendererABC,
+    RenderResult,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_ledgers() -> Any:
+    """Clear provenance + cost ledgers around every test."""
+
+    PROVENANCE_LEDGER.clear()
+    COST_LEDGER.clear()
+    yield
+    PROVENANCE_LEDGER.clear()
+    COST_LEDGER.clear()
+
+
+class _FakeRenderer(RendererABC):
+    """In-process renderer returning a synthetic RenderResult."""
+
+    NAME = "fake"
+
+    def __init__(self) -> None:
+        # Compatible no-op: we override render() to skip network entirely.
+        pass
+
+    async def is_available(self) -> bool:
+        return True
+
+    def supported_adapters(self) -> Any:  # type: ignore[override]
+        from cognithor.video.renderer_base import DEFAULT_ALLOWED_ADAPTERS
+
+        return DEFAULT_ALLOWED_ADAPTERS
+
+    async def render(self, request: Any) -> RenderResult:
+        # Synthetic output path; the file does NOT need to exist
+        # because the TRUST-wiring uses the path as a string identifier.
+        out = Path("/tmp") / "fake-render-output.mp4"
+        return RenderResult(
+            run_id=request.run_id,
+            output_path=out,
+            output_format=OutputFormat.MP4,
+            duration_ms=4321,
+            width=request.width,
+            height=request.height,
+            fps=request.fps,
+            bytes_written=98765,
+        )
+
+
+@pytest.fixture
+def fake_renderer_factory() -> Any:
+    """Patch the registry so video_render dispatches to _FakeRenderer."""
+
+    from cognithor.mcp import video_tools
+
+    fake_registry = {"fake": _FakeRenderer}
+    with patch.dict(video_tools.renderer_registry, fake_registry, clear=False):
+        yield
+
+
+# ---------------------------------------------------------------------------
+# Happy-path emission
+# ---------------------------------------------------------------------------
+
+
+class TestEmitProvenance:
+    @pytest.mark.asyncio
+    async def test_provenance_tag_recorded_for_rendered_mp4(
+        self,
+        fake_renderer_factory: Any,
+    ) -> None:
+        result = await _video_render_handler(
+            run_id="run-prov-1",
+            html_text="<div data-composition-id='x'></div>",
+            renderer="fake",
+        )
+        assert result["ok"] is True
+        # Output path is the ledger key.
+        out_path = result["output_path"]
+        tag = PROVENANCE_LEDGER.current(out_path)
+        assert tag is not None
+        assert tag.source_type == SourceType.TOOL_OUTPUT
+        # source_id should hash-encode the html_text input.
+        assert tag.source_id.startswith("html-text:")
+        # Notes mention the output format + dimensions.
+        assert "mp4" in tag.notes
+        assert "run-prov-1" in tag.notes
+
+    @pytest.mark.asyncio
+    async def test_provenance_source_id_distinguishes_text_vs_path(
+        self,
+        tmp_path: Path,
+        fake_renderer_factory: Any,
+    ) -> None:
+        # Path-based input — source_id should include the path.
+        html_path = tmp_path / "comp.html"
+        html_path.write_text("<div/>", encoding="utf-8")
+        result = await _video_render_handler(
+            run_id="run-prov-2",
+            html_path=str(html_path),
+            renderer="fake",
+        )
+        assert result["ok"] is True
+        tag = PROVENANCE_LEDGER.current(result["output_path"])
+        assert tag is not None
+        assert tag.source_id.startswith("html-path:")
+        assert str(html_path) in tag.source_id
+
+
+class TestEmitCost:
+    @pytest.mark.asyncio
+    async def test_cost_entry_recorded_zero_micro_usd(
+        self,
+        fake_renderer_factory: Any,
+    ) -> None:
+        await _video_render_handler(
+            run_id="run-cost-1",
+            html_text="<div/>",
+            renderer="fake",
+        )
+        # Filter by tool name to find our entry without depending on
+        # ledger size (other tests may have written too).
+        entries = [e for e in COST_LEDGER.entries() if e.tool == "video_render"]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.kind == CostKind.OTHER
+        assert entry.cost_usd_micro == 0
+        assert entry.run_id == "run-cost-1"
+        # Subprocess runtime rides unit_count.
+        assert entry.unit_count == 4321  # synthesised by _FakeRenderer
+        assert "mp4" in entry.notes
+        assert "98765" in entry.notes
+
+
+# ---------------------------------------------------------------------------
+# Best-effort: TRUST emission must NEVER fail the caller
+# ---------------------------------------------------------------------------
+
+
+class TestBestEffort:
+    @pytest.mark.asyncio
+    async def test_provenance_failure_does_not_break_render(
+        self,
+        fake_renderer_factory: Any,
+    ) -> None:
+        with patch.object(
+            PROVENANCE_LEDGER,
+            "tag",
+            side_effect=RuntimeError("ledger fault"),
+        ):
+            result = await _video_render_handler(
+                run_id="run-fault-1",
+                html_text="<div/>",
+                renderer="fake",
+            )
+        # Render succeeded despite ledger fault.
+        assert result["ok"] is True
+        assert result["run_id"] == "run-fault-1"
+
+    @pytest.mark.asyncio
+    async def test_cost_failure_does_not_break_render(
+        self,
+        fake_renderer_factory: Any,
+    ) -> None:
+        with patch.object(
+            COST_LEDGER,
+            "record",
+            side_effect=RuntimeError("ledger fault"),
+        ):
+            result = await _video_render_handler(
+                run_id="run-fault-2",
+                html_text="<div/>",
+                renderer="fake",
+            )
+        assert result["ok"] is True
+
+
+# ---------------------------------------------------------------------------
+# Failure path — no TRUST emission
+# ---------------------------------------------------------------------------
+
+
+class TestNoEmissionOnFailure:
+    @pytest.mark.asyncio
+    async def test_unknown_renderer_emits_no_tag(self) -> None:
+        await _video_render_handler(
+            run_id="run-fail-1",
+            html_text="<div/>",
+            renderer="does-not-exist",
+        )
+        # Empty ledger → no entry was emitted
+        assert len(PROVENANCE_LEDGER) == 0
+        assert len(COST_LEDGER.entries()) == 0


### PR DESCRIPTION
## Summary

Sprint-27 HF-4 — wires the operational-trust ledgers into the `video_render` MCP tool so every successful render emits a **ProvenanceTag** (TRUST-9) and a **CostEntry** (TRUST-9 cost-ledger) into the canonical singletons.

- Provenance: `PROVENANCE_LEDGER.tag(output_path, ProvenanceTag(source_type=TOOL_OUTPUT, source_id=html-text:<sha256[:16]> | html-path:<path>, ...))`
- Cost: `COST_LEDGER.record(CostEntry(kind=OTHER, tool="video_render", cost_usd_micro=0, run_id=..., unit_count=duration_ms, notes="..."))` — zero-USD entry; subprocess runtime rides `unit_count` so the ledger captures resource cost even when there is no monetary cost.
- Best-effort: every emit is wrapped in `contextlib.suppress(Exception)` — a ledger fault must never break the MCP tool callers.
- Failure paths (unknown renderer, invalid request) emit nothing.

## Tests (all green locally)

`tests/test_video/test_hf4_trust_wiring.py` — 6 new tests:

- `TestEmitProvenance::test_provenance_tag_recorded_for_rendered_mp4`
- `TestEmitProvenance::test_provenance_source_id_distinguishes_text_vs_path`
- `TestEmitCost::test_cost_entry_recorded_zero_micro_usd`
- `TestBestEffort::test_provenance_failure_does_not_break_render`
- `TestBestEffort::test_cost_failure_does_not_break_render`
- `TestNoEmissionOnFailure::test_unknown_renderer_emits_no_tag`

Total `tests/test_video/`: 56/56 pass (50 prior + 6 HF-4 new).

## Quality gates

- `mypy --strict src/cognithor/mcp/video_tools.py` — clean
- `ruff check src/ tests/` + `ruff format --check src/ tests/` — clean
- `pytest tests/test_video/ -q` — 56 passed

## Test plan

- [x] Provenance tag emitted with the rendered output path as ledger key
- [x] `source_id` distinguishes html_text (sha256 hash prefix) from html_path (raw path)
- [x] Cost entry tagged `tool="video_render"`, `kind=OTHER`, `cost_usd_micro=0`, `unit_count=duration_ms`
- [x] Provenance ledger fault → render still returns `ok: True`
- [x] Cost ledger fault → render still returns `ok: True`
- [x] Unknown renderer → no provenance + no cost entry written

## Follow-up

- Gatekeeper-side RED rule for raw HTML render (orange-tier already in HF-3 schema annotation; full risk wiring in next HF batch).