### PR TITLE
fix(deep-pr7): refuse ARC corpus task paths that escape corpus_root

### DIFF
--- a/src/cognithor/channels/program_synthesis/synthesis/arc_corpus.py
+++ b/src/cognithor/channels/program_synthesis/synthesis/arc_corpus.py
@@ -134,7 +134,7 @@ def load_corpus(
     ``subset="held_out"`` to filter via the manifest; pass ``subset=None``
     to load every ``tasks/*.json``.
     """
-    root = Path(corpus_root)
+    root = Path(corpus_root).resolve()
     if subset is not None:
         manifest_path = root / "manifest.json"
         if not manifest_path.exists():
@@ -145,7 +145,22 @@ def load_corpus(
         subsets = manifest.get("subsets", {})
         if subset not in subsets:
             raise KeyError(f"subset {subset!r} not in manifest; available: {sorted(subsets)}")
-        files = [root / rel for rel in subsets[subset]["task_files"]]
+        # Path-traversal guard: a tampered manifest could ship a relative path
+        # like "../../etc/passwd" or an absolute path; ``Path.__truediv__``
+        # discards ``root`` when the right side is absolute, and a ``..``
+        # escape is silently traversed. Resolve each candidate and require
+        # it to live under ``root`` — otherwise the load is refused before
+        # any ``read_text`` happens.
+        files = []
+        for rel in subsets[subset]["task_files"]:
+            candidate = (root / rel).resolve()
+            try:
+                candidate.relative_to(root)
+            except ValueError as exc:
+                raise ValueError(
+                    f"corpus task path {rel!r} escapes corpus_root {str(root)!r}"
+                ) from exc
+            files.append(candidate)
     else:
         files = sorted((root / "tasks").glob("*.json"))
     if not files:

--- a/tests/test_channels/test_program_synthesis/phase2/test_arc_corpus.py
+++ b/tests/test_channels/test_program_synthesis/phase2/test_arc_corpus.py
@@ -147,6 +147,58 @@ class TestLoadCorpus:
         with pytest.raises(FileNotFoundError, match="No ARC"):
             load_corpus(tmp_path, subset=None)
 
+    def test_manifest_with_traversal_path_refused(self, tmp_path: Path) -> None:
+        """Deep-PR7: tampered manifest with ``..`` escape must be rejected."""
+        (tmp_path / "tasks").mkdir()
+        # Write a legitimate task in a sibling dir to give the traversal a real
+        # target; the corpus-loader must still refuse the escape.
+        outside = tmp_path.parent / "leaked.json"
+        _write_task(outside, examples=[([[1]], [[1]])])
+        try:
+            (tmp_path / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "version": "evil",
+                        "subsets": {
+                            "train": {
+                                "n": 1,
+                                "task_files": ["../leaked.json"],
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with pytest.raises(ValueError, match="escapes corpus_root"):
+                load_corpus(tmp_path, subset="train")
+        finally:
+            outside.unlink(missing_ok=True)
+
+    def test_manifest_with_absolute_path_refused(self, tmp_path: Path) -> None:
+        """Absolute paths in task_files must also be refused."""
+        (tmp_path / "tasks").mkdir()
+        outside = tmp_path.parent / "absolute_leak.json"
+        _write_task(outside, examples=[([[1]], [[1]])])
+        try:
+            (tmp_path / "manifest.json").write_text(
+                json.dumps(
+                    {
+                        "version": "evil",
+                        "subsets": {
+                            "train": {
+                                "n": 1,
+                                "task_files": [str(outside)],
+                            }
+                        },
+                    }
+                ),
+                encoding="utf-8",
+            )
+            with pytest.raises(ValueError, match="escapes corpus_root"):
+                load_corpus(tmp_path, subset="train")
+        finally:
+            outside.unlink(missing_ok=True)
+
 
 # ---------------------------------------------------------------------------
 # TaskSpec / BenchmarkTask projection


### PR DESCRIPTION
## Summary

Pass-2 deep-audit finding **PSE-1** (REAL-MED). PSE-2 / PSE-3 / PSE-4 verified FALSE-POSITIVE.

`arc_corpus.load_corpus()` built file paths via `root / rel` from manifest-supplied `task_files` strings with **no** `.resolve()` + `.relative_to(root)` guard. Two attack shapes:

| Shape | Example `task_files` entry | Effect |
|---|---|---|
| Relative escape | `"../../etc/passwd"` | Traverses out of `corpus_root` |
| Absolute path | `"/tmp/leak.json"` | `Path.__truediv__` discards `root` on POSIX |

## Threat model context

Narrow **today**: `corpus_root` is operator-supplied via CLI `--arc-corpus` flag (`benchmark_runner.py:359`, `sprint6_symbolic_repair_runner.py:335`, `sprint7_cascade_runner.py:288`), not gateway/PGE-controlled. **But**: `load_corpus()` is reused by three runners and any future MCP/REST wiring would inherit the unchecked read. Fixing at the source closes the door once.

## Fix

`src/cognithor/channels/program_synthesis/synthesis/arc_corpus.py:137`

```python
root = Path(corpus_root).resolve()
...
files = []
for rel in subsets[subset]["task_files"]:
    candidate = (root / rel).resolve()
    try:
        candidate.relative_to(root)
    except ValueError as exc:
        raise ValueError(
            f"corpus task path {rel!r} escapes corpus_root {str(root)!r}"
        ) from exc
    files.append(candidate)
```

No file is ever opened until the path passes the guard. Both relative `..` escapes and absolute paths now raise `ValueError`.

## Test plan

- [x] 2 new regression tests in `tests/test_channels/test_program_synthesis/phase2/test_arc_corpus.py`:
  - `test_manifest_with_traversal_path_refused` — `../leaked.json` rejected
  - `test_manifest_with_absolute_path_refused` — absolute path rejected
- [x] `pytest tests/test_channels/test_program_synthesis/phase2/test_arc_corpus.py -q` → **18 passed**
- [x] `mypy --strict src/cognithor/channels/program_synthesis/synthesis/arc_corpus.py` → clean
- [x] `ruff check` + `ruff format --check` clean
- [ ] CI green

## False-positive evidence

| Finding | Why FP |
|---|---|
| PSE-2 (suspicion-weight literals) | All in `Phase2Config` (lines 91, 92, 99, 100, 101). `alpha_mixer.py` reads via config exclusively, no literals. |
| PSE-3 (`current_alpha` hardcoded) | `DualPriorMixer.get_prior` uses `mix_alpha(...)`; `AlphaController.alpha_performance` reads `cfg.alpha_cold_start`. The `0.6` default in `arc_corpus.py:93,163` is the benchmark-driver default, not the Phase-2 mixer. |
| PSE-4 (telemetry leaks grids) | `phase2/telemetry.py` is Prometheus-only counters. Zero `log.*grid` / `log.*examples` / `log.*input` matches across `program_synthesis/`. Grids serialised into LLM prompts via `_compact_repr`, but that goes to the LLM backend, not Python loggers. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)