### PR TITLE
fix(deep-pr4): MCP hardening (CRIT shell, ReDoS, SSRF, format, timeout)

### DIFF
--- a/src/cognithor/i18n/locales/de.json
+++ b/src/cognithor/i18n/locales/de.json
@@ -334,6 +334,7 @@
     "pdf_read_failed": "PDF-Lesen fehlgeschlagen: {error}",
     "ppt_read_failed": "PPT-Lesen fehlgeschlagen: {error}",
     "docx_read_failed": "DOCX-Lesen fehlgeschlagen: {error}",
+    "invalid_audio_format": "Ungültiges Audio-Ausgabeformat: {fmt}. Erlaubt: {allowed}",
     "invalid_sample_rate": "Ungültige Samplerate: {rate}. Erlaubt: {allowed}",
     "ffmpeg_error": "ffmpeg Fehler: {error}",
     "audio_converted": "Konvertiert: {path}",

--- a/src/cognithor/i18n/locales/en.json
+++ b/src/cognithor/i18n/locales/en.json
@@ -334,6 +334,7 @@
     "pdf_read_failed": "PDF read failed: {error}",
     "ppt_read_failed": "PPT read failed: {error}",
     "docx_read_failed": "DOCX read failed: {error}",
+    "invalid_audio_format": "Invalid audio output format: {fmt}. Allowed: {allowed}",
     "invalid_sample_rate": "Invalid sample rate: {rate}. Allowed: {allowed}",
     "ffmpeg_error": "ffmpeg error: {error}",
     "audio_converted": "Converted: {path}",

--- a/src/cognithor/i18n/locales/zh.json
+++ b/src/cognithor/i18n/locales/zh.json
@@ -334,6 +334,7 @@
     "pdf_read_failed": "PDF 读取失败：{error}",
     "ppt_read_failed": "PPT 读取失败：{error}",
     "docx_read_failed": "DOCX 读取失败：{error}",
+    "invalid_audio_format": "无效的音频输出格式：{fmt}。允许：{allowed}",
     "invalid_sample_rate": "无效采样率：{rate}。允许：{allowed}",
     "ffmpeg_error": "ffmpeg 错误：{error}",
     "audio_converted": "已转换：{path}",

--- a/src/cognithor/mcp/api_hub.py
+++ b/src/cognithor/mcp/api_hub.py
@@ -45,6 +45,42 @@ _MAX_RESPONSE_CHARS = 50_000
 _DEFAULT_TIMEOUT = 30  # seconds per request
 _DEFAULT_RATE_LIMIT = 60  # requests per minute
 _ALLOWED_METHODS = frozenset({"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD"})
+# httpx default is 20 redirects. We tighten to 3 since legitimate APIs
+# rarely chain more than one or two redirects.
+_MAX_REDIRECTS = 3
+
+
+def _is_private_host(host: str) -> bool:
+    """Return True if *host* resolves to a loopback/private/link-local IP.
+
+    SSRF-defense helper: a redirect chain that passes through a private
+    address (incl. AWS/Azure/GCP metadata service 169.254.169.254 or
+    Ollama/vLLM at 127.0.0.1) leaks internal data even when the operator-
+    configured base_url is public. We refuse to surface response bodies
+    from such chains.
+    """
+    import ipaddress
+
+    if not host:
+        return False
+    try:
+        addr = ipaddress.ip_address(host)
+    except ValueError:
+        # Hostname, not an IP. We don't resolve it here — full DNS-rebind
+        # protection requires socket-level interception. The httpx caller
+        # passes user-configured base_urls (operator trust), so a
+        # hostname like "metadata.internal" passes; but a literal IP
+        # redirect target is the practical attack vector.
+        return False
+    return bool(
+        addr.is_loopback
+        or addr.is_private
+        or addr.is_link_local
+        or addr.is_multicast
+        or addr.is_unspecified
+        or addr.is_reserved
+    )
+
 
 # Fernet encryption (optional)
 _fernet: Any = None
@@ -775,7 +811,11 @@ class APIHub:
         """HTTP-Request via httpx (async)."""
         import httpx
 
-        async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+        async with httpx.AsyncClient(
+            timeout=timeout,
+            follow_redirects=True,
+            max_redirects=_MAX_REDIRECTS,
+        ) as client:
             kwargs: dict[str, Any] = {
                 "method": method,
                 "url": url,
@@ -787,6 +827,20 @@ class APIHub:
                 kwargs["json"] = body
 
             response = await client.request(**kwargs)
+            # SSRF defense: refuse to return a response body that came
+            # from a redirect chain visiting a private/loopback IP.
+            # The request was already made — but never propagating the
+            # body upward stops the planner / LLM from seeing internal
+            # data such as cloud-metadata creds or local Ollama state.
+            for prior in (*response.history, response):
+                host = prior.url.host
+                if host and _is_private_host(host):
+                    log.warning(
+                        "api_hub_redirect_blocked",
+                        target_host=host,
+                        chain_length=len(response.history),
+                    )
+                    return 502, "Redirect chain reached a private/loopback host; refused."
             return response.status_code, response.text
 
     @staticmethod

--- a/src/cognithor/mcp/background_tasks.py
+++ b/src/cognithor/mcp/background_tasks.py
@@ -52,6 +52,22 @@ MAX_LOG_SIZE_BYTES = 10 * 1024 * 1024  # 10 MB per log file
 LOG_CLEANUP_DAYS = 7  # Delete logs of finished jobs older than 7 days
 DEFAULT_TIMEOUT = 3600  # 1 hour
 DEFAULT_CHECK_INTERVAL = 30  # seconds
+# Hard upper bound for caller-supplied timeouts (24 h). Prevents a planner-
+# supplied 999_999_999s value from pinning a worker forever.
+MAX_TIMEOUT_SECONDS = 86_400
+MAX_WAIT_TIMEOUT_SECONDS = 3_600
+# Caller-supplied grep patterns are passed to ``re.compile``. A naive pattern
+# like ``(a+)+$`` against a 10 MB log triggers catastrophic backtracking that
+# stalls the loop. Cap the pattern length so even a deliberately bad pattern
+# fits in a small backtracking budget. Independent from Gatekeeper checks —
+# this is defense-in-depth at the MCP boundary for any direct caller.
+MAX_GREP_PATTERN_LENGTH = 200
+# Substitution metacharacters that have no legitimate single-command use in a
+# background task. Chained operators (;, &, |, &&, ||) are also dangerous but
+# Gatekeeper's shell_ast_guard already rejects them — we duplicate only the
+# substitution checks here so direct programmatic callers (tests, channels)
+# bypassing the Gatekeeper are still protected.
+_MCP_SUBSTITUTION_PATTERN = re.compile(r"\$\(|`|<\(")
 
 
 # ============================================================================
@@ -130,6 +146,13 @@ class BackgroundProcessManager:
         channel: str = "",
     ) -> str:
         """Start a command in the background. Returns job_id."""
+        if _MCP_SUBSTITUTION_PATTERN.search(command):
+            raise ValueError(
+                "background_task: command contains shell-substitution metacharacters "
+                "($(...), backticks, or <(...)). Refusing to spawn — wrap intent in a "
+                "dedicated script and start that instead."
+            )
+        timeout_seconds = max(1, min(int(timeout_seconds), MAX_TIMEOUT_SECONDS))
         job_id = f"bg_{uuid.uuid4().hex[:12]}"
         log_file = self._log_dir / f"{job_id}.log"
         cwd = working_dir or None
@@ -377,7 +400,16 @@ class BackgroundProcessManager:
             return []
 
         if grep:
-            pattern = re.compile(grep, re.IGNORECASE)
+            if len(grep) > MAX_GREP_PATTERN_LENGTH:
+                raise ValueError(
+                    f"background_task: grep pattern too long "
+                    f"({len(grep)} > {MAX_GREP_PATTERN_LENGTH} chars). "
+                    "Use a shorter pattern."
+                )
+            try:
+                pattern = re.compile(grep, re.IGNORECASE)
+            except re.error as exc:
+                raise ValueError(f"background_task: invalid grep pattern: {exc}") from exc
             all_lines = [ln for ln in all_lines if pattern.search(ln)]
 
         if tail > 0:
@@ -744,7 +776,7 @@ def register_background_tools(
         job_id = kwargs.get("job_id", "")
         if not job_id:
             return "Error: 'job_id' is required."
-        timeout = int(kwargs.get("timeout", 300))
+        timeout = max(1, min(int(kwargs.get("timeout", 300)), MAX_WAIT_TIMEOUT_SECONDS))
         job = await manager.wait_job(job_id, timeout=timeout)
         if not job:
             return f"Job '{job_id}' not found."

--- a/src/cognithor/mcp/media.py
+++ b/src/cognithor/mcp/media.py
@@ -1052,6 +1052,10 @@ class MediaPipeline:
 
     # Erlaubte Audio-Samplerates
     ALLOWED_SAMPLE_RATES = frozenset({8000, 11025, 16000, 22050, 32000, 44100, 48000, 96000})
+    # Audio-Format Allow-List. ``output_format`` is interpolated into the
+    # output path (line below); without this allowlist, a value like
+    # ``"../etc/passwd"`` would escape the workspace via path traversal.
+    ALLOWED_AUDIO_FORMATS = frozenset({"wav", "mp3", "ogg", "flac"})
 
     async def convert_audio(
         self,
@@ -1067,6 +1071,16 @@ class MediaPipeline:
             output_format: Zielformat (wav, mp3, ogg, flac).
             sample_rate: Ziel-Samplerate (8000-96000).
         """
+        output_format = (output_format or "").lower().strip()
+        if output_format not in self.ALLOWED_AUDIO_FORMATS:
+            return MediaResult(
+                success=False,
+                error=t(
+                    "media.invalid_audio_format",
+                    fmt=output_format,
+                    allowed=sorted(self.ALLOWED_AUDIO_FORMATS),
+                ),
+            )
         if sample_rate not in self.ALLOWED_SAMPLE_RATES:
             return MediaResult(
                 success=False,

--- a/tests/test_mcp/test_api_hub.py
+++ b/tests/test_mcp/test_api_hub.py
@@ -25,6 +25,7 @@ from cognithor.mcp.api_hub import (
     APIHub,
     _build_auth_headers,
     _build_auth_params,
+    _is_private_host,
     _load_integrations,
     _mask_credential,
     _RateLimiter,
@@ -416,6 +417,37 @@ class TestApiConnect:
         loaded = _load_integrations(config)
         assert "test" in loaded
         assert loaded["test"]["base_url"] == "https://api.example.com"
+
+
+class TestSSRFGuards:
+    """Deep-PR4: SSRF + redirect-chain hardening."""
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "127.0.0.1",
+            "10.0.0.1",
+            "172.16.5.5",
+            "192.168.1.1",
+            "169.254.169.254",  # AWS/Azure/GCP metadata service
+            "::1",
+            "fc00::1",
+        ],
+    )
+    def test_is_private_host_blocks_internal_ips(self, host: str) -> None:
+        assert _is_private_host(host) is True
+
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "8.8.8.8",
+            "1.1.1.1",
+            "api.example.com",  # hostname not resolved here
+            "",
+        ],
+    )
+    def test_is_private_host_allows_public_or_hostnames(self, host: str) -> None:
+        assert _is_private_host(host) is False
 
 
 class TestApiCall:

--- a/tests/test_mcp/test_media.py
+++ b/tests/test_mcp/test_media.py
@@ -307,6 +307,25 @@ class TestConvertAudio:
             assert result.success is False
             assert "ffmpeg" in result.error
 
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "fmt",
+        ["../etc/passwd", "pipe:0", "WAV.exe", "exe", "", "wav.."],
+    )
+    async def test_convert_rejects_format_outside_allowlist(
+        self, pipeline: MediaPipeline, workspace: Path, fmt: str
+    ) -> None:
+        """output_format must be in the allowlist before path interpolation."""
+        f = workspace / "audio.mp3"
+        f.write_bytes(b"\xff\xfb" + b"\x00" * 100)
+        result = await pipeline.convert_audio(str(f), output_format=fmt)
+        assert result.success is False
+        # The error must reference invalid format, NOT proceed to ffmpeg
+        assert any(
+            term in result.error.lower()
+            for term in ["audio_format", "audio-ausgabeformat", "output format", "音频"]
+        )
+
 
 # ============================================================================
 # Bildskalierung

--- a/tests/unit/test_background_tasks.py
+++ b/tests/unit/test_background_tasks.py
@@ -6,6 +6,60 @@ from pathlib import Path
 import pytest
 
 
+class TestBackgroundManagerHardening:
+    """Defense-in-depth checks at the MCP boundary (Deep-PR4)."""
+
+    @pytest.fixture
+    def manager(self, tmp_path):
+        from cognithor.mcp.background_tasks import BackgroundProcessManager
+
+        return BackgroundProcessManager(
+            db_path=tmp_path / "jobs.db",
+            log_dir=tmp_path / "logs",
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "echo $(whoami)",
+            "echo `whoami`",
+            "diff <(ls /tmp) <(ls /var)",
+        ],
+    )
+    async def test_start_rejects_substitution_metacharacters(self, manager, command):
+        """Command-substitution metacharacters must be rejected at MCP boundary."""
+        with pytest.raises(ValueError, match="substitution"):
+            await manager.start(command)
+
+    @pytest.mark.asyncio
+    async def test_start_clamps_oversized_timeout(self, manager):
+        """timeout_seconds is capped at MAX_TIMEOUT_SECONDS (24 h)."""
+        from cognithor.mcp.background_tasks import MAX_TIMEOUT_SECONDS
+
+        job_id = await manager.start("echo hi", timeout_seconds=999_999_999)
+        job = manager.get_job(job_id)
+        assert job["timeout_seconds"] == MAX_TIMEOUT_SECONDS
+
+    @pytest.mark.asyncio
+    async def test_read_log_rejects_oversized_grep(self, manager):
+        """grep patterns longer than MAX_GREP_PATTERN_LENGTH are refused."""
+        job_id = await manager.start("echo hi")
+        await asyncio.sleep(0.5)
+        await manager.check_job(job_id)
+        with pytest.raises(ValueError, match="grep pattern too long"):
+            manager.read_log(job_id, grep="a" * 5000)
+
+    @pytest.mark.asyncio
+    async def test_read_log_rejects_invalid_grep(self, manager):
+        """Malformed regex patterns surface a friendly error, not a 500."""
+        job_id = await manager.start("echo hi")
+        await asyncio.sleep(0.5)
+        await manager.check_job(job_id)
+        with pytest.raises(ValueError, match="invalid grep pattern"):
+            manager.read_log(job_id, grep="[unclosed")
+
+
 class TestBackgroundProcessManager:
     """Core lifecycle: start, track, finish, query."""
 


### PR DESCRIPTION
## Summary

Pass-2 deep-audit findings **MCP-1 / MCP-2 / MCP-3 / MCP-4 (audio) / MCP-5 (background)** after a multi-agent false-positive filter. Three sub-findings verified FALSE-POSITIVE.

| Finding | Verified verdict | Location |
|---|---|---|
| MCP-1 SSRF via redirect | **REAL-HIGH** (downgraded from CRIT) | `api_hub.py:778` |
| MCP-2 shell injection (Win+Linux) | **REAL-CRIT** (defense-in-depth at MCP boundary) | `background_tasks.py:153` |
| MCP-3 ReDoS in grep | **REAL-HIGH** | `background_tasks.py:380` |
| MCP-4 audio format allowlist | **REAL-HIGH** | `media.py:1084` |
| MCP-4 image format | FALSE-POSITIVE (Pillow rejects unknown safely) | — |
| MCP-5 timeout (database) | FALSE-POSITIVE (already clamped at 30 s) | — |
| MCP-5 timeout (api_hub) | FALSE-POSITIVE (no exposed timeout param) | — |
| MCP-5 timeout (background) | **REAL-HIGH** | `background_tasks.py:556,747` |

## Fixes

### 1. `background_tasks.py` substitution guard (MCP-2 defense-in-depth)
`BackgroundProcessManager.start()` now refuses command strings containing `$(...)`, backticks, or `<(...)`. Gatekeeper's `shell_ast_guard` already blocks chained operators (`;`, `&&`, `||`, `|`) under SEC-CRIT-1; this guard covers direct programmatic callers (tests, future channels) that bypass the Planner→Gatekeeper flow.

### 2. `background_tasks.py` timeout cap (MCP-5)
- `start()`: `timeout_seconds` clamped to `MAX_TIMEOUT_SECONDS = 86_400` (24 h)
- `_wait_job` MCP handler: `timeout` clamped to `MAX_WAIT_TIMEOUT_SECONDS = 3_600` (1 h)

### 3. `background_tasks.py` ReDoS bound (MCP-3)
`read_log` grep pattern capped at `MAX_GREP_PATTERN_LENGTH = 200`, `re.compile` wrapped in `try/except` so malformed regex surfaces a friendly `ValueError` instead of stalling.

### 4. `api_hub.py` redirect SSRF defense (MCP-1)
- `httpx.AsyncClient(..., max_redirects=3)` (was unbounded → httpx default 20)
- New `_is_private_host()` helper checks each URL in `response.history` for loopback/private/link-local/multicast/reserved IPs (covers 169.254.169.254 metadata, 127.0.0.1 Ollama)
- If any redirect step targeted a private host, response body is replaced with `(502, "Redirect chain reached a private/loopback host; refused.")`

### 5. `media.py` `convert_audio` format allowlist (MCP-4)
`output_format` now validated against `ALLOWED_AUDIO_FORMATS = {wav, mp3, ogg, flac}` BEFORE path interpolation at line 1084. Blocks path traversal (`"../etc/passwd"`) and ffmpeg protocol injection (`"pipe:0"`).

i18n: new `media.invalid_audio_format` key added to en/de/zh.

## Test plan

- [x] 12 new tests added:
  - 3 × substitution-metachar reject (`$()`, backticks, `<()`)
  - 1 × timeout clamp at 86_400
  - 2 × grep-pattern guard (length + invalid regex)
  - 7 × `_is_private_host` parametrized (private vs. public)
  - 6 × `convert_audio` format reject (path-traversal, exe, empty, capital, etc.)
- [x] `pytest tests/unit/test_background_tasks.py tests/test_mcp/test_api_hub.py tests/test_mcp/test_media.py -q` → **112 passed**
- [x] `pytest tests/unit/test_background_tasks.py tests/test_mcp/ -q` (full MCP suite) → **1216 passed**
- [x] `mypy --strict` on all 3 source files → clean
- [x] `ruff check` + `ruff format --check` on all 6 touched files → clean
- [ ] CI green

## False-positive evidence

- **MCP-1 downgrade**: `base_url` is operator-controlled at `api_connect` setup time, not planner-supplied at runtime. SSRF requires a malicious legitimate server — second-order risk, hence HIGH not CRIT.
- **MCP-4 image FP**: `media.py:1163` falls through to `Pillow.Image.save()` which raises on unknown formats; no path-interpolation gap.
- **MCP-5 db FP**: `database_tools.py:752` clamps `limit` at `_MAX_ROW_LIMIT=5000`, query execution guarded by `_QUERY_TIMEOUT_S=30`.
- **MCP-5 api_hub FP**: `api_call` does not expose a `timeout` parameter in its MCP schema; hardcoded to `_DEFAULT_TIMEOUT=30 s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)