### PR TITLE
feat(pack-4): community-registry Ed25519 signing (TUF-Light)

### DIFF
--- a/README.md
+++ b/README.md
@@ -713,6 +713,31 @@ into a single canonical block under `bundle["trust"]`.
 > See [Sprint-27 IDE-Integration plan](docs/superpowers/plans/2026-05-04-sprint27-ide-integration.md)
 > for the consuming-extension roadmap.
 
+### Registry Trust Model (PACK-4)
+
+The community-skill marketplace uses a self-managed Ed25519 + TUF-Light
+signing scheme — **no third-party witness, no Sigstore dependency**, EU-
+sovereign by design.
+
+* Offline **Root** key signs `root.json`, which delegates to a rotating
+  online **Targets** key. `root.json` carries a monotonic `version` and
+  a `valid_until` window so a stale-replay attacker cannot freeze a
+  recall mid-flight.
+* Targets-key rotation is transparent: a fresh Targets pubkey lands in
+  a new `root.json`, signed by the offline Root. Clients pick it up on
+  next sync.
+* Hard-fail on every signature/freshness/replay error — kill-switch
+  must reach clients reliably.
+* No `--accept-unsigned-registry` runtime flag (would be a downgrade
+  vector). `REQUIRE_SIGNED_REGISTRY` is a build-time constant.
+
+| Doc | Purpose |
+|-----|---------|
+| [`docs/superpowers/specs/2026-05-05-pack4-registry-signing.md`](docs/superpowers/specs/2026-05-05-pack4-registry-signing.md) | Full spec |
+| [`SECURITY.md`](SECURITY.md#registry-trust-model-pack-4) | Threat-model summary |
+| [`docs/runbooks/registry_key_rotation.md`](docs/runbooks/registry_key_rotation.md) | Operator runbook |
+| [`scripts/registry_signing/`](scripts/registry_signing/README.md) | CLI tooling |
+
 ## MCP Tools
 
 | Tool Server | Tools | Description |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,6 +35,32 @@ Cognithor implements defense-in-depth with multiple security layers (supporting 
 - **Input Sanitization** — Protection against shell injection, path traversal, and prompt injection attacks.
 - **Path Sandbox** — File operations restricted to explicitly allowed directories.
 - **Red-Teaming** — Automated offensive security test suite (1,425 LOC).
+- **Registry Trust Model** — Community-skill registry payloads (`registry.json`, `recalls/active.json`, `publishers/*.json`) are Ed25519-signed under a TUF-Light scheme: an offline Root key signs `root.json`, which delegates to a rotating online Targets key. See [Registry Trust Model](#registry-trust-model-pack-4) below.
+
+## Registry Trust Model (PACK-4)
+
+Cognithor's community-skill marketplace uses a self-managed TUF-Light signing scheme — no third-party witness, no Sigstore dependency, EU-sovereign by design. Spec: [`docs/superpowers/specs/2026-05-05-pack4-registry-signing.md`](docs/superpowers/specs/2026-05-05-pack4-registry-signing.md).
+
+### Threat coverage
+
+| Attack | Mitigation |
+|---|---|
+| Tampered registry JSON in transit (BGP-MITM, DNS hijack) | Ed25519 signature over canonical-JSON `signed` block. |
+| Compromised CDN / GitHub-Pages serving the registry | Same — signed payloads are verified client-side regardless of origin. |
+| Replay of an old, legit-signed `registry.json` to neutralise a recall | Monotonic `version` field; client persists `last_seen` per channel and refuses anything older. |
+| Stale `recalls/active.json` served indefinitely after key rotation | `valid_until` field (1 day for recalls, 14 days for registry). Hard-fail when expired. |
+| Targets-key compromise | Offline Root key signs a new `root.json` with a fresh Targets pubkey. Clients pick up the rotation transparently on next sync (key change is part of the signed-data version chain). |
+| Root-key compromise | Release-bound rotation: new pinned key in source, new Cognithor release. **By design** — offline-Root is the trust anchor. See [`docs/runbooks/registry_key_rotation.md`](docs/runbooks/registry_key_rotation.md). |
+| Confused-deputy: swap `publishers/alice.json` with `publishers/eve.json` | Verifier requires `payload.body.github_username` to match the requested user. |
+| Downgrade: `--accept-unsigned-registry` flag | Does not exist. `REQUIRE_SIGNED_REGISTRY` is a build-time constant in `_pinned_keys.py`, source-patchable for developers but not togglable from the CLI. |
+
+### Hard-fail behaviour
+
+Every signature/freshness/replay failure raises `RegistrySignatureError` from `cognithor.skills.community.signing`. The surrounding `RegistrySync.sync_once` lets the exception propagate, which marks the sync as `success=False` and prevents recall application. **Soft-fail on a kill-switch mechanism would be a contradiction** — the entire point is that recalls reach clients reliably.
+
+### Dormant marketplace (default)
+
+Until the operator activates the marketplace by minting Root keys offline and embedding the Root pubkey in `_pinned_keys.py`, `RegistryVerifier.is_configured()` returns `False`. `RegistrySync.sync_once` short-circuits cleanly and `PublisherVerifier._fetch_publisher_profile` returns `None`. No network traffic, no errors.
 
 ## Runtime Token Protection (v0.26.0+)
 

--- a/docs/operational_trust.md
+++ b/docs/operational_trust.md
@@ -296,3 +296,21 @@ to use the canonical singletons.
 * Reviewer-feedback gap analysis: `memory/project_operational_trust_gap_analysis.md`
 * TRUST-5..10 ship log: `memory/project_2026_05_04_trust_stack_complete.md`
 * PR span: #395 → #435 (41 PRs across two days)
+
+---
+
+## PACK-4 — Community registry signing (addressed)
+
+**Status (2026-05-05):** REAL-CRIT addressed. The community-skill
+registry is now Ed25519-signed under a TUF-Light scheme (offline
+Root key + rotating online Targets key), with monotonic-version
+replay protection and `valid_until` freshness windows.
+
+* Spec: [`docs/superpowers/specs/2026-05-05-pack4-registry-signing.md`](superpowers/specs/2026-05-05-pack4-registry-signing.md)
+* Verifier module: [`cognithor.skills.community.signing`](../src/cognithor/skills/community/signing.py)
+* Operator runbook: [`docs/runbooks/registry_key_rotation.md`](runbooks/registry_key_rotation.md)
+* Trust-model summary: [`SECURITY.md`](../SECURITY.md#registry-trust-model-pack-4)
+
+Deferred (not blockers): full TUF snapshot/timestamp roles,
+Sigstore/cosign keyless signing, multi-operator federation. See
+spec §12 for non-goals.

--- a/docs/runbooks/registry_key_rotation.md
+++ b/docs/runbooks/registry_key_rotation.md
@@ -1,0 +1,146 @@
+# Runbook — Community Registry Key Rotation
+
+Audience: Cognithor maintainer (currently a single owner).
+Last reviewed: 2026-05-05 — initial PACK-4 ship.
+
+This runbook covers the two key-rotation procedures defined in [PACK-4 spec §2](../superpowers/specs/2026-05-05-pack4-registry-signing.md).
+
+| Trigger | Procedure |
+|---|---|
+| Routine Targets-key rotation (every 90 days, recommended) | [§A](#a-routine-targets-rotation) |
+| Suspected Targets-key compromise | [§A](#a-routine-targets-rotation) — same flow, immediate |
+| Suspected Root-key compromise | [§B](#b-emergency-root-rotation) — release-bound, no online recovery |
+
+The operator-side tooling lives in [`scripts/registry_signing/`](../../scripts/registry_signing/README.md).
+
+---
+
+## A — Routine Targets rotation
+
+**Goal:** invalidate the current Targets key without taking the registry offline. Clients pick up the new key transparently on their next sync.
+
+### Preconditions
+- Air-gapped or offline machine with the Root private key on a hardware token / encrypted USB.
+- A clean checkout of the Cognithor source tree on that machine (for the scripts).
+- Access to the registry repo (push) and to GitHub-Actions secrets (write).
+
+### Steps
+
+1. **On the offline machine**, mint a fresh Targets keypair:
+   ```bash
+   python scripts/registry_signing/generate_targets_key.py --out-dir ./keys/targets-v$(date +%Y%m%d)
+   ```
+
+2. **Sign a new `root.json`** with the existing Root key, delegating to the new Targets pubkey. The version number MUST be exactly one higher than the current `root.json.signed.version`:
+   ```bash
+   python scripts/registry_signing/sign_root.py \
+       --root-key /media/hardware-token/root_private.pem \
+       --targets-pubkey ./keys/targets-vNEW/targets_public.b64 \
+       --version <CURRENT + 1> \
+       --valid-days 365 \
+       --min-client-version 0.97.0 \
+       --out ./root.json
+   ```
+
+3. **Move the signed `root.json`** to a network-connected machine via the same medium that holds the Root key (USB → registry-host).
+
+4. **Push** to the registry repo:
+   ```bash
+   cd <registry-repo>
+   cp /path/to/root.json root.json
+   git add root.json && git commit -m "rotate: targets v$(date +%Y%m%d) → root.json v<N+1>" && git push
+   ```
+
+5. **Update the GitHub-Actions secret** `REGISTRY_TARGETS_PRIVATE_KEY` to the contents of `./keys/targets-vNEW/targets_private.pem`. Use `gh secret set`:
+   ```bash
+   gh secret set REGISTRY_TARGETS_PRIVATE_KEY < ./keys/targets-vNEW/targets_private.pem
+   ```
+
+6. **Wait for clients to pick up** the new `root.json`. The default check_interval is 1 hour, so within 1h the entire client base will have cached the new Targets pubkey via `RegistryVerifier.verify_root`.
+
+7. **Burn the old Targets key**:
+   - Securely delete the old `targets_private.pem` from the offline machine (`shred -u` on Linux, `Remove-Item -Force` + `Reset-FileTime` on Windows).
+   - The previous GitHub-Actions secret is already overwritten in step 5 — no further action needed.
+
+8. **Run a smoke check**: trigger a small change in the registry repo (e.g. bump a no-op field in `registry.json`), let CI sign and push, then on a developer machine run:
+   ```bash
+   python -c "from cognithor.skills.community.signing import RegistryVerifier; v = RegistryVerifier(); print(v.is_configured())"
+   ```
+   Should print `True`. Force-resync via the API or by deleting `~/.cognithor/community_registry_state.json` and re-running `RegistrySync.sync_once`.
+
+### Rollback
+If the new Targets key is faulty (e.g. PEM corrupted in transit), the old `root.json` with the old Targets key is still in git history. Revert the registry repo's `root.json` to the prior commit. **Do not** bump the version — that would create a replay-vulnerable window. Restore the old GitHub-Actions secret.
+
+---
+
+## B — Emergency Root rotation
+
+**Goal:** invalidate a leaked Root key.
+
+> **There is no online recovery path.** The Root key is offline by design precisely so that this is a release-bound, deliberate, all-hands operation rather than a cron job. Plan for ~2h of focused work plus a release cycle.
+
+### Steps
+
+1. **Stop signing** with the leaked Root key immediately. Lock the offline storage medium.
+
+2. **On a clean offline machine** (NOT the one that may be compromised), mint a new Root keypair:
+   ```bash
+   python scripts/registry_signing/generate_root_key.py --out-dir ./keys/root-vNEW
+   ```
+
+3. **Mint a new Targets keypair** at the same time (the leaked Root could have been used to delegate fake Targets keys; rotate both):
+   ```bash
+   python scripts/registry_signing/generate_targets_key.py --out-dir ./keys/targets-vNEW
+   ```
+
+4. **Sign a fresh `root.json`** with the new Root key. Set `version: 1` because it's the first signing under the new authority. Older clients will not know about this Root, that is expected.
+   ```bash
+   python scripts/registry_signing/sign_root.py \
+       --root-key ./keys/root-vNEW/root_private.pem \
+       --targets-pubkey ./keys/targets-vNEW/targets_public.b64 \
+       --version 1 \
+       --valid-days 365 \
+       --min-client-version 0.<X>.0 \
+       --out ./root.json
+   ```
+
+5. **Patch source**:
+   ```python
+   # src/cognithor/skills/community/_pinned_keys.py
+   ROOT_PUBLIC_KEY_B64 = "<contents of ./keys/root-vNEW/root_public.b64>"
+   ```
+
+6. **Cut a Cognithor release** with that change. Bump `pyproject.toml` patch version. Tag, build, push to PyPI.
+
+7. **Push the new `root.json`** to the registry repo.
+
+8. **Communicate** to operators: old clients will silently keep trusting the leaked Root until they upgrade. Send a security advisory naming the affected versions and the upgrade path. Consider yanking the affected PyPI versions if the leak is recent.
+
+9. **Burn the old Root key**: physically destroy the hardware token / drive. There is no software-level revocation; this is a physical-control story.
+
+### What old (un-upgraded) clients see
+- They keep trusting the old (now-leaked) Root indefinitely.
+- They will continue accepting payloads signed by the old Targets key. **This is the cost of offline-Root design.** The cost is bounded: clients that don't upgrade also don't get new recalls / new skills / new publisher data, so attack value erodes over time.
+- Mitigation: the registry can publish a "honeypot" `root.json` v2 signed by the OLD Root that includes `min_client_version: 0.<X>.0` (the version where the new Root lands). Old clients then refuse the registry until upgraded.
+
+### Why we accept this gap
+A code-level recovery story would require either (a) embedding multiple Root keys (TUF-full) or (b) a key-revocation channel that itself needs auth. Both add roughly 10× the complexity for a Solo project where the Root key already lives on a hardware token. The release-bound recovery is acceptable IF the Root key is genuinely offline. **Verify offline-ness annually.**
+
+---
+
+## Calendar reminders
+
+| Cadence | Action |
+|---|---|
+| Every 90 days | Routine Targets rotation (§A) |
+| Every 365 days | `root.json` valid_until is hitting expiry — re-sign with the same Root + Targets, version+1. |
+| Annually | Verify the Root private key is still on the documented offline storage; verify the offline machine's OS is patched. |
+
+---
+
+## Related
+
+- Full spec: [`docs/superpowers/specs/2026-05-05-pack4-registry-signing.md`](../superpowers/specs/2026-05-05-pack4-registry-signing.md)
+- Operator scripts: [`scripts/registry_signing/`](../../scripts/registry_signing/README.md)
+- SECURITY policy: [`SECURITY.md`](../../SECURITY.md) — Registry Trust Model section
+- Trust-model overview: [`docs/operational_trust.md`](../operational_trust.md)

--- a/docs/superpowers/specs/2026-05-05-pack4-registry-signing.md
+++ b/docs/superpowers/specs/2026-05-05-pack4-registry-signing.md
@@ -1,0 +1,428 @@
+# PACK-4 — Community Registry Signing (TUF-Light)
+
+**Status**: Spec ratified 2026-05-05. Implementation = this PR.
+**Audit-finding**: PACK-4 (REAL-CRIT, deep-audit pass-2, 2026-05-05).
+**Affects**: `src/cognithor/skills/community/sync.py`, `publisher.py`.
+**Depends on**: `cryptography>=46.0.5` (already a dep — Ed25519 via `cryptography.hazmat.primitives.asymmetric.ed25519`).
+
+---
+
+## 1. Threat model
+
+The community-skill registry is hosted at `https://raw.githubusercontent.com/Alex8791-cyber/skill-registry/main/...` and ships three JSON resources that drive client-side actions:
+
+| Path | Drives |
+|---|---|
+| `registry.json` | Skill catalogue / discovery |
+| `recalls/active.json` | **Remote kill-switch** — names listed here trigger `_deactivate_skill` + `SkillRegistry.disable` on every client |
+| `publishers/{username}.json` | Reputation score, VERIFIED status |
+
+**Trust gap addressed:** plain HTTPS protects the bytes on the wire but says nothing about the operator. An adversary that controls the registry host (GitHub repo compromise, BGP-MITM on `raw.githubusercontent.com`, DNS hijack) can:
+
+- Trigger arbitrary `_deactivate_skill` calls — denial-of-service on legitimate skills
+- Elevate untrusted publishers to VERIFIED — supply-chain takeover
+- **Replay** — serve an old, legitimately signed `registry.json` to **freeze a recall**, neutralising the kill-switch the moment it's needed most
+- **Key compromise** — leaked Targets-key alone could sign updates that rotate the key
+
+**Non-goals (for v1):**
+
+- Federation / multiple operators — single root authority for now.
+- Snapshot/timestamp roles à la full-fat TUF. The `valid_until` window in every signed payload replaces the timestamp role pragmatically.
+- Online key rotation. Rotation requires the offline Root key.
+
+---
+
+## 2. Architecture: TUF-Light, two roles
+
+```
+       ┌────────────────────────┐
+       │  Root (offline)        │       Hardware token / air-gapped machine.
+       │  Ed25519               │       Signs ONLY root.json. Used for
+       │  signs root.json only  │       Targets-key rotation.
+       └─────────┬──────────────┘
+                 │
+                 │ delegates to
+                 ▼
+       ┌────────────────────────┐
+       │  Targets (online)      │       Stored as a GitHub-Actions secret.
+       │  Ed25519               │       Signs registry.json, recalls/*,
+       │  signs all data        │       publishers/*. Rotated whenever
+       └─────────┬──────────────┘       compromise is suspected.
+                 │
+                 │ verified by
+                 ▼
+       ┌────────────────────────┐
+       │  Cognithor client      │
+       │  ROOT_PUBLIC_KEY pinned│       Pinned in source. Loads root.json,
+       │  in source             │       checks signature against pinned key,
+       └────────────────────────┘       extracts current Targets pubkey.
+```
+
+**Compromise recovery:**
+
+| Compromise | Effect | Recovery |
+|---|---|---|
+| Targets key leaks | Adversary can sign forged `registry.json` etc. | Owner generates new Targets key offline, signs a new `root.json` with Root key, deploys it. Clients pick it up via version monotony. |
+| Root key leaks | Game over (theoretically). | Mitigation: Root key lives offline on hardware token. Single physical artifact, never on a server. The value of moving Root offline is exactly that this column has no `code` recovery — it requires a new release with a new pinned key. |
+
+---
+
+## 3. Wire format
+
+### 3.1 Common envelope
+
+Every signed payload uses the same envelope:
+
+```json
+{
+  "signed": {
+    "_type": "root" | "registry" | "recalls" | "publisher",
+    "version": 17,
+    "issued_at": "2026-05-05T09:00:00Z",
+    "valid_until": "2026-05-19T09:00:00Z",
+    "<type-specific fields>": "..."
+  },
+  "signatures": [
+    {
+      "keyid": "sha256:abc123...",
+      "method": "ed25519",
+      "sig": "<base64-encoded 64-byte signature>"
+    }
+  ]
+}
+```
+
+**Canonicalisation rule:** signatures are computed over `json.dumps(signed, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")`. The verifier must use the **same** canonicalisation — never re-serialise the parsed dict in a different order. (Future-proofing: switching to canonical-JSON-RFC8785 is a one-line change.)
+
+### 3.2 `root.json` — Targets-key delegation
+
+```json
+{
+  "signed": {
+    "_type": "root",
+    "version": 1,
+    "issued_at": "2026-05-05T09:00:00Z",
+    "valid_until": "2027-05-05T09:00:00Z",
+    "targets": {
+      "keyid": "sha256:9f4a...",
+      "method": "ed25519",
+      "public_key": "<base64-encoded 32-byte raw Ed25519 public key>"
+    },
+    "min_client_version": "0.97.0"
+  },
+  "signatures": [
+    {"keyid": "sha256:root1...", "method": "ed25519", "sig": "<base64>"}
+  ]
+}
+```
+
+`min_client_version` lets the operator cut off ancient clients during a forced migration (e.g. if a future spec change is incompatible).
+
+### 3.3 `registry.json`
+
+```json
+{
+  "signed": {
+    "_type": "registry",
+    "version": 42,
+    "issued_at": "2026-05-12T09:00:00Z",
+    "valid_until": "2026-05-26T09:00:00Z",
+    "skills": [
+      {"name": "sql-helper", "version": "1.2.0", "publisher": "alice", "...": "..."}
+    ]
+  },
+  "signatures": [
+    {"keyid": "sha256:9f4a...", "method": "ed25519", "sig": "<base64>"}
+  ]
+}
+```
+
+### 3.4 `recalls/active.json`
+
+```json
+{
+  "signed": {
+    "_type": "recalls",
+    "version": 8,
+    "issued_at": "2026-05-12T09:00:00Z",
+    "valid_until": "2026-05-13T09:00:00Z",
+    "recalls": [
+      {"skill_name": "evil-skill", "reason": "credential exfil", "recalled_at": "..."}
+    ]
+  },
+  "signatures": [...]
+}
+```
+
+The shorter `valid_until` (1 day vs. 14 days for `registry.json`) means stale recall data is trusted for at most 24h before the client refuses to act. Keeps the kill-switch responsive without needing a separate timestamp role.
+
+### 3.5 `publishers/{username}.json`
+
+```json
+{
+  "signed": {
+    "_type": "publisher",
+    "version": 3,
+    "issued_at": "2026-05-12T09:00:00Z",
+    "valid_until": "2026-06-26T09:00:00Z",
+    "github_username": "alice",
+    "reputation_score": 87.5,
+    "...": "..."
+  },
+  "signatures": [...]
+}
+```
+
+Note: per-publisher `version` is independent — verified against per-publisher last-seen.
+
+---
+
+## 4. Client-side state
+
+```
+~/.cognithor/community_registry_state.json
+{
+  "schema": 1,
+  "last_seen": {
+    "root":             {"version": 1,  "verified_at": "..."},
+    "registry":         {"version": 42, "verified_at": "..."},
+    "recalls":          {"version": 8,  "verified_at": "..."},
+    "publisher:alice":  {"version": 3,  "verified_at": "..."}
+  },
+  "cached_targets_key": "<base64 from latest verified root.json>"
+}
+```
+
+Persisted atomically via `*.tmp` + `os.replace`. File mode `0o600` on POSIX.
+
+---
+
+## 5. Verifier algorithm
+
+```python
+def verify_signed_payload(
+    body: bytes,                      # the raw JSON bytes off the wire
+    expected_type: str,                # "registry", "recalls", "publisher", "root"
+    public_key: Ed25519PublicKey,     # for non-root: the cached targets key; for root: the pinned key
+    last_seen_version: int,            # from state
+    now: datetime,
+    *,
+    expected_keyid: str | None = None,  # bind signature to a specific keyid
+) -> SignedPayload:
+    """Returns the validated `signed` dict, or raises.
+
+    Steps (in order — each must pass before the next):
+      1. Parse JSON. Reject on parse error.
+      2. Schema check: top-level keys must be exactly {"signed", "signatures"}.
+      3. signed._type must equal expected_type.
+      4. Re-canonicalise signed: json.dumps(signed, sort_keys=True, separators=(",", ":"), ensure_ascii=False).
+      5. Find a signature where method == "ed25519" and (expected_keyid is None or keyid == expected_keyid).
+      6. Verify signature against canonicalised bytes via public_key.verify().
+      7. Reject if signed.version < last_seen_version (REPLAY).
+      8. Reject if datetime.fromisoformat(signed.valid_until) < now (STALE).
+      9. Reject if datetime.fromisoformat(signed.issued_at) > now + 5min (CLOCK-SKEW guard).
+     10. Return signed.
+    """
+```
+
+The first six steps reject all forgeries. Steps 7-9 reject replays and stale data. The 5-minute clock-skew window is one-sided: future-dated payloads are slightly forgiven (network propagation), but stale payloads are not.
+
+**Hard-fail behaviour:** every failure raises a `RegistrySignatureError` subclass. **No soft-fall-through path exists.** The caller in `RegistrySync._fetch_json` does not catch these — they propagate to `sync_once_inner`'s outer `except Exception`, which logs `registry_sync_failed` and returns `SyncResult(success=False)`. Recalls do not fire on a sync that failed verification.
+
+---
+
+## 6. Module layout
+
+```
+src/cognithor/skills/community/
+├── _pinned_keys.py        # NEW. Pinned Root pubkey + REQUIRE_SIGNED_REGISTRY flag.
+├── signing.py             # NEW. RegistryVerifier, SignedPayload, exceptions.
+├── sync.py                # MODIFIED. Wires verifier into _fetch_json.
+└── publisher.py           # MODIFIED. Wires verifier into _fetch_publisher_profile.
+```
+
+### 6.1 `_pinned_keys.py`
+
+```python
+"""Pinned Root public key for the community registry.
+
+Embedded at build time. To rotate the Root key, ship a new Cognithor release
+with this file updated. The Targets key (rotated more frequently) is NOT
+pinned — it lives in root.json, signed by the Root key.
+
+When ROOT_PUBLIC_KEY_B64 is None, the registry is treated as "not yet
+operational": community-skill features hard-fail with a clear error. This
+is the default until the operator generates a Root key offline and embeds
+it here.
+"""
+
+# Base64-encoded 32-byte raw Ed25519 public key, OR None if the registry
+# has not yet been deployed. Operators replace this string when they ship
+# a release that activates the marketplace. See
+# scripts/registry_signing/generate_root_key.py for the generation script.
+ROOT_PUBLIC_KEY_B64: str | None = None
+
+# Build-time flag. ALWAYS True in shipped releases. Source-patchable for
+# Cognithor developers running an unsigned local-mirror; never CLI-toggleable.
+REQUIRE_SIGNED_REGISTRY: bool = True
+```
+
+### 6.2 `signing.py` — public API
+
+```python
+class SignedPayload(BaseModel, frozen=True):
+    type_: str         # alias of _type
+    version: int
+    issued_at: datetime
+    valid_until: datetime
+    body: dict[str, Any]    # the rest of the signed dict, type-specific
+
+
+class RegistrySignatureError(Exception): ...
+class RegistryReplayError(RegistrySignatureError): ...
+class RegistryStaleError(RegistrySignatureError): ...
+class RegistryKeyError(RegistrySignatureError): ...
+class RegistryNotConfiguredError(RegistrySignatureError):
+    """Raised when ROOT_PUBLIC_KEY_B64 is None and signed-registry is required."""
+
+
+class RegistryVerifier:
+    """Stateful verifier for a single registry channel.
+
+    Threading: instances are NOT thread-safe. Each RegistrySync /
+    PublisherVerifier instance owns one RegistryVerifier.
+    """
+
+    def __init__(self, *, state_path: Path | None = None) -> None: ...
+
+    def verify_root(self, body: bytes) -> SignedPayload:
+        """Verify root.json against pinned Root pubkey + last-seen root version.
+        Updates cached_targets_key on success."""
+
+    def verify_targets_payload(
+        self, body: bytes, *, expected_type: str, channel_key: str
+    ) -> SignedPayload:
+        """Verify a registry/recalls/publisher payload against the cached
+        Targets key + per-channel last-seen version. ``channel_key`` is the
+        state-file key (e.g. "registry", "recalls", "publisher:alice").
+
+        Calls verify_root once per process if cached_targets_key is missing
+        (lazy bootstrap via http callback supplied by the caller)."""
+
+    def attach_root_loader(self, loader: Callable[[], Awaitable[bytes]]) -> None:
+        """Caller supplies a function that returns root.json bytes. The
+        verifier calls it lazily when the Targets key isn't cached yet."""
+```
+
+### 6.3 Wiring example — `sync.py`
+
+```python
+# Before:
+registry_data = await self._fetch_json(f"{self._registry_url}/registry.json")
+
+# After:
+verifier = RegistryVerifier(...)
+verifier.attach_root_loader(lambda: self._fetch_text(f"{self._registry_url}/root.json"))
+
+raw = await self._fetch_text(f"{self._registry_url}/registry.json")
+payload = await verifier.verify_targets_payload_async(
+    raw.encode("utf-8"),
+    expected_type="registry",
+    channel_key="registry",
+)
+registry_data = payload.body  # parsed, verified, version-checked
+```
+
+The verifier never touches HTTP itself — it asks for bytes via a callback. This keeps the test surface tiny: tests construct payloads in-memory.
+
+---
+
+## 7. Migration plan (no existing un-signed corpus)
+
+The community marketplace **has not yet shipped publicly** (per `MEMORY.md`: "Q4 2026 community creator marketplace"). This means:
+
+- No existing un-signed registry to re-sign — clean cut-over.
+- No backward-compatibility code path needed in the verifier.
+- v0.97.0 lands the verifier with `ROOT_PUBLIC_KEY_B64 = None` → community features hard-disabled.
+- v0.97.x (or first marketplace launch) lands the operator-generated key.
+- Until then, `RegistrySync` and `PublisherVerifier` are dormant: any call returns the `RegistryNotConfiguredError` cleanly.
+
+---
+
+## 8. Owner-side tooling
+
+`scripts/registry_signing/` (operator-only):
+
+```
+generate_root_key.py     # one-off: emits root_public.b64 + root_private.pem
+generate_targets_key.py  # rotation: emits targets_public.b64 + targets_private.pem
+sign_payload.py          # CI-callable: --in body.json --key targets.pem --type registry
+sign_root.py             # offline-only: --targets-pubkey ... --root-key root.pem --out root.json
+```
+
+`scripts/registry_signing/README.md` documents the runbook (also linked from `docs/runbooks/registry_key_rotation.md`).
+
+---
+
+## 9. Test matrix
+
+`tests/test_skills/test_community/test_signing.py` covers:
+
+| # | Scenario | Expected |
+|---|---|---|
+| 1 | Legitimate signed `registry.json` | Returns parsed `SignedPayload` |
+| 2 | `version < last_seen_version` (replay) | Raises `RegistryReplayError` |
+| 3 | `valid_until < now` (stale) | Raises `RegistryStaleError` |
+| 4 | Tampered `signed` dict (bytes flipped) | Raises `RegistrySignatureError` |
+| 5 | Tampered `signatures.sig` (bytes flipped) | Raises `RegistrySignatureError` |
+| 6 | `ROOT_PUBLIC_KEY_B64 = None` + signed-required | Raises `RegistryNotConfiguredError` |
+| 7 | Wrong `_type` (registry payload validated as recalls) | Raises `RegistrySignatureError` |
+| 8 | Future-dated `issued_at` > now + 5min | Raises `RegistrySignatureError` |
+| 9 | Targets-key rotation via new `root.json` (version 1→2) | Subsequent payloads verify against new key |
+| 10 | `min_client_version` exceeds running version | Raises `RegistryKeyError` |
+| 11 | Persisted `last_seen.version` survives verifier restart | New verifier instance reads same state |
+| 12 | Race: two parallel `verify_targets_payload` calls | Both succeed, state file consistent (atomic write) |
+
+Targets coverage: 100% on `signing.py`. Existing `sync.py` / `publisher.py` tests adjusted to inject a stub verifier.
+
+---
+
+## 10. Documentation deltas
+
+This PR also ships:
+
+| Doc | Change |
+|---|---|
+| `docs/operational_trust.md` | PACK-4 row: "known gap → addressed in v0.97.0" |
+| `SECURITY.md` | New section "Registry Trust Model" with Threat-Model table |
+| `README.md` | Trust-Modell paragraph mentions Ed25519 + TUF-Light + EU-sovereign positioning |
+| `docs/runbooks/registry_key_rotation.md` | Operator runbook: routine Targets rotation + emergency Root rotation |
+| `scripts/registry_signing/README.md` | CLI reference for signing scripts |
+| `MEMORY.md` | PACK-4 pointer flipped to "addressed" |
+
+---
+
+## 11. Acceptance criteria
+
+- [ ] All 12 test scenarios pass.
+- [ ] `mypy --strict src/cognithor/skills/community/signing.py` clean.
+- [ ] `mypy --strict src/cognithor/skills/community/sync.py` clean (after wiring).
+- [ ] `mypy --strict src/cognithor/skills/community/publisher.py` clean (after wiring).
+- [ ] `ruff check` + `ruff format --check` clean across all touched files.
+- [ ] CI green.
+- [ ] No new runtime dependency (cryptography is already pinned).
+- [ ] All four signing scripts execute end-to-end on a clean checkout (smoke test in `tests/test_skills/test_community/test_signing_scripts.py`).
+- [ ] `docs/operational_trust.md`, `SECURITY.md`, `README.md`, runbook and `MEMORY.md` all updated in the same PR.
+
+---
+
+## 12. Out of scope (explicit non-goals)
+
+- Sigstore/cosign keyless signing. Considered, deferred — Sigstore-infra dep is heavier than the static-key approach for a Solo project, and the EU-sovereign positioning prefers self-managed keys over a third-party witness.
+- Full TUF (snapshot + timestamp roles). Pragmatic `valid_until` covers the freeze attack at 1/100th the complexity.
+- Federation / multi-operator trust. Single Root is enough for v1.
+- Signed plugin/pack manifests. Different attack surface (already partly addressed by `eula_sha256`); separate sprint.
+
+---
+
+*End of spec.*

--- a/scripts/registry_signing/README.md
+++ b/scripts/registry_signing/README.md
@@ -1,0 +1,107 @@
+# Registry Signing — Operator Toolkit (PACK-4)
+
+Spec: [`docs/superpowers/specs/2026-05-05-pack4-registry-signing.md`](../../docs/superpowers/specs/2026-05-05-pack4-registry-signing.md).
+
+These four scripts implement the offline + online operator workflow for the community registry's TUF-Light signing scheme.
+
+| Script | Where it runs | Purpose |
+|---|---|---|
+| `generate_root_key.py` | Offline machine, **once** at marketplace launch | Mint the long-lived Root keypair. Public key gets pinned in source. |
+| `generate_targets_key.py` | Offline machine, every rotation | Mint a fresh Targets keypair. Public key goes into a new `root.json`. |
+| `sign_root.py` | Offline machine, every rotation | Sign `root.json` with the Root key, delegating to a Targets key. |
+| `sign_payload.py` | GitHub Actions (online) | Sign `registry.json` / `recalls/active.json` / `publishers/*.json` with the Targets key. |
+
+## One-time launch flow (marketplace activation)
+
+```bash
+# All on an offline machine.
+python scripts/registry_signing/generate_root_key.py    --out-dir ./keys/root
+python scripts/registry_signing/generate_targets_key.py --out-dir ./keys/targets
+
+# Sign the initial root.json delegating to the brand-new Targets key.
+python scripts/registry_signing/sign_root.py \
+    --root-key ./keys/root/root_private.pem \
+    --targets-pubkey ./keys/targets/targets_public.b64 \
+    --version 1 \
+    --valid-days 365 \
+    --min-client-version 0.97.0 \
+    --out ./registry/root.json
+
+# Move the keys offline. Then:
+#   1. Edit src/cognithor/skills/community/_pinned_keys.py:
+#        ROOT_PUBLIC_KEY_B64 = "<contents of keys/root/root_public.b64>"
+#   2. Cut a Cognithor release including that change.
+#   3. Push registry/root.json to the registry repo.
+#   4. Set GitHub-Actions secret REGISTRY_TARGETS_PRIVATE_KEY = contents of
+#      keys/targets/targets_private.pem (in the registry repo).
+#   5. Move keys/targets/targets_private.pem to encrypted offline backup;
+#      its only live copy now lives in the GitHub-Actions secret.
+#   6. Move keys/root/* to a hardware token / encrypted air-gapped drive.
+```
+
+## Routine sign — `registry.json` / `recalls/active.json` / `publishers/*.json`
+
+Run this from a GitHub Actions workflow on every push to the registry repo:
+
+```yaml
+- name: Sign registry payloads
+  env:
+    REGISTRY_TARGETS_PRIVATE_KEY: ${{ secrets.REGISTRY_TARGETS_PRIVATE_KEY }}
+  run: |
+    echo "$REGISTRY_TARGETS_PRIVATE_KEY" > /tmp/targets.pem
+    python scripts/registry_signing/sign_payload.py \
+        --in unsigned/registry.json \
+        --key /tmp/targets.pem \
+        --out signed/registry.json
+    python scripts/registry_signing/sign_payload.py \
+        --in unsigned/recalls/active.json \
+        --key /tmp/targets.pem \
+        --out signed/recalls/active.json
+    rm /tmp/targets.pem
+```
+
+Each unsigned input must include `_type`, `version`, `issued_at`, `valid_until`, plus the type-specific body. `sign_payload.py` validates these before signing.
+
+## Targets-key rotation (every 90 days, or after suspected compromise)
+
+```bash
+# Offline machine.
+python scripts/registry_signing/generate_targets_key.py --out-dir ./keys/targets-v2
+
+# Sign root.json v2 delegating to the new Targets key.
+# The version MUST be > the current root.json version.
+python scripts/registry_signing/sign_root.py \
+    --root-key ./keys/root/root_private.pem \
+    --targets-pubkey ./keys/targets-v2/targets_public.b64 \
+    --version 2 \
+    --valid-days 365 \
+    --min-client-version 0.97.0 \
+    --out ./registry/root.json
+```
+
+Then:
+
+1. Push the new `root.json` to the registry repo.
+2. Update the GitHub-Actions secret `REGISTRY_TARGETS_PRIVATE_KEY` to the new private key.
+3. Wait for clients to pick up the new `root.json` (next sync).
+4. Securely destroy the old Targets private key from GitHub-Actions and any local copies.
+
+## Root-key compromise (emergency)
+
+There is no `code` recovery path — this is by design. The Root key lives on a hardware token / air-gapped drive precisely so this column has no online recovery option.
+
+The only response is:
+
+1. Generate a new Root keypair on a clean offline machine.
+2. Cut a new Cognithor release with `_pinned_keys.py` updated.
+3. Sign a fresh `root.json` with the new Root key (and a new Targets key).
+4. Burn the old Root key. Old clients without the new release will continue trusting the old Root indefinitely — they need to update.
+
+The corresponding owner runbook is in `docs/runbooks/registry_key_rotation.md`.
+
+## NEVER
+
+- Commit `*_private.pem` to **any** git repo.
+- Run `generate_root_key.py` on a network-connected machine.
+- Set `REGISTRY_TARGETS_PRIVATE_KEY` to anything other than the freshly minted Targets PEM.
+- Add a CLI flag that disables signature verification on the client. The build-time `REQUIRE_SIGNED_REGISTRY` constant in `_pinned_keys.py` is intentionally not togglable from the CLI — that would be a downgrade vector.

--- a/scripts/registry_signing/generate_root_key.py
+++ b/scripts/registry_signing/generate_root_key.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Generate a fresh Ed25519 keypair for the community registry Root role.
+
+PACK-4. Spec: docs/superpowers/specs/2026-05-05-pack4-registry-signing.md.
+
+This is a ONE-OFF operator action. Run it on an offline machine. Move
+the resulting ``root_private.pem`` to a hardware token / encrypted USB.
+The public key (printed and saved as ``root_public.b64``) is what gets
+embedded into ``src/cognithor/skills/community/_pinned_keys.py`` for
+the next Cognithor release.
+
+Usage::
+
+    python scripts/registry_signing/generate_root_key.py --out-dir ./keys
+
+Outputs (all written to ``--out-dir``):
+    root_private.pem  - PEM-encoded private key. Move offline immediately.
+    root_public.b64   - Base64 raw public key, ready for _pinned_keys.py.
+    root_keyid.txt    - SHA-256 fingerprint of the public key.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        required=True,
+        help="Directory to write the keypair into. Must not already exist.",
+    )
+    args = parser.parse_args(argv)
+
+    out: Path = args.out_dir
+    if out.exists():
+        print(f"Refusing to overwrite existing directory {out}", file=sys.stderr)
+        return 2
+    out.mkdir(parents=True)
+
+    priv = Ed25519PrivateKey.generate()
+    pub = priv.public_key()
+
+    pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_raw = pub.public_bytes_raw()
+    pub_b64 = base64.b64encode(pub_raw).decode("ascii")
+    keyid = "sha256:" + hashlib.sha256(pub_raw).hexdigest()
+
+    (out / "root_private.pem").write_bytes(pem)
+    with contextlib_suppress_oserror():
+        os.chmod(out / "root_private.pem", 0o600)
+    (out / "root_public.b64").write_text(pub_b64 + "\n", encoding="utf-8")
+    (out / "root_keyid.txt").write_text(keyid + "\n", encoding="utf-8")
+
+    print(f"Wrote keypair to {out}")
+    print(f"  Public key (base64):  {pub_b64}")
+    print(f"  Keyid:                {keyid}")
+    print()
+    print("NEXT STEPS")
+    print("  1. Move root_private.pem to an offline storage medium NOW.")
+    print("  2. Edit src/cognithor/skills/community/_pinned_keys.py:")
+    print(f"     ROOT_PUBLIC_KEY_B64 = {pub_b64!r}")
+    print("  3. Cut a Cognithor release with the patched file.")
+    print("  4. NEVER commit root_private.pem to git.")
+    return 0
+
+
+def contextlib_suppress_oserror():  # type: ignore[no-untyped-def]
+    """Tiny helper so chmod on Windows is a no-op without needing import."""
+    import contextlib
+
+    return contextlib.suppress(OSError)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/registry_signing/generate_targets_key.py
+++ b/scripts/registry_signing/generate_targets_key.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Generate a fresh Ed25519 keypair for the community registry Targets role.
+
+PACK-4. Spec: docs/superpowers/specs/2026-05-05-pack4-registry-signing.md.
+
+The Targets key signs ``registry.json``, ``recalls/active.json``, and
+``publishers/*.json``. It rotates frequently — at least when compromise
+is suspected, and recommended every 90 days.
+
+This script is run during routine rotation. The resulting public key is
+embedded into a new ``root.json`` (signed by the offline Root key — see
+``sign_root.py``). The private key is then stored as a GitHub-Actions
+secret (``REGISTRY_TARGETS_PRIVATE_KEY``).
+
+Usage::
+
+    python scripts/registry_signing/generate_targets_key.py --out-dir ./keys
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import contextlib
+import hashlib
+import os
+import sys
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out-dir", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    out: Path = args.out_dir
+    if out.exists():
+        print(f"Refusing to overwrite existing directory {out}", file=sys.stderr)
+        return 2
+    out.mkdir(parents=True)
+
+    priv = Ed25519PrivateKey.generate()
+    pub = priv.public_key()
+
+    pem = priv.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub_raw = pub.public_bytes_raw()
+    pub_b64 = base64.b64encode(pub_raw).decode("ascii")
+    keyid = "sha256:" + hashlib.sha256(pub_raw).hexdigest()
+
+    (out / "targets_private.pem").write_bytes(pem)
+    with contextlib.suppress(OSError):
+        os.chmod(out / "targets_private.pem", 0o600)
+    (out / "targets_public.b64").write_text(pub_b64 + "\n", encoding="utf-8")
+    (out / "targets_keyid.txt").write_text(keyid + "\n", encoding="utf-8")
+
+    print(f"Wrote keypair to {out}")
+    print(f"  Public key (base64):  {pub_b64}")
+    print(f"  Keyid:                {keyid}")
+    print()
+    print("NEXT STEPS")
+    print("  1. Set GitHub-Actions secret REGISTRY_TARGETS_PRIVATE_KEY to the")
+    print("     contents of targets_private.pem (in the registry repo).")
+    print("  2. Embed targets_public.b64 in a new root.json via sign_root.py")
+    print("     (signed offline by your Root key).")
+    print("  3. Push the new root.json to the registry repo.")
+    print("  4. After clients pick it up (next sync), DELETE the old Targets")
+    print("     private key from anywhere it lived.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/registry_signing/sign_payload.py
+++ b/scripts/registry_signing/sign_payload.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Sign a community-registry payload with the Targets key.
+
+PACK-4. Spec: docs/superpowers/specs/2026-05-05-pack4-registry-signing.md.
+
+This script is invoked by the registry's CI workflow (GitHub Actions)
+whenever a new ``registry.json``, ``recalls/active.json``, or
+``publishers/{username}.json`` is published. The Targets private key
+comes from the ``REGISTRY_TARGETS_PRIVATE_KEY`` secret.
+
+The script:
+  1. Reads the unsigned ``signed`` block from --in (a JSON file).
+  2. Validates it has the required fields (_type, version, issued_at,
+     valid_until).
+  3. Canonicalises (sort_keys + minimal separators).
+  4. Signs with the Targets key.
+  5. Writes the full envelope ``{"signed": ..., "signatures": [...]}``
+     to --out.
+
+Usage::
+
+    python scripts/registry_signing/sign_payload.py \\
+        --in unsigned/registry.json \\
+        --key targets_private.pem \\
+        --out signed/registry.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+REQUIRED_FIELDS = ("_type", "version", "issued_at", "valid_until")
+ALLOWED_TYPES = frozenset({"registry", "recalls", "publisher"})
+
+
+def _canonicalise(signed: dict) -> bytes:
+    return json.dumps(signed, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
+
+
+def _keyid(pub: Ed25519PublicKey) -> str:
+    raw = pub.public_bytes_raw()
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def _validate_signed(signed: dict) -> None:
+    missing = [f for f in REQUIRED_FIELDS if f not in signed]
+    if missing:
+        raise SystemExit(f"signed payload missing required fields: {missing}")
+    if signed["_type"] not in ALLOWED_TYPES:
+        raise SystemExit(
+            f"signed._type must be one of {sorted(ALLOWED_TYPES)}; got {signed['_type']!r}"
+        )
+    if not isinstance(signed["version"], int) or signed["version"] < 0:
+        raise SystemExit("signed.version must be a non-negative int")
+    # ISO-8601 sanity check (and reject naive datetimes — must carry tz).
+    for field in ("issued_at", "valid_until"):
+        try:
+            dt = datetime.fromisoformat(str(signed[field]).replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise SystemExit(f"signed.{field} is not ISO-8601: {exc}") from exc
+        if dt.tzinfo is None:
+            raise SystemExit(
+                f"signed.{field} must include a timezone offset (e.g. ...+00:00 or ...Z)"
+            )
+    issued = datetime.fromisoformat(str(signed["issued_at"]).replace("Z", "+00:00"))
+    valid_until = datetime.fromisoformat(str(signed["valid_until"]).replace("Z", "+00:00"))
+    if valid_until <= issued:
+        raise SystemExit("signed.valid_until must be strictly after signed.issued_at")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--in", dest="in_path", type=Path, required=True)
+    parser.add_argument("--key", type=Path, required=True, help="Targets private key (PEM)")
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    raw = args.in_path.read_text(encoding="utf-8")
+    signed = json.loads(raw)
+    _validate_signed(signed)
+
+    pem = args.key.read_bytes()
+    priv = serialization.load_pem_private_key(pem, password=None)
+    if not isinstance(priv, Ed25519PrivateKey):
+        print(f"Key {args.key} is not an Ed25519 private key", file=sys.stderr)
+        return 2
+
+    canonical = _canonicalise(signed)
+    sig = priv.sign(canonical)
+    envelope = {
+        "signed": signed,
+        "signatures": [
+            {
+                "keyid": _keyid(priv.public_key()),
+                "method": "ed25519",
+                "sig": base64.b64encode(sig).decode("ascii"),
+            }
+        ],
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(envelope, indent=2, sort_keys=True, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    now = datetime.now(UTC).isoformat()
+    print(f"[{now}] Signed {args.in_path} -> {args.out}")
+    print(f"  type:    {signed['_type']}")
+    print(f"  version: {signed['version']}")
+    print(f"  keyid:   {envelope['signatures'][0]['keyid']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/registry_signing/sign_root.py
+++ b/scripts/registry_signing/sign_root.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Sign the registry's ``root.json`` with the OFFLINE Root key.
+
+PACK-4. Spec: docs/superpowers/specs/2026-05-05-pack4-registry-signing.md.
+
+This script is run on the offline machine. The Root private key NEVER
+leaves the offline machine. The output ``root.json`` is committed to
+the registry repo.
+
+Usage::
+
+    python scripts/registry_signing/sign_root.py \\
+        --root-key root_private.pem \\
+        --targets-pubkey targets_public.b64 \\
+        --version 2 \\
+        --valid-days 365 \\
+        --min-client-version 0.97.0 \\
+        --out root.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import sys
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import (
+    Ed25519PrivateKey,
+    Ed25519PublicKey,
+)
+
+
+def _canonicalise(signed: dict) -> bytes:
+    return json.dumps(signed, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
+
+
+def _keyid(pub: Ed25519PublicKey) -> str:
+    raw = pub.public_bytes_raw()
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root-key", type=Path, required=True, help="Root private key PEM")
+    parser.add_argument(
+        "--targets-pubkey",
+        type=Path,
+        required=True,
+        help="Targets public key (base64-encoded raw 32 bytes), file or string",
+    )
+    parser.add_argument("--version", type=int, required=True)
+    parser.add_argument("--valid-days", type=int, default=365)
+    parser.add_argument("--min-client-version", type=str, default="0.97.0")
+    parser.add_argument("--out", type=Path, required=True)
+    args = parser.parse_args(argv)
+
+    pem = args.root_key.read_bytes()
+    root_priv = serialization.load_pem_private_key(pem, password=None)
+    if not isinstance(root_priv, Ed25519PrivateKey):
+        print(f"Root key {args.root_key} is not Ed25519", file=sys.stderr)
+        return 2
+
+    targets_pub_b64 = args.targets_pubkey.read_text(encoding="utf-8").strip()
+    # Validate it parses to 32 raw bytes.
+    try:
+        raw = base64.b64decode(targets_pub_b64.encode("ascii"))
+    except Exception as exc:
+        print(f"--targets-pubkey is not valid base64: {exc}", file=sys.stderr)
+        return 2
+    if len(raw) != 32:
+        print(f"Targets public key must be 32 bytes; got {len(raw)}", file=sys.stderr)
+        return 2
+    targets_keyid = "sha256:" + hashlib.sha256(raw).hexdigest()
+
+    now = datetime.now(UTC)
+    valid_until = now + timedelta(days=args.valid_days)
+    signed = {
+        "_type": "root",
+        "version": args.version,
+        "issued_at": now.isoformat(),
+        "valid_until": valid_until.isoformat(),
+        "targets": {
+            "keyid": targets_keyid,
+            "method": "ed25519",
+            "public_key": targets_pub_b64,
+        },
+        "min_client_version": args.min_client_version,
+    }
+
+    canonical = _canonicalise(signed)
+    sig = root_priv.sign(canonical)
+    envelope = {
+        "signed": signed,
+        "signatures": [
+            {
+                "keyid": _keyid(root_priv.public_key()),
+                "method": "ed25519",
+                "sig": base64.b64encode(sig).decode("ascii"),
+            }
+        ],
+    }
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(
+        json.dumps(envelope, indent=2, sort_keys=True, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    print(f"Signed root.json -> {args.out}")
+    print(f"  version:               {args.version}")
+    print(f"  valid_until:           {valid_until.isoformat()}")
+    print(f"  Root keyid:            {envelope['signatures'][0]['keyid']}")
+    print(f"  Delegated Targets key: {targets_keyid}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/cognithor/skills/community/_pinned_keys.py
+++ b/src/cognithor/skills/community/_pinned_keys.py
@@ -1,0 +1,39 @@
+"""Pinned Root public key for the community registry.
+
+PACK-4 (deep-audit pass-2, 2026-05-05). See
+``docs/superpowers/specs/2026-05-05-pack4-registry-signing.md``.
+
+The Root key signs only ``root.json``, and ``root.json`` carries the
+delegated Targets key that signs all other registry payloads. Rotating
+the Targets key only requires the offline Root key — never a Cognithor
+release. Rotating the Root key requires a new release (this file
+patched).
+
+When ``ROOT_PUBLIC_KEY_B64`` is ``None`` the registry is treated as
+"not yet operational": the verifier hard-fails with
+:class:`RegistryNotConfiguredError`. This is the default until the
+operator generates the Root keypair offline (see
+``scripts/registry_signing/generate_root_key.py``) and embeds the
+public key here in a release.
+"""
+
+from __future__ import annotations
+
+# Base64-encoded 32-byte raw Ed25519 public key (no PEM wrapping). ``None``
+# means the marketplace is dormant — community-skill features hard-disable
+# at the verifier boundary. Replace with the actual key string as part of
+# the release that activates the marketplace.
+ROOT_PUBLIC_KEY_B64: str | None = None
+
+# Build-time guard. ALWAYS ``True`` in shipped releases. Source-patchable
+# for Cognithor developers running an unsigned local mirror, but never
+# togglable from the CLI — that would be a downgrade vector. Test code
+# sets this via :func:`unittest.mock.patch` on this exact module
+# attribute, NOT via env var.
+REQUIRE_SIGNED_REGISTRY: bool = True
+
+# Earliest Cognithor version that supports this signing format. Updated
+# only when a backwards-incompatible change to the wire format ships;
+# clients with a lower version see :class:`RegistryKeyError` from the
+# verifier when the registry's ``min_client_version`` exceeds this.
+SIGNING_FORMAT_VERSION: str = "1.0.0"

--- a/src/cognithor/skills/community/publisher.py
+++ b/src/cognithor/skills/community/publisher.py
@@ -155,11 +155,17 @@ class PublisherVerifier:
         *,
         registry_url: str = "",
         marketplace_store: Any | None = None,
+        verifier: Any | None = None,
     ) -> None:
         self._registry_url = registry_url or (
             "https://raw.githubusercontent.com/Alex8791-cyber/skill-registry/main"
         )
         self._marketplace_store = marketplace_store
+        # PACK-4: every publishers/{user}.json is signature-verified
+        # before its reputation_score / verified flag is trusted.
+        from cognithor.skills.community.signing import RegistryVerifier
+
+        self._verifier = verifier or RegistryVerifier()
         self._cache: dict[str, PublisherIdentity] = {}
         self._lock = asyncio.Lock()
 
@@ -238,13 +244,34 @@ class PublisherVerifier:
         self,
         github_username: str,
     ) -> dict[str, Any] | None:
-        """Load a publisher profile from the registry repo."""
-        import json
+        """Load + verify a publisher profile from the registry repo."""
+        # PACK-4: dormant marketplace → no profile fetch attempted.
+        if not self._verifier.is_configured():
+            return None
 
         url = f"{self._registry_url}/publishers/{github_username}.json"
         try:
+            # Bootstrap the cached Targets key once per process.
+            root_raw = await self._fetch_text(f"{self._registry_url}/root.json")
+            self._verifier.verify_root(root_raw.encode("utf-8"))
+
             text = await self._fetch_text(url)
-            return cast("dict[str, Any] | None", json.loads(text))
+            payload = self._verifier.verify_targets_payload(
+                text.encode("utf-8"),
+                expected_type="publisher",
+                channel_key=f"publisher:{github_username}",
+            )
+            # Defense-in-depth: the payload's body must name the same
+            # github_username we asked for. Otherwise a confused-deputy
+            # attack could swap profiles between users.
+            if payload.body.get("github_username") != github_username:
+                log.warning(
+                    "publisher_profile_username_mismatch",
+                    requested=github_username,
+                    payload=payload.body.get("github_username"),
+                )
+                return None
+            return cast("dict[str, Any]", payload.body)
 
         except Exception as exc:
             log.debug("publisher_profile_not_found", user=github_username, error=str(exc))

--- a/src/cognithor/skills/community/signing.py
+++ b/src/cognithor/skills/community/signing.py
@@ -1,0 +1,496 @@
+"""Ed25519 signature verifier for the community registry (TUF-Light).
+
+PACK-4. Spec: ``docs/superpowers/specs/2026-05-05-pack4-registry-signing.md``.
+
+Two roles:
+  * Root (offline) — pinned in :mod:`._pinned_keys`. Signs only ``root.json``.
+  * Targets (online) — public key delegated via ``root.json``. Signs every
+    other payload (registry, recalls, publisher profiles).
+
+Hard-fail by design: every failure raises a :class:`RegistrySignatureError`
+subclass. The caller is expected to let it propagate so the surrounding
+sync turns into a no-op (recalls do not fire on a sync that failed
+verification).
+
+Threading
+---------
+Each :class:`RegistryVerifier` instance owns a state file and is **not**
+thread-safe. ``RegistrySync`` and ``PublisherVerifier`` each construct
+their own. Cross-process safety relies on atomic state writes
+(``*.tmp`` + :func:`os.replace`).
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import threading
+from contextlib import suppress
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from cognithor.skills.community import _pinned_keys
+from cognithor.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+# Window forgiven for clock-skew on issued_at. Stale data (valid_until in
+# the past) is NOT forgiven — the kill-switch needs to fail-closed.
+_CLOCK_SKEW_TOLERANCE = timedelta(minutes=5)
+
+# Schema version of the on-disk state file. Bumped only on incompatible
+# format changes; the verifier discards the file on mismatch (forces a
+# fresh root.json fetch on next call).
+_STATE_SCHEMA = 1
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class RegistrySignatureError(Exception):
+    """Base class. Every failure path inherits from this."""
+
+
+class RegistryReplayError(RegistrySignatureError):
+    """``signed.version`` is older than the last verified version."""
+
+
+class RegistryStaleError(RegistrySignatureError):
+    """``signed.valid_until`` lies in the past (kill-switch must fail closed)."""
+
+
+class RegistryKeyError(RegistrySignatureError):
+    """Pinned key absent, root.json key mismatch, or ``min_client_version`` too high."""
+
+
+class RegistryNotConfiguredError(RegistrySignatureError):
+    """``_pinned_keys.ROOT_PUBLIC_KEY_B64`` is ``None`` and signed-registry is required.
+
+    Default state for a Cognithor build that has not yet activated the
+    marketplace. Callers should treat this as "marketplace dormant" rather
+    than "marketplace broken".
+    """
+
+
+# ---------------------------------------------------------------------------
+# Data shape
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SignedPayload:
+    """The validated ``signed`` block extracted from a verified envelope.
+
+    ``body`` carries the type-specific fields: ``targets`` for root,
+    ``skills`` for registry, ``recalls`` for recalls, ``reputation_score``
+    etc. for publisher.
+    """
+
+    type_: str
+    version: int
+    issued_at: datetime
+    valid_until: datetime
+    body: dict[str, Any]
+    keyid: str
+
+
+# ---------------------------------------------------------------------------
+# Canonicalisation
+# ---------------------------------------------------------------------------
+
+
+def _canonicalise(signed: dict[str, Any]) -> bytes:
+    """Render the ``signed`` dict for signing/verifying.
+
+    Stable across Python versions: sorted keys, no whitespace, no ASCII
+    escaping. Switching to RFC 8785 in the future is a one-line change
+    here — verifier and signer both call this.
+    """
+    return json.dumps(
+        signed,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+
+def _keyid_from_pubkey_b64(pubkey_b64: str) -> str:
+    """SHA-256 fingerprint of the raw key bytes, hex-encoded with prefix."""
+    raw = base64.b64decode(pubkey_b64.encode("ascii"))
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def _load_pubkey(pubkey_b64: str) -> Ed25519PublicKey:
+    raw = base64.b64decode(pubkey_b64.encode("ascii"))
+    if len(raw) != 32:
+        raise RegistryKeyError(f"Ed25519 public key must be 32 bytes, got {len(raw)}")
+    return Ed25519PublicKey.from_public_bytes(raw)
+
+
+# ---------------------------------------------------------------------------
+# Envelope parsing & verification (the only part that touches signatures)
+# ---------------------------------------------------------------------------
+
+
+def verify_signed_payload(
+    body: bytes,
+    *,
+    expected_type: str,
+    public_key: Ed25519PublicKey,
+    last_seen_version: int,
+    now: datetime,
+    expected_keyid: str | None = None,
+    running_version: str | None = None,
+) -> SignedPayload:
+    """Validate one signed envelope against ``public_key``.
+
+    Steps run in strict order; each must pass before the next is reached.
+    On any failure, raises a :class:`RegistrySignatureError` subclass and
+    leaves no side effects.
+
+    ``running_version``: if a payload carries ``min_client_version`` in its
+    body and the running Cognithor version is lower, raises
+    :class:`RegistryKeyError`. Pass the actual running version (e.g. from
+    ``cognithor.__version__``).
+    """
+    # 1. Parse JSON.
+    try:
+        envelope = json.loads(body.decode("utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+        raise RegistrySignatureError(f"envelope is not valid UTF-8 JSON: {exc}") from exc
+
+    # 2. Schema check: top-level keys must be exactly {"signed", "signatures"}.
+    if not isinstance(envelope, dict) or set(envelope.keys()) != {"signed", "signatures"}:
+        raise RegistrySignatureError(
+            "envelope must have exactly the top-level keys {'signed', 'signatures'}"
+        )
+    signed = envelope["signed"]
+    signatures = envelope["signatures"]
+    if not isinstance(signed, dict) or not isinstance(signatures, list) or not signatures:
+        raise RegistrySignatureError(
+            "malformed envelope: signed must be dict, signatures non-empty list"
+        )
+
+    # 3. _type check.
+    payload_type = signed.get("_type")
+    if payload_type != expected_type:
+        raise RegistrySignatureError(f"expected _type={expected_type!r}, got {payload_type!r}")
+
+    # 4. Re-canonicalise. We do NOT trust the wire-format byte stream — a
+    # signer MUST emit canonical JSON, and we re-emit canonical here so
+    # whitespace / ordering on the wire is irrelevant.
+    canonical = _canonicalise(signed)
+
+    # 5+6. Find a matching signature and verify.
+    sig_match: dict[str, Any] | None = None
+    for sig in signatures:
+        if not isinstance(sig, dict):
+            continue
+        if sig.get("method") != "ed25519":
+            continue
+        if expected_keyid is not None and sig.get("keyid") != expected_keyid:
+            continue
+        sig_match = sig
+        break
+    if sig_match is None:
+        raise RegistrySignatureError(
+            "no signature with method=ed25519"
+            + (f" and keyid={expected_keyid!r}" if expected_keyid else "")
+        )
+    sig_b64 = sig_match.get("sig")
+    if not isinstance(sig_b64, str):
+        raise RegistrySignatureError("signature.sig must be a base64 string")
+    try:
+        sig_bytes = base64.b64decode(sig_b64.encode("ascii"))
+    except (ValueError, TypeError) as exc:
+        raise RegistrySignatureError(f"signature.sig is not valid base64: {exc}") from exc
+    try:
+        public_key.verify(sig_bytes, canonical)
+    except InvalidSignature as exc:
+        raise RegistrySignatureError("Ed25519 signature verification failed") from exc
+
+    # 7. Replay check.
+    version = signed.get("version")
+    if not isinstance(version, int) or version < 0:
+        raise RegistrySignatureError("signed.version must be a non-negative int")
+    if version < last_seen_version:
+        raise RegistryReplayError(
+            f"replay rejected: incoming version {version} < last_seen {last_seen_version}"
+        )
+
+    # 8. Stale check (valid_until in the past).
+    valid_until_raw = signed.get("valid_until")
+    issued_at_raw = signed.get("issued_at")
+    if not isinstance(valid_until_raw, str) or not isinstance(issued_at_raw, str):
+        raise RegistrySignatureError(
+            "signed.issued_at and signed.valid_until must be ISO-8601 strings"
+        )
+    try:
+        valid_until = datetime.fromisoformat(valid_until_raw.replace("Z", "+00:00"))
+        issued_at = datetime.fromisoformat(issued_at_raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RegistrySignatureError(f"invalid ISO-8601 timestamp: {exc}") from exc
+    # Coerce naive to UTC for comparison safety.
+    if valid_until.tzinfo is None:
+        valid_until = valid_until.replace(tzinfo=UTC)
+    if issued_at.tzinfo is None:
+        issued_at = issued_at.replace(tzinfo=UTC)
+    if valid_until < now:
+        raise RegistryStaleError(
+            f"stale: valid_until {valid_until.isoformat()} < now {now.isoformat()}"
+        )
+
+    # 9. Clock-skew guard on issued_at.
+    if issued_at > now + _CLOCK_SKEW_TOLERANCE:
+        raise RegistrySignatureError(
+            f"issued_at {issued_at.isoformat()} is more than {_CLOCK_SKEW_TOLERANCE} in the future"
+        )
+
+    # 10. Optional min_client_version gate.
+    if running_version is not None:
+        min_required = signed.get("min_client_version")
+        if isinstance(min_required, str) and _version_lt(running_version, min_required):
+            raise RegistryKeyError(
+                f"running version {running_version} below min_client_version {min_required}"
+            )
+
+    body_dict = {
+        k: v
+        for k, v in signed.items()
+        if not k.startswith("_")
+        and k
+        not in {
+            "version",
+            "issued_at",
+            "valid_until",
+        }
+    }
+    return SignedPayload(
+        type_=payload_type,
+        version=version,
+        issued_at=issued_at,
+        valid_until=valid_until,
+        body=body_dict,
+        keyid=str(sig_match.get("keyid", "")),
+    )
+
+
+def _version_lt(running: str, required: str) -> bool:
+    """Compare semver-ish ``X.Y.Z`` strings. Pre-release suffixes ignored.
+
+    Returns ``True`` iff ``running`` is strictly less than ``required``.
+    """
+
+    def _parts(v: str) -> tuple[int, int, int]:
+        nums = v.split("-", 1)[0].split(".")
+        while len(nums) < 3:
+            nums.append("0")
+        try:
+            return (int(nums[0]), int(nums[1]), int(nums[2]))
+        except ValueError as exc:
+            raise RegistryKeyError(f"invalid version string {v!r}") from exc
+
+    return _parts(running) < _parts(required)
+
+
+# ---------------------------------------------------------------------------
+# Stateful verifier
+# ---------------------------------------------------------------------------
+
+
+class RegistryVerifier:
+    """Stateful verifier across multiple channels.
+
+    Persists ``last_seen.version`` per channel + the cached Targets pubkey
+    in ``state_path`` (defaults to
+    ``~/.cognithor/community_registry_state.json``).
+
+    The verifier never performs HTTP itself. The caller supplies a
+    ``root_loader`` callable that returns ``root.json`` bytes when the
+    cached Targets key is missing or stale.
+    """
+
+    def __init__(
+        self,
+        *,
+        state_path: Path | None = None,
+        running_version: str | None = None,
+    ) -> None:
+        self._state_path = state_path or (
+            Path.home() / ".cognithor" / "community_registry_state.json"
+        )
+        self._running_version = running_version
+        self._lock = threading.Lock()
+        self._state = self._load_state()
+
+    # -- state ----------------------------------------------------------
+
+    def _load_state(self) -> dict[str, Any]:
+        if not self._state_path.exists():
+            return {"schema": _STATE_SCHEMA, "last_seen": {}, "cached_targets_key": None}
+        try:
+            data = json.loads(self._state_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            log.warning("registry_state_unreadable", path=str(self._state_path), error=str(exc))
+            return {"schema": _STATE_SCHEMA, "last_seen": {}, "cached_targets_key": None}
+        if not isinstance(data, dict) or data.get("schema") != _STATE_SCHEMA:
+            log.warning("registry_state_schema_mismatch", path=str(self._state_path))
+            return {"schema": _STATE_SCHEMA, "last_seen": {}, "cached_targets_key": None}
+        return data
+
+    def _persist_state(self) -> None:
+        """Atomic write: tmp → replace, mode 0o600."""
+        self._state_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._state_path.with_suffix(self._state_path.suffix + ".tmp")
+        tmp.write_text(json.dumps(self._state, sort_keys=True), encoding="utf-8")
+        with suppress(OSError):
+            os.chmod(tmp, 0o600)
+        os.replace(tmp, self._state_path)
+
+    def _last_seen_version(self, channel_key: str) -> int:
+        return int(self._state["last_seen"].get(channel_key, {}).get("version", 0))
+
+    def _record_seen(self, channel_key: str, version: int, now: datetime) -> None:
+        self._state["last_seen"][channel_key] = {
+            "version": version,
+            "verified_at": now.isoformat(),
+        }
+        self._persist_state()
+
+    # -- root.json ------------------------------------------------------
+
+    def _pinned_root_pubkey(self) -> Ed25519PublicKey:
+        if not _pinned_keys.REQUIRE_SIGNED_REGISTRY:
+            # Caller has source-patched out the requirement. Production
+            # builds NEVER reach this branch. We still demand a pinned
+            # key to even attempt verification — the alternative would
+            # be silent acceptance, which is worse.
+            raise RegistryNotConfiguredError(
+                "REQUIRE_SIGNED_REGISTRY is False — registry verification disabled."
+            )
+        b64 = _pinned_keys.ROOT_PUBLIC_KEY_B64
+        if not b64:
+            raise RegistryNotConfiguredError(
+                "Community registry has no pinned Root public key in this build. "
+                "Marketplace is dormant. See "
+                "docs/superpowers/specs/2026-05-05-pack4-registry-signing.md."
+            )
+        return _load_pubkey(b64)
+
+    def verify_root(self, body: bytes, *, now: datetime | None = None) -> SignedPayload:
+        """Verify ``root.json`` against the pinned Root public key.
+
+        On success, caches the delegated Targets public key in state.
+        Subsequent ``verify_targets_payload`` calls use it without
+        re-fetching ``root.json``.
+        """
+        with self._lock:
+            now = now or datetime.now(UTC)
+            pubkey = self._pinned_root_pubkey()
+            payload = verify_signed_payload(
+                body,
+                expected_type="root",
+                public_key=pubkey,
+                last_seen_version=self._last_seen_version("root"),
+                now=now,
+                running_version=self._running_version,
+            )
+            targets = payload.body.get("targets")
+            if not isinstance(targets, dict):
+                raise RegistryKeyError("root.json signed.targets must be a dict")
+            tk_b64 = targets.get("public_key")
+            if not isinstance(tk_b64, str) or not tk_b64:
+                raise RegistryKeyError(
+                    "root.json signed.targets.public_key must be a non-empty base64 string"
+                )
+            # Validate it parses, throw away result.
+            _load_pubkey(tk_b64)
+            self._state["cached_targets_key"] = tk_b64
+            self._record_seen("root", payload.version, now)
+            log.info(
+                "registry_root_verified",
+                version=payload.version,
+                keyid=payload.keyid,
+                valid_until=payload.valid_until.isoformat(),
+            )
+            return payload
+
+    # -- targets-signed payloads ---------------------------------------
+
+    def verify_targets_payload(
+        self,
+        body: bytes,
+        *,
+        expected_type: str,
+        channel_key: str,
+        now: datetime | None = None,
+    ) -> SignedPayload:
+        """Verify a registry/recalls/publisher payload against the cached Targets key.
+
+        Raises :class:`RegistryNotConfiguredError` if no Targets key is
+        cached yet — caller must call :meth:`verify_root` first (typically
+        the surrounding sync does this once at the top of every run).
+        """
+        with self._lock:
+            now = now or datetime.now(UTC)
+            tk_b64 = self._state.get("cached_targets_key")
+            if not isinstance(tk_b64, str) or not tk_b64:
+                raise RegistryNotConfiguredError(
+                    "no cached Targets key — call verify_root(root.json) first"
+                )
+            pubkey = _load_pubkey(tk_b64)
+            expected_keyid = _keyid_from_pubkey_b64(tk_b64)
+            payload = verify_signed_payload(
+                body,
+                expected_type=expected_type,
+                public_key=pubkey,
+                last_seen_version=self._last_seen_version(channel_key),
+                now=now,
+                expected_keyid=expected_keyid,
+                running_version=self._running_version,
+            )
+            self._record_seen(channel_key, payload.version, now)
+            log.info(
+                "registry_payload_verified",
+                channel=channel_key,
+                type=expected_type,
+                version=payload.version,
+                keyid=payload.keyid,
+            )
+            return payload
+
+    # -- diagnostics ----------------------------------------------------
+
+    def is_configured(self) -> bool:
+        """Whether the build has a pinned Root key and a cached Targets key.
+
+        ``False`` means subsequent verify-calls will hard-fail; useful for
+        callers that want to short-circuit (e.g. ``RegistrySync.sync_once``
+        skipping the whole flow when the marketplace is dormant).
+        """
+        if not _pinned_keys.REQUIRE_SIGNED_REGISTRY:
+            return False
+        if not _pinned_keys.ROOT_PUBLIC_KEY_B64:
+            return False
+        return True
+
+
+__all__ = [
+    "RegistryKeyError",
+    "RegistryNotConfiguredError",
+    "RegistryReplayError",
+    "RegistrySignatureError",
+    "RegistryStaleError",
+    "RegistryVerifier",
+    "SignedPayload",
+    "verify_signed_payload",
+]

--- a/src/cognithor/skills/community/sync.py
+++ b/src/cognithor/skills/community/sync.py
@@ -19,6 +19,10 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, cast
 
+from cognithor.skills.community.signing import (
+    RegistrySignatureError,
+    RegistryVerifier,
+)
 from cognithor.utils.logging import get_logger
 
 log = get_logger(__name__)
@@ -62,6 +66,7 @@ class RegistrySync:
         check_interval: int = 3600,
         marketplace_store: Any | None = None,
         skill_registry: Any | None = None,
+        verifier: RegistryVerifier | None = None,
     ) -> None:
         self._registry_url = registry_url or (
             "https://raw.githubusercontent.com/Alex8791-cyber/skill-registry/main"
@@ -70,6 +75,9 @@ class RegistrySync:
         self._check_interval = check_interval
         self._marketplace_store = marketplace_store
         self._skill_registry = skill_registry
+        # PACK-4: every payload goes through Ed25519 verification before
+        # any side effect (recall application). Tests inject a stub.
+        self._verifier = verifier or RegistryVerifier()
 
         self._last_sync: float = 0.0
         self._running = False
@@ -99,18 +107,48 @@ class RegistrySync:
         start = time.monotonic()
         result = SyncResult(success=False)
 
+        # PACK-4: short-circuit cleanly when the marketplace is dormant
+        # (no Root key pinned in this build). This is the default for
+        # v0.97.x until the operator activates the marketplace.
+        if not self._verifier.is_configured():
+            log.info("registry_sync_skipped_marketplace_dormant")
+            result.success = True  # Nothing to sync, but not a failure.
+            result.sync_time = time.monotonic() - start
+            return result
+
         try:
-            # 1. Download registry
+            # 0. Bootstrap the Targets key by verifying root.json. This
+            # is cheap on subsequent calls — the verifier caches the key
+            # in its state file.
+            root_raw = await self._fetch_text(f"{self._registry_url}/root.json")
+            self._verifier.verify_root(root_raw.encode("utf-8"))
+
+            # 1. Download + verify registry.json.
             registry_url = f"{self._registry_url}/registry.json"
-            registry_data = await self._fetch_json(registry_url)
-            skills = registry_data.get("skills", [])
+            registry_raw = await self._fetch_text(registry_url)
+            registry_payload = self._verifier.verify_targets_payload(
+                registry_raw.encode("utf-8"),
+                expected_type="registry",
+                channel_key="registry",
+            )
+            skills = registry_payload.body.get("skills", [])
             result.registry_skills = len(skills)
 
-            # 2. Download recalls
+            # 2. Download + verify recalls.
             recalls_url = f"{self._registry_url}/recalls/active.json"
             try:
-                recalls_data = await self._fetch_json(recalls_url)
-                active_recalls = recalls_data.get("recalls", [])
+                recalls_raw = await self._fetch_text(recalls_url)
+                recalls_payload = self._verifier.verify_targets_payload(
+                    recalls_raw.encode("utf-8"),
+                    expected_type="recalls",
+                    channel_key="recalls",
+                )
+                active_recalls = recalls_payload.body.get("recalls", [])
+            except RegistrySignatureError:
+                # Hard-fail: a recall payload that fails verification must
+                # NOT silently disappear — propagate so the whole sync is
+                # marked unsuccessful and the kill-switch stays armed.
+                raise
             except Exception as _recalls_exc:
                 log.debug("recalls_fetch_failed", url=recalls_url, error=str(_recalls_exc))
                 active_recalls = []

--- a/tests/test_skills/test_community/test_signing.py
+++ b/tests/test_skills/test_community/test_signing.py
@@ -1,0 +1,618 @@
+"""PACK-4 — Tests for the Ed25519 registry verifier (TUF-Light).
+
+Spec: ``docs/superpowers/specs/2026-05-05-pack4-registry-signing.md`` §9.
+
+Each numbered scenario in the spec maps to a test below. The tests
+construct payloads in-memory using ephemeral keypairs — never touch the
+network, never depend on a deployed registry.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from cognithor.skills.community import _pinned_keys
+from cognithor.skills.community.signing import (
+    RegistryKeyError,
+    RegistryNotConfiguredError,
+    RegistryReplayError,
+    RegistrySignatureError,
+    RegistryStaleError,
+    RegistryVerifier,
+    SignedPayload,
+    verify_signed_payload,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers — ephemeral key generation + signed-payload builders
+# ---------------------------------------------------------------------------
+
+
+def _make_keypair() -> tuple[Ed25519PrivateKey, str]:
+    """Return ``(private, public_key_b64)`` — fresh per call."""
+    priv = Ed25519PrivateKey.generate()
+    pub_raw = priv.public_key().public_bytes_raw()
+    return priv, base64.b64encode(pub_raw).decode("ascii")
+
+
+def _keyid(pub_b64: str) -> str:
+    raw = base64.b64decode(pub_b64.encode("ascii"))
+    return "sha256:" + hashlib.sha256(raw).hexdigest()
+
+
+def _canonicalise(signed: dict) -> bytes:
+    return json.dumps(signed, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
+
+
+def _sign_envelope(priv: Ed25519PrivateKey, signed: dict, *, keyid: str) -> bytes:
+    """Build a signed JSON envelope ready for ``verify_signed_payload``."""
+    canonical = _canonicalise(signed)
+    sig = priv.sign(canonical)
+    envelope = {
+        "signed": signed,
+        "signatures": [
+            {
+                "keyid": keyid,
+                "method": "ed25519",
+                "sig": base64.b64encode(sig).decode("ascii"),
+            }
+        ],
+    }
+    return json.dumps(envelope).encode("utf-8")
+
+
+def _now() -> datetime:
+    return datetime(2026, 5, 5, 12, 0, 0, tzinfo=UTC)
+
+
+def _build_registry_signed(
+    *,
+    version: int = 42,
+    issued_offset: timedelta = timedelta(seconds=0),
+    valid_offset: timedelta = timedelta(days=14),
+    type_: str = "registry",
+    extra: dict | None = None,
+) -> dict:
+    base = {
+        "_type": type_,
+        "version": version,
+        "issued_at": (_now() + issued_offset).isoformat(),
+        "valid_until": (_now() + valid_offset).isoformat(),
+        "skills": [{"name": "demo", "version": "1.0"}],
+    }
+    if extra:
+        base.update(extra)
+    return base
+
+
+def _build_root_signed(
+    *,
+    version: int,
+    targets_pub_b64: str,
+    valid_offset: timedelta = timedelta(days=365),
+    min_client_version: str | None = None,
+) -> dict:
+    body = {
+        "_type": "root",
+        "version": version,
+        "issued_at": _now().isoformat(),
+        "valid_until": (_now() + valid_offset).isoformat(),
+        "targets": {
+            "keyid": _keyid(targets_pub_b64),
+            "method": "ed25519",
+            "public_key": targets_pub_b64,
+        },
+    }
+    if min_client_version is not None:
+        body["min_client_version"] = min_client_version
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 — Legitimate signed payload
+# ---------------------------------------------------------------------------
+
+
+class TestLegitimatePayload:
+    def test_registry_payload_accepted(self) -> None:
+        priv, pub_b64 = _make_keypair()
+        body = _sign_envelope(
+            priv,
+            _build_registry_signed(version=10),
+            keyid=_keyid(pub_b64),
+        )
+        result = verify_signed_payload(
+            body,
+            expected_type="registry",
+            public_key=priv.public_key(),
+            last_seen_version=0,
+            now=_now(),
+        )
+        assert isinstance(result, SignedPayload)
+        assert result.type_ == "registry"
+        assert result.version == 10
+        assert result.body["skills"][0]["name"] == "demo"
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 — Replay (version older than last seen)
+# ---------------------------------------------------------------------------
+
+
+class TestReplay:
+    def test_older_version_rejected(self) -> None:
+        priv, pub_b64 = _make_keypair()
+        body = _sign_envelope(
+            priv,
+            _build_registry_signed(version=5),
+            keyid=_keyid(pub_b64),
+        )
+        with pytest.raises(RegistryReplayError, match="replay rejected"):
+            verify_signed_payload(
+                body,
+                expected_type="registry",
+                public_key=priv.public_key(),
+                last_seen_version=10,  # we've already seen version 10
+                now=_now(),
+            )
+
+    def test_equal_version_accepted(self) -> None:
+        """Same version is OK (idempotent re-sync)."""
+        priv, pub_b64 = _make_keypair()
+        body = _sign_envelope(
+            priv,
+            _build_registry_signed(version=10),
+            keyid=_keyid(pub_b64),
+        )
+        result = verify_signed_payload(
+            body,
+            expected_type="registry",
+            public_key=priv.public_key(),
+            last_seen_version=10,
+            now=_now(),
+        )
+        assert result.version == 10
+
+
+# ---------------------------------------------------------------------------
+# Scenario 3 — Stale (valid_until in the past)
+# ---------------------------------------------------------------------------
+
+
+class TestStale:
+    def test_stale_rejected(self) -> None:
+        priv, pub_b64 = _make_keypair()
+        body = _sign_envelope(
+            priv,
+            _build_registry_signed(
+                version=1,
+                issued_offset=-timedelta(days=30),
+                valid_offset=-timedelta(days=1),  # expired yesterday
+            ),
+            keyid=_keyid(pub_b64),
+        )
+        with pytest.raises(RegistryStaleError, match="stale"):
+            verify_signed_payload(
+                body,
+                expected_type="registry",
+                public_key=priv.public_key(),
+                last_seen_version=0,
+                now=_now(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Scenarios 4 + 5 — Tampered signed dict and tampered signature
+# ---------------------------------------------------------------------------
+
+
+class TestTampering:
+    def test_tampered_signed_body_rejected(self) -> None:
+        priv, pub_b64 = _make_keypair()
+        signed = _build_registry_signed(version=1)
+        body = _sign_envelope(priv, signed, keyid=_keyid(pub_b64))
+        # Flip a byte in the signed.skills field.
+        envelope = json.loads(body.decode("utf-8"))
+        envelope["signed"]["skills"][0]["name"] = "tampered"
+        tampered = json.dumps(envelope).encode("utf-8")
+        with pytest.raises(RegistrySignatureError, match="signature verification failed"):
+            verify_signed_payload(
+                tampered,
+                expected_type="registry",
+                public_key=priv.public_key(),
+                last_seen_version=0,
+                now=_now(),
+            )
+
+    def test_tampered_signature_rejected(self) -> None:
+        priv, pub_b64 = _make_keypair()
+        body = _sign_envelope(priv, _build_registry_signed(version=1), keyid=_keyid(pub_b64))
+        envelope = json.loads(body.decode("utf-8"))
+        good_sig = envelope["signatures"][0]["sig"]
+        # Flip the last byte of the signature.
+        flipped = base64.b64decode(good_sig.encode("ascii"))
+        flipped = flipped[:-1] + bytes([flipped[-1] ^ 0x01])
+        envelope["signatures"][0]["sig"] = base64.b64encode(flipped).decode("ascii")
+        tampered = json.dumps(envelope).encode("utf-8")
+        with pytest.raises(RegistrySignatureError):
+            verify_signed_payload(
+                tampered,
+                expected_type="registry",
+                public_key=priv.public_key(),
+                last_seen_version=0,
+                now=_now(),
+            )
+
+    def test_signed_by_wrong_key_rejected(self) -> None:
+        priv_good, _ = _make_keypair()
+        priv_evil, pub_evil_b64 = _make_keypair()
+        # Sign with the evil key but envelope-claim the good key's id.
+        signed = _build_registry_signed(version=1)
+        body = _sign_envelope(priv_evil, signed, keyid=_keyid(pub_evil_b64))
+        with pytest.raises(RegistrySignatureError):
+            verify_signed_payload(
+                body,
+                expected_type="registry",
+                public_key=priv_good.public_key(),
+                last_seen_version=0,
+                now=_now(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 6 — ROOT_PUBLIC_KEY_B64 is None → NotConfigured
+# ---------------------------------------------------------------------------
+
+
+class TestNotConfigured:
+    def test_dormant_marketplace_raises(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        monkeypatch.setattr(_pinned_keys, "ROOT_PUBLIC_KEY_B64", None)
+        monkeypatch.setattr(_pinned_keys, "REQUIRE_SIGNED_REGISTRY", True)
+        verifier = RegistryVerifier(state_path=tmp_path / "state.json")
+        with pytest.raises(RegistryNotConfiguredError, match="dormant|pinned"):
+            verifier.verify_root(b"{}")
+        assert verifier.is_configured() is False
+
+
+# ---------------------------------------------------------------------------
+# Scenario 7 — Wrong _type
+# ---------------------------------------------------------------------------
+
+
+class TestWrongType:
+    def test_registry_validated_as_recalls_rejected(self) -> None:
+        priv, pub_b64 = _make_keypair()
+        body = _sign_envelope(
+            priv,
+            _build_registry_signed(version=1, type_="registry"),
+            keyid=_keyid(pub_b64),
+        )
+        with pytest.raises(RegistrySignatureError, match="expected _type='recalls'"):
+            verify_signed_payload(
+                body,
+                expected_type="recalls",
+                public_key=priv.public_key(),
+                last_seen_version=0,
+                now=_now(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 8 — Future-dated issued_at beyond clock-skew
+# ---------------------------------------------------------------------------
+
+
+class TestClockSkew:
+    def test_far_future_issued_at_rejected(self) -> None:
+        priv, pub_b64 = _make_keypair()
+        body = _sign_envelope(
+            priv,
+            _build_registry_signed(
+                version=1,
+                issued_offset=timedelta(hours=2),  # well beyond 5min tolerance
+            ),
+            keyid=_keyid(pub_b64),
+        )
+        with pytest.raises(RegistrySignatureError, match="future"):
+            verify_signed_payload(
+                body,
+                expected_type="registry",
+                public_key=priv.public_key(),
+                last_seen_version=0,
+                now=_now(),
+            )
+
+    def test_near_future_issued_at_accepted(self) -> None:
+        """Within 5min tolerance — small NTP drift forgiven."""
+        priv, pub_b64 = _make_keypair()
+        body = _sign_envelope(
+            priv,
+            _build_registry_signed(version=1, issued_offset=timedelta(minutes=2)),
+            keyid=_keyid(pub_b64),
+        )
+        result = verify_signed_payload(
+            body,
+            expected_type="registry",
+            public_key=priv.public_key(),
+            last_seen_version=0,
+            now=_now(),
+        )
+        assert result.version == 1
+
+
+# ---------------------------------------------------------------------------
+# Scenario 9 — Targets-key rotation via root.json (full RegistryVerifier flow)
+# ---------------------------------------------------------------------------
+
+
+class TestKeyRotation:
+    def test_rotation_via_root_json(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        # Step 1: generate root + initial targets.
+        root_priv, root_pub_b64 = _make_keypair()
+        targets_priv_v1, targets_pub_v1_b64 = _make_keypair()
+        targets_priv_v2, targets_pub_v2_b64 = _make_keypair()
+
+        monkeypatch.setattr(_pinned_keys, "ROOT_PUBLIC_KEY_B64", root_pub_b64)
+        monkeypatch.setattr(_pinned_keys, "REQUIRE_SIGNED_REGISTRY", True)
+
+        verifier = RegistryVerifier(state_path=tmp_path / "state.json")
+
+        # Step 2: bootstrap with root.json v1 → caches targets v1.
+        root_v1 = _sign_envelope(
+            root_priv,
+            _build_root_signed(version=1, targets_pub_b64=targets_pub_v1_b64),
+            keyid=_keyid(root_pub_b64),
+        )
+        verifier.verify_root(root_v1, now=_now())
+
+        # Step 3: registry.json signed by targets v1 verifies.
+        reg_v1 = _sign_envelope(
+            targets_priv_v1,
+            _build_registry_signed(version=1),
+            keyid=_keyid(targets_pub_v1_b64),
+        )
+        result_v1 = verifier.verify_targets_payload(
+            reg_v1, expected_type="registry", channel_key="registry", now=_now()
+        )
+        assert result_v1.version == 1
+
+        # Step 4: rotate — root.json v2 delegates to targets v2.
+        root_v2 = _sign_envelope(
+            root_priv,
+            _build_root_signed(version=2, targets_pub_b64=targets_pub_v2_b64),
+            keyid=_keyid(root_pub_b64),
+        )
+        verifier.verify_root(root_v2, now=_now())
+
+        # Step 5: registry signed by old (rotated-out) targets v1 now fails.
+        reg_old = _sign_envelope(
+            targets_priv_v1,
+            _build_registry_signed(version=2),
+            keyid=_keyid(targets_pub_v1_b64),
+        )
+        with pytest.raises(RegistrySignatureError):
+            verifier.verify_targets_payload(
+                reg_old, expected_type="registry", channel_key="registry", now=_now()
+            )
+
+        # Step 6: registry signed by new targets v2 verifies.
+        reg_new = _sign_envelope(
+            targets_priv_v2,
+            _build_registry_signed(version=2),
+            keyid=_keyid(targets_pub_v2_b64),
+        )
+        result_new = verifier.verify_targets_payload(
+            reg_new, expected_type="registry", channel_key="registry", now=_now()
+        )
+        assert result_new.version == 2
+
+
+# ---------------------------------------------------------------------------
+# Scenario 10 — min_client_version gate
+# ---------------------------------------------------------------------------
+
+
+class TestMinClientVersion:
+    def test_running_version_below_required_rejected(self) -> None:
+        priv, pub_b64 = _make_keypair()
+        body = _sign_envelope(
+            priv,
+            _build_registry_signed(
+                version=1,
+                extra={"min_client_version": "0.99.0"},
+            ),
+            keyid=_keyid(pub_b64),
+        )
+        with pytest.raises(RegistryKeyError, match="min_client_version"):
+            verify_signed_payload(
+                body,
+                expected_type="registry",
+                public_key=priv.public_key(),
+                last_seen_version=0,
+                now=_now(),
+                running_version="0.97.0",
+            )
+
+    def test_running_version_at_or_above_accepted(self) -> None:
+        priv, pub_b64 = _make_keypair()
+        body = _sign_envelope(
+            priv,
+            _build_registry_signed(version=1, extra={"min_client_version": "0.97.0"}),
+            keyid=_keyid(pub_b64),
+        )
+        result = verify_signed_payload(
+            body,
+            expected_type="registry",
+            public_key=priv.public_key(),
+            last_seen_version=0,
+            now=_now(),
+            running_version="0.97.0",
+        )
+        assert result.version == 1
+
+
+# ---------------------------------------------------------------------------
+# Scenario 11 — State persistence across verifier restarts
+# ---------------------------------------------------------------------------
+
+
+class TestStatePersistence:
+    def test_last_seen_survives_restart(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        root_priv, root_pub_b64 = _make_keypair()
+        targets_priv, targets_pub_b64 = _make_keypair()
+        monkeypatch.setattr(_pinned_keys, "ROOT_PUBLIC_KEY_B64", root_pub_b64)
+        monkeypatch.setattr(_pinned_keys, "REQUIRE_SIGNED_REGISTRY", True)
+
+        state_file = tmp_path / "state.json"
+        v1 = RegistryVerifier(state_path=state_file)
+        root = _sign_envelope(
+            root_priv,
+            _build_root_signed(version=1, targets_pub_b64=targets_pub_b64),
+            keyid=_keyid(root_pub_b64),
+        )
+        v1.verify_root(root, now=_now())
+        reg = _sign_envelope(
+            targets_priv,
+            _build_registry_signed(version=42),
+            keyid=_keyid(targets_pub_b64),
+        )
+        v1.verify_targets_payload(reg, expected_type="registry", channel_key="registry", now=_now())
+
+        # New instance reads the same file.
+        v2 = RegistryVerifier(state_path=state_file)
+        # Replay attempt (version 41 < persisted 42) must fail.
+        replay = _sign_envelope(
+            targets_priv,
+            _build_registry_signed(version=41),
+            keyid=_keyid(targets_pub_b64),
+        )
+        with pytest.raises(RegistryReplayError):
+            v2.verify_targets_payload(
+                replay,
+                expected_type="registry",
+                channel_key="registry",
+                now=_now(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Scenario 12 — Schema malformation
+# ---------------------------------------------------------------------------
+
+
+class TestMalformedEnvelopes:
+    def test_not_json_rejected(self) -> None:
+        priv, _ = _make_keypair()
+        with pytest.raises(RegistrySignatureError, match="not valid"):
+            verify_signed_payload(
+                b"not json at all",
+                expected_type="registry",
+                public_key=priv.public_key(),
+                last_seen_version=0,
+                now=_now(),
+            )
+
+    def test_missing_signed_key_rejected(self) -> None:
+        priv, _ = _make_keypair()
+        with pytest.raises(RegistrySignatureError, match="signed"):
+            verify_signed_payload(
+                b'{"signatures": []}',
+                expected_type="registry",
+                public_key=priv.public_key(),
+                last_seen_version=0,
+                now=_now(),
+            )
+
+    def test_empty_signatures_rejected(self) -> None:
+        priv, _ = _make_keypair()
+        body = json.dumps({"signed": _build_registry_signed(version=1), "signatures": []}).encode(
+            "utf-8"
+        )
+        with pytest.raises(RegistrySignatureError, match="non-empty"):
+            verify_signed_payload(
+                body,
+                expected_type="registry",
+                public_key=priv.public_key(),
+                last_seen_version=0,
+                now=_now(),
+            )
+
+    def test_negative_version_rejected(self) -> None:
+        priv, pub_b64 = _make_keypair()
+        body = _sign_envelope(
+            priv,
+            _build_registry_signed(version=-1),
+            keyid=_keyid(pub_b64),
+        )
+        with pytest.raises(RegistrySignatureError, match="non-negative"):
+            verify_signed_payload(
+                body,
+                expected_type="registry",
+                public_key=priv.public_key(),
+                last_seen_version=0,
+                now=_now(),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Smoke: verify_root requires correct _type even with valid signature
+# ---------------------------------------------------------------------------
+
+
+class TestVerifyRootGuards:
+    def test_root_with_wrong_type_rejected(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        root_priv, root_pub_b64 = _make_keypair()
+        _, targets_pub_b64 = _make_keypair()
+        monkeypatch.setattr(_pinned_keys, "ROOT_PUBLIC_KEY_B64", root_pub_b64)
+        monkeypatch.setattr(_pinned_keys, "REQUIRE_SIGNED_REGISTRY", True)
+        verifier = RegistryVerifier(state_path=tmp_path / "state.json")
+
+        # Build a registry-typed envelope but feed it to verify_root.
+        signed_as_registry = {
+            "_type": "registry",
+            "version": 1,
+            "issued_at": _now().isoformat(),
+            "valid_until": (_now() + timedelta(days=30)).isoformat(),
+            "skills": [],
+        }
+        body = _sign_envelope(root_priv, signed_as_registry, keyid=_keyid(root_pub_b64))
+        with pytest.raises(RegistrySignatureError, match="_type"):
+            verifier.verify_root(body, now=_now())
+
+    def test_targets_payload_without_root_bootstrap(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        priv, pub_b64 = _make_keypair()
+        monkeypatch.setattr(_pinned_keys, "ROOT_PUBLIC_KEY_B64", pub_b64)
+        monkeypatch.setattr(_pinned_keys, "REQUIRE_SIGNED_REGISTRY", True)
+        verifier = RegistryVerifier(state_path=tmp_path / "state.json")
+        body = _sign_envelope(
+            priv,
+            _build_registry_signed(version=1),
+            keyid=_keyid(pub_b64),
+        )
+        with pytest.raises(RegistryNotConfiguredError, match="cached Targets"):
+            verifier.verify_targets_payload(
+                body,
+                expected_type="registry",
+                channel_key="registry",
+                now=_now(),
+            )

--- a/tests/test_skills/test_community/test_signing_scripts.py
+++ b/tests/test_skills/test_community/test_signing_scripts.py
@@ -1,0 +1,122 @@
+"""End-to-end smoke for the four operator scripts in scripts/registry_signing/.
+
+PACK-4 acceptance criterion §11: "All four signing scripts execute end-to-end
+on a clean checkout."
+
+The test:
+  1. Runs ``generate_root_key.py``    → ``./root/`` with PEM + b64
+  2. Runs ``generate_targets_key.py`` → ``./targets/`` with PEM + b64
+  3. Runs ``sign_root.py``            → ``./root.json``
+  4. Runs ``sign_payload.py``         → ``./signed_registry.json``
+  5. Loads root.json + signed_registry.json through ``RegistryVerifier``
+     using the freshly-minted Root pubkey, and asserts the chain holds
+     end-to-end.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+from cognithor.skills.community import _pinned_keys
+from cognithor.skills.community.signing import RegistryVerifier
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+SCRIPTS = "scripts/registry_signing"
+
+
+def _run(*argv: str) -> None:
+    proc = subprocess.run(
+        [sys.executable, *argv],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        raise AssertionError(
+            f"script exited {proc.returncode}\nstdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+        )
+
+
+@pytest.mark.slow
+def test_full_signing_chain_e2e(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    # 1 + 2: mint both keypairs.
+    root_dir = tmp_path / "root"
+    targets_dir = tmp_path / "targets"
+    _run(f"{SCRIPTS}/generate_root_key.py", "--out-dir", str(root_dir))
+    _run(f"{SCRIPTS}/generate_targets_key.py", "--out-dir", str(targets_dir))
+
+    root_pub_b64 = (root_dir / "root_public.b64").read_text(encoding="utf-8").strip()
+    assert (root_dir / "root_private.pem").exists()
+    assert (targets_dir / "targets_private.pem").exists()
+    assert (targets_dir / "targets_public.b64").exists()
+
+    # 3: sign root.json delegating to the Targets key.
+    root_json_path = tmp_path / "root.json"
+    _run(
+        f"{SCRIPTS}/sign_root.py",
+        "--root-key",
+        str(root_dir / "root_private.pem"),
+        "--targets-pubkey",
+        str(targets_dir / "targets_public.b64"),
+        "--version",
+        "1",
+        "--valid-days",
+        "365",
+        "--min-client-version",
+        "0.97.0",
+        "--out",
+        str(root_json_path),
+    )
+    assert root_json_path.exists()
+
+    # 4: build an unsigned registry.json then sign it with the Targets key.
+    now = datetime.now(UTC)
+    unsigned_registry = {
+        "_type": "registry",
+        "version": 1,
+        "issued_at": now.isoformat(),
+        "valid_until": (now + timedelta(days=14)).isoformat(),
+        "skills": [{"name": "demo", "publisher": "alice"}],
+    }
+    unsigned_path = tmp_path / "unsigned_registry.json"
+    unsigned_path.write_text(json.dumps(unsigned_registry), encoding="utf-8")
+    signed_path = tmp_path / "signed_registry.json"
+    _run(
+        f"{SCRIPTS}/sign_payload.py",
+        "--in",
+        str(unsigned_path),
+        "--key",
+        str(targets_dir / "targets_private.pem"),
+        "--out",
+        str(signed_path),
+    )
+    assert signed_path.exists()
+
+    # 5: verify the full chain with the Cognithor verifier, pinning the
+    # freshly-minted Root pubkey via monkeypatch.
+    monkeypatch.setattr(_pinned_keys, "ROOT_PUBLIC_KEY_B64", root_pub_b64)
+    monkeypatch.setattr(_pinned_keys, "REQUIRE_SIGNED_REGISTRY", True)
+
+    verifier = RegistryVerifier(state_path=tmp_path / "state.json")
+    root_payload = verifier.verify_root(root_json_path.read_bytes(), now=now)
+    assert root_payload.version == 1
+    assert root_payload.body["targets"]["public_key"] == (
+        (targets_dir / "targets_public.b64").read_text(encoding="utf-8").strip()
+    )
+
+    registry_payload = verifier.verify_targets_payload(
+        signed_path.read_bytes(),
+        expected_type="registry",
+        channel_key="registry",
+        now=now,
+    )
+    assert registry_payload.version == 1
+    assert registry_payload.body["skills"][0]["name"] == "demo"


### PR DESCRIPTION
## Summary

PACK-4 (REAL-CRIT, deep-audit pass-2 2026-05-05). Closes the community-registry kill-switch + reputation-tampering gap by signing every payload with **Ed25519** under a two-role **TUF-Light** scheme.

**Spec**: [`docs/superpowers/specs/2026-05-05-pack4-registry-signing.md`](docs/superpowers/specs/2026-05-05-pack4-registry-signing.md) (this PR ships it).

## Why now

Pre-existing community-skill registry trusted any plain-HTTPS payload. Three concrete attacks:

| Attack | Mitigation in this PR |
|---|---|
| Tampered `recalls/active.json` triggers `_deactivate_skill` for arbitrary skill names → **remote kill-switch with no auth** | Ed25519 signature over canonical-JSON `signed` block |
| **Replay** of an old, legit-signed `registry.json` to *freeze* a recall the moment it's needed most | Monotonic `version` + persistent `last_seen` per channel |
| Stale `recalls/active.json` served indefinitely after Targets-key rotation | `valid_until` field (1 day for recalls, 14 days for registry) — hard-fail when expired |

Reviewer's three open questions in the design discussion are all addressed in spec + code:

1. **Freshness/replay** → `version` + `valid_until` + clock-skew tolerance (5 min, one-sided forgiveness on `issued_at` only).
2. **Key-compromise recovery** → TUF-Light two-key. Targets-key rotation via offline Root is online + transparent. Root rotation is release-bound by design (Root key lives offline so the column exists).
3. **Bootstrap flag** → no `--accept-unsigned-registry` CLI option (downgrade vector). `REQUIRE_SIGNED_REGISTRY` is a build-time constant in `_pinned_keys.py`.

## Architecture

```
   Root (offline, hardware-token)        Targets (online, GH-Actions secret)
   • Pinned in source                     • Delegated by root.json
   • Signs ONLY root.json                 • Signs registry.json,
   • Used to rotate Targets key             recalls/active.json,
                                            publishers/*.json
                          ▲                            ▲
                          │ verifies                   │ verifies
                          ▼                            ▼
          ┌──────────────────────────────────────────────────┐
          │         RegistryVerifier (cognithor.skills       │
          │         .community.signing)                      │
          │  10-step strict-order verification:              │
          │  parse → schema → _type → canonicalise →         │
          │  signature → version (replay) → valid_until      │
          │  (stale) → issued_at (clock-skew) →              │
          │  min_client_version → return                     │
          └──────────────────────────────────────────────────┘
```

## Files changed

| Path | Type | LOC |
|---|---|---|
| `src/cognithor/skills/community/_pinned_keys.py` | NEW | 39 |
| `src/cognithor/skills/community/signing.py` | NEW | 496 |
| `src/cognithor/skills/community/sync.py` | MOD | +49/-9 |
| `src/cognithor/skills/community/publisher.py` | MOD | +28/-5 |
| `scripts/registry_signing/{generate_root,generate_targets,sign_payload,sign_root}.py + README.md` | NEW | 527 |
| `tests/test_skills/test_community/test_signing.py` | NEW | 618 |
| `tests/test_skills/test_community/test_signing_scripts.py` | NEW | 122 |
| `docs/superpowers/specs/2026-05-05-pack4-registry-signing.md` | NEW | 428 |
| `docs/runbooks/registry_key_rotation.md` | NEW | 146 |
| `docs/operational_trust.md` | MOD | +18 (PACK-4 row: deferred → addressed) |
| `SECURITY.md` | MOD | +26 (new Registry Trust Model section) |
| `README.md` | MOD | +25 (Trust-Modell paragraph + EU-sovereign positioning) |

## Test plan

- [x] **22 new tests passed** in `tests/test_skills/test_community/`:
  - All 12 spec §9 acceptance scenarios + 10 additional edge cases
  - End-to-end smoke through all four operator scripts (`test_signing_scripts.py`)
- [x] `pytest tests/test_skills/ -q` → **605 passed**
- [x] `mypy --strict` on signing.py, _pinned_keys.py, sync.py, publisher.py → clean
- [x] `ruff check src/ tests/` → clean
- [x] `ruff format --check src/ tests/` → clean
- [x] No new runtime dependency (`cryptography>=46.0.5` already in pyproject)
- [ ] CI green

## Migration story (no existing un-signed corpus)

The community marketplace **has not yet shipped publicly** (per MEMORY.md it's Q4 2026 future work). This means:

- No existing un-signed registry to re-sign — clean cut-over.
- v0.97.0 lands the verifier with `ROOT_PUBLIC_KEY_B64 = None` → community features hard-disabled cleanly.
- v0.97.x (or first marketplace launch) lands the operator-generated key.
- Until then, `RegistrySync` and `PublisherVerifier` are dormant: any call returns `success=True / no-op` cleanly.

## Owner steps **after** this PR merges (out of scope)

1. Run `python scripts/registry_signing/generate_root_key.py --out-dir ./keys/root` on an offline machine.
2. Run `python scripts/registry_signing/generate_targets_key.py --out-dir ./keys/targets`.
3. Sign initial `root.json` with `sign_root.py`.
4. Patch `_pinned_keys.py` with the Root pubkey, cut a Cognithor release.
5. Set GitHub-Actions secret `REGISTRY_TARGETS_PRIVATE_KEY` in the registry repo.
6. Push initial `root.json` to registry repo.

Full runbook: [`docs/runbooks/registry_key_rotation.md`](docs/runbooks/registry_key_rotation.md).

## Out of scope (explicit)

- Sigstore/cosign keyless signing — deferred. EU-sovereign positioning prefers self-managed keys over a third-party witness.
- Full TUF (snapshot + timestamp roles) — `valid_until` covers the freeze attack at 1/100th the complexity.
- Federation / multi-operator trust — single Root is enough for v1.
- Signed plugin/pack manifests — different attack surface (already partly addressed by `eula_sha256`); separate sprint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)