### PR TITLE
fix(deep-pr6): warn when pack registers tools without explicit risk-level

### DIFF
--- a/src/cognithor/packs/loader.py
+++ b/src/cognithor/packs/loader.py
@@ -402,12 +402,22 @@ class PackLoader:
         module_name = spec.name
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
+        # Snapshot the tool registry so we can detect tools that *this*
+        # pack adds during ``register(context)`` and audit their risk
+        # declarations afterwards. Built-in tools registered before pack
+        # load are filtered out by name comparison.
+        mcp = getattr(context, "mcp_client", None)
+        registry = getattr(mcp, "_tool_registry", None) if mcp is not None else None
+        pre_existing: frozenset[str] = (
+            frozenset(registry.keys()) if isinstance(registry, dict) else frozenset()
+        )
         try:
             spec.loader.exec_module(module)
             pack_cls = module.Pack
             instance: AgentPack = pack_cls(manifest)
             instance.register(context)
             self._register_tool_risks(manifest, context)
+            self._warn_undeclared_tool_risks(manifest, context, pre_existing)
             self._loaded[qid] = instance
             _log.info("pack.loaded", qualified_id=qid, version=manifest.version)
             self._fingerprint_pack(manifest, entrypoint)
@@ -517,4 +527,49 @@ class PackLoader:
                 description=(existing.description if existing else ""),
                 input_schema=(existing.input_schema if existing else {}),
                 risk_level=risk,
+            )
+
+    @staticmethod
+    def _warn_undeclared_tool_risks(
+        manifest: PackManifest,
+        context: PackContext,
+        pre_existing: frozenset[str],
+    ) -> None:
+        """Surface pack tools that have no explicit risk-level declaration.
+
+        Defense-in-depth for SEC-CRIT-2 / PACK-2: a pack can register
+        builtin tools via ``mcp_client.register_builtin_handler`` without
+        passing ``risk_level``. Such tools fall through to the
+        Gatekeeper's hardcoded fallback, which classifies unknown tools
+        as ORANGE — safe but stricter than intended and silent. Authors
+        should either pass ``risk_level="..."`` to the registrar or
+        declare ``tool_risks`` in ``pack_manifest.json``. Emit one
+        WARNING per undeclared tool so operators notice the omission.
+        """
+        mcp = getattr(context, "mcp_client", None)
+        registry = getattr(mcp, "_tool_registry", None) if mcp is not None else None
+        if not isinstance(registry, dict):
+            return
+        declared = set((manifest.tool_risks or {}).keys())
+        for tool_name in sorted(set(registry) - pre_existing):
+            info = registry.get(tool_name)
+            if info is None:
+                continue
+            risk = (getattr(info, "risk_level", "") or "").strip()
+            if risk:
+                continue
+            if tool_name in declared:
+                # Manifest declared a risk but ``_register_tool_risks``
+                # left risk_level empty — already audited by the
+                # built-in-override guard. Nothing to add here.
+                continue
+            _log.warning(
+                "pack_tool_risk_undeclared",
+                pack=manifest.qualified_id,
+                tool=tool_name,
+                fallback_risk="orange",
+                hint=(
+                    "Pass risk_level=... to register_builtin_handler "
+                    "or add tool_risks in pack_manifest.json."
+                ),
             )

--- a/tests/test_packs/test_tool_risks.py
+++ b/tests/test_packs/test_tool_risks.py
@@ -211,11 +211,38 @@ class TestUndeclaredToolRiskWarning:
         mcp._tool_registry = registry  # type: ignore[attr-defined]
         return PackContext(mcp_client=mcp)
 
-    def test_warns_when_pack_tool_has_empty_risk_and_no_declaration(self, capsys):
+    def _intercept_warnings(self, monkeypatch) -> list[tuple[str, dict]]:
+        """Replace loader._log with a stub that records .warning calls.
+
+        ``capsys`` proved flaky in CI because structlog's renderer writes
+        to stderr/stdout via paths pytest captures inconsistently across
+        runners (Linux py3.13 was the most affected). Intercepting at the
+        logger boundary is deterministic.
+        """
+        from cognithor.packs import loader as loader_mod
+
+        records: list[tuple[str, dict]] = []
+
+        class _RecordingLogger:
+            def warning(self, event: str, **kwargs):
+                records.append((event, kwargs))
+
+            def info(self, *_a, **_kw):
+                pass
+
+            def debug(self, *_a, **_kw):
+                pass
+
+            def error(self, *_a, **_kw):
+                pass
+
+        monkeypatch.setattr(loader_mod, "_log", _RecordingLogger())
+        return records
+
+    def test_warns_when_pack_tool_has_empty_risk_and_no_declaration(self, monkeypatch):
         """Pack registered a tool without risk_level AND without manifest entry."""
+        records = self._intercept_warnings(monkeypatch)
         manifest = _make_manifest(tools=["my_tool"])  # no tool_risks
-        # Pack has just registered ``my_tool`` via ``register_builtin_handler``
-        # with risk_level="" — the realistic shape after pack code runs.
         registry: dict[str, MCPToolInfo] = {
             "my_tool": MCPToolInfo(name="my_tool", server="builtin", risk_level=""),
         }
@@ -226,12 +253,14 @@ class TestUndeclaredToolRiskWarning:
             ctx,
             pre_existing=frozenset(),
         )
-        out = capsys.readouterr().out
-        assert "pack_tool_risk_undeclared" in out
-        assert "my_tool" in out
+        assert any(
+            event == "pack_tool_risk_undeclared" and kw.get("tool") == "my_tool"
+            for event, kw in records
+        ), records
 
-    def test_silent_when_pack_tool_has_explicit_risk(self, capsys):
+    def test_silent_when_pack_tool_has_explicit_risk(self, monkeypatch):
         """Tool registered with risk_level= "..." → no warning."""
+        records = self._intercept_warnings(monkeypatch)
         manifest = _make_manifest(tools=["safe_tool"])
         registry: dict[str, MCPToolInfo] = {
             "safe_tool": MCPToolInfo(name="safe_tool", server="builtin", risk_level="green"),
@@ -243,12 +272,12 @@ class TestUndeclaredToolRiskWarning:
             ctx,
             pre_existing=frozenset(),
         )
-        out = capsys.readouterr().out
-        assert "pack_tool_risk_undeclared" not in out
+        assert not any(event == "pack_tool_risk_undeclared" for event, _ in records)
 
-    def test_silent_when_manifest_declares_risk(self, capsys):
+    def test_silent_when_manifest_declares_risk(self, monkeypatch):
         """Manifest tool_risks declared → ``_register_tool_risks`` already
         handled it; no double-warning."""
+        records = self._intercept_warnings(monkeypatch)
         manifest = _make_manifest(
             tools=["declared_tool"],
             tool_risks={"declared_tool": "yellow"},
@@ -263,12 +292,12 @@ class TestUndeclaredToolRiskWarning:
             ctx,
             pre_existing=frozenset(),
         )
-        out = capsys.readouterr().out
-        assert "pack_tool_risk_undeclared" not in out
+        assert not any(event == "pack_tool_risk_undeclared" for event, _ in records)
 
-    def test_pre_existing_tools_excluded_from_check(self, capsys):
+    def test_pre_existing_tools_excluded_from_check(self, monkeypatch):
         """Tools that existed before the pack loaded must not trigger
         the warning — only this pack's new additions matter."""
+        records = self._intercept_warnings(monkeypatch)
         manifest = _make_manifest(tools=["new_tool"])
         registry: dict[str, MCPToolInfo] = {
             "old_builtin": MCPToolInfo(name="old_builtin", server="builtin", risk_level=""),
@@ -281,14 +310,9 @@ class TestUndeclaredToolRiskWarning:
             ctx,
             pre_existing=frozenset(["old_builtin"]),
         )
-        out = capsys.readouterr().out
-        assert "tool=new_tool" in out
-        # The pre-existing builtin must NOT generate the undeclared warning.
-        # Take only lines containing the warning event name and check
-        # ``old_builtin`` doesn't appear in those.
-        warning_lines = [ln for ln in out.splitlines() if "pack_tool_risk_undeclared" in ln]
-        assert warning_lines, out
-        assert not any("old_builtin" in ln for ln in warning_lines)
+        flagged = [kw.get("tool") for event, kw in records if event == "pack_tool_risk_undeclared"]
+        assert "new_tool" in flagged, records
+        assert "old_builtin" not in flagged, records
 
 
 class TestCognithorToolDecorator:

--- a/tests/test_packs/test_tool_risks.py
+++ b/tests/test_packs/test_tool_risks.py
@@ -200,6 +200,97 @@ class TestPackLoaderRegistersRisks:
         PackLoader._register_tool_risks(manifest, ctx)
 
 
+class TestUndeclaredToolRiskWarning:
+    """Deep-PR6: undeclared pack-tool risks emit operator-visible WARNING."""
+
+    def _mock_context(self, registry: dict[str, MCPToolInfo]) -> PackContext:
+        class MockMCP:
+            pass
+
+        mcp = MockMCP()
+        mcp._tool_registry = registry  # type: ignore[attr-defined]
+        return PackContext(mcp_client=mcp)
+
+    def test_warns_when_pack_tool_has_empty_risk_and_no_declaration(self, capsys):
+        """Pack registered a tool without risk_level AND without manifest entry."""
+        manifest = _make_manifest(tools=["my_tool"])  # no tool_risks
+        # Pack has just registered ``my_tool`` via ``register_builtin_handler``
+        # with risk_level="" — the realistic shape after pack code runs.
+        registry: dict[str, MCPToolInfo] = {
+            "my_tool": MCPToolInfo(name="my_tool", server="builtin", risk_level=""),
+        }
+        ctx = self._mock_context(registry)
+
+        PackLoader._warn_undeclared_tool_risks(
+            manifest,
+            ctx,
+            pre_existing=frozenset(),
+        )
+        out = capsys.readouterr().out
+        assert "pack_tool_risk_undeclared" in out
+        assert "my_tool" in out
+
+    def test_silent_when_pack_tool_has_explicit_risk(self, capsys):
+        """Tool registered with risk_level= "..." → no warning."""
+        manifest = _make_manifest(tools=["safe_tool"])
+        registry: dict[str, MCPToolInfo] = {
+            "safe_tool": MCPToolInfo(name="safe_tool", server="builtin", risk_level="green"),
+        }
+        ctx = self._mock_context(registry)
+
+        PackLoader._warn_undeclared_tool_risks(
+            manifest,
+            ctx,
+            pre_existing=frozenset(),
+        )
+        out = capsys.readouterr().out
+        assert "pack_tool_risk_undeclared" not in out
+
+    def test_silent_when_manifest_declares_risk(self, capsys):
+        """Manifest tool_risks declared → ``_register_tool_risks`` already
+        handled it; no double-warning."""
+        manifest = _make_manifest(
+            tools=["declared_tool"],
+            tool_risks={"declared_tool": "yellow"},
+        )
+        registry: dict[str, MCPToolInfo] = {
+            "declared_tool": MCPToolInfo(name="declared_tool", server="builtin", risk_level=""),
+        }
+        ctx = self._mock_context(registry)
+
+        PackLoader._warn_undeclared_tool_risks(
+            manifest,
+            ctx,
+            pre_existing=frozenset(),
+        )
+        out = capsys.readouterr().out
+        assert "pack_tool_risk_undeclared" not in out
+
+    def test_pre_existing_tools_excluded_from_check(self, capsys):
+        """Tools that existed before the pack loaded must not trigger
+        the warning — only this pack's new additions matter."""
+        manifest = _make_manifest(tools=["new_tool"])
+        registry: dict[str, MCPToolInfo] = {
+            "old_builtin": MCPToolInfo(name="old_builtin", server="builtin", risk_level=""),
+            "new_tool": MCPToolInfo(name="new_tool", server="builtin", risk_level=""),
+        }
+        ctx = self._mock_context(registry)
+
+        PackLoader._warn_undeclared_tool_risks(
+            manifest,
+            ctx,
+            pre_existing=frozenset(["old_builtin"]),
+        )
+        out = capsys.readouterr().out
+        assert "tool=new_tool" in out
+        # The pre-existing builtin must NOT generate the undeclared warning.
+        # Take only lines containing the warning event name and check
+        # ``old_builtin`` doesn't appear in those.
+        warning_lines = [ln for ln in out.splitlines() if "pack_tool_risk_undeclared" in ln]
+        assert warning_lines, out
+        assert not any("old_builtin" in ln for ln in warning_lines)
+
+
 class TestCognithorToolDecorator:
     def test_attaches_metadata(self):
         @cognithor_tool(name="probe", risk_level="green", description="Ping")


### PR DESCRIPTION
## Summary

Pass-2 deep-audit finding **PACK-2** (defense-in-depth for SEC-CRIT-2). PACK-1 (zip path traversal) and PACK-3 (sys.path manipulation) verified FALSE-POSITIVE. PACK-4 (registry signature gap) confirmed REAL-CRIT but documented as a dedicated future sprint — not a one-PR fix.

## The gap

A pack can register MCP tools via `mcp_client.register_builtin_handler` **without** passing `risk_level=...` AND **without** declaring the tool in its `pack_manifest.json` `tool_risks` field. The Gatekeeper's hardcoded fallback then classifies them as ORANGE — safe-but-stricter than intended, and silent.

## Fix

`PackLoader._load_one`:
1. Snapshot `mcp_client._tool_registry` keys **before** `instance.register(context)` runs
2. Run pack init + existing `_register_tool_risks` 
3. Call new `_warn_undeclared_tool_risks` which diffs against the post-load registry and warns once per pack-added tool with empty `risk_level` AND not in `manifest.tool_risks`

```text
[warning] pack_tool_risk_undeclared
  pack=acme/example
  tool=my_new_tool
  fallback_risk=orange
  hint='Pass risk_level=... to register_builtin_handler or add tool_risks in pack_manifest.json.'
```

Pre-existing built-in tools (registered before the pack ran) are excluded from the check — only this pack's new additions matter.

## Test plan

- [x] 4 new tests in `TestUndeclaredToolRiskWarning`:
  - warn-on-empty-risk + no-manifest-decl
  - silent-when-explicit-risk-level set
  - silent-when-manifest-declares risk
  - pre-existing-tools excluded from check
- [x] `pytest tests/test_packs/test_tool_risks.py -q` → **24 passed**
- [x] `pytest tests/test_packs/ -q` → **84 passed** (no regressions in surrounding suite)
- [x] `mypy --strict src/cognithor/packs/loader.py` → clean
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green

## False-positive evidence

- **PACK-1** (zip path traversal): `installer.py:357-366` constructs `eula_path = pack_root / "eula.md"` via Path concatenation, never trusting zip member names; SHA-256 always computed against the verified file.
- **PACK-3** (sys.path manipulation): `loader.py` uses `importlib.util.spec_from_file_location` + `module_from_spec` + `exec_module` exclusively. Zero `sys.path` mutations.

## Deferred — PACK-4 — registry signature gap

The reviewer confirmed `skills/community/sync.py` and `publisher.py` fetch `registry.json`, `recalls/active.json`, `publishers/*.json` over plain HTTPS without **any** signature verification. Anyone with control of the registry host (GitHub repo compromise, BGP-MITM) can trigger remote skill kill-switch + reputation tampering.

**Why not in this PR**: needs a full PKI design — Ed25519 signing keypair, `.sig` files in registry repo, key rotation policy, migration plan for existing un-signed registry. Documented at `memory/project_pack4_registry_signature_gap.md` for a dedicated sprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)