### PR TITLE
feat(extensions/vscode): TRUST-1 receipt sidebar webview (Sprint-27 PR-G)

### DIFF
--- a/extensions/vscode/media/icon.svg
+++ b/extensions/vscode/media/icon.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="9"/>
+  <path d="M12 7v5l3 2"/>
+  <path d="M9 19l1.5-2"/>
+  <path d="M15 19l-1.5-2"/>
+</svg>

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -35,6 +35,8 @@
   "main": "./dist/extension.js",
   "activationEvents": [
     "onCommand:cognithor.runPlan",
+    "onCommand:cognithor.viewReceipt",
+    "onView:cognithor.receipts",
     "onStartupFinished"
   ],
   "contributes": {
@@ -43,8 +45,64 @@
         "command": "cognithor.runPlan",
         "title": "Cognithor: Run Plan",
         "category": "Cognithor"
+      },
+      {
+        "command": "cognithor.viewReceipt",
+        "title": "Cognithor: View TRUST-1 Receipt",
+        "category": "Cognithor",
+        "icon": "$(file-binary)"
+      },
+      {
+        "command": "cognithor.refreshReceipts",
+        "title": "Cognithor: Refresh Receipts",
+        "category": "Cognithor",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "cognithor.forgetReceipts",
+        "title": "Cognithor: Forget All Receipts",
+        "category": "Cognithor",
+        "icon": "$(clear-all)"
       }
     ],
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "cognithor",
+          "title": "Cognithor",
+          "icon": "media/icon.svg"
+        }
+      ]
+    },
+    "views": {
+      "cognithor": [
+        {
+          "id": "cognithor.receipts",
+          "name": "TRUST-1 Receipts",
+          "icon": "$(file-binary)",
+          "contextualTitle": "Cognithor"
+        }
+      ]
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "cognithor.refreshReceipts",
+          "when": "view == cognithor.receipts",
+          "group": "navigation"
+        },
+        {
+          "command": "cognithor.viewReceipt",
+          "when": "view == cognithor.receipts",
+          "group": "navigation"
+        },
+        {
+          "command": "cognithor.forgetReceipts",
+          "when": "view == cognithor.receipts",
+          "group": "1_modification"
+        }
+      ]
+    },
     "configuration": {
       "title": "Cognithor",
       "properties": {
@@ -62,6 +120,21 @@
           "type": "string",
           "default": "127.0.0.1",
           "description": "Bind address for the cognithor agent ws server. Keep this as 127.0.0.1 unless you know what you are doing."
+        },
+        "cognithor.apiHost": {
+          "type": "string",
+          "default": "127.0.0.1",
+          "description": "Host of the cognithor REST API server (default: 127.0.0.1)."
+        },
+        "cognithor.apiPort": {
+          "type": "number",
+          "default": 8741,
+          "description": "Port of the cognithor REST API server (default: 8741)."
+        },
+        "cognithor.receiptIncludeTrust": {
+          "type": "boolean",
+          "default": true,
+          "description": "Fold the TRUST-5..10 ledger bundle into receipts when fetching."
         }
       }
     }

--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -17,6 +17,7 @@
 
 import * as vscode from "vscode";
 import { McpBridge, readBridgeConfig } from "./mcp_bridge";
+import { ReceiptTreeProvider, ReceiptViewer } from "./receipt_view";
 import { WsClient } from "./ws_client";
 
 let bridge: McpBridge | null = null;
@@ -107,6 +108,68 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     },
   );
   context.subscriptions.push(runPlan);
+
+  // --------------------------------------------------------------------
+  // TRUST-1 receipt viewer (PR-G)
+  // --------------------------------------------------------------------
+  const receiptViewer = new ReceiptViewer(context.workspaceState);
+  const receiptTree = new ReceiptTreeProvider(receiptViewer);
+  context.subscriptions.push(
+    vscode.window.registerTreeDataProvider("cognithor.receipts", receiptTree),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand(
+      "cognithor.viewReceipt",
+      async (traceIdArg?: string) => {
+        let traceId = traceIdArg;
+        if (typeof traceId !== "string" || traceId.length === 0) {
+          const recent = receiptViewer.recentTraceIds();
+          if (recent.length > 0) {
+            const picked = await vscode.window.showQuickPick(
+              [
+                ...recent.map((id) => ({ label: id, value: id })),
+                { label: "Enter a different trace id...", value: "__custom__" },
+              ],
+              { placeHolder: "Pick a recent trace id or enter a new one" },
+            );
+            if (!picked) return;
+            traceId = picked.value === "__custom__" ? undefined : picked.value;
+          }
+          if (typeof traceId !== "string") {
+            const entered = await vscode.window.showInputBox({
+              prompt: "Cognithor trace id",
+              placeHolder: "e.g. trace_abc123...",
+            });
+            if (!entered) return;
+            traceId = entered;
+          }
+        }
+        await receiptViewer.show(traceId);
+        receiptTree.refresh();
+      },
+    ),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("cognithor.refreshReceipts", () => {
+      receiptTree.refresh();
+    }),
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand("cognithor.forgetReceipts", async () => {
+      const confirm = await vscode.window.showWarningMessage(
+        "Forget all remembered Cognithor trace ids?",
+        { modal: true },
+        "Forget",
+      );
+      if (confirm === "Forget") {
+        await receiptViewer.forgetAll();
+        receiptTree.refresh();
+      }
+    }),
+  );
 }
 
 async function pickPlanFile(): Promise<vscode.Uri | undefined> {

--- a/extensions/vscode/src/receipt_view.ts
+++ b/extensions/vscode/src/receipt_view.ts
@@ -1,0 +1,226 @@
+/**
+ * Cognithor TRUST-1 receipt webview (Sprint-27 PR-G).
+ *
+ * Renders the JSON run-receipt returned by
+ * `GET /api/crew/trace/{trace_id}/receipt` (with optional
+ * `?include_trust=true` for the TRUST-5..10 bundle) into a
+ * VS Code webview panel.
+ *
+ * Self-contained — no dependency on the PR-F WS client. The
+ * sidebar tree-view collects trace_ids the user has typed in;
+ * a single command (`cognithor.viewReceipt`) prompts for a
+ * trace_id and opens the panel. Trace IDs are persisted in
+ * workspace memento storage so the sidebar survives reloads.
+ */
+
+import * as http from "node:http";
+import * as vscode from "vscode";
+
+const RECEIPT_HISTORY_KEY = "cognithor.receiptTraceIds";
+const MAX_HISTORY = 20;
+
+export interface ReceiptViewConfig {
+  apiHost: string;
+  apiPort: number;
+  includeTrust: boolean;
+}
+
+export function readReceiptConfig(): ReceiptViewConfig {
+  const config = vscode.workspace.getConfiguration("cognithor");
+  return {
+    apiHost: config.get<string>("apiHost", "127.0.0.1"),
+    apiPort: config.get<number>("apiPort", 8741),
+    includeTrust: config.get<boolean>("receiptIncludeTrust", true),
+  };
+}
+
+interface FetchedReceipt {
+  status: number;
+  body: string;
+}
+
+function fetchReceipt(
+  config: ReceiptViewConfig,
+  traceId: string,
+): Promise<FetchedReceipt> {
+  // Tight URL construction: trace_id is path-segment encoded so a
+  // user pasting whitespace or `/` doesn't accidentally redirect
+  // the request elsewhere.
+  const encoded = encodeURIComponent(traceId);
+  const path =
+    `/api/crew/trace/${encoded}/receipt` +
+    (config.includeTrust ? "?include_trust=true" : "");
+
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        host: config.apiHost,
+        port: config.apiPort,
+        path,
+        method: "GET",
+        headers: { Accept: "application/json" },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (chunk: Buffer) => chunks.push(chunk));
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString("utf-8"),
+          });
+        });
+        res.on("error", reject);
+      },
+    );
+    req.setTimeout(5_000, () => {
+      req.destroy(new Error(`receipt fetch timeout (${config.apiHost}:${config.apiPort})`));
+    });
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function renderReceiptHtml(traceId: string, body: string, status: number): string {
+  let pretty = body;
+  let parsedOk = false;
+  try {
+    const parsed = JSON.parse(body) as unknown;
+    pretty = JSON.stringify(parsed, null, 2);
+    parsedOk = true;
+  } catch {
+    // Non-JSON body (e.g. error string) — render verbatim.
+  }
+  const heading = parsedOk
+    ? `Run receipt for trace ${escapeHtml(traceId)}`
+    : `Receipt fetch returned status ${status}`;
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline';" />
+  <title>${escapeHtml(heading)}</title>
+  <style>
+    body { font-family: var(--vscode-font-family); color: var(--vscode-foreground);
+           background: var(--vscode-editor-background); padding: 1rem; }
+    h1 { font-size: 1.2rem; margin: 0 0 0.5rem; }
+    .meta { opacity: 0.7; font-size: 0.85rem; margin-bottom: 1rem; }
+    pre { background: var(--vscode-editor-background); border: 1px solid var(--vscode-panel-border);
+          padding: 0.75rem; overflow: auto; white-space: pre-wrap; word-break: break-word;
+          font-family: var(--vscode-editor-font-family, monospace); font-size: 0.85rem; }
+    .err { color: var(--vscode-errorForeground); }
+  </style>
+</head>
+<body>
+  <h1>${escapeHtml(heading)}</h1>
+  <div class="meta">HTTP ${status} · ${escapeHtml(traceId)}</div>
+  <pre class="${parsedOk ? "" : "err"}">${escapeHtml(pretty)}</pre>
+</body>
+</html>`;
+}
+
+export class ReceiptViewer {
+  private panel: vscode.WebviewPanel | null = null;
+
+  constructor(private readonly state: vscode.Memento) {}
+
+  recentTraceIds(): string[] {
+    return this.state.get<string[]>(RECEIPT_HISTORY_KEY, []);
+  }
+
+  rememberTraceId(traceId: string): Thenable<void> {
+    const existing = this.recentTraceIds();
+    const filtered = [traceId, ...existing.filter((t) => t !== traceId)];
+    return this.state.update(
+      RECEIPT_HISTORY_KEY,
+      filtered.slice(0, MAX_HISTORY),
+    );
+  }
+
+  forgetAll(): Thenable<void> {
+    return this.state.update(RECEIPT_HISTORY_KEY, []);
+  }
+
+  async show(traceId: string, config?: ReceiptViewConfig): Promise<void> {
+    const cfg = config ?? readReceiptConfig();
+    const trimmed = traceId.trim();
+    if (!trimmed) {
+      void vscode.window.showWarningMessage("Cognithor: empty trace id");
+      return;
+    }
+
+    let result: FetchedReceipt;
+    try {
+      result = await fetchReceipt(cfg, trimmed);
+    } catch (err) {
+      const message = (err as Error).message;
+      void vscode.window.showErrorMessage(
+        `Cognithor: receipt fetch failed — ${message}`,
+      );
+      return;
+    }
+
+    if (result.status === 200) {
+      await this.rememberTraceId(trimmed);
+    }
+
+    const html = renderReceiptHtml(trimmed, result.body, result.status);
+    if (this.panel === null || this.panel.visible === false) {
+      this.panel = vscode.window.createWebviewPanel(
+        "cognithor.receipt",
+        `Cognithor Receipt · ${trimmed.slice(0, 12)}`,
+        vscode.ViewColumn.Beside,
+        { enableScripts: false, retainContextWhenHidden: true },
+      );
+      this.panel.onDidDispose(() => {
+        this.panel = null;
+      });
+    } else {
+      this.panel.title = `Cognithor Receipt · ${trimmed.slice(0, 12)}`;
+      this.panel.reveal(vscode.ViewColumn.Beside, true);
+    }
+    this.panel.webview.html = html;
+  }
+}
+
+class ReceiptTreeItem extends vscode.TreeItem {
+  constructor(public readonly traceId: string) {
+    super(traceId, vscode.TreeItemCollapsibleState.None);
+    this.tooltip = `Open receipt for trace ${traceId}`;
+    this.contextValue = "cognithor.receipt";
+    this.iconPath = new vscode.ThemeIcon("file-binary");
+    this.command = {
+      command: "cognithor.viewReceipt",
+      title: "View Receipt",
+      arguments: [traceId],
+    };
+  }
+}
+
+export class ReceiptTreeProvider implements vscode.TreeDataProvider<ReceiptTreeItem> {
+  private readonly emitter = new vscode.EventEmitter<void>();
+  readonly onDidChangeTreeData = this.emitter.event;
+
+  constructor(private readonly viewer: ReceiptViewer) {}
+
+  refresh(): void {
+    this.emitter.fire();
+  }
+
+  getTreeItem(element: ReceiptTreeItem): vscode.TreeItem {
+    return element;
+  }
+
+  getChildren(): ReceiptTreeItem[] {
+    return this.viewer.recentTraceIds().map((id) => new ReceiptTreeItem(id));
+  }
+}


### PR DESCRIPTION
## Summary

Sprint-27 PR-G adds a Cognithor activity-bar container with a **TRUST-1 Receipts** tree-view + a webview panel that renders the run-receipt JSON returned by `GET /api/crew/trace/{trace_id}/receipt`.

## Wiring

- **`src/receipt_view.ts`** — self-contained module:
  - `ReceiptViewer` class fetches over plain http (5 s timeout, `path-segment` encoded trace_id).
  - Persists up to 20 most-recent trace_ids in workspace memento storage (`cognithor.receiptTraceIds`).
  - Strict CSP webview (no scripts) — escapes all user-supplied values to prevent HTML injection.
  - VS Code theme tokens for colours, monospace font for the JSON body.
  - Tree provider implements `vscode.TreeDataProvider`; tree items click-trigger `cognithor.viewReceipt`.

- **Three commands** registered in `extension.ts`:
  - `cognithor.viewReceipt` — quick-pick of recent IDs or input-box for new ones.
  - `cognithor.refreshReceipts` — refresh tree.
  - `cognithor.forgetReceipts` — modal-confirm clear of remembered IDs.

- **`package.json` contributions**:
  - `viewsContainers` entry: Cognithor activity-bar icon (new `media/icon.svg`).
  - `views` entry: `cognithor.receipts` tree-view in the container.
  - `menus` entries for the three commands.
  - Three new config keys: `cognithor.apiHost` (127.0.0.1), `cognithor.apiPort` (8741), `cognithor.receiptIncludeTrust` (true).

## Quality gates

- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run compile` — `dist/extension.js` 16.6 KB

## Test plan

- [x] User invokes "Cognithor: View TRUST-1 Receipt" from palette.
- [x] Quick-pick of recent IDs appears when there's history.
- [x] Input-box appears when there's no history (or "enter different" picked).
- [x] Webview opens in side column with HTTP status + parsed JSON body.
- [x] Receipt fetch error surfaces a VS Code error notification.
- [x] Tree-view in activity bar shows persisted recent IDs.
- [x] "Forget all receipts" modal-confirms before clearing.
- [x] Trace ID with `/` or whitespace gets URL-encoded (no path-traversal).
- [x] Strict CSP — receipt body cannot inject scripts.

## Follow-up

- PR-H (#123): hover provider that surfaces `gatekeeper_decision_explanation` from the receipt directly in code.
- PR-K (#126): end-to-end smoke that boots gateway + runs plan + auto-fetches the resulting receipt into this view.