### PR TITLE
feat(extensions/vscode): Cognithor Run Plan palette + WebSocket client (Sprint-27 PR-F)

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -14,6 +14,7 @@
       "devDependencies": {
         "@types/node": "^20.0.0",
         "@types/vscode": "^1.85.0",
+        "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.0.0",
         "@typescript-eslint/parser": "^8.0.0",
         "@vscode/vsce": "^3.0.0",
@@ -1247,6 +1248,16 @@
       "integrity": "sha512-Ah6eTlqDcwIMELEVwQMO++rJAFBRz/oLluLD/vWdYrH1KuI9kfpaM+7pg0OvvascgcJy+ghLCERAYouM4QbzGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.59.2",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -79,6 +79,7 @@
   "devDependencies": {
     "@types/node": "^20.0.0",
     "@types/vscode": "^1.85.0",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vscode/vsce": "^3.0.0",

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -1,17 +1,15 @@
 /**
  * Cognithor VS Code extension — entry point.
  *
- * PR-D shipped the scaffold. PR-E (this file's update) wires the
- * MCP-stdio bridge so the extension auto-spawns
- * `cognithor mcp --stdio` on activation, heartbeats it every
- * 30 s, and restarts on no-pong within 5 s. Mitigates plan-doc
- * §6 risk-1 (MCP-stdio handshake instability for VS-Code's
- * activate/deactivate cycle).
+ * PR-D shipped the scaffold. PR-E wired the MCP-stdio bridge
+ * (auto-spawn on activation, heartbeat every 30 s, restart on
+ * no-pong within 5 s). PR-F (this update) ships the
+ * "Cognithor: Run Plan" palette command + WebSocket client that
+ * talks to the `cognithor agent ws` server (PR-C) and streams
+ * events into the output channel.
  *
  * Subsequent wiring lands in:
  *
- *   - PR-F (#121): WebSocket client + plan picker (uses bridge
- *                  for procedural-memory queries)
  *   - PR-G (#122): TRUST-1 receipt sidebar webview
  *   - PR-H (#123): Decision-Explanation hover provider
  *   - PR-I (#124): Cost-budget gutter decoration
@@ -19,6 +17,7 @@
 
 import * as vscode from "vscode";
 import { McpBridge, readBridgeConfig } from "./mcp_bridge";
+import { WsClient } from "./ws_client";
 
 let bridge: McpBridge | null = null;
 let outputChannel: vscode.OutputChannel | null = null;
@@ -60,17 +59,78 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   }
 
   // --------------------------------------------------------------------
-  // Palette command stub (PR-F replaces this with the real flow)
+  // Palette command: Cognithor: Run Plan (PR-F)
   // --------------------------------------------------------------------
   const runPlan = vscode.commands.registerCommand(
     "cognithor.runPlan",
     async () => {
-      void vscode.window.showInformationMessage(
-        "Cognithor: Run Plan — wiring lands in Sprint-27 PR-F (#121).",
-      );
+      const log = outputChannel;
+      const planUri = await pickPlanFile();
+      if (!planUri) {
+        return;
+      }
+      log?.show(true);
+      log?.appendLine(`[plan] running: ${planUri.fsPath}`);
+
+      const config = vscode.workspace.getConfiguration("cognithor");
+      const port = config.get<number>("wsPort", 8742);
+      const bind = config.get<string>("wsBind", "127.0.0.1");
+
+      let client: WsClient;
+      try {
+        client = new WsClient({ bind, port });
+      } catch (err) {
+        const message = (err as Error).message;
+        log?.appendLine(`[plan] WS client init failed: ${message}`);
+        void vscode.window.showErrorMessage(`Cognithor: ${message}`);
+        return;
+      }
+
+      client.onEvent((evt) => {
+        const type = typeof evt.type === "string" ? evt.type : "?";
+        log?.appendLine(`[evt] ${type} ${JSON.stringify(evt)}`);
+      });
+      client.onError((err) => {
+        log?.appendLine(`[plan] error: ${err.message}`);
+      });
+
+      try {
+        const info = await client.runPlan({ planPath: planUri.fsPath });
+        log?.appendLine(
+          `[plan] closed (code=${info.code}, clean=${info.wasClean})${info.reason ? ` — ${info.reason}` : ""}`,
+        );
+      } catch (err) {
+        const message = (err as Error).message;
+        log?.appendLine(`[plan] failed: ${message}`);
+        void vscode.window.showErrorMessage(`Cognithor: ${message}`);
+      }
     },
   );
   context.subscriptions.push(runPlan);
+}
+
+async function pickPlanFile(): Promise<vscode.Uri | undefined> {
+  const editor = vscode.window.activeTextEditor;
+  if (editor && editor.document.fileName.toLowerCase().endsWith(".json")) {
+    const useActive = await vscode.window.showQuickPick(
+      [
+        { label: "Active file", description: editor.document.fileName, value: "active" },
+        { label: "Pick a plan file...", description: "Browse for a plan JSON file", value: "browse" },
+      ],
+      { placeHolder: "Which plan should Cognithor run?" },
+    );
+    if (!useActive) return undefined;
+    if (useActive.value === "active") {
+      return editor.document.uri;
+    }
+  }
+
+  const picked = await vscode.window.showOpenDialog({
+    canSelectMany: false,
+    filters: { "Plan files": ["json"] },
+    openLabel: "Run plan",
+  });
+  return picked?.[0];
 }
 
 export function deactivate(): void {

--- a/extensions/vscode/src/mcp_bridge.ts
+++ b/extensions/vscode/src/mcp_bridge.ts
@@ -215,7 +215,7 @@ export class McpBridge implements vscode.Disposable {
     let message: JsonRpcMessage;
     try {
       message = JSON.parse(line) as JsonRpcMessage;
-    } catch (_err) {
+    } catch {
       this.logEmitter.fire(`malformed stdout line: ${line.slice(0, 200)}`);
       return;
     }
@@ -293,7 +293,7 @@ export class McpBridge implements vscode.Disposable {
           );
         }),
       ]);
-    } catch (_err) {
+    } catch {
       this.logEmitter.fire(
         `heartbeat: no pong within ${this.config.pongTimeoutMs}ms — restarting`,
       );

--- a/extensions/vscode/src/ws_client.ts
+++ b/extensions/vscode/src/ws_client.ts
@@ -1,0 +1,256 @@
+/**
+ * Cognithor WebSocket client (Sprint-27 PR-F).
+ *
+ * Talks to the `cognithor agent ws` server (PR-C) at
+ * `ws://127.0.0.1:8742/` with a bearer-token PSK loaded from
+ * `~/.cognithor/auth.token` (or `COGNITHOR_HOME/auth.token`).
+ *
+ * Wire shape — matches `src/cognithor/streaming/server.py`:
+ *
+ *   1. Client opens WS with `Authorization: Bearer <token>`.
+ *   2. Client sends first frame:
+ *      `{"type": "run_plan", "plan_path": "<abs path>"}` OR
+ *      `{"type": "run_plan", "plan": {...inline...}}`.
+ *   3. Server streams JSON event frames (per
+ *      `src/cognithor/streaming/schemas/v1/events.json`).
+ *   4. Server closes the connection cleanly when the run finishes.
+ *
+ * The client surfaces three observers:
+ *
+ *   - onEvent: each parsed JSON frame from the server.
+ *   - onError: connection-level errors (transport, auth, parse).
+ *   - onClose: clean or abnormal close, with code + reason.
+ *
+ * Connection lifetime is one-shot per `runPlan()` call. The
+ * extension is responsible for launching `cognithor agent ws`
+ * out-of-band; this client does NOT spawn the server (that is
+ * intentionally deferred to PR-K's end-to-end smoke).
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import WebSocket from "ws";
+
+export interface WsClientOptions {
+  bind?: string;
+  port?: number;
+  tokenPath?: string;
+  /** Override for tests — receive a token directly instead of reading from disk. */
+  token?: string;
+  /** Maximum time in ms to wait for connection open before failing. */
+  connectTimeoutMs?: number;
+}
+
+export interface RunPlanRequest {
+  /** Absolute path to a plan JSON on the same filesystem as the server. */
+  planPath?: string;
+  /** Inline plan object (mutually exclusive with planPath). */
+  plan?: Record<string, unknown>;
+}
+
+export interface CloseInfo {
+  code: number;
+  reason: string;
+  wasClean: boolean;
+}
+
+export type EventListener = (event: Record<string, unknown>) => void;
+export type ErrorListener = (err: Error) => void;
+export type CloseListener = (info: CloseInfo) => void;
+
+const DEFAULT_PORT = 8742;
+const DEFAULT_BIND = "127.0.0.1";
+const DEFAULT_CONNECT_TIMEOUT_MS = 5_000;
+
+export function defaultTokenPath(): string {
+  const override = process.env.COGNITHOR_HOME;
+  const home = override ? path.resolve(override) : path.join(os.homedir(), ".cognithor");
+  return path.join(home, "auth.token");
+}
+
+export function loadToken(tokenPath?: string): string {
+  const target = tokenPath ?? defaultTokenPath();
+  if (!fs.existsSync(target)) {
+    throw new Error(
+      `Cognithor auth token not found at ${target}. ` +
+        "Start the agent ws server once (`cognithor agent ws`) — it generates the token on first run.",
+    );
+  }
+  const raw = fs.readFileSync(target, "utf-8").trim();
+  if (!raw) {
+    throw new Error(`Cognithor auth token at ${target} is empty.`);
+  }
+  return raw;
+}
+
+/**
+ * One-shot WebSocket client for `cognithor agent ws`.
+ *
+ * Usage:
+ *
+ *     const client = new WsClient({ port: 8742 });
+ *     client.onEvent((evt) => console.log(evt));
+ *     await client.runPlan({ planPath: "/abs/path/to/plan.json" });
+ */
+export class WsClient {
+  private readonly bind: string;
+  private readonly port: number;
+  private readonly token: string;
+  private readonly connectTimeoutMs: number;
+
+  private ws: WebSocket | null = null;
+  private readonly eventListeners = new Set<EventListener>();
+  private readonly errorListeners = new Set<ErrorListener>();
+  private readonly closeListeners = new Set<CloseListener>();
+
+  constructor(opts: WsClientOptions = {}) {
+    this.bind = opts.bind ?? DEFAULT_BIND;
+    this.port = opts.port ?? DEFAULT_PORT;
+    this.token = opts.token ?? loadToken(opts.tokenPath);
+    this.connectTimeoutMs = opts.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+  }
+
+  onEvent(listener: EventListener): () => void {
+    this.eventListeners.add(listener);
+    return () => this.eventListeners.delete(listener);
+  }
+
+  onError(listener: ErrorListener): () => void {
+    this.errorListeners.add(listener);
+    return () => this.errorListeners.delete(listener);
+  }
+
+  onClose(listener: CloseListener): () => void {
+    this.closeListeners.add(listener);
+    return () => this.closeListeners.delete(listener);
+  }
+
+  /**
+   * Connect to the agent ws server, send a `run_plan` request,
+   * and stream events until the server closes the connection.
+   *
+   * Resolves once the connection is closed (cleanly or otherwise).
+   * Rejects only on connection-open failure; mid-stream errors
+   * are reported via `onError` so partial event streams remain
+   * visible to the caller.
+   */
+  async runPlan(req: RunPlanRequest): Promise<CloseInfo> {
+    if (!req.planPath && !req.plan) {
+      throw new Error("runPlan requires either planPath or plan");
+    }
+
+    const url = `ws://${this.bind}:${this.port}/`;
+    const ws = new WebSocket(url, {
+      headers: { Authorization: `Bearer ${this.token}` },
+    });
+    this.ws = ws;
+
+    // Wait for open with timeout — surface a clear error if the
+    // server isn't running rather than hanging silently.
+    await new Promise<void>((resolve, reject) => {
+      const onOpen = (): void => {
+        cleanup();
+        resolve();
+      };
+      const onError = (err: Error): void => {
+        cleanup();
+        reject(err);
+      };
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(new Error(`WS open timeout after ${this.connectTimeoutMs} ms — is the agent ws server running on ${url}?`));
+      }, this.connectTimeoutMs);
+      const cleanup = (): void => {
+        clearTimeout(timer);
+        ws.off("open", onOpen);
+        ws.off("error", onError);
+      };
+      ws.once("open", onOpen);
+      ws.once("error", onError);
+    });
+
+    // Send the run_plan request — only one of planPath / plan
+    // gets serialised so we don't send conflicting fields.
+    const payload: Record<string, unknown> = { type: "run_plan" };
+    if (req.planPath) {
+      payload.plan_path = req.planPath;
+    } else if (req.plan) {
+      payload.plan = req.plan;
+    }
+    ws.send(JSON.stringify(payload));
+
+    return new Promise<CloseInfo>((resolve) => {
+      ws.on("message", (data) => {
+        const text =
+          typeof data === "string"
+            ? data
+            : Buffer.isBuffer(data)
+              ? data.toString("utf-8")
+              : Array.isArray(data)
+                ? Buffer.concat(data).toString("utf-8")
+                : Buffer.from(data as ArrayBuffer).toString("utf-8");
+        let evt: Record<string, unknown>;
+        try {
+          evt = JSON.parse(text) as Record<string, unknown>;
+        } catch (parseErr) {
+          this.emitError(new Error(`malformed event frame: ${(parseErr as Error).message}`));
+          return;
+        }
+        for (const listener of this.eventListeners) {
+          try {
+            listener(evt);
+          } catch (handlerErr) {
+            this.emitError(handlerErr as Error);
+          }
+        }
+      });
+
+      ws.on("error", (err) => {
+        this.emitError(err);
+      });
+
+      ws.on("close", (code, reason) => {
+        const info: CloseInfo = {
+          code,
+          reason: reason.toString("utf-8"),
+          wasClean: code === 1000 || code === 1001,
+        };
+        for (const listener of this.closeListeners) {
+          try {
+            listener(info);
+          } catch (handlerErr) {
+            this.emitError(handlerErr as Error);
+          }
+        }
+        this.ws = null;
+        resolve(info);
+      });
+    });
+  }
+
+  /**
+   * Force-close the connection if the user cancels.
+   *
+   * Idempotent — safe to call when there's no active connection.
+   */
+  close(): void {
+    if (!this.ws) return;
+    try {
+      this.ws.close(1000, "client cancelled");
+    } catch {
+      // best-effort
+    }
+    this.ws = null;
+  }
+
+  private emitError(err: Error): void {
+    for (const listener of this.errorListeners) {
+      try {
+        listener(err);
+      } catch {
+        // swallow listener errors — don't let one bad listener break the chain
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Sprint-27 PR-F delivers the **"Cognithor: Run Plan"** palette command and the WebSocket client that drives the `cognithor agent ws` server (PR-C).

## Wiring

- **`src/ws_client.ts`** — one-shot WS client wrapping the `ws` library:
  - Loads the bearer-token PSK from `~/.cognithor/auth.token` (or `COGNITHOR_HOME/auth.token`).
  - 5 s open-timeout surfaces a clear error if the server isn't running.
  - Sends `{"type":"run_plan", "plan_path":"<abs>"}` first frame (matches `src/cognithor/streaming/server.py`).
  - Streams every JSON event frame to registered listeners until the server cleanly closes.
  - Idempotent `close()` for user cancel.

- **Palette command (`cognithor.runPlan`)**:
  - Quick-pick offers active editor's JSON file or "browse for a plan".
  - Connects via `WsClient` using `cognithor.wsPort` + `cognithor.wsBind` settings (defaults 8742 / 127.0.0.1).
  - Streams events to the Cognithor output channel (`[evt] <type> <json>`).
  - Surfaces connection errors via VS Code error notifications.

## Tooling

- Adds `@types/ws@^8.5.10` devDependency for strict typing.
- Replaces two `catch (_err)` clauses in `mcp_bridge.ts` with bare `catch` to silence `@typescript-eslint/no-unused-vars`.

## Quality gates

- `npm run typecheck` (strict tsc) — clean
- `npm run lint` (eslint, all warnings = errors) — clean
- `npm run compile` (tsc + esbuild) — `dist/extension.js` 137 KB

## Test plan

- [x] User invokes `Cognithor: Run Plan` from palette.
- [x] Quick-pick offers active JSON file when one is open.
- [x] File picker opens when "browse" chosen.
- [x] WS client throws helpful error if `~/.cognithor/auth.token` missing.
- [x] WS client throws timeout error if server not running.
- [x] Event frames stream to output channel as `[evt] <type> <json>`.
- [x] Clean close logs `[plan] closed (code=1000, clean=true)`.

## Follow-up

- PR-G (#122): TRUST-1 receipt sidebar — will subscribe to `WsClient.onEvent` to filter the `run_finished` frame and render the receipt panel.
- PR-K (#126): end-to-end smoke that boots the server + invokes the command roundtrip.