### PR TITLE
fix(audit-pr2): AuditLogger thread-safe persist + canonical disk write

### DIFF
--- a/src/cognithor/audit/__init__.py
+++ b/src/cognithor/audit/__init__.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
@@ -234,6 +235,11 @@ class AuditLogger:
         # link to it via ``prev_hash``. Loaded lazily from disk on
         # first persist to a given file (handles process restarts).
         self._last_hash_per_file: dict[Path, str] = {}
+        # Audit-PR2: serialise read-prev-hash + write + cache update
+        # so concurrent appenders (multi-channel async handlers) cannot
+        # link two entries to the same prev_hash and break the chain.
+        # Mirrors HashlineAuditor's threading.Lock pattern.
+        self._persist_lock = threading.Lock()
 
         if log_dir:
             log_dir.mkdir(parents=True, exist_ok=True)
@@ -822,17 +828,40 @@ class AuditLogger:
         writing, then this entry's own hash is cached for the next
         write. Tampering after-the-fact (insertion / deletion / edit)
         can be surfaced by ``validate_chain``.
+
+        Audit-PR2: the read-prev / write / cache-update sequence is
+        guarded by ``self._persist_lock`` because the gateway feeds
+        the same singleton from multiple async coroutines (each
+        running on a thread pool). Without the lock, two concurrent
+        appenders read the same prev_hash and either link both
+        entries to the same predecessor (chain breaks at validation)
+        or stomp the cache so the *next* entry chains off the wrong
+        head.
+
+        The on-disk JSON is written with ``sort_keys=True`` so the
+        bytes match what ``canonical_hash()`` hashes — the cache hit
+        on the next call and a freshly-recomputed hash from disk
+        (after process restart) yield the same digest regardless of
+        the dataclass's insertion order.
         """
         if self._log_dir is None:
             return
         try:
             date_str = entry.timestamp[:10]  # YYYY-MM-DD
             log_file = self._log_dir / f"audit_{date_str}.jsonl"
-            entry.prev_hash = self._last_hash_for_file(log_file)
-            with log_file.open("a", encoding="utf-8") as f:
-                f.write(json.dumps(entry.to_dict(), ensure_ascii=False) + "\n")
-            # Cache this entry's hash for the next persist.
-            self._last_hash_per_file[log_file] = entry.canonical_hash()
+            with self._persist_lock:
+                entry.prev_hash = self._last_hash_for_file(log_file)
+                with log_file.open("a", encoding="utf-8") as f:
+                    f.write(
+                        json.dumps(
+                            entry.to_dict(),
+                            sort_keys=True,
+                            ensure_ascii=False,
+                        )
+                        + "\n",
+                    )
+                # Cache this entry's hash for the next persist.
+                self._last_hash_per_file[log_file] = entry.canonical_hash()
         except Exception as exc:
             logger.error("Audit persistence failed: %s", exc)
 

--- a/tests/test_audit/test_audit_logger.py
+++ b/tests/test_audit/test_audit_logger.py
@@ -410,6 +410,49 @@ class TestHashChain:
         assert not ok
         assert any("prev_hash mismatch" in e for e in errors), errors
 
+    def test_chain_survives_concurrent_appenders(self, tmp_path: Path) -> None:
+        """Audit-PR2 — ``_persist_lock`` keeps the chain consistent
+        when multiple threads append at the same time. Without the
+        lock, two appenders read the same prev_hash and the chain
+        breaks at validation.
+        """
+
+        import threading
+
+        audit_dir = tmp_path / "audit"
+        audit_dir.mkdir()
+        logger = AuditLogger(log_dir=audit_dir)
+
+        def append_batch(start: int) -> None:
+            for i in range(20):
+                logger.log_tool_call(
+                    f"tool_{start}_{i}",
+                    {"k": str(i)},
+                    agent_name=f"thread_{start}",
+                    success=True,
+                )
+
+        # 4 threads × 20 entries = 80 concurrent appenders.
+        workers = [threading.Thread(target=append_batch, args=(t,)) for t in range(4)]
+        for w in workers:
+            w.start()
+        for w in workers:
+            w.join()
+
+        files = list(audit_dir.glob("audit_*.jsonl"))
+        assert len(files) == 1, f"expected 1 file, got {files}"
+        log_file = files[0]
+
+        # All 80 entries written.
+        lines = log_file.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 80
+
+        # Chain validates — no two entries share a prev_hash, no
+        # entry's prev_hash is stale.
+        fresh_logger = AuditLogger(log_dir=audit_dir)
+        ok, errors = fresh_logger.validate_chain(log_file)
+        assert ok, f"concurrent-append chain should validate; errors: {errors[:3]}"
+
     def test_validate_chain_detects_deletion(self, tmp_path: Path) -> None:
         audit_dir = tmp_path / "audit"
         log_file = self._write_three_entries(audit_dir)


### PR DESCRIPTION
## Summary

Closes 2 audit findings on `cognithor.audit.AuditLogger`:

| # | Severity | Description |
|---|---|---|
| C-1 | **CRIT** | `_persist_entry` read-prev / write / cache-update sequence had no lock — concurrent async appenders break the SHA-256 hash chain |
| H-2 | HIGH | On-disk JSON written without `sort_keys=True` while `canonical_hash()` uses it — future-proofing gap, hash mismatch on restart for any future `to_dict()` reorder |

## Fixes

- `AuditLogger.__init__` constructs `threading.Lock()` as `self._persist_lock` (matches `HashlineAuditor` pattern).
- `_persist_entry` body wrapped in `with self._persist_lock:` — serialises read+write+cache.
- Disk write uses `json.dumps(..., sort_keys=True, ensure_ascii=False)` so canonical bytes match `canonical_hash()` regardless of dict insertion order.

## Test

New `test_chain_survives_concurrent_appenders`:
- 4 threads × 20 entries = 80 concurrent appenders.
- Validates chain end-to-end with a fresh logger reading from disk.
- Without the lock this test fails at `test_validate_chain_passes_clean_log` semantics; with the lock it passes.

All 79 prior audit_logger tests still green.

## Quality gates

- `mypy --strict src/cognithor/audit/__init__.py` — clean
- `ruff check src/ tests/` — clean
- `ruff format --check src/ tests/` — clean
- `pytest tests/test_audit/ -q` — 102 passed

## Notes

This is PR-2 of the multi-PR audit cleanup. Stacks cleanly on main; no overlap with PR-1 (#460 — Sprint-27 fresh-code hardening).