### PR TITLE
fix(audit-pr7): bootstrap OLLAMA_HOST + preflight env-var rebrand + Dart format CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,14 @@ jobs:
         working-directory: flutter_app
         run: dart analyze
 
+      - name: Dart format check
+        # Audit-PR7 (Flutter F9): Dart format drift had no CI gate.
+        # Mirrors the existing Python `ruff format --check` step so a
+        # mis-formatted Dart commit fails on the same kind of check
+        # rather than slipping through to release.
+        working-directory: flutter_app
+        run: dart format --output=none --set-exit-if-changed lib/ test/ integration_test/
+
       - name: Flutter test
         working-directory: flutter_app
         run: flutter test --reporter=compact

--- a/flutter_app/test/providers/packs_provider_test.dart
+++ b/flutter_app/test/providers/packs_provider_test.dart
@@ -51,9 +51,7 @@ void main() {
     });
 
     test('refresh swallows errors and leaves packs unchanged', () async {
-      when(
-        () => api.get('packs/loaded'),
-      ).thenThrow(Exception('offline'));
+      when(() => api.get('packs/loaded')).thenThrow(Exception('offline'));
 
       await provider.refresh();
 

--- a/flutter_app/test/providers/research_provider_test.dart
+++ b/flutter_app/test/providers/research_provider_test.dart
@@ -138,9 +138,7 @@ void main() {
     });
 
     test('loadHistory swallows errors silently', () async {
-      when(
-        () => api.get('research/history'),
-      ).thenThrow(Exception('offline'));
+      when(() => api.get('research/history')).thenThrow(Exception('offline'));
 
       await provider.loadHistory();
 
@@ -162,9 +160,7 @@ void main() {
     });
 
     test('loadResult sets error on failure', () async {
-      when(
-        () => api.get('research/missing'),
-      ).thenThrow(Exception('404'));
+      when(() => api.get('research/missing')).thenThrow(Exception('404'));
 
       await provider.loadResult('missing');
 
@@ -186,9 +182,7 @@ void main() {
         );
         await provider.loadHistory();
 
-        when(
-          () => api.delete('research/r1'),
-        ).thenAnswer((_) async => {});
+        when(() => api.delete('research/r1')).thenAnswer((_) async => {});
         await provider.deleteResearch('r1');
 
         expect(provider.history.map((r) => r.id), ['r2']);

--- a/flutter_app/test/providers/sessions_provider_test.dart
+++ b/flutter_app/test/providers/sessions_provider_test.dart
@@ -44,8 +44,9 @@ void main() {
       });
 
       test('captures API error response', () async {
-        when(() => api.listSessions())
-            .thenAnswer((_) async => {'error': 'offline'});
+        when(
+          () => api.listSessions(),
+        ).thenAnswer((_) async => {'error': 'offline'});
 
         await provider.loadSessions();
 
@@ -72,10 +73,12 @@ void main() {
 
     group('createNewSession', () {
       test('sets activeSessionId and reloads', () async {
-        when(() => api.createSession())
-            .thenAnswer((_) async => {'session_id': 'new-id'});
-        when(() => api.listSessions())
-            .thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
+        when(
+          () => api.createSession(),
+        ).thenAnswer((_) async => {'session_id': 'new-id'});
+        when(
+          () => api.listSessions(),
+        ).thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
 
         final id = await provider.createNewSession();
 
@@ -85,8 +88,9 @@ void main() {
       });
 
       test('captures error from API', () async {
-        when(() => api.createSession())
-            .thenAnswer((_) async => {'error': 'rate-limit'});
+        when(
+          () => api.createSession(),
+        ).thenAnswer((_) async => {'error': 'rate-limit'});
 
         final id = await provider.createNewSession();
 
@@ -103,10 +107,12 @@ void main() {
 
     group('createIncognitoSession', () {
       test('sets activeSessionId and reloads', () async {
-        when(() => api.createIncognitoSession())
-            .thenAnswer((_) async => {'session_id': 'incog-1'});
-        when(() => api.listSessions())
-            .thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
+        when(
+          () => api.createIncognitoSession(),
+        ).thenAnswer((_) async => {'session_id': 'incog-1'});
+        when(
+          () => api.listSessions(),
+        ).thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
 
         final id = await provider.createIncognitoSession();
 
@@ -115,8 +121,9 @@ void main() {
       });
 
       test('returns null on API error', () async {
-        when(() => api.createIncognitoSession())
-            .thenAnswer((_) async => {'error': 'denied'});
+        when(
+          () => api.createIncognitoSession(),
+        ).thenAnswer((_) async => {'error': 'denied'});
 
         final id = await provider.createIncognitoSession();
 
@@ -144,8 +151,9 @@ void main() {
       });
 
       test('returns null on error', () async {
-        when(() => api.getSessionHistory('s1'))
-            .thenAnswer((_) async => {'error': 'gone'});
+        when(
+          () => api.getSessionHistory('s1'),
+        ).thenAnswer((_) async => {'error': 'gone'});
 
         final result = await provider.loadHistory('s1');
 
@@ -158,8 +166,9 @@ void main() {
       test('clears activeSessionId when deleting active', () async {
         provider.activeSessionId = 's1';
         when(() => api.deleteSession('s1')).thenAnswer((_) async => {});
-        when(() => api.listSessions())
-            .thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
+        when(
+          () => api.listSessions(),
+        ).thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
 
         await provider.deleteSession('s1');
 
@@ -169,8 +178,9 @@ void main() {
       test('keeps activeSessionId when deleting other', () async {
         provider.activeSessionId = 's1';
         when(() => api.deleteSession('s2')).thenAnswer((_) async => {});
-        when(() => api.listSessions())
-            .thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
+        when(
+          () => api.listSessions(),
+        ).thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
 
         await provider.deleteSession('s2');
 
@@ -240,10 +250,12 @@ void main() {
     });
 
     test('renameSession reloads list on success', () async {
-      when(() => api.renameSession('s1', 'new-title'))
-          .thenAnswer((_) async => {});
-      when(() => api.listSessions())
-          .thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
+      when(
+        () => api.renameSession('s1', 'new-title'),
+      ).thenAnswer((_) async => {});
+      when(
+        () => api.listSessions(),
+      ).thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
 
       await provider.renameSession('s1', 'new-title');
 
@@ -251,12 +263,17 @@ void main() {
     });
 
     test('moveToFolder reloads sessions and folders', () async {
-      when(() => api.moveSessionToFolder('s1', 'Personal'))
-          .thenAnswer((_) async => {});
-      when(() => api.listSessions())
-          .thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
-      when(() => api.listFolders())
-          .thenAnswer((_) async => {'folders': <String>['Personal']});
+      when(
+        () => api.moveSessionToFolder('s1', 'Personal'),
+      ).thenAnswer((_) async => {});
+      when(
+        () => api.listSessions(),
+      ).thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
+      when(() => api.listFolders()).thenAnswer(
+        (_) async => {
+          'folders': <String>['Personal'],
+        },
+      );
 
       await provider.moveToFolder('s1', 'Personal');
 
@@ -266,42 +283,52 @@ void main() {
     });
 
     test('autoSessionOnStartup creates new when shouldNew=true', () async {
-      when(() => api.shouldNewSession(timeoutMinutes: 30))
-          .thenAnswer((_) async => true);
-      when(() => api.createSession())
-          .thenAnswer((_) async => {'session_id': 'fresh'});
-      when(() => api.listSessions())
-          .thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
+      when(
+        () => api.shouldNewSession(timeoutMinutes: 30),
+      ).thenAnswer((_) async => true);
+      when(
+        () => api.createSession(),
+      ).thenAnswer((_) async => {'session_id': 'fresh'});
+      when(
+        () => api.listSessions(),
+      ).thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
 
       final id = await provider.autoSessionOnStartup();
 
       expect(id, 'fresh');
     });
 
-    test('autoSessionOnStartup resumes most recent when shouldNew=false', () async {
-      when(() => api.shouldNewSession(timeoutMinutes: 30))
-          .thenAnswer((_) async => false);
-      when(() => api.listSessions()).thenAnswer(
-        (_) async => {
-          'sessions': <Map<String, dynamic>>[
-            {'id': 'recent'},
-          ],
-        },
-      );
+    test(
+      'autoSessionOnStartup resumes most recent when shouldNew=false',
+      () async {
+        when(
+          () => api.shouldNewSession(timeoutMinutes: 30),
+        ).thenAnswer((_) async => false);
+        when(() => api.listSessions()).thenAnswer(
+          (_) async => {
+            'sessions': <Map<String, dynamic>>[
+              {'id': 'recent'},
+            ],
+          },
+        );
 
-      final id = await provider.autoSessionOnStartup();
+        final id = await provider.autoSessionOnStartup();
 
-      expect(id, 'recent');
-      expect(provider.activeSessionId, 'recent');
-    });
+        expect(id, 'recent');
+        expect(provider.activeSessionId, 'recent');
+      },
+    );
 
     test('autoSessionOnStartup creates new when no sessions exist', () async {
-      when(() => api.shouldNewSession(timeoutMinutes: 30))
-          .thenAnswer((_) async => false);
-      when(() => api.listSessions())
-          .thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
-      when(() => api.createSession())
-          .thenAnswer((_) async => {'session_id': 'new-fallback'});
+      when(
+        () => api.shouldNewSession(timeoutMinutes: 30),
+      ).thenAnswer((_) async => false);
+      when(
+        () => api.listSessions(),
+      ).thenAnswer((_) async => {'sessions': <Map<String, dynamic>>[]});
+      when(
+        () => api.createSession(),
+      ).thenAnswer((_) async => {'session_id': 'new-fallback'});
 
       final id = await provider.autoSessionOnStartup();
 

--- a/flutter_app/test/providers/sources_provider_test.dart
+++ b/flutter_app/test/providers/sources_provider_test.dart
@@ -57,9 +57,7 @@ void main() {
     });
 
     test('refresh sets error on failure', () async {
-      when(
-        () => api.get('leads/sources'),
-      ).thenThrow(Exception('unreachable'));
+      when(() => api.get('leads/sources')).thenThrow(Exception('unreachable'));
 
       await provider.refresh();
 

--- a/scripts/bootstrap_windows.py
+++ b/scripts/bootstrap_windows.py
@@ -185,7 +185,12 @@ COGNITHOR_HOME = Path(
     or (Path.home() / ".cognithor")
 )
 MARKER_FILE = COGNITHOR_HOME / ".cognithor_initialized"
-OLLAMA_URL = "http://localhost:11434"
+# Audit-PR7 (Flutter F4): bootstrap previously hardcoded
+# `http://localhost:11434`. The companion `preflight_check.py`
+# correctly honours `OLLAMA_HOST` — the bootstrap now matches so
+# users running Ollama on a custom host/port don't trip over the
+# "is Ollama running?" probe during install.
+OLLAMA_URL = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
 BACKEND_PORT = 8741
 
 # ── ANSI-Farben (werden bei fehlender Unterstuetzung deaktiviert) ──────────

--- a/scripts/preflight_check.py
+++ b/scripts/preflight_check.py
@@ -348,8 +348,16 @@ def check_ports() -> None:
     header("8. Network Ports")
     import socket
 
-    api_port = int(os.environ.get("JARVIS_API_PORT", "8741"))
-    api_host = os.environ.get("JARVIS_API_HOST", "127.0.0.1")
+    # Audit-PR7 (Flutter F8): the env-var namespace was rebranded to
+    # COGNITHOR_* (other call sites already read COGNITHOR_API_TOKEN).
+    # Fall back through the legacy JARVIS_* names so existing user
+    # environments keep working until the next major bump.
+    api_port = int(
+        os.environ.get("COGNITHOR_API_PORT") or os.environ.get("JARVIS_API_PORT") or "8741",
+    )
+    api_host = (
+        os.environ.get("COGNITHOR_API_HOST") or os.environ.get("JARVIS_API_HOST") or "127.0.0.1"
+    )
 
     try:
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)


### PR DESCRIPTION
## Summary

Three audit findings from Audit Agent #6 closed in one PR.

| # | Severity | Description |
|---|---|---|
| F4 | HIGH | `bootstrap_windows.py` hardcoded `OLLAMA_URL` — ignored `OLLAMA_HOST` env var |
| F8 | HIGH | `preflight_check.py` read `JARVIS_API_PORT` not `COGNITHOR_API_PORT` |
| F9 | HIGH | Flutter CI lacked `dart format --check` step (Python had ruff format gate) |

## Fixes

### F4
`OLLAMA_URL = os.environ.get("OLLAMA_HOST", "http://localhost:11434")` — matches `preflight_check.py`.

### F8
Reads `COGNITHOR_API_PORT` first, falls back to legacy `JARVIS_API_PORT` for backwards-compat. Same for `*_API_HOST`.

### F9
Added a `Dart format check` step in the Flutter CI job, mirroring the Python `ruff format --check`. Surfaced 4 pre-existing format-drift files in `test/providers/` — auto-fixed via `dart format` and committed alongside the new gate.

## Tests + quality gates

- `flutter analyze` — clean
- `dart format --output=none --set-exit-if-changed lib/ test/ integration_test/` — clean (236 files, 0 changed)
- `ruff check src/ tests/` + `ruff format --check src/ tests/` — clean
- `pytest tests/test_streaming/ tests/test_video/` — 165 passed, 1 skipped

Stacks cleanly on main; no overlap with PR-1..6.