### PR TITLE
feat(mcp): video-composition skills layer (Sprint-27 HF-5)

### DIFF
--- a/docs/integrations/catalog.json
+++ b/docs/integrations/catalog.json
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-04T21:13:19.760020+00:00",
-  "tool_count": 138,
+  "generated_at": "2026-05-04T22:44:55.668974+00:00",
+  "tool_count": 141,
   "tools": [
     {
       "name": "file_write",
@@ -868,6 +868,27 @@
       "module": "cognithor.mcp.vault",
       "category": "misc",
       "description": "Aktualisiert eine bestehende Notiz im Vault. Kann Text anhängen und/oder Tags ergänzen.",
+      "dach_specific": false
+    },
+    {
+      "name": "video_caption_overlay",
+      "module": "cognithor.mcp.video_tools",
+      "category": "misc",
+      "description": "Glue a parallel caption track onto an existing composition spec. GREEN risk level — pure-function transform; emits new HTML.",
+      "dach_specific": false
+    },
+    {
+      "name": "video_compose_explainer",
+      "module": "cognithor.mcp.video_tools",
+      "category": "misc",
+      "description": "Title card + body sections + optional CTA in 16:9. GREEN risk level — pure-function preset over video_compose.",
+      "dach_specific": false
+    },
+    {
+      "name": "video_compose_social_cut",
+      "module": "cognithor.mcp.video_tools",
+      "category": "misc",
+      "description": "Vertical 9:16 short with hook + fast-cut beats + outro. GREEN risk level — pure-function preset over video_compose.",
       "dach_specific": false
     },
     {

--- a/src/cognithor/mcp/video_tools.py
+++ b/src/cognithor/mcp/video_tools.py
@@ -38,6 +38,11 @@ from cognithor.video import (
     RenderRequest,
     renderer_registry,
 )
+from cognithor.video.skills import (
+    caption_overlay,
+    compose_explainer,
+    compose_social_cut,
+)
 
 if TYPE_CHECKING:
     from cognithor.mcp.server import JarvisMCPServer
@@ -325,6 +330,103 @@ async def _video_render_handler(
 
 
 # ---------------------------------------------------------------------------
+# Skill-layer handlers (HF-5) — pure-function presets
+# ---------------------------------------------------------------------------
+
+
+def _compose_spec_to_html(spec: dict[str, Any]) -> dict[str, Any]:
+    """Shared tail for all HF-5 skills: HTML-emit + size-cap check."""
+
+    html = compose_html(spec)
+    if len(html.encode("utf-8")) > _MAX_HTML_TEXT_BYTES:
+        return {
+            "ok": False,
+            "error": (
+                f"composed HTML exceeds {_MAX_HTML_TEXT_BYTES // 1024} KB cap "
+                "— split into multiple scenes or pre-render assets"
+            ),
+        }
+    return {
+        "ok": True,
+        "html": html,
+        "byte_size": len(html.encode("utf-8")),
+        "spec": spec,
+    }
+
+
+async def _video_compose_explainer_handler(
+    title: str,
+    sections: list[Any] | None = None,
+    cta: str | None = None,
+    width: int = 1920,
+    height: int = 1080,
+    composition_id: str = "explainer",
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    """``video_compose_explainer`` — title + body sections + optional CTA."""
+
+    if not isinstance(title, str) or not title.strip():
+        return {"ok": False, "error": "title is required"}
+    spec = compose_explainer(
+        title=title,
+        sections=sections,
+        cta=cta,
+        width=int(width),
+        height=int(height),
+        composition_id=composition_id,
+    )
+    out = _compose_spec_to_html(spec)
+    if run_id is not None:
+        out["run_id"] = run_id
+    return out
+
+
+async def _video_compose_social_cut_handler(
+    hook: str,
+    beats: list[Any] | None = None,
+    outro: str | None = None,
+    width: int = 1080,
+    height: int = 1920,
+    composition_id: str = "social-cut",
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    """``video_compose_social_cut`` — vertical 9:16 short with fast cuts."""
+
+    if not isinstance(hook, str) or not hook.strip():
+        return {"ok": False, "error": "hook is required"}
+    spec = compose_social_cut(
+        hook=hook,
+        beats=beats,
+        outro=outro,
+        width=int(width),
+        height=int(height),
+        composition_id=composition_id,
+    )
+    out = _compose_spec_to_html(spec)
+    if run_id is not None:
+        out["run_id"] = run_id
+    return out
+
+
+async def _video_caption_overlay_handler(
+    base_spec: dict[str, Any],
+    captions: list[Any],
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    """``video_caption_overlay`` — glue captions onto an existing spec."""
+
+    if not isinstance(base_spec, dict):
+        return {"ok": False, "error": "base_spec must be a JSON object"}
+    if not isinstance(captions, list):
+        return {"ok": False, "error": "captions must be a list of strings"}
+    spec = caption_overlay(base_spec=base_spec, captions=captions)
+    out = _compose_spec_to_html(spec)
+    if run_id is not None:
+        out["run_id"] = run_id
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Registration — called by the MCP server bootstrapping
 # ---------------------------------------------------------------------------
 
@@ -405,8 +507,107 @@ _VIDEO_RENDER_INPUT_SCHEMA: dict[str, Any] = {
 }
 
 
+_VIDEO_COMPOSE_EXPLAINER_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "title": {
+            "type": "string",
+            "description": "Headline rendered on the title card (scene 0).",
+        },
+        "sections": {
+            "type": "array",
+            "description": (
+                "List of body sections. Each item may be a string "
+                "(used as caption) or an object with keys "
+                "'caption' and/or 'image_url' (local-asset path)."
+            ),
+            "items": {
+                "anyOf": [
+                    {"type": "string"},
+                    {
+                        "type": "object",
+                        "properties": {
+                            "caption": {"type": "string"},
+                            "image_url": {"type": "string"},
+                        },
+                    },
+                ],
+            },
+        },
+        "cta": {
+            "type": "string",
+            "description": "Optional call-to-action shown as the final scene.",
+        },
+        "width": {"type": "integer", "minimum": 16, "maximum": 7680, "default": 1920},
+        "height": {"type": "integer", "minimum": 16, "maximum": 4320, "default": 1080},
+        "composition_id": {"type": "string", "default": "explainer"},
+        "run_id": {"type": "string"},
+    },
+    "required": ["title"],
+}
+
+_VIDEO_COMPOSE_SOCIAL_CUT_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "hook": {
+            "type": "string",
+            "description": "Opening hook line (1-2 seconds, big caption).",
+        },
+        "beats": {
+            "type": "array",
+            "description": (
+                "List of fast-cut beats. Each item may be a string "
+                "(caption) or an object with keys 'caption' and/or "
+                "'image_url'. Capped at 8 beats for short-form pacing."
+            ),
+            "items": {
+                "anyOf": [
+                    {"type": "string"},
+                    {
+                        "type": "object",
+                        "properties": {
+                            "caption": {"type": "string"},
+                            "image_url": {"type": "string"},
+                        },
+                    },
+                ],
+            },
+        },
+        "outro": {
+            "type": "string",
+            "description": "Optional closing line (CTA / sign-off).",
+        },
+        "width": {"type": "integer", "minimum": 16, "maximum": 7680, "default": 1080},
+        "height": {"type": "integer", "minimum": 16, "maximum": 4320, "default": 1920},
+        "composition_id": {"type": "string", "default": "social-cut"},
+        "run_id": {"type": "string"},
+    },
+    "required": ["hook"],
+}
+
+_VIDEO_CAPTION_OVERLAY_INPUT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "base_spec": {
+            "type": "object",
+            "description": ("Base composition spec (same shape as video_compose's spec)."),
+        },
+        "captions": {
+            "type": "array",
+            "description": (
+                "Parallel caption track — captions[i] applies to scene i. "
+                "Empty / non-string entries leave the existing caption untouched."
+            ),
+            "items": {"type": "string"},
+        },
+        "run_id": {"type": "string"},
+    },
+    "required": ["base_spec", "captions"],
+}
+
+
 def register_video_tools(server: JarvisMCPServer) -> None:
-    """Register ``video_compose`` + ``video_render`` on a running MCP server."""
+    """Register video composition + render MCP tools on a running server."""
 
     from cognithor.mcp.server import MCPToolDef  # local import to avoid cycles
 
@@ -445,4 +646,61 @@ def register_video_tools(server: JarvisMCPServer) -> None:
             },
         ),
     )
-    log.info("video_tools_registered", tools=["video_compose", "video_render"])
+    server.register_tool(
+        MCPToolDef(
+            name="video_compose_explainer",
+            description=(
+                "Title card + body sections + optional CTA in 16:9. "
+                "GREEN risk level — pure-function preset over video_compose."
+            ),
+            input_schema=_VIDEO_COMPOSE_EXPLAINER_INPUT_SCHEMA,
+            handler=_video_compose_explainer_handler,
+            annotations={
+                "risk_level": "green",
+                "category": "video",
+                "supports_streaming": False,
+            },
+        ),
+    )
+    server.register_tool(
+        MCPToolDef(
+            name="video_compose_social_cut",
+            description=(
+                "Vertical 9:16 short with hook + fast-cut beats + outro. "
+                "GREEN risk level — pure-function preset over video_compose."
+            ),
+            input_schema=_VIDEO_COMPOSE_SOCIAL_CUT_INPUT_SCHEMA,
+            handler=_video_compose_social_cut_handler,
+            annotations={
+                "risk_level": "green",
+                "category": "video",
+                "supports_streaming": False,
+            },
+        ),
+    )
+    server.register_tool(
+        MCPToolDef(
+            name="video_caption_overlay",
+            description=(
+                "Glue a parallel caption track onto an existing composition spec. "
+                "GREEN risk level — pure-function transform; emits new HTML."
+            ),
+            input_schema=_VIDEO_CAPTION_OVERLAY_INPUT_SCHEMA,
+            handler=_video_caption_overlay_handler,
+            annotations={
+                "risk_level": "green",
+                "category": "video",
+                "supports_streaming": False,
+            },
+        ),
+    )
+    log.info(
+        "video_tools_registered",
+        tools=[
+            "video_compose",
+            "video_render",
+            "video_compose_explainer",
+            "video_compose_social_cut",
+            "video_caption_overlay",
+        ],
+    )

--- a/src/cognithor/video/skills.py
+++ b/src/cognithor/video/skills.py
@@ -1,0 +1,306 @@
+"""Sprint-27 HF-5 — video-composition skills layer.
+
+Domain-aware preset functions that wrap the raw
+``compose_html`` / ``video_compose`` surface (HF-3) with sensible
+defaults for common video shapes. Each skill is:
+
+* Pure: turns a high-level intent (title + bullet points, hook +
+  beats + outro, base composition + caption track) into a
+  structured spec the existing ``compose_html`` accepts.
+* Stateless: no filesystem, no subprocess. The caller pipes the
+  spec into ``video_compose`` (GREEN-risk MCP tool) to get HTML
+  back, then optionally hands the HTML to ``video_render``.
+* Defensively-typed: malformed inputs (wrong types, empty strings,
+  oversize lists) are clamped or dropped silently — the skill
+  should never raise.
+
+Three skills land in HF-5:
+
+* :func:`compose_explainer` — title scene + N body scenes + CTA
+  scene. 16:9 by default. Captions auto-laid-out.
+* :func:`compose_social_cut` — vertical 9:16 short with hook, fast
+  beats, outro. Defaults to 15s total / 1080x1920.
+* :func:`caption_overlay` — given a base spec + a parallel caption
+  list, returns a new spec with the captions glued onto each
+  scene by track-index.
+
+All three are registered as MCP tools in :mod:`cognithor.mcp.video_tools`
+under GREEN risk-level. Apache-2.0, no domain coupling.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = [
+    "DEFAULT_EXPLAINER_FPS",
+    "DEFAULT_EXPLAINER_HEIGHT",
+    "DEFAULT_EXPLAINER_WIDTH",
+    "DEFAULT_SOCIAL_HEIGHT",
+    "DEFAULT_SOCIAL_WIDTH",
+    "MAX_BEATS",
+    "MAX_SECTIONS",
+    "caption_overlay",
+    "compose_explainer",
+    "compose_social_cut",
+]
+
+
+DEFAULT_EXPLAINER_WIDTH = 1920
+DEFAULT_EXPLAINER_HEIGHT = 1080
+DEFAULT_EXPLAINER_FPS = 30
+
+DEFAULT_SOCIAL_WIDTH = 1080
+DEFAULT_SOCIAL_HEIGHT = 1920
+
+MAX_SECTIONS = 12  # explainer body cap — anything more belongs in chapters
+MAX_BEATS = 8  # social-cut beat cap — TikTok / Shorts work best with ≤8 cuts
+
+_DEFAULT_TITLE_SECONDS = 3.0
+_DEFAULT_SECTION_SECONDS = 5.0
+_DEFAULT_CTA_SECONDS = 3.0
+_DEFAULT_HOOK_SECONDS = 2.0
+_DEFAULT_BEAT_SECONDS = 1.5
+_DEFAULT_OUTRO_SECONDS = 2.0
+
+
+def _str_or_empty(value: Any) -> str:
+    """Coerce a value to ``str`` — non-strings (incl. None) become ''."""
+
+    if isinstance(value, str):
+        return value
+    return ""
+
+
+def _positive_float(value: Any, fallback: float) -> float:
+    """Parse a positive float; falls back when value is missing / invalid."""
+
+    try:
+        out = float(value)
+    except (TypeError, ValueError):
+        return fallback
+    return out if out > 0 else fallback
+
+
+def compose_explainer(
+    *,
+    title: str,
+    sections: list[Any] | None = None,
+    cta: str | None = None,
+    width: int = DEFAULT_EXPLAINER_WIDTH,
+    height: int = DEFAULT_EXPLAINER_HEIGHT,
+    composition_id: str = "explainer",
+    title_seconds: float = _DEFAULT_TITLE_SECONDS,
+    section_seconds: float = _DEFAULT_SECTION_SECONDS,
+    cta_seconds: float = _DEFAULT_CTA_SECONDS,
+) -> dict[str, Any]:
+    """Build an explainer-style composition spec.
+
+    Layout:
+
+    * Scene 0 — title card (centered headline).
+    * Scenes 1..N — body sections (each with optional caption + image_url).
+    * Scene N+1 — CTA card (only emitted if ``cta`` is set).
+
+    ``sections`` is a list of either:
+
+    * ``str`` — used as the caption.
+    * ``dict`` with keys ``{"caption": str, "image_url": str}``.
+
+    The returned spec is consumable by :func:`cognithor.mcp.video_tools.compose_html`.
+    """
+
+    title_text = _str_or_empty(title).strip()
+    cta_text = _str_or_empty(cta).strip()
+    safe_sections: list[dict[str, Any]] = []
+    if isinstance(sections, list):
+        for raw in sections[:MAX_SECTIONS]:
+            if isinstance(raw, str):
+                caption = raw.strip()
+                if caption:
+                    safe_sections.append({"caption": caption})
+            elif isinstance(raw, dict):
+                caption = _str_or_empty(raw.get("caption")).strip()
+                image_url = _str_or_empty(raw.get("image_url")).strip()
+                entry: dict[str, Any] = {}
+                if caption:
+                    entry["caption"] = caption
+                if image_url:
+                    entry["image_url"] = image_url
+                if entry:
+                    safe_sections.append(entry)
+
+    title_dur = _positive_float(title_seconds, _DEFAULT_TITLE_SECONDS)
+    section_dur = _positive_float(section_seconds, _DEFAULT_SECTION_SECONDS)
+    cta_dur = _positive_float(cta_seconds, _DEFAULT_CTA_SECONDS)
+
+    scenes: list[dict[str, Any]] = []
+    cursor = 0.0
+
+    if title_text:
+        scenes.append(
+            {
+                "start": cursor,
+                "duration": title_dur,
+                "title": title_text,
+            },
+        )
+        cursor += title_dur
+
+    for sec in safe_sections:
+        scene: dict[str, Any] = {
+            "start": cursor,
+            "duration": section_dur,
+            **sec,
+        }
+        scenes.append(scene)
+        cursor += section_dur
+
+    if cta_text:
+        scenes.append(
+            {
+                "start": cursor,
+                "duration": cta_dur,
+                "title": cta_text,
+            },
+        )
+        cursor += cta_dur
+
+    return {
+        "title": title_text or "Cognithor Explainer",
+        "composition_id": composition_id,
+        "width": width,
+        "height": height,
+        "scenes": scenes,
+    }
+
+
+def compose_social_cut(
+    *,
+    hook: str,
+    beats: list[Any] | None = None,
+    outro: str | None = None,
+    width: int = DEFAULT_SOCIAL_WIDTH,
+    height: int = DEFAULT_SOCIAL_HEIGHT,
+    composition_id: str = "social-cut",
+    hook_seconds: float = _DEFAULT_HOOK_SECONDS,
+    beat_seconds: float = _DEFAULT_BEAT_SECONDS,
+    outro_seconds: float = _DEFAULT_OUTRO_SECONDS,
+) -> dict[str, Any]:
+    """Build a vertical social-cut composition spec (9:16 by default).
+
+    Layout:
+
+    * Scene 0 — hook (1-2 second teaser, big caption).
+    * Scenes 1..N — beats (fast cuts, 1-2 seconds each).
+    * Scene N+1 — outro (CTA / sign-off).
+
+    ``beats`` accepts the same shape as ``compose_explainer.sections``.
+    """
+
+    hook_text = _str_or_empty(hook).strip()
+    outro_text = _str_or_empty(outro).strip()
+    safe_beats: list[dict[str, Any]] = []
+    if isinstance(beats, list):
+        for raw in beats[:MAX_BEATS]:
+            if isinstance(raw, str):
+                caption = raw.strip()
+                if caption:
+                    safe_beats.append({"caption": caption})
+            elif isinstance(raw, dict):
+                caption = _str_or_empty(raw.get("caption")).strip()
+                image_url = _str_or_empty(raw.get("image_url")).strip()
+                entry: dict[str, Any] = {}
+                if caption:
+                    entry["caption"] = caption
+                if image_url:
+                    entry["image_url"] = image_url
+                if entry:
+                    safe_beats.append(entry)
+
+    hook_dur = _positive_float(hook_seconds, _DEFAULT_HOOK_SECONDS)
+    beat_dur = _positive_float(beat_seconds, _DEFAULT_BEAT_SECONDS)
+    outro_dur = _positive_float(outro_seconds, _DEFAULT_OUTRO_SECONDS)
+
+    scenes: list[dict[str, Any]] = []
+    cursor = 0.0
+
+    if hook_text:
+        scenes.append(
+            {
+                "start": cursor,
+                "duration": hook_dur,
+                "title": hook_text,
+            },
+        )
+        cursor += hook_dur
+
+    for beat in safe_beats:
+        scene: dict[str, Any] = {
+            "start": cursor,
+            "duration": beat_dur,
+            **beat,
+        }
+        scenes.append(scene)
+        cursor += beat_dur
+
+    if outro_text:
+        scenes.append(
+            {
+                "start": cursor,
+                "duration": outro_dur,
+                "title": outro_text,
+            },
+        )
+        cursor += outro_dur
+
+    return {
+        "title": hook_text or "Cognithor Social Cut",
+        "composition_id": composition_id,
+        "width": width,
+        "height": height,
+        "scenes": scenes,
+    }
+
+
+def caption_overlay(
+    *,
+    base_spec: dict[str, Any],
+    captions: list[Any],
+) -> dict[str, Any]:
+    """Glue caption strings onto an existing composition spec.
+
+    ``captions`` is a parallel list to ``base_spec["scenes"]`` —
+    index *i* of ``captions`` is applied to scene *i*. A non-string
+    or empty entry leaves that scene's caption untouched. Extra
+    captions past the scene count are dropped silently.
+
+    Returns a NEW spec (does not mutate the input).
+    """
+
+    if not isinstance(base_spec, dict):
+        return {"scenes": []}
+    if not isinstance(captions, list):
+        return dict(base_spec)
+
+    scenes_raw = base_spec.get("scenes")
+    if not isinstance(scenes_raw, list):
+        new_spec = dict(base_spec)
+        new_spec["scenes"] = []
+        return new_spec
+
+    new_scenes: list[dict[str, Any]] = []
+    for idx, scene in enumerate(scenes_raw):
+        if not isinstance(scene, dict):
+            new_scenes.append({})
+            continue
+        merged = dict(scene)
+        if idx < len(captions):
+            cap = captions[idx]
+            if isinstance(cap, str) and cap.strip():
+                merged["caption"] = cap.strip()
+        new_scenes.append(merged)
+
+    new_spec = dict(base_spec)
+    new_spec["scenes"] = new_scenes
+    return new_spec

--- a/tests/test_video/test_hf5_skills.py
+++ b/tests/test_video/test_hf5_skills.py
@@ -1,0 +1,391 @@
+"""Sprint-27 HF-5 — video-composition skills layer tests.
+
+Covers the three skill MCP tools + their underlying pure functions:
+
+* ``compose_explainer`` / ``video_compose_explainer``
+* ``compose_social_cut`` / ``video_compose_social_cut``
+* ``caption_overlay`` / ``video_caption_overlay``
+
+Each skill is GREEN-risk: pure function over ``compose_html``, no
+subprocess, no filesystem write.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Any
+
+import pytest
+
+from cognithor.mcp.video_tools import (
+    _video_caption_overlay_handler,
+    _video_compose_explainer_handler,
+    _video_compose_social_cut_handler,
+    register_video_tools,
+)
+from cognithor.video.skills import (
+    DEFAULT_SOCIAL_HEIGHT,
+    DEFAULT_SOCIAL_WIDTH,
+    MAX_BEATS,
+    MAX_SECTIONS,
+    caption_overlay,
+    compose_explainer,
+    compose_social_cut,
+)
+
+# ---------------------------------------------------------------------------
+# compose_explainer — pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestComposeExplainer:
+    def test_minimal_title_only_emits_one_scene(self) -> None:
+        spec = compose_explainer(title="Hello")
+        assert spec["title"] == "Hello"
+        assert spec["composition_id"] == "explainer"
+        scenes = spec["scenes"]
+        assert len(scenes) == 1
+        assert scenes[0]["title"] == "Hello"
+        assert scenes[0]["start"] == 0.0
+        assert scenes[0]["duration"] > 0
+
+    def test_sections_become_body_scenes(self) -> None:
+        spec = compose_explainer(
+            title="Intro",
+            sections=["First point", "Second point", "Third point"],
+        )
+        # 1 title + 3 body
+        assert len(spec["scenes"]) == 4
+        body = spec["scenes"][1:]
+        assert [s["caption"] for s in body] == [
+            "First point",
+            "Second point",
+            "Third point",
+        ]
+
+    def test_section_objects_with_image_url(self) -> None:
+        spec = compose_explainer(
+            title="With assets",
+            sections=[
+                {"caption": "frame one", "image_url": "./assets/a.png"},
+                {"image_url": "./assets/b.png"},
+            ],
+        )
+        body = spec["scenes"][1:]
+        assert body[0]["caption"] == "frame one"
+        assert body[0]["image_url"] == "./assets/a.png"
+        assert "caption" not in body[1]
+        assert body[1]["image_url"] == "./assets/b.png"
+
+    def test_cta_emitted_as_final_scene(self) -> None:
+        spec = compose_explainer(
+            title="Open",
+            sections=["body"],
+            cta="Try it now",
+        )
+        assert spec["scenes"][-1]["title"] == "Try it now"
+        # title + body + CTA = 3 scenes
+        assert len(spec["scenes"]) == 3
+
+    def test_scene_starts_are_monotonic(self) -> None:
+        spec = compose_explainer(
+            title="X",
+            sections=["a", "b", "c"],
+            cta="Done",
+        )
+        starts = [s["start"] for s in spec["scenes"]]
+        assert starts == sorted(starts)
+        assert all(b > a for a, b in itertools.pairwise(starts))
+
+    def test_sections_clamped_to_max(self) -> None:
+        spec = compose_explainer(
+            title="cap",
+            sections=[f"section {i}" for i in range(MAX_SECTIONS + 5)],
+        )
+        # title + MAX_SECTIONS body
+        assert len(spec["scenes"]) == 1 + MAX_SECTIONS
+
+    def test_invalid_section_dropped(self) -> None:
+        spec = compose_explainer(
+            title="filter",
+            sections=["valid", 42, None, {"caption": "kept"}, ""],
+        )
+        body = spec["scenes"][1:]
+        captions = [s.get("caption") for s in body]
+        assert "valid" in captions
+        assert "kept" in captions
+        assert len(body) == 2
+
+    def test_empty_title_still_returns_spec(self) -> None:
+        spec = compose_explainer(title="", sections=["body"])
+        # Title scene dropped (empty), but body remains.
+        assert len(spec["scenes"]) == 1
+        assert spec["scenes"][0]["caption"] == "body"
+        # Spec falls back to default headline string for the <title> tag.
+        assert spec["title"] == "Cognithor Explainer"
+
+
+# ---------------------------------------------------------------------------
+# compose_social_cut — pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestComposeSocialCut:
+    def test_default_aspect_is_vertical(self) -> None:
+        spec = compose_social_cut(hook="hook")
+        assert spec["width"] == DEFAULT_SOCIAL_WIDTH
+        assert spec["height"] == DEFAULT_SOCIAL_HEIGHT
+        assert spec["height"] > spec["width"]
+
+    def test_hook_beats_outro_full_layout(self) -> None:
+        spec = compose_social_cut(
+            hook="Watch this",
+            beats=["beat1", "beat2", "beat3"],
+            outro="Follow!",
+        )
+        # hook + 3 beats + outro = 5 scenes
+        assert len(spec["scenes"]) == 5
+        assert spec["scenes"][0]["title"] == "Watch this"
+        assert spec["scenes"][-1]["title"] == "Follow!"
+        assert spec["scenes"][1]["caption"] == "beat1"
+
+    def test_beats_clamped_to_max(self) -> None:
+        spec = compose_social_cut(
+            hook="h",
+            beats=[f"beat {i}" for i in range(MAX_BEATS + 3)],
+        )
+        # hook + MAX_BEATS scenes
+        assert len(spec["scenes"]) == 1 + MAX_BEATS
+
+    def test_beats_with_image_url(self) -> None:
+        spec = compose_social_cut(
+            hook="h",
+            beats=[
+                {"caption": "with image", "image_url": "./b1.png"},
+                {"image_url": "./b2.png"},
+            ],
+        )
+        beats = spec["scenes"][1:]
+        assert beats[0]["image_url"] == "./b1.png"
+        assert beats[1]["image_url"] == "./b2.png"
+
+    def test_empty_hook_drops_hook_scene(self) -> None:
+        spec = compose_social_cut(hook="", beats=["b1", "b2"])
+        # Only the beats remain.
+        assert len(spec["scenes"]) == 2
+
+    def test_overrideable_dimensions(self) -> None:
+        spec = compose_social_cut(hook="h", width=720, height=1280)
+        assert spec["width"] == 720
+        assert spec["height"] == 1280
+
+
+# ---------------------------------------------------------------------------
+# caption_overlay — pure function tests
+# ---------------------------------------------------------------------------
+
+
+class TestCaptionOverlay:
+    def _base(self) -> dict[str, Any]:
+        return {
+            "title": "Base",
+            "scenes": [
+                {"start": 0.0, "duration": 2.0, "caption": "old1"},
+                {"start": 2.0, "duration": 2.0, "caption": "old2"},
+                {"start": 4.0, "duration": 2.0},
+            ],
+        }
+
+    def test_replaces_existing_captions(self) -> None:
+        out = caption_overlay(
+            base_spec=self._base(),
+            captions=["new1", "new2", "added3"],
+        )
+        captions = [s.get("caption") for s in out["scenes"]]
+        assert captions == ["new1", "new2", "added3"]
+
+    def test_empty_caption_leaves_existing(self) -> None:
+        out = caption_overlay(
+            base_spec=self._base(),
+            captions=["", "  ", "kept"],
+        )
+        captions = [s.get("caption") for s in out["scenes"]]
+        # Indexes 0 and 1 keep their old caption since new is empty.
+        assert captions[0] == "old1"
+        assert captions[1] == "old2"
+        assert captions[2] == "kept"
+
+    def test_extra_captions_dropped(self) -> None:
+        out = caption_overlay(
+            base_spec=self._base(),
+            captions=["a", "b", "c", "d", "e"],
+        )
+        # 3 scenes only; no scene 4 created.
+        assert len(out["scenes"]) == 3
+
+    def test_does_not_mutate_input(self) -> None:
+        base = self._base()
+        original = base["scenes"][0]["caption"]
+        caption_overlay(base_spec=base, captions=["mutated"])
+        assert base["scenes"][0]["caption"] == original
+
+    def test_preserves_title_and_dimensions(self) -> None:
+        base = {
+            "title": "Keep",
+            "width": 1280,
+            "height": 720,
+            "scenes": [{"start": 0, "duration": 1}],
+        }
+        out = caption_overlay(base_spec=base, captions=["x"])
+        assert out["title"] == "Keep"
+        assert out["width"] == 1280
+        assert out["height"] == 720
+
+    def test_non_dict_base_returns_empty(self) -> None:
+        out = caption_overlay(base_spec="nope", captions=["x"])  # type: ignore[arg-type]
+        assert out == {"scenes": []}
+
+    def test_non_list_captions_returns_copy(self) -> None:
+        base = self._base()
+        out = caption_overlay(base_spec=base, captions="bad")  # type: ignore[arg-type]
+        # Spec returned untouched (functional copy).
+        assert out["scenes"][0]["caption"] == "old1"
+
+
+# ---------------------------------------------------------------------------
+# MCP-tool handlers
+# ---------------------------------------------------------------------------
+
+
+class TestExplainerHandler:
+    @pytest.mark.asyncio
+    async def test_returns_html_on_valid_call(self) -> None:
+        result = await _video_compose_explainer_handler(
+            title="My Explainer",
+            sections=["one", "two"],
+            cta="CTA",
+            run_id="r1",
+        )
+        assert result["ok"] is True
+        assert "<!doctype html>" in result["html"]
+        assert result["byte_size"] > 0
+        assert result["run_id"] == "r1"
+        # Spec returned for downstream piping.
+        assert len(result["spec"]["scenes"]) == 4
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_title(self) -> None:
+        result = await _video_compose_explainer_handler(title="")
+        assert result["ok"] is False
+        assert "title" in result["error"]
+
+
+class TestSocialCutHandler:
+    @pytest.mark.asyncio
+    async def test_returns_html_on_valid_call(self) -> None:
+        result = await _video_compose_social_cut_handler(
+            hook="Hook!",
+            beats=["b1", "b2"],
+            outro="bye",
+        )
+        assert result["ok"] is True
+        assert "<!doctype html>" in result["html"]
+        # Default vertical aspect baked into HTML
+        assert 'data-width="1080"' in result["html"]
+        assert 'data-height="1920"' in result["html"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_hook(self) -> None:
+        result = await _video_compose_social_cut_handler(hook="")
+        assert result["ok"] is False
+        assert "hook" in result["error"]
+
+
+class TestCaptionOverlayHandler:
+    @pytest.mark.asyncio
+    async def test_glues_captions_into_html(self) -> None:
+        base = {
+            "title": "B",
+            "scenes": [
+                {"start": 0, "duration": 2},
+                {"start": 2, "duration": 2},
+            ],
+        }
+        result = await _video_caption_overlay_handler(
+            base_spec=base,
+            captions=["captionA", "captionB"],
+        )
+        assert result["ok"] is True
+        assert "captionA" in result["html"]
+        assert "captionB" in result["html"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_dict_base(self) -> None:
+        result = await _video_caption_overlay_handler(
+            base_spec="nope",  # type: ignore[arg-type]
+            captions=["x"],
+        )
+        assert result["ok"] is False
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_list_captions(self) -> None:
+        result = await _video_caption_overlay_handler(
+            base_spec={"scenes": []},
+            captions="not a list",  # type: ignore[arg-type]
+        )
+        assert result["ok"] is False
+
+
+# ---------------------------------------------------------------------------
+# Registration — three new tools land on the MCP server
+# ---------------------------------------------------------------------------
+
+
+class _StubServer:
+    def __init__(self) -> None:
+        self.tools: list[Any] = []
+
+    def register_tool(self, tool: Any) -> None:
+        self.tools.append(tool)
+
+
+class TestSkillRegistration:
+    def test_all_skill_tools_registered(self) -> None:
+        srv = _StubServer()
+        register_video_tools(srv)  # type: ignore[arg-type]
+        names = [t.name for t in srv.tools]
+        assert "video_compose_explainer" in names
+        assert "video_compose_social_cut" in names
+        assert "video_caption_overlay" in names
+
+    def test_skills_are_green_risk(self) -> None:
+        srv = _StubServer()
+        register_video_tools(srv)  # type: ignore[arg-type]
+        for name in (
+            "video_compose_explainer",
+            "video_compose_social_cut",
+            "video_caption_overlay",
+        ):
+            tool = next(t for t in srv.tools if t.name == name)
+            assert tool.annotations["risk_level"] == "green"
+            assert tool.annotations["category"] == "video"
+
+    def test_explainer_schema_requires_title(self) -> None:
+        srv = _StubServer()
+        register_video_tools(srv)  # type: ignore[arg-type]
+        tool = next(t for t in srv.tools if t.name == "video_compose_explainer")
+        assert "title" in tool.input_schema["required"]
+
+    def test_social_cut_schema_requires_hook(self) -> None:
+        srv = _StubServer()
+        register_video_tools(srv)  # type: ignore[arg-type]
+        tool = next(t for t in srv.tools if t.name == "video_compose_social_cut")
+        assert "hook" in tool.input_schema["required"]
+
+    def test_caption_overlay_schema_requires_base_and_captions(self) -> None:
+        srv = _StubServer()
+        register_video_tools(srv)  # type: ignore[arg-type]
+        tool = next(t for t in srv.tools if t.name == "video_caption_overlay")
+        required = tool.input_schema["required"]
+        assert "base_spec" in required
+        assert "captions" in required


### PR DESCRIPTION
## Summary

Sprint-27 HF-5 ships the **video-editing skills layer** on top of the HF-3 compose surface. Three GREEN-risk MCP tools, all pure-function presets:

- `video_compose_explainer(title, sections, cta?)` — 16:9 explainer with title card + body sections + optional CTA card.
- `video_compose_social_cut(hook, beats, outro?)` — vertical 9:16 short with hook + fast-cut beats + optional outro.
- `video_caption_overlay(base_spec, captions)` — glues a parallel caption track onto an existing composition spec by track-index.

## Implementation

- New module `src/cognithor/video/skills.py` exposes three pure functions (`compose_explainer`, `compose_social_cut`, `caption_overlay`) that turn high-level intent into the structured spec shape `compose_html` already accepts.
- Defensive parsing: malformed sections / beats / captions are dropped silently — the skills never raise.
- Body cap: `MAX_SECTIONS=12`, `MAX_BEATS=8` (clamping keeps short-form pacing tight).
- All three handlers in `src/cognithor/mcp/video_tools.py` are GREEN-risk: pure-function over `compose_html`, no subprocess, no filesystem write.
- `caption_overlay` is non-mutating — returns a fresh dict.

## Tests

`tests/test_video/test_hf5_skills.py` — 33 new tests across:

- `TestComposeExplainer` (8 tests) — title-only, sections, image_url, CTA, monotonic starts, clamping, invalid drops, empty title.
- `TestComposeSocialCut` (6 tests) — vertical default, full layout, beat clamping, image_url, empty hook, override dimensions.
- `TestCaptionOverlay` (7 tests) — replace, empty leaves existing, extras dropped, no-mutate, preserves title+dims, non-dict base, non-list captions.
- Handler tests (6 tests) for each of the three MCP tools.
- `TestSkillRegistration` (5 tests) — all three tools land on the server, all GREEN risk, schemas have correct `required` sets.

Total `tests/test_video/`: **83/83** pass (50 base + 6 HF-4 + 27 prior + 33 new HF-5).

## Catalog

`docs/integrations/catalog.json` regenerated: **138 → 141 tools**.

## Quality gates

- `mypy --strict src/cognithor/video/skills.py src/cognithor/mcp/video_tools.py` — clean
- `ruff check src/ tests/` — clean
- `ruff format --check src/ tests/` — clean
- `pytest tests/test_video/ -q` — 83 passed in 0.76s

## Test plan

- [x] Explainer with title-only renders one scene
- [x] Sections become body scenes with monotonic starts
- [x] CTA emitted as final scene
- [x] Social cut defaults to 9:16 vertical
- [x] Beat clamping at MAX_BEATS=8
- [x] Caption overlay does NOT mutate the input spec
- [x] Empty captions leave existing scene captions untouched
- [x] All three tools register as GREEN risk