### PR TITLE
fix(deep-pr5): stop logging user-text content + i18n locale-miss visibility

### DIFF
--- a/src/cognithor/__main__.py
+++ b/src/cognithor/__main__.py
@@ -1558,7 +1558,7 @@ def main() -> None:
                                         )
                                         if result.success and result.text and result.text.strip():
                                             text = result.text.strip()
-                                            log.info("ws_audio_transcribed", text=text[:80])
+                                            log.info("ws_audio_transcribed", text_len=len(text))
                                             metadata.pop("audio_base64", None)
                                             metadata.pop("file_base64", None)
                                             metadata["transcribed_from"] = "audio"

--- a/src/cognithor/channels/talk_mode.py
+++ b/src/cognithor/channels/talk_mode.py
@@ -90,7 +90,7 @@ class TalkMode:
                     log.debug("talk_mode_no_speech_detected")
                     continue
 
-                log.info("talk_mode_heard", text=text[:100])
+                log.info("talk_mode_heard", text_len=len(text))
 
                 # Phase 4: Verarbeiten (via Voice-Channel Handler)
                 if self._voice._handler:

--- a/src/cognithor/channels/voice_ws_bridge.py
+++ b/src/cognithor/channels/voice_ws_bridge.py
@@ -112,7 +112,7 @@ class VoiceMessageHandler:
             )
 
             if result.success and result.text.strip():
-                log.info("voice_ws_transcribed", text=result.text[:80])
+                log.info("voice_ws_transcribed", text_len=len(result.text))
                 return cast("str | None", result.text.strip())
 
             log.warning("voice_ws_empty_transcription")

--- a/src/cognithor/core/planner.py
+++ b/src/cognithor/core/planner.py
@@ -781,7 +781,7 @@ class Planner:
 
         # Retry once if JSON parsing failed (LLM produced malformed JSON)
         if plan.parse_failed:
-            log.warning("planner_json_retry", model=model, goal=user_message[:80])
+            log.warning("planner_json_retry", model=model, goal_len=len(user_message))
             retry_hint = (
                 "\n\nIMPORTANT: Your previous response contained "
                 "malformed JSON that could not be parsed. "
@@ -855,7 +855,7 @@ class Planner:
             and not plan.steps
             and not getattr(plan, "_action_retry_done", False)
         ):
-            log.warning("planner_action_refused_retry", goal=user_message[:80])
+            log.warning("planner_action_refused_retry", goal_len=len(user_message))
             action_hint = (
                 "\n\nKRITISCH: Du hast eine Text-Antwort generiert statt "
                 "einen Tool-Plan. Der Nutzer hat eine AKTION verlangt. "

--- a/src/cognithor/gateway/pge_loop.py
+++ b/src/cognithor/gateway/pge_loop.py
@@ -151,7 +151,7 @@ async def run_pge_loop(
     _is_correction = any(t in _lower_msg for t in _CORRECTION_TRIGGERS)
 
     if _is_correction and session.iteration_count > 0:
-        log.info("live_correction_detected", text=msg.text[:80])
+        log.info("live_correction_detected", text_len=len(msg.text))
         if hasattr(gw, "_correction_memory") and gw._correction_memory:
             gw._correction_memory.store(
                 user_message=getattr(session, "last_user_message", "") or "",
@@ -168,7 +168,7 @@ async def run_pge_loop(
                     if gap not in goals and len(goals) < 20:
                         goals.append(gap)
                         config.evolution.learning_goals = goals
-                        log.info("evolution_gap_from_correction", correction=msg.text[:60])
+                        log.info("evolution_gap_from_correction", correction_len=len(msg.text))
             except Exception:
                 log.debug("evolution_correction_injection_failed", exc_info=True)
         wm.add_message(

--- a/src/cognithor/i18n/__init__.py
+++ b/src/cognithor/i18n/__init__.py
@@ -223,7 +223,15 @@ def _ensure_loaded(locale: str) -> None:
     pack_path = _find_pack_file(locale)
     if pack_path is None:
         if locale != _DEFAULT_LOCALE:
-            logger.debug("i18n_pack_not_found locale=%s", locale)
+            # Promoted from DEBUG → WARNING so operators notice when a
+            # configured locale ships no pack file (e.g. ``ar`` referenced
+            # in docs but not under ``i18n/locales/``). Falls back silently
+            # to English afterwards, which previously left ops blind.
+            logger.warning(
+                "i18n_pack_not_found locale=%s — falling back to %s",
+                locale,
+                _DEFAULT_LOCALE,
+            )
         with _lock:
             _packs[locale] = {}
         return


### PR DESCRIPTION
## Summary

Pass-2 deep-audit findings **XC-1** + **XC-4**. XC-2 verified FALSE-POSITIVE (pack-loader already uses `WARNING`); XC-3 (no-redact in stdlib fallback) deferred to its own PR — this one stays surgical.

### XC-1 — User-text PII no longer leaked to log files

7 INFO/WARNING log lines previously embedded the first 60–100 chars of user-typed (or transcribed) text. Long enough to capture passwords / API keys / personal data when present in messages.

**All replaced with `…_len=len(...)` — content-free length signal.**

| File:line | Event | Before | After |
|---|---|---|---|
| `gateway/pge_loop.py:154` | `live_correction_detected` | `text=msg.text[:80]` | `text_len=len(msg.text)` |
| `gateway/pge_loop.py:171` | `evolution_gap_from_correction` | `correction=msg.text[:60]` | `correction_len=len(msg.text)` |
| `channels/talk_mode.py:93` | `talk_mode_heard` | `text=text[:100]` | `text_len=len(text)` |
| `channels/voice_ws_bridge.py:115` | `voice_ws_transcribed` | `text=result.text[:80]` | `text_len=len(result.text)` |
| `__main__.py:1561` | `ws_audio_transcribed` | `text=text[:80]` | `text_len=len(text)` |
| `core/planner.py:784` | `planner_json_retry` | `goal=user_message[:80]` | `goal_len=len(user_message)` |
| `core/planner.py:858` | `planner_action_refused_retry` | `goal=user_message[:80]` | `goal_len=len(user_message)` |

Length still gives operators useful signal (correlate failure rate to message size, detect zero-length anomalies); content is gone.

### XC-4 — i18n locale-miss now visible to operators

`i18n/__init__.py:226` — promoted `logger.debug` → `logger.warning` when a non-default locale (`ar`, `fr`, …) has no shipped pack. Before: silent fallback to English with no operator-visible signal. After: one WARNING per missed locale on first lookup, naming the requested locale and the fallback.

## Test plan

- [x] `pytest tests/test_core/test_planner.py tests/test_channels/test_voice_ws_bridge.py tests/test_channels/test_talk_mode.py tests/test_utils/test_error_messages.py -q` → **65 passed**
- [x] `ruff check` + `ruff format --check` clean on all 6 touched files
- [ ] CI green

## False-positive evidence

- **XC-2** — verifier traced every failure path in `packs/loader.py` (`_validate_pack`, `_load_one`, lines 267-418) and confirmed all use `_log.warning(...)`, not `_log.debug`. No fix needed.
- **XC-3** — real but bigger surface; deferred to a follow-up PR with a structlog redaction processor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)