### PR TITLE
fix(audit-pr10): SQL inject_check bypass + --arc null-deref + list_directory depth cap

### DIFF
--- a/src/cognithor/__main__.py
+++ b/src/cognithor/__main__.py
@@ -769,7 +769,19 @@ def main() -> None:
         config.models.coder.name = "qwen2.5-coder:7b"
 
     if getattr(args, "arc", False):
-        config.arc.enabled = True
+        # Audit-PR10 (audit-MED-1): the previous form `config.arc.enabled = True`
+        # raised AttributeError on clean installs where the user's
+        # config.yaml has no `arc:` block (config.arc is None then).
+        # Guarding with a truthiness check keeps the flag a no-op (with
+        # a clear stderr line) instead of silently crashing the boot path.
+        if getattr(config, "arc", None) is not None:
+            config.arc.enabled = True
+        else:
+            print(
+                "[warn] --arc flag ignored: no `arc:` section in config.yaml. "
+                "Add an arc block to enable ARC tools.",
+                file=sys.stderr,
+            )
 
     # 1.9 Auto-migrate plaintext API keys from config.yaml / .env to OS Keyring
     try:

--- a/src/cognithor/mcp/database_tools.py
+++ b/src/cognithor/mcp/database_tools.py
@@ -112,14 +112,27 @@ def _format_table(columns: list[str], rows: list[tuple[Any, ...]], row_count: in
 
 
 def _check_injection(sql: str, params: list[Any] | None) -> None:
-    """Raise if the raw SQL contains obvious injection patterns when no params."""
-    if params:
-        return  # parameterised queries are safe
+    """Raise if the raw SQL contains obvious injection patterns.
+
+    Audit-PR10 (audit-MED-3): the previous implementation early-returned
+    when ANY ``params`` were supplied, on the assumption that
+    parameterised queries are safe. That left a smuggling vector — an
+    attacker who can influence the caller's ``params`` argument
+    (e.g. by passing a dummy placeholder) bypasses the multi-statement,
+    UNION, and comment-terminator checks entirely while keeping the
+    SQL string un-escaped. The injection patterns scan the SQL text
+    itself for shapes that don't belong even WITH params (multi-stmt
+    via ``; DROP``, ``UNION SELECT 1`` smuggling, ``-- ``-comment
+    terminators), so they should run regardless of whether the call
+    site claims to use placeholders.
+    """
+
     for pattern in _INJECTION_PATTERNS:
         if pattern.search(sql):
             raise DatabaseError(
                 f"Potential SQL injection detected (pattern: {pattern.pattern}). "
-                "Use parameterized queries instead."
+                "Use parameterized queries — and don't smuggle multi-statement "
+                "or comment-terminator content into the SQL string itself."
             )
 
 

--- a/src/cognithor/mcp/filesystem.py
+++ b/src/cognithor/mcp/filesystem.py
@@ -304,6 +304,13 @@ class FileSystemTools:
         if not validated.is_dir():
             raise FileSystemError(f"Kein Verzeichnis: {path}")
 
+        # Audit-PR10 (audit-LOW-2): clamp depth at 10. The output is
+        # already capped by _max_tree_entries, but the recursion itself
+        # has no upper bound — a deeply-nested directory tree at depth=50
+        # would walk every path branch even though only the first few
+        # thousand entries land in the rendered output. Clamping at 10
+        # keeps the tool's worst-case wall time bounded.
+        depth = max(0, min(depth, 10))
         lines: list[str] = [f"{validated.name}/"]
         self._tree(validated, lines, prefix="", depth=depth, max_depth=depth)
 


### PR DESCRIPTION
## Summary

Three more audit findings closed:

| # | Severity | Description |
|---|---|---|
| MED-3 | MED | `_check_injection` early-returned when params present — UNION / multi-stmt smuggling possible |
| MED-1 | MED | `--arc` flag null-derefed on configs without `arc:` section |
| LOW-2 | LOW | `list_directory` depth unbounded — O(N^depth) on deep trees |

## Fixes

### MED-3
`_check_injection` now scans the SQL string regardless of whether `params` is supplied. The injection patterns (`; DROP`, `UNION SELECT`, comment-terminators) are unsafe in the SQL text *itself* — having a `?` placeholder doesn't sanitize them.

### MED-1
`if getattr(config, "arc", None) is not None: config.arc.enabled = True` — crash-free path; emits stderr warning when config has no `arc:` block.

### LOW-2
`depth = max(0, min(depth, 10))` before recursion. Output cap unchanged.

## Tests + quality gates

- `pytest -k 'database_tools or filesystem'` — 94 passed, 1 skipped
- mypy --strict + ruff check + format — clean

Stacks cleanly on main; no overlap with PR-1..9.