### PR TITLE
fix(audit-pr1): Sprint-27 fresh-code hardening (5 audit findings)

### DIFF
--- a/extensions/vscode/src/extension.ts
+++ b/extensions/vscode/src/extension.ts
@@ -90,8 +90,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
 
       client.onEvent((evt) => {
-        const type = typeof evt.type === "string" ? evt.type : "?";
-        log?.appendLine(`[evt] ${type} ${JSON.stringify(evt)}`);
+        // The streaming wire format uses `event` as the discriminator
+        // (per src/cognithor/streaming/schemas/v1/events.json). The
+        // earlier code logged `evt.type` which never exists on the
+        // wire, so every entry showed as `?` in the output channel.
+        const kind = typeof evt.event === "string" ? evt.event : "?";
+        log?.appendLine(`[evt] ${kind} ${JSON.stringify(evt)}`);
       });
       client.onError((err) => {
         log?.appendLine(`[plan] error: ${err.message}`);

--- a/extensions/vscode/src/ws_client.ts
+++ b/extensions/vscode/src/ws_client.ts
@@ -155,10 +155,25 @@ export class WsClient {
       };
       const onError = (err: Error): void => {
         cleanup();
+        try {
+          ws.terminate();
+        } catch {
+          // best-effort
+        }
+        this.ws = null;
         reject(err);
       };
       const timer = setTimeout(() => {
         cleanup();
+        // Tear the dangling socket down before rejecting so the
+        // node process doesn't accumulate orphan TCP connections
+        // on every "agent ws not running" attempt.
+        try {
+          ws.terminate();
+        } catch {
+          // best-effort
+        }
+        this.ws = null;
         reject(new Error(`WS open timeout after ${this.connectTimeoutMs} ms — is the agent ws server running on ${url}?`));
       }, this.connectTimeoutMs);
       const cleanup = (): void => {

--- a/src/cognithor/mcp/video_tools.py
+++ b/src/cognithor/mcp/video_tools.py
@@ -28,7 +28,9 @@ from __future__ import annotations
 
 import contextlib
 import hashlib
+import html
 import re
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from cognithor.utils.logging import get_logger
@@ -124,13 +126,20 @@ def _scene_body(scene: dict[str, Any]) -> str:
             f'font-size:2.5vw;margin:0">{_sanitize_text(caption)}</p>',
         )
     image_url = scene.get("image_url")
-    if isinstance(image_url, str) and image_url.startswith(
-        ("file://", "/", "./", "../"),
+    # Local-asset references only (no http(s), no ../ traversal) — the
+    # composition must self-contain its assets per the HF-1 threat
+    # model. html.escape() defends against attribute injection (e.g.
+    # `/x" onload="evil()`) — even though the render runs inside a
+    # sandboxed Puppeteer with strict CSP, defense-in-depth keeps the
+    # composed HTML safe to ship to any other consumer.
+    if (
+        isinstance(image_url, str)
+        and image_url.startswith(("file://", "/", "./"))
+        and ".." not in image_url.split("/")
     ):
-        # Local-asset references only (no http(s)) — composition
-        # must self-contain its assets per HF-1 threat model.
+        safe_url = html.escape(image_url, quote=True)
         parts.append(
-            f'    <img src="{image_url}" '
+            f'    <img src="{safe_url}" '
             'style="position:absolute;inset:0;width:100%;height:100%;'
             'object-fit:cover" />',
         )
@@ -278,6 +287,48 @@ async def _video_compose_handler(
     }
 
 
+def _resolve_safe_html_path(raw: str) -> Path:
+    """Resolve + sandbox-check an agent-supplied html_path string.
+
+    The HyperFrames Puppeteer subprocess opens the file with full
+    filesystem-read permissions. An unvalidated agent-controlled
+    path would let a malicious plan exfiltrate ``/etc/passwd`` or
+    ``~/.ssh/id_rsa`` into the rendered MP4. We restrict reads to
+    three trusted roots:
+
+    * the current working directory (typical project workflow),
+    * ``~/.cognithor/`` (the agent's own home / render cache), and
+    * the OS temp directory (where ``video_compose`` -> file
+      pipelines and tests stash inline HTML).
+
+    Anything outside those roots — including ``..``-laden relative
+    paths that resolve outside cwd — raises ``ValueError`` and is
+    surfaced as a structured ``"path not in trusted roots"`` error.
+    """
+
+    import os
+    import tempfile
+
+    p = Path(raw).expanduser().resolve(strict=False)
+    cwd = Path.cwd().resolve()
+    home_dir = (
+        Path(os.environ.get("COGNITHOR_HOME", Path.home() / ".cognithor")).expanduser().resolve()
+    )
+    tmp_dir = Path(tempfile.gettempdir()).resolve()
+    trusted = (cwd, home_dir, tmp_dir)
+    for root in trusted:
+        try:
+            p.relative_to(root)
+            return p
+        except ValueError:
+            continue
+    msg = (
+        f"html_path {raw!r} not in trusted roots — "
+        f"must be under cwd, ~/.cognithor/, or the OS temp directory"
+    )
+    raise ValueError(msg)
+
+
 async def _video_render_handler(
     run_id: str,
     html_text: str | None = None,
@@ -304,10 +355,17 @@ async def _video_render_handler(
             "available": sorted(renderer_registry),
         }
 
+    safe_html_path: Path | None = None
+    if html_path is not None:
+        try:
+            safe_html_path = _resolve_safe_html_path(html_path)
+        except ValueError as exc:
+            return {"ok": False, "error": str(exc)}
+
     try:
         request = RenderRequest(
             run_id=run_id,
-            html_path=__import__("pathlib").Path(html_path) if html_path else None,
+            html_path=safe_html_path,
             html_text=html_text,
             output_format=_coerce_format(output_format),
             width=int(width),

--- a/src/cognithor/streaming/schemas/v1/events.json
+++ b/src/cognithor/streaming/schemas/v1/events.json
@@ -21,7 +21,17 @@
       "properties": {
         "event": {
           "type": "string",
-          "description": "Discriminator: one of run_started / plan_step / gate_decision / tool_result / run_complete / run_error / run_cancelled / sink_dropped."
+          "enum": [
+            "run_started",
+            "plan_step",
+            "gate_decision",
+            "tool_result",
+            "run_complete",
+            "run_error",
+            "run_cancelled",
+            "sink_dropped"
+          ],
+          "description": "Discriminator. Closed enum so consumer-side switch tables can be machine-generated; per-event $defs each pin a single const that intersects with this enum."
         },
         "schema_version": {
           "type": "integer",

--- a/src/cognithor/video/renderer_base.py
+++ b/src/cognithor/video/renderer_base.py
@@ -108,6 +108,9 @@ class RenderRequest:
         if self.width < 16 or self.height < 16:
             msg = "RenderRequest width / height must be >= 16"
             raise ValueError(msg)
+        if self.width > 7680 or self.height > 4320:
+            msg = "RenderRequest width <= 7680, height <= 4320"
+            raise ValueError(msg)
         if self.fps < 1 or self.fps > 240:
             msg = "RenderRequest fps must be in [1, 240]"
             raise ValueError(msg)

--- a/tests/test_video/test_video_tools.py
+++ b/tests/test_video/test_video_tools.py
@@ -208,6 +208,76 @@ class TestVideoRenderHandler:
         assert result["ok"] is False
         assert "render request" in result["error"]
 
+    @pytest.mark.asyncio
+    async def test_html_path_outside_trusted_roots_rejected(self) -> None:
+        # /etc/passwd is the canonical exfil target; must be rejected
+        # before the renderer is invoked. Audit finding SEC C-2.
+        result = await _video_render_handler(
+            run_id="r1",
+            html_path="/etc/passwd",
+            renderer="hyperframes",
+        )
+        assert result["ok"] is False
+        assert "trusted roots" in result["error"]
+
+
+class TestSceneBodySanitization:
+    """Audit findings SEC H-1 + SEC M-3 — image_url escape + ../ reject."""
+
+    def test_image_url_with_attribute_injection_is_escaped(self) -> None:
+        from cognithor.mcp.video_tools import compose_html
+
+        html_out = compose_html(
+            {
+                "scenes": [
+                    {
+                        "start": 0,
+                        "duration": 1,
+                        "image_url": '/assets/a.png" onload="evil()',
+                    },
+                ],
+            },
+        )
+        # The literal injection payload must NOT appear unescaped.
+        assert '" onload="evil()' not in html_out
+        # The escaped form should be present (html.escape with quote=True
+        # turns the inner `"` into `&quot;`).
+        assert "&quot;" in html_out or "/assets/a.png" not in html_out
+
+    def test_dotdot_traversal_in_image_url_is_dropped(self) -> None:
+        from cognithor.mcp.video_tools import compose_html
+
+        html_out = compose_html(
+            {
+                "scenes": [
+                    {
+                        "start": 0,
+                        "duration": 1,
+                        "image_url": "../../../etc/passwd",
+                    },
+                ],
+            },
+        )
+        # The composed HTML must not contain the traversal path.
+        assert "etc/passwd" not in html_out
+
+    def test_render_request_width_height_upper_bound(self) -> None:
+        # Audit finding HF-3 #5 — direct Python callers must hit the
+        # cap, not just the JSON schema layer.
+        import pytest as _pytest
+
+        from cognithor.video.renderer_base import OutputFormat, RenderRequest
+
+        with _pytest.raises(ValueError, match="<= 7680"):
+            RenderRequest(
+                run_id="r",
+                html_text="<x/>",
+                output_format=OutputFormat.MP4,
+                width=99999,
+                height=4320,
+                fps=30,
+            )
+
 
 # ---------------------------------------------------------------------------
 # register_video_tools — schema + handler wired correctly


### PR DESCRIPTION
## Summary

Multi-agent code audit (Audit Agent #4 — Sprint-27 fresh code) surfaced 5 verified bugs in the HF-3..HF-5 + PR-F code merged in the last hours. Fixed in one tightly-scoped PR.

## Findings closed

| # | Severity | File | Description |
|---|---|---|---|
| 1 | HIGH | `streaming/schemas/v1/events.json` | `EnvelopeFields.event` missing `enum` — no machine-readable closed discriminator |
| 2 | HIGH | `video/renderer_base.py` | `RenderRequest` missing upper-bound check on `width`/`height` |
| 3 | HIGH | `extensions/vscode/src/ws_client.ts` | Open-timeout / error rejection leaks the WebSocket |
| 4 | HIGH | `extensions/vscode/src/extension.ts` | Logged `evt.type` instead of `evt.event` — every event shows as `?` |
| 5a | CRIT | `mcp/video_tools.py` `_video_render_handler` | `html_path` accepted without sandbox; agent could feed `/etc/passwd` to Puppeteer |
| 5b | HIGH | `mcp/video_tools.py` `_scene_body` | `image_url` HTML attribute not escaped — attribute injection via `/x\" onload=\"evil()` |
| 5c | MED | `mcp/video_tools.py` `_scene_body` | `image_url` allowed `../` traversal prefix |

## Fixes

- `events.json` — added closed `enum` of all 8 event types to `EnvelopeFields.event`.
- `renderer_base.py` — added upper-bound check (\`<= 7680\` / \`<= 4320\`).
- `ws_client.ts` — both `onError` and timeout paths now \`ws.terminate()\` + \`this.ws = null\` before rejecting.
- `extension.ts` — \`evt.type\` -> \`evt.event\`, with a comment explaining the wire-format discriminator key.
- `video_tools.py`:
  - New \`_resolve_safe_html_path()\` helper — resolves the path and rejects anything outside cwd / \`~/.cognithor/\` / OS temp dir.
  - \`_scene_body\` runs \`html.escape(image_url, quote=True)\` before embedding in the \`<img src>\` attribute.
  - \`_scene_body\` removes \`\"../\"\` from the allowed prefix tuple AND rejects any \`..\` segment in the URL.

## Tests

`tests/test_video/test_video_tools.py` — 4 new tests:

- \`test_html_path_outside_trusted_roots_rejected\` — \`/etc/passwd\` returns \`{ok: false, error: ...trusted roots...}\` before invoking the renderer.
- \`test_image_url_with_attribute_injection_is_escaped\` — payload \`/assets/a.png\" onload=\"evil()\` does NOT appear unescaped in the composed HTML.
- \`test_dotdot_traversal_in_image_url_is_dropped\` — \`../../../etc/passwd\` does NOT appear in the composed HTML at all.
- \`test_render_request_width_height_upper_bound\` — \`RenderRequest(width=99999)\` raises \`ValueError\` matching \`<= 7680\`.

Total \`tests/test_video/\` — **99 passed, 1 skipped**. Streaming suite 70/70 green.

## Quality gates

- \`mypy --strict src/cognithor/mcp/video_tools.py src/cognithor/video/renderer_base.py\` — clean
- \`ruff check src/ tests/\` — clean
- \`ruff format --check src/ tests/\` — clean
- \`npm run typecheck + lint + compile\` — clean

## Follow-ups (other audit findings, separate PRs)

This is PR-1 of a multi-PR audit cleanup. Subsequent PRs cover: Gatekeeper risk-classification holes (14 unclassified tools), AuditLogger thread-safety + canonical write, GDPR endpoint SQL injection + IDOR, PGE wiring fixes (params mutation, completed_ids on failure, ContextVar leaks), pack-loader hygiene, channel auth gaps, Flutter provider leaks, etc. Each will be its own PR with its own quality gates.