### PR TITLE
fix(audit-pr5): always clear ContextVars in message-handler finally

### DIFF
--- a/src/cognithor/gateway/message_handler.py
+++ b/src/cognithor/gateway/message_handler.py
@@ -20,6 +20,7 @@ on the Gateway. Part of the staged `gateway.py` split — see
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import time
 from typing import TYPE_CHECKING, Any, cast
 
@@ -495,10 +496,25 @@ async def handle_message(
             )
     finally:
         _cleanup_skill_state()
-
-    # Coding-Override aufraeumen
-    if gw._model_router:
-        gw._model_router.clear_coding_override()
+        # Audit-PR5 (WIRING-1 + WIRING-3): both ContextVar cleanups
+        # moved INTO the finally block. The previous placement (after
+        # the try/finally) only ran on the success path — if
+        # `_run_pge_loop` raised an uncaught exception (e.g. a backend
+        # transport error), the ContextVars leaked for the rest of
+        # the asyncio Task's lifetime, leaving subsequent unrelated
+        # requests pinned to the coding model OR pinned to a
+        # large-context profile (e.g. arc_agi3 num_ctx=131072) that
+        # smaller follow-up requests cannot afford. ContextVar
+        # cleanup must always run.
+        if gw._model_router:
+            gw._model_router.clear_coding_override()
+            # ContextPipeline._maybe_apply_context_profile sets the
+            # profile via a bare ContextVar.set() (no scope token).
+            # Symmetric clear at message-handler exit is the
+            # complementary half — keeps the variable from bleeding
+            # into the next message in this asyncio Task context.
+            with contextlib.suppress(Exception):
+                gw._model_router.clear_context_profile()
 
     # ── Autonomous Task Evaluation ──
     if auto_task is not None:


### PR DESCRIPTION
## Summary

Closes 2 ContextVar-leak findings in \`gateway/message_handler.py\`:

| # | Severity | Description |
|---|---|---|
| WIRING-1 | HIGH | \`clear_coding_override()\` outside try/finally — leaks on uncaught exception |
| WIRING-3 | HIGH | No symmetric clear for \`set_context_profile()\` — \`arc_agi3\`-pinned Task pollutes follow-ups |

## Fix

Both \`clear_coding_override()\` and \`clear_context_profile()\` moved INTO the \`finally\` block. \`clear_context_profile()\` is wrapped in \`contextlib.suppress(Exception)\` for backwards-compat with older model_router instances.

## Note on deferred fixes

Audit Agent #1 also flagged BUG-1 (Gatekeeper \`action.params\` in-place mutation) and BUG-2 (\`completed_ids\` only on success). On verification:

- **BUG-1** — the hash compute in \`pge_loop.py:584\` runs AFTER \`evaluate_plan\` returns, so the audit hash actually matches what the Executor sees. The replan-loop concern is real but secondary; better as its own PR with explicit GateDecision-carrying-resolved-params plumbing.
- **BUG-2** — independent (non-dependent) DAG nodes already proceed correctly; the cascade-on-failure happens transitively for dependents which is intentional. The audit's "single failure → full plan abort" claim does not hold under tracing. Deferred pending a clearer reproduction test.

## Tests + quality gates

- \`pytest tests/test_gateway/ -q\` — 323 passed
- mypy --strict + ruff check + format — clean

Stacks cleanly on main; no overlap with PR-1..4.