### PR TITLE
fix(deep-pr1): gateway task-leak + sync-in-async + unbounded set

### DIFF
--- a/src/cognithor/gateway/gateway.py
+++ b/src/cognithor/gateway/gateway.py
@@ -16,8 +16,15 @@ import asyncio
 import re
 import threading
 import time
+from collections import deque
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar, cast
+
+# Deep-PR1 (DEEP-1 HIGH-1): cap on remembered cancelled session_ids.
+# Sized for typical deployments where ~1k cancellations / hour is a
+# generous upper bound; the eviction is FIFO so the oldest entries
+# fall off when the cap is hit.
+_CANCELLED_SESSIONS_MAX: int = 1024
 
 from cognithor.config import CognithorConfig, load_config
 from cognithor.core.agent_router import (
@@ -423,6 +430,11 @@ class Gateway:
         self._session_lock = threading.Lock()
         self._running = False
         self._cancelled_sessions: set[str] = set()
+        # Deep-PR1 (DEEP-1 HIGH-1): FIFO ring tracking the order
+        # session_ids were added to ``_cancelled_sessions`` so the
+        # cap-eviction in ``cancel_session`` can drop the oldest entry
+        # without scanning the whole set.
+        self._cancelled_session_order: deque[str] = deque()
         self._context_pipeline = None
         self._message_queue: DurableMessageQueue | None = None
         self._background_tasks: set[asyncio.Task[Any]] = set()
@@ -1540,10 +1552,25 @@ class Gateway:
         Der PGE-Loop prueft dieses Flag und bricht beim naechsten
         Iterationsschritt sauber ab.
 
-        Returns:
-            True wenn die Session gefunden und als cancelled markiert wurde.
+        Deep-PR1 (DEEP-1 HIGH-1): the set was unbounded — every
+        cancellation added a session_id permanently because the
+        discard call only fired if the PGE loop reached its top-of-
+        iteration cancel-check. Pre-flight cancellations and post-
+        completion cancels never discarded. Long-running deployments
+        accumulated thousands of session_ids. Now we cap the set at
+        ``_CANCELLED_SESSIONS_MAX`` and evict the oldest entry when
+        the cap is hit. The set is GIL-protected for add/discard but
+        we wrap mutations in ``_session_lock`` for cross-thread
+        safety (``cancel_session`` can be called from a signal
+        handler via ``shutdown()``).
         """
-        self._cancelled_sessions.add(session_id)
+
+        with self._session_lock:
+            self._cancelled_sessions.add(session_id)
+            self._cancelled_session_order.append(session_id)
+            while len(self._cancelled_session_order) > _CANCELLED_SESSIONS_MAX:
+                evicted = self._cancelled_session_order.popleft()
+                self._cancelled_sessions.discard(evicted)
         log.info("session_cancelled", session=session_id[:8])
         return True
 

--- a/src/cognithor/gateway/pge_loop.py
+++ b/src/cognithor/gateway/pge_loop.py
@@ -272,35 +272,44 @@ async def run_pge_loop(
             if _force_plan is not None:
                 log.info("reddit_hard_route_applied", goal=_force_plan.goal)
 
-        # Planner
-        if _force_plan is not None:
-            plan = _force_plan
-        elif session.iteration_count == 1:
-            plan = await gw._planner.plan(
-                user_message=msg.text,
-                working_memory=wm,
-                tool_schemas=tool_schemas,
-                model_override=_agent_model,
-                temperature_override=_agent_temperature,
-                top_p_override=_agent_top_p,
-            )
-        else:
-            plan = await gw._planner.replan(
-                original_goal=msg.text,
-                results=all_results,
-                working_memory=wm,
-                tool_schemas=tool_schemas,
-                model_override=_agent_model,
-                temperature_override=_agent_temperature,
-                top_p_override=_agent_top_p,
-            )
-
-        # Stop keepalive once planner responds
-        _keepalive_event.set()
-        _keepalive_task.cancel()
-        with contextlib.suppress(BaseException):
-            await _keepalive_task
-        gw._background_tasks.discard(_keepalive_task)
+        # Deep-PR1 (DEEP-1 CRIT-1 + MED-2): wrap the planner call in
+        # try/finally so the keepalive task is ALWAYS cancelled and
+        # discarded from `_background_tasks`, regardless of whether
+        # the planner raises or any later loop iteration `break`s.
+        # Previously, a `httpx.ConnectError` from the planner left
+        # the keepalive coroutine running forever, accumulating one
+        # orphaned task per failed planner call.
+        try:
+            # Planner
+            if _force_plan is not None:
+                plan = _force_plan
+            elif session.iteration_count == 1:
+                plan = await gw._planner.plan(
+                    user_message=msg.text,
+                    working_memory=wm,
+                    tool_schemas=tool_schemas,
+                    model_override=_agent_model,
+                    temperature_override=_agent_temperature,
+                    top_p_override=_agent_top_p,
+                )
+            else:
+                plan = await gw._planner.replan(
+                    original_goal=msg.text,
+                    results=all_results,
+                    working_memory=wm,
+                    tool_schemas=tool_schemas,
+                    model_override=_agent_model,
+                    temperature_override=_agent_temperature,
+                    top_p_override=_agent_top_p,
+                )
+        finally:
+            # Stop keepalive — runs on success, exception, AND any
+            # subsequent `break` further down in the loop body.
+            _keepalive_event.set()
+            _keepalive_task.cancel()
+            with contextlib.suppress(BaseException):
+                await _keepalive_task
+            gw._background_tasks.discard(_keepalive_task)
 
         all_plans.append(plan)
         await _pipeline_cb(

--- a/src/cognithor/gateway/post_processing.py
+++ b/src/cognithor/gateway/post_processing.py
@@ -326,13 +326,21 @@ async def run_post_processing(
     # GEPA: Run evolution cycle if due
     if getattr(gw, "_evolution_orchestrator", None):
         try:
+            import asyncio as _asyncio
             import time as _time
 
             orch = gw._evolution_orchestrator
             gepa_cfg = getattr(gw._config, "gepa", None)
             interval = (gepa_cfg.evolution_interval_hours * 3600) if gepa_cfg else 21600
             if _time.time() - getattr(orch, "_last_cycle_time", 0) > interval:
-                evo_result = orch.run_evolution_cycle()
+                # Deep-PR1 (DEEP-1 CRIT-2): `run_evolution_cycle()` is
+                # a synchronous method that performs trace analysis,
+                # proposal generation, and DB writes. Calling it
+                # directly inside this async background task froze
+                # the asyncio event loop for the full cycle duration —
+                # blocking every concurrent message handler, keepalive
+                # tick, and WebSocket write. Run on a worker thread.
+                evo_result = await _asyncio.to_thread(orch.run_evolution_cycle)
                 log.info(
                     "gepa_evolution_cycle_completed",
                     cycle_id=evo_result.cycle_id,


### PR DESCRIPTION
## Summary

Deep-audit Pass 2 flagged 3 correctness issues in `cognithor/gateway/`. All verified by reading the source at the cited line.

| # | Severity | Description |
|---|---|---|
| CRIT-1 + MED-2 | CRIT | Keepalive task leaked on planner exception AND `break` paths |
| CRIT-2 | CRIT | `run_evolution_cycle()` blocks the asyncio event loop |
| HIGH-1 | HIGH | `_cancelled_sessions` set grew unbounded |

## Fixes

- `pge_loop.py` — wrap the planner call in `try/finally` so the keepalive task is always cancelled + discarded from `_background_tasks`.
- `post_processing.py` — wrap `orch.run_evolution_cycle()` in `asyncio.to_thread(...)` so it doesn't freeze the event loop.
- `gateway.py` — `_cancelled_sessions` now has a FIFO `deque` companion + 1024-entry cap; oldest entries evict on overflow under `_session_lock`.

## Tests + quality gates

- 323 gateway tests pass
- mypy --strict on the three touched files — clean
- ruff check + format --check on src/ + tests/ — clean

This is the first PR of a multi-PR deep-audit cleanup; more fixes coming for ledger integrity, MCP input validation, channel auth gaps, packs marketplace, etc.