### PR TITLE
fix(deep-pr3): channel hardening (Telegram voice / Mattermost allow-list / Signal fail-closed)

### DIFF
--- a/src/cognithor/channels/mattermost.py
+++ b/src/cognithor/channels/mattermost.py
@@ -41,6 +41,7 @@ class MattermostChannel(Channel):
         url: str = "",
         token: str = "",
         default_channel: str = "",
+        allowed_channels: list[str] | None = None,
     ) -> None:
         self._url = url.rstrip("/")
         self._token_store_ref = get_token_store()
@@ -48,6 +49,12 @@ class MattermostChannel(Channel):
             self._token_store_ref.store("mattermost_token", token)
         self._has_token = bool(token)
         self._default_channel = default_channel
+        # When set, only inbound posts in these channel-IDs reach the
+        # handler. Empty set = log a warning and accept any channel the
+        # bot user is a member of (legacy behaviour). Operators should
+        # set this whenever the bot may be force-invited to channels by
+        # admins outside the trusted set.
+        self._allowed_channels: set[str] = set(allowed_channels or [])
         self._handler: MessageHandler | None = None
         self._running = False
         self._http_client: Any | None = None
@@ -87,6 +94,13 @@ class MattermostChannel(Channel):
         if not self._url or not self._token:
             logger.warning("Mattermost: URL oder Token nicht konfiguriert")
             return
+
+        if not self._allowed_channels:
+            logger.warning(
+                "Mattermost: kein allowed_channels gesetzt — jede Mitgliedschaft "
+                "des Bots kann den Agenten ansteuern. Setze allowed_channels "
+                "auf eine Liste vertrauenswuerdiger Channel-IDs."
+            )
 
         try:
             import httpx
@@ -178,6 +192,12 @@ class MattermostChannel(Channel):
             return
 
         channel_id = post.get("channel_id", "")
+        if self._allowed_channels and channel_id not in self._allowed_channels:
+            logger.debug(
+                "Mattermost: post in non-allowlisted channel %s ignored",
+                channel_id,
+            )
+            return
         post_id = post.get("id", "")
         session_id = f"mm_{user_id}_{channel_id}"
         self._session_users[session_id] = user_id

--- a/src/cognithor/channels/signal.py
+++ b/src/cognithor/channels/signal.py
@@ -268,11 +268,12 @@ class SignalChannel(Channel):
             return
 
         if self._webhook_host != "127.0.0.1" and not self._webhook_secret:
-            logger.warning(
-                "Signal: Webhook auf %s ohne webhook_secret exponiert — "
-                "Anfragen koennen nicht authentifiziert werden. "
-                "Setze webhook_secret fuer HMAC-Verifizierung.",
-                self._webhook_host,
+            raise RuntimeError(
+                f"Signal: Webhook-Host {self._webhook_host!r} ist nicht "
+                "localhost und es ist kein webhook_secret gesetzt. "
+                "Diese Konfiguration wuerde unauthentifizierte Anfragen "
+                "von beliebigen Quellen akzeptieren. Setze webhook_secret "
+                "fuer HMAC-Verifizierung oder binde an 127.0.0.1."
             )
 
         app = web.Application()

--- a/src/cognithor/channels/telegram.py
+++ b/src/cognithor/channels/telegram.py
@@ -597,6 +597,14 @@ class TelegramChannel(Channel):
         if voice is None:
             return
 
+        if voice.file_size and voice.file_size > MAX_DOCUMENT_SIZE:
+            await update.effective_message.reply_text(
+                f"Sprachnachricht zu gross "
+                f"({voice.file_size // 1_048_576} MB, "
+                f"max {MAX_DOCUMENT_SIZE // 1_048_576} MB)"
+            )
+            return
+
         # Start typing indicator
         typing_task = self._start_typing(chat_id)
 

--- a/tests/test_channels/test_mattermost.py
+++ b/tests/test_channels/test_mattermost.py
@@ -82,6 +82,44 @@ class TestMattermostChannel:
         ch._handler.assert_not_called()
 
     @pytest.mark.asyncio
+    async def test_on_message_blocks_non_allowlisted_channel(self) -> None:
+        """Mit gesetzter allow-list werden Posts aus anderen Channels ignoriert."""
+        ch = MattermostChannel(allowed_channels=["ch_trusted"])
+        ch._bot_user_id = "bot123"
+        ch._handler = AsyncMock()
+        ch._create_post = AsyncMock()
+
+        post = {
+            "user_id": "user456",
+            "message": "drive the agent",
+            "channel_id": "ch_evil",
+            "id": "msg1",
+            "root_id": "",
+        }
+        await ch._on_message(post)
+        ch._handler.assert_not_called()
+        ch._create_post.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_on_message_allows_allowlisted_channel(self) -> None:
+        """Posts aus dem allow-listeten Channel werden weitergegeben."""
+        ch = MattermostChannel(allowed_channels=["ch_trusted"])
+        ch._bot_user_id = "bot123"
+        response_msg = OutgoingMessage(channel="mattermost", text="ok", session_id="s1")
+        ch._handler = AsyncMock(return_value=response_msg)
+        ch._create_post = AsyncMock(return_value="post_id")
+
+        post = {
+            "user_id": "user456",
+            "message": "hello",
+            "channel_id": "ch_trusted",
+            "id": "msg1",
+            "root_id": "",
+        }
+        await ch._on_message(post)
+        ch._handler.assert_called_once()
+
+    @pytest.mark.asyncio
     async def test_on_reaction_approve(self) -> None:
         ch = MattermostChannel()
         loop = asyncio.get_running_loop()

--- a/tests/test_channels/test_signal.py
+++ b/tests/test_channels/test_signal.py
@@ -154,18 +154,42 @@ class TestSignalLifecycle:
 
     @pytest.mark.asyncio
     async def test_setup_webhook_allows_non_localhost_with_secret(self) -> None:
-        """Non-localhost bind MIT webhook_secret darf starten."""
+        """Non-localhost bind MIT webhook_secret darf starten (no RuntimeError).
+
+        Stubs aiohttp.web so we don't actually bind a TCP server in CI.
+        The assertion is the absence of the fail-closed RuntimeError.
+        """
+        from types import SimpleNamespace
+
         ch = SignalChannel(
             phone_number="+491234567",
             webhook_host="0.0.0.0",
             webhook_port=18099,
             webhook_secret="s3cret",
         )
-        try:
+
+        fake_runner = AsyncMock()
+        fake_runner.setup = AsyncMock()
+        fake_site = AsyncMock()
+        fake_site.start = AsyncMock()
+
+        fake_web = SimpleNamespace(
+            Application=lambda: SimpleNamespace(
+                router=SimpleNamespace(
+                    add_post=lambda *_a, **_kw: None,
+                    add_get=lambda *_a, **_kw: None,
+                ),
+            ),
+            AppRunner=lambda _app: fake_runner,
+            TCPSite=lambda _r, _h, _p: fake_site,
+        )
+        fake_aiohttp = SimpleNamespace(web=fake_web)
+
+        with patch.dict("sys.modules", {"aiohttp": fake_aiohttp}):
             await ch._setup_webhook()
-        finally:
-            if ch._webhook_runner is not None:
-                await ch._webhook_runner.cleanup()
+
+        fake_runner.setup.assert_awaited_once()
+        fake_site.start.assert_awaited_once()
 
 
 # ============================================================================

--- a/tests/test_channels/test_signal.py
+++ b/tests/test_channels/test_signal.py
@@ -140,6 +140,33 @@ class TestSignalLifecycle:
         mock_http.aclose.assert_called_once()
         assert signal_ch._http is None
 
+    @pytest.mark.asyncio
+    async def test_setup_webhook_refuses_non_localhost_without_secret(self) -> None:
+        """Non-localhost bind ohne webhook_secret muss fail-closed sein."""
+        ch = SignalChannel(
+            phone_number="+491234567",
+            webhook_host="0.0.0.0",
+            webhook_port=8090,
+            webhook_secret="",
+        )
+        with pytest.raises(RuntimeError, match="webhook_secret"):
+            await ch._setup_webhook()
+
+    @pytest.mark.asyncio
+    async def test_setup_webhook_allows_non_localhost_with_secret(self) -> None:
+        """Non-localhost bind MIT webhook_secret darf starten."""
+        ch = SignalChannel(
+            phone_number="+491234567",
+            webhook_host="0.0.0.0",
+            webhook_port=18099,
+            webhook_secret="s3cret",
+        )
+        try:
+            await ch._setup_webhook()
+        finally:
+            if ch._webhook_runner is not None:
+                await ch._webhook_runner.cleanup()
+
 
 # ============================================================================
 # Outbound: Send

--- a/tests/test_channels/test_telegram.py
+++ b/tests/test_channels/test_telegram.py
@@ -467,6 +467,29 @@ class TestDocumentSizeLimit:
         )
 
     @pytest.mark.asyncio
+    async def test_voice_too_large_rejected(self) -> None:
+        """Sprachnachrichten ueber MAX_DOCUMENT_SIZE werden abgelehnt."""
+        ch = TelegramChannel(token="t", allowed_users=[42])
+        ch._handler = AsyncMock()
+
+        update = MagicMock()
+        update.effective_user.id = 42
+        update.effective_chat.id = 100
+        voice = MagicMock()
+        voice.file_size = MAX_DOCUMENT_SIZE + 1
+        voice.file_unique_id = "vid"
+        update.effective_message.voice = voice
+        update.effective_message.audio = None
+        update.effective_message.reply_text = AsyncMock()
+
+        await ch._on_voice_message(update, MagicMock())
+
+        ch._handler.assert_not_called()
+        update.effective_message.reply_text.assert_called_once()
+        msg = update.effective_message.reply_text.call_args[0][0]
+        assert "gross" in msg.lower() or "MB" in msg
+
+    @pytest.mark.asyncio
     async def test_document_within_limit_accepted(self) -> None:
         """Dokumente innerhalb des Limits werden verarbeitet."""
         ch = TelegramChannel(token="t")

--- a/tests/test_security/test_f014_signal_webhook_signature.py
+++ b/tests/test_security/test_f014_signal_webhook_signature.py
@@ -147,7 +147,14 @@ class TestSecretWithInvalidJSON:
 
 
 class TestExposedWebhookWarning:
-    """Prueft die Warnung bei exponiertem Webhook ohne Secret."""
+    """Deep-PR3 update: non-localhost bind without webhook_secret is now
+    a hard ``RuntimeError`` (fail-closed) rather than a passive WARNING.
+
+    Previously the channel logged a warning and proceeded to bind anyway,
+    accepting unauthenticated POSTs from any host. The new contract:
+    refuse to start unless the operator either binds to 127.0.0.1 or sets
+    a HMAC secret.
+    """
 
     @pytest.mark.asyncio
     async def test_warning_on_exposed_without_secret(self) -> None:
@@ -155,26 +162,12 @@ class TestExposedWebhookWarning:
             webhook_host="0.0.0.0",
             webhook_secret="",
         )
-        with patch("cognithor.channels.signal.logger") as mock_logger:
-            try:
-                from aiohttp import web  # noqa: F401
-            except ImportError:
-                pytest.skip("aiohttp nicht installiert")
-            with patch("aiohttp.web.AppRunner") as mock_runner:
-                mock_instance = AsyncMock()
-                mock_runner.return_value = mock_instance
-                with patch("aiohttp.web.TCPSite") as mock_site:
-                    mock_site_instance = AsyncMock()
-                    mock_site.return_value = mock_site_instance
-                    ch._http = AsyncMock()
-                    ch._http.post = AsyncMock()
-                    await ch._setup_webhook()
-            mock_logger.warning.assert_any_call(
-                "Signal: Webhook auf %s ohne webhook_secret exponiert — "
-                "Anfragen koennen nicht authentifiziert werden. "
-                "Setze webhook_secret fuer HMAC-Verifizierung.",
-                "0.0.0.0",
-            )
+        try:
+            from aiohttp import web  # noqa: F401
+        except ImportError:
+            pytest.skip("aiohttp nicht installiert")
+        with pytest.raises(RuntimeError, match="webhook_secret"):
+            await ch._setup_webhook()
 
     @pytest.mark.asyncio
     async def test_no_warning_on_localhost(self) -> None:


### PR DESCRIPTION
## Summary

Pass-2 deep-audit findings **CH-2 / CH-3 / CH-4** after a **multi-agent false-positive filter**:

| Finding | Verified verdict |
|---|---|
| CH-1 Slack HMAC | **FALSE-POSITIVE** — Slack uses Socket Mode (`AsyncSocketModeHandler`), no HTTP intake. `slack_bolt` already verifies signatures internally for interactive payloads. |
| CH-2 Telegram voice cap | **REAL-HIGH** — `_on_voice_message` had no `file_size` guard before `download_to_drive()`. |
| CH-2 WhatsApp/Voice cap | FALSE-POSITIVE — Meta API caps at 16 MB server-side; voice uses `AudioAccumulator.MAX_BYTES = 100 MB`. |
| CH-3 Mattermost allow-list | **REAL-HIGH** — `_on_message` accepted any channel the bot is a member of. |
| CH-3 IRC allow-list | FALSE-POSITIVE — nick-mention gate + operator-controlled join list. |
| CH-4 Signal fail-closed | **REAL-HIGH (conditional)** — non-localhost bind + empty `webhook_secret` only logged WARNING and proceeded. |
| CH-5 PR-9 ReDoS coverage | FALSE-POSITIVE — no unbounded-quantifier regex in any flagged channel. |

## Fixes

### 1. Telegram voice size cap — `src/cognithor/channels/telegram.py:596`
Mirror the existing document-size guard from line 769:
```python
if voice.file_size and voice.file_size > MAX_DOCUMENT_SIZE:
    await update.effective_message.reply_text(
        f"Sprachnachricht zu gross ({voice.file_size // 1_048_576} MB, max {MAX_DOCUMENT_SIZE // 1_048_576} MB)"
    )
    return
```
Closes a DoS path where a 2 GB Telegram voice message would land on the bot's workspace disk unconditionally.

### 2. Mattermost channel allow-list — `src/cognithor/channels/mattermost.py`
New optional constructor arg `allowed_channels: list[str] | None`. When set, `_on_message` ignores posts from any channel outside the set. When unset, `start()` emits a WARNING because any bot membership can drive the agent — guards against force-invite by an admin into a channel outside the trusted set.

### 3. Signal non-localhost fail-closed — `src/cognithor/channels/signal.py:270`
`_setup_webhook` now `raise RuntimeError` if `webhook_host != "127.0.0.1"` AND `webhook_secret == ""`. Previously only logged WARNING and accepted unauthenticated POSTs from any host on the network. Operators must either bind to localhost or set an HMAC secret.

## Test plan

- [x] 5 new tests added (voice-cap reject, MM allow-list block + allow, Signal refuse + allow-with-secret)
- [x] `pytest tests/test_channels/{telegram,mattermost,signal}.py` → **98 passed in 4.96s**
- [x] `mypy --strict` on all 3 channel modules → clean
- [x] `ruff check` + `ruff format --check` on all 6 touched files → clean
- [ ] CI green

## False-positive evidence

Reviewer agent confirmed (read-only):
- `channels/slack.py` — uses `slack_bolt.adapter.socket_mode.async_handler.AsyncSocketModeHandler` (outbound WS), no HTTP listener.
- `channels/irc.py:202-204` — `text.lower().startswith(self._nick.lower())` already gates inbound.
- Signal/IRC/Mattermost/Twitch/Feishu — zero `re.compile`/`re.sub`/`re.match` calls. Matrix uses lazy quantifiers only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)