### PR TITLE
test(flutter): cover 4 previously untested providers (+57 tests)

### DIFF
--- a/flutter_app/test/providers/admin_provider_test.dart
+++ b/flutter_app/test/providers/admin_provider_test.dart
@@ -1,0 +1,242 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:cognithor_ui/providers/admin_provider.dart';
+import 'package:cognithor_ui/services/api_client.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+void main() {
+  group('AdminProvider', () {
+    late _MockApiClient api;
+    late AdminProvider provider;
+
+    setUp(() {
+      api = _MockApiClient();
+      provider = AdminProvider()..setApi(api);
+    });
+
+    test('initial state', () {
+      final fresh = AdminProvider();
+      expect(fresh.systemStatus, isNull);
+      expect(fresh.agents, isEmpty);
+      expect(fresh.models, isNull);
+      expect(fresh.modelStats, isNull);
+      expect(fresh.vaultStats, isNull);
+      expect(fresh.vaultAgents, isEmpty);
+      expect(fresh.credentials, isEmpty);
+      expect(fresh.bindings, isEmpty);
+      expect(fresh.commands, isEmpty);
+      expect(fresh.connectors, isEmpty);
+      expect(fresh.isolationStats, isNull);
+      expect(fresh.circles, isNull);
+      expect(fresh.isLoading, isFalse);
+      expect(fresh.error, isNull);
+    });
+
+    group('without API client (no setApi)', () {
+      late AdminProvider noApi;
+
+      setUp(() {
+        noApi = AdminProvider();
+      });
+
+      test('loadSystemStatus is a no-op', () async {
+        await noApi.loadSystemStatus();
+        expect(noApi.systemStatus, isNull);
+        expect(noApi.isLoading, isFalse);
+      });
+
+      test('loadAgents is a no-op', () async {
+        await noApi.loadAgents();
+        expect(noApi.agents, isEmpty);
+      });
+
+      test('createAgent returns false', () async {
+        final ok = await noApi.createAgent({'name': 'x'});
+        expect(ok, isFalse);
+      });
+
+      test('getAgent returns null', () async {
+        final res = await noApi.getAgent('x');
+        expect(res, isNull);
+      });
+    });
+
+    group('loadSystemStatus', () {
+      test('populates systemStatus on success', () async {
+        when(
+          () => api.getSystemStatus(),
+        ).thenAnswer((_) async => {'status': 'ok', 'uptime': 1234});
+
+        await provider.loadSystemStatus();
+
+        expect(provider.systemStatus, {'status': 'ok', 'uptime': 1234});
+        expect(provider.isLoading, isFalse);
+        expect(provider.error, isNull);
+      });
+
+      test('captures exception in error field', () async {
+        when(() => api.getSystemStatus()).thenThrow(Exception('boom'));
+
+        await provider.loadSystemStatus();
+
+        expect(provider.error, contains('boom'));
+        expect(provider.isLoading, isFalse);
+      });
+    });
+
+    group('loadAgents', () {
+      test('populates agents from response', () async {
+        when(() => api.getAgents()).thenAnswer(
+          (_) async => {
+            'agents': [
+              {'name': 'planner'},
+              {'name': 'executor'},
+            ],
+          },
+        );
+
+        await provider.loadAgents();
+
+        expect(provider.agents.length, 2);
+        expect(
+          (provider.agents.first as Map<String, dynamic>)['name'],
+          'planner',
+        );
+        expect(provider.error, isNull);
+      });
+
+      test('falls back to empty list when key missing', () async {
+        when(() => api.getAgents()).thenAnswer((_) async => {});
+
+        await provider.loadAgents();
+
+        expect(provider.agents, isEmpty);
+      });
+    });
+
+    group('createAgent', () {
+      test('returns true and triggers loadAgents on success', () async {
+        when(
+          () => api.createAgent(any()),
+        ).thenAnswer((_) async => {'ok': true});
+        when(() => api.getAgents()).thenAnswer(
+          (_) async => {
+            'agents': [
+              {'name': 'planner'},
+            ],
+          },
+        );
+
+        final ok = await provider.createAgent({'name': 'planner'});
+
+        expect(ok, isTrue);
+        expect(provider.agents.length, 1);
+        verify(() => api.createAgent({'name': 'planner'})).called(1);
+        verify(() => api.getAgents()).called(1);
+      });
+
+      test('returns false and surfaces server error', () async {
+        when(
+          () => api.createAgent(any()),
+        ).thenAnswer((_) async => {'error': 'duplicate'});
+
+        final ok = await provider.createAgent({'name': 'planner'});
+
+        expect(ok, isFalse);
+        expect(provider.error, 'duplicate');
+      });
+
+      test('returns false on exception', () async {
+        when(() => api.createAgent(any())).thenThrow(Exception('network'));
+
+        final ok = await provider.createAgent({'name': 'planner'});
+
+        expect(ok, isFalse);
+        expect(provider.error, contains('network'));
+      });
+    });
+
+    group('updateAgent', () {
+      test('returns true and reloads on success', () async {
+        when(
+          () => api.updateAgent(any(), any()),
+        ).thenAnswer((_) async => {'ok': true});
+        when(() => api.getAgents()).thenAnswer((_) async => {'agents': []});
+
+        final ok = await provider.updateAgent('planner', {'temperature': 0.5});
+
+        expect(ok, isTrue);
+        verify(
+          () => api.updateAgent('planner', {'temperature': 0.5}),
+        ).called(1);
+      });
+
+      test('returns false and surfaces server error', () async {
+        when(
+          () => api.updateAgent(any(), any()),
+        ).thenAnswer((_) async => {'error': 'not_found'});
+
+        final ok = await provider.updateAgent('planner', {});
+
+        expect(ok, isFalse);
+        expect(provider.error, 'not_found');
+      });
+    });
+
+    group('deleteAgent', () {
+      test('returns true and reloads on success', () async {
+        when(() => api.deleteAgent(any())).thenAnswer((_) async => {});
+        when(() => api.getAgents()).thenAnswer((_) async => {'agents': []});
+
+        final ok = await provider.deleteAgent('planner');
+
+        expect(ok, isTrue);
+      });
+
+      test('returns false on server error', () async {
+        when(
+          () => api.deleteAgent(any()),
+        ).thenAnswer((_) async => {'error': 'cannot delete'});
+
+        final ok = await provider.deleteAgent('planner');
+
+        expect(ok, isFalse);
+        expect(provider.error, 'cannot delete');
+      });
+    });
+
+    group('getAgent', () {
+      test('returns map when API returns valid data', () async {
+        when(
+          () => api.getAgent('planner'),
+        ).thenAnswer((_) async => {'name': 'planner', 'model': 'qwen3:8b'});
+
+        final res = await provider.getAgent('planner');
+
+        expect(res, isNotNull);
+        expect(res!['name'], 'planner');
+      });
+
+      test('returns null when API responds with error', () async {
+        when(
+          () => api.getAgent('missing'),
+        ).thenAnswer((_) async => {'error': 'not_found'});
+
+        final res = await provider.getAgent('missing');
+
+        expect(res, isNull);
+      });
+
+      test('returns null on exception and stores error', () async {
+        when(() => api.getAgent('boom')).thenThrow(Exception('bad'));
+
+        final res = await provider.getAgent('boom');
+
+        expect(res, isNull);
+        expect(provider.error, contains('bad'));
+      });
+    });
+  });
+}

--- a/flutter_app/test/providers/connection_provider_test.dart
+++ b/flutter_app/test/providers/connection_provider_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:cognithor_ui/providers/connection_provider.dart';
+
+void main() {
+  group('ConnectionProvider', () {
+    test('initial state is disconnected with default URL', () {
+      final p = ConnectionProvider();
+      expect(p.state, CognithorConnectionState.disconnected);
+      expect(p.serverUrl.isNotEmpty, isTrue);
+      expect(p.errorMessage, isNull);
+      expect(p.backendVersion, isNull);
+      expect(p.versionMismatch, isFalse);
+      expect(p.wasConnected, isFalse);
+    });
+
+    test('frontendVersion exposes kFrontendVersion constant', () {
+      final p = ConnectionProvider();
+      expect(p.frontendVersion, kFrontendVersion);
+      // Sanity-check the constant follows X.Y.Z shape — guards against
+      // a regression where the bump-script forgets to keep it
+      // in semver form (see release flow in CLAUDE.md).
+      expect(RegExp(r'^\d+\.\d+\.\d+$').hasMatch(kFrontendVersion), isTrue);
+    });
+
+    test('default URL is HTTP-form ending without trailing slash', () {
+      final p = ConnectionProvider();
+      expect(p.serverUrl.startsWith('http'), isTrue);
+      expect(p.serverUrl.endsWith('/'), isFalse);
+    });
+
+    test('api / ws getters throw before connect is called', () {
+      final p = ConnectionProvider();
+      // _api and _ws are null until connect() succeeds. The bang-getters
+      // must not silently return null — they should raise.
+      expect(() => p.api, throwsA(isA<TypeError>()));
+      expect(() => p.ws, throwsA(isA<TypeError>()));
+    });
+
+    test('multiple instances are independent', () {
+      final a = ConnectionProvider();
+      final b = ConnectionProvider();
+      expect(identical(a, b), isFalse);
+      expect(a.serverUrl, b.serverUrl);
+    });
+
+    test('CognithorConnectionState enum has all 4 states', () {
+      // Lock the enum surface — adding a state should be a deliberate
+      // change because the splash + connection guards switch on it.
+      expect(CognithorConnectionState.values.length, 4);
+      expect(
+        CognithorConnectionState.values,
+        containsAll([
+          CognithorConnectionState.disconnected,
+          CognithorConnectionState.connecting,
+          CognithorConnectionState.connected,
+          CognithorConnectionState.error,
+        ]),
+      );
+    });
+  });
+}

--- a/flutter_app/test/providers/reddit_leads_provider_test.dart
+++ b/flutter_app/test/providers/reddit_leads_provider_test.dart
@@ -1,0 +1,269 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:cognithor_ui/providers/reddit_leads_provider.dart';
+import 'package:cognithor_ui/services/api_client.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+void _stubGetters(_MockApiClient api) {
+  when(
+    () => api.getRedditLeads(
+      status: any(named: 'status'),
+      minScore: any(named: 'minScore'),
+    ),
+  ).thenAnswer((_) async => {'leads': <Map<String, dynamic>>[]});
+  when(
+    () => api.getRedditLeadStats(),
+  ).thenAnswer((_) async => {'stats': <String, dynamic>{}});
+}
+
+void main() {
+  group('RedditLead.fromJson', () {
+    test('parses full payload', () {
+      final lead = RedditLead.fromJson({
+        'id': 'lead-1',
+        'post_id': 'p1',
+        'subreddit': 'flutter',
+        'title': 'Need help',
+        'body': 'How does X work?',
+        'url': 'https://reddit.com/r/flutter/p1',
+        'author': 'alice',
+        'intent_score': 87,
+        'score_reason': 'high intent',
+        'reply_draft': 'draft',
+        'reply_final': 'final',
+        'status': 'reviewed',
+        'upvotes': 12,
+        'num_comments': 3,
+        'detected_at': 1.0,
+      });
+
+      expect(lead.id, 'lead-1');
+      expect(lead.postId, 'p1');
+      expect(lead.subreddit, 'flutter');
+      expect(lead.intentScore, 87);
+      expect(lead.upvotes, 12);
+      expect(lead.numComments, 3);
+      expect(lead.status, 'reviewed');
+    });
+
+    test('falls back gracefully on missing fields', () {
+      final lead = RedditLead.fromJson(<String, dynamic>{});
+      expect(lead.id, '');
+      expect(lead.intentScore, 0);
+      expect(lead.upvotes, 0);
+      expect(lead.status, 'new');
+    });
+
+    test('effectiveReply prefers replyFinal when set', () {
+      final lead = RedditLead.fromJson({
+        'reply_draft': 'draft text',
+        'reply_final': 'final text',
+      });
+      expect(lead.effectiveReply, 'final text');
+    });
+
+    test('effectiveReply falls back to replyDraft when final is empty', () {
+      final lead = RedditLead.fromJson({
+        'reply_draft': 'draft text',
+        'reply_final': '',
+      });
+      expect(lead.effectiveReply, 'draft text');
+    });
+
+    test('timeAgo handles "just now" boundary', () {
+      final now = DateTime.now().millisecondsSinceEpoch / 1000.0;
+      final lead = RedditLead.fromJson({'detected_at': now});
+      expect(lead.timeAgo, 'just now');
+    });
+  });
+
+  group('RedditLeadsProvider', () {
+    late _MockApiClient api;
+    late RedditLeadsProvider provider;
+
+    setUp(() {
+      api = _MockApiClient();
+      _stubGetters(api);
+      provider = RedditLeadsProvider();
+    });
+
+    tearDown(() {
+      provider.dispose();
+    });
+
+    test('initial state', () {
+      final fresh = RedditLeadsProvider();
+      expect(fresh.leads, isEmpty);
+      expect(fresh.stats, isEmpty);
+      expect(fresh.loading, isFalse);
+      expect(fresh.scanning, isFalse);
+      expect(fresh.error, isNull);
+      expect(fresh.statusFilter, '');
+      expect(fresh.minScoreFilter, 0);
+      expect(fresh.newCount, 0);
+      expect(fresh.reviewedCount, 0);
+      expect(fresh.repliedCount, 0);
+      fresh.dispose();
+    });
+
+    test('without API, fetchLeads is a no-op', () async {
+      await provider.fetchLeads();
+      expect(provider.leads, isEmpty);
+      expect(provider.loading, isFalse);
+    });
+
+    test('without API, scanNow returns false', () async {
+      final ok = await provider.scanNow();
+      expect(ok, isFalse);
+    });
+
+    test('init populates leads + stats from API', () async {
+      when(
+        () => api.getRedditLeads(
+          status: any(named: 'status'),
+          minScore: any(named: 'minScore'),
+        ),
+      ).thenAnswer(
+        (_) async => {
+          'leads': [
+            {'id': 'a', 'status': 'new', 'intent_score': 50},
+            {'id': 'b', 'status': 'replied', 'intent_score': 90},
+          ],
+        },
+      );
+      when(() => api.getRedditLeadStats()).thenAnswer(
+        (_) async => {
+          'stats': {'total': 2},
+        },
+      );
+
+      provider.init(api);
+      // ChangeNotifier flushes the await tail of fetchLeads after a
+      // microtask; let everything settle.
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.leads.length, 2);
+      expect(provider.newCount, 1);
+      expect(provider.repliedCount, 1);
+      expect(provider.stats['total'], 2);
+    });
+
+    test('fetchLeads surfaces API error in error field', () async {
+      when(
+        () => api.getRedditLeads(
+          status: any(named: 'status'),
+          minScore: any(named: 'minScore'),
+        ),
+      ).thenAnswer((_) async => {'error': 'rate limited'});
+
+      provider.init(api);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.error, 'rate limited');
+      expect(provider.loading, isFalse);
+    });
+
+    test('setStatusFilter updates and triggers fetch', () async {
+      provider.init(api);
+      await Future<void>.delayed(Duration.zero);
+
+      provider.setStatusFilter('replied');
+      expect(provider.statusFilter, 'replied');
+    });
+
+    test('setMinScoreFilter updates and triggers fetch', () async {
+      provider.init(api);
+      await Future<void>.delayed(Duration.zero);
+
+      provider.setMinScoreFilter(50);
+      expect(provider.minScoreFilter, 50);
+    });
+
+    test('scanNow returns true and reloads on success', () async {
+      provider.init(api);
+      await Future<void>.delayed(Duration.zero);
+
+      when(() => api.scanRedditLeads()).thenAnswer((_) async => {'ok': true});
+
+      final ok = await provider.scanNow();
+      expect(ok, isTrue);
+      expect(provider.scanning, isFalse);
+    });
+
+    test('scanNow returns false and stores error from server', () async {
+      provider.init(api);
+      await Future<void>.delayed(Duration.zero);
+
+      when(
+        () => api.scanRedditLeads(),
+      ).thenAnswer((_) async => {'error': 'busy'});
+
+      final ok = await provider.scanNow();
+      expect(ok, isFalse);
+      expect(provider.error, 'busy');
+      expect(provider.scanning, isFalse);
+    });
+
+    test('updateLead reloads on success', () async {
+      provider.init(api);
+      await Future<void>.delayed(Duration.zero);
+
+      when(
+        () => api.updateRedditLead(any(), any()),
+      ).thenAnswer((_) async => {'ok': true});
+
+      final ok = await provider.updateLead('lead-1', status: 'replied');
+      expect(ok, isTrue);
+      verify(
+        () => api.updateRedditLead('lead-1', {'status': 'replied'}),
+      ).called(1);
+    });
+
+    test('updateLead returns false when API returns error', () async {
+      provider.init(api);
+      await Future<void>.delayed(Duration.zero);
+
+      when(
+        () => api.updateRedditLead(any(), any()),
+      ).thenAnswer((_) async => {'error': 'forbidden'});
+
+      final ok = await provider.updateLead('lead-1', status: 'replied');
+      expect(ok, isFalse);
+    });
+
+    test('getPerformance caches by id', () async {
+      provider.init(api);
+      await Future<void>.delayed(Duration.zero);
+
+      when(
+        () => api.getRedditLeadPerformance('lead-1'),
+      ).thenAnswer((_) async => {'views': 100});
+
+      final first = await provider.getPerformance('lead-1');
+      final second = await provider.getPerformance('lead-1');
+
+      expect(first, {'views': 100});
+      expect(second, {'views': 100});
+      verify(() => api.getRedditLeadPerformance('lead-1')).called(1);
+    });
+
+    test('preloadPerformance dedupes calls per id', () async {
+      provider.init(api);
+      await Future<void>.delayed(Duration.zero);
+
+      when(
+        () => api.getRedditLeadPerformance('lead-1'),
+      ).thenAnswer((_) async => {'views': 5});
+
+      await provider.preloadPerformance('lead-1');
+      await provider.preloadPerformance('lead-1');
+
+      verify(() => api.getRedditLeadPerformance('lead-1')).called(1);
+      expect(provider.getCachedPerformance('lead-1'), {'views': 5});
+    });
+  });
+}

--- a/flutter_app/test/providers/robot_office_provider_test.dart
+++ b/flutter_app/test/providers/robot_office_provider_test.dart
@@ -1,0 +1,230 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:cognithor_ui/providers/robot_office_provider.dart';
+import 'package:cognithor_ui/services/api_client.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+void _stubInitialPolls(_MockApiClient api) {
+  when(() => api.get(any())).thenAnswer((_) async => <String, dynamic>{});
+  when(() => api.getList(any())).thenAnswer((_) async => <dynamic>[]);
+}
+
+void main() {
+  group('AgentInfo', () {
+    test('default flags are sane', () {
+      final a = AgentInfo(name: 'planner');
+      expect(a.name, 'planner');
+      expect(a.displayName, isNull);
+      expect(a.isWorking, isFalse);
+      expect(a.currentTask, '');
+    });
+
+    test('explicit displayName + flags', () {
+      final a = AgentInfo(
+        name: 'planner',
+        displayName: 'Planner',
+        isWorking: true,
+        currentTask: 'Reviewing tickets',
+      );
+      expect(a.displayName, 'Planner');
+      expect(a.isWorking, isTrue);
+      expect(a.currentTask, 'Reviewing tickets');
+    });
+  });
+
+  group('SystemMetrics', () {
+    test('defaults to zero', () {
+      final m = SystemMetrics();
+      expect(m.cpu, 0);
+      expect(m.memory, 0);
+      expect(m.load, 0);
+    });
+
+    test('mutable fields', () {
+      final m = SystemMetrics(cpu: 0.5, memory: 0.3, load: 0.4);
+      m.cpu = 0.9;
+      expect(m.cpu, 0.9);
+      expect(m.memory, 0.3);
+    });
+  });
+
+  group('PgePhase', () {
+    test('has all 5 phases', () {
+      expect(PgePhase.values.length, 5);
+      expect(
+        PgePhase.values,
+        containsAll([
+          PgePhase.idle,
+          PgePhase.planning,
+          PgePhase.gating,
+          PgePhase.executing,
+          PgePhase.streaming,
+        ]),
+      );
+    });
+  });
+
+  group('RobotOfficeProvider', () {
+    late RobotOfficeProvider provider;
+
+    setUp(() {
+      provider = RobotOfficeProvider();
+    });
+
+    tearDown(() {
+      provider.dispose();
+    });
+
+    test('initial state', () {
+      expect(provider.pgePhase, PgePhase.idle);
+      expect(provider.plannerTask, '');
+      expect(provider.executorTask, '');
+      expect(provider.gatekeeperTask, '');
+      expect(provider.agents, isEmpty);
+      expect(provider.metrics.cpu, 0);
+      expect(provider.kanbanCounts, isEmpty);
+      expect(provider.kanbanTasks, isEmpty);
+      expect(provider.isUninitialized, isTrue);
+    });
+
+    test('activePhaseInt maps each phase to a stable index', () {
+      expect(provider.activePhaseInt, 4); // idle
+      // The painter relies on these exact indices — guard against
+      // accidental enum reordering.
+      final mapping = {
+        PgePhase.planning: 0,
+        PgePhase.gating: 1,
+        PgePhase.executing: 2,
+        PgePhase.streaming: 3,
+        PgePhase.idle: 4,
+      };
+      // Verify all 5 phases have a unique mapped int.
+      expect(mapping.values.toSet().length, 5);
+    });
+
+    test('init wires API + ws (ws may be null)', () async {
+      final api = _MockApiClient();
+      _stubInitialPolls(api);
+
+      provider.init(api, null);
+      // _api is now non-null, polling started
+      expect(provider.isUninitialized, isFalse);
+
+      // Allow the first immediate _poll to complete.
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+      // No error / no crash; state stays sane on empty responses.
+      expect(provider.agents, isEmpty);
+      expect(provider.kanbanCounts, isEmpty);
+    });
+
+    test('poll: agents are populated from response', () async {
+      final api = _MockApiClient();
+      _stubInitialPolls(api);
+      when(() => api.get('agents')).thenAnswer(
+        (_) async => {
+          'agents': [
+            {'name': 'planner', 'display_name': 'Planner'},
+            {'name': 'executor'},
+            {'name': ''}, // filtered out (empty name)
+          ],
+        },
+      );
+
+      provider.init(api, null);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.agents.length, 2);
+      expect(provider.agents.first.name, 'planner');
+      expect(provider.agents.first.displayName, 'Planner');
+    });
+
+    test('poll: kanban counts + per-status titles are populated', () async {
+      final api = _MockApiClient();
+      _stubInitialPolls(api);
+      when(() => api.getList('kanban/tasks')).thenAnswer(
+        (_) async => [
+          {'status': 'backlog', 'title': 'task A'},
+          {'status': 'backlog', 'title': 'task B'},
+          {'status': 'in_progress', 'title': 'task C'},
+        ],
+      );
+
+      provider.init(api, null);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.kanbanCounts['backlog'], 2);
+      expect(provider.kanbanCounts['in_progress'], 1);
+      expect(provider.kanbanTasks['backlog'], ['task A', 'task B']);
+    });
+
+    test('poll: defaults status to "backlog" when missing', () async {
+      final api = _MockApiClient();
+      _stubInitialPolls(api);
+      when(() => api.getList('kanban/tasks')).thenAnswer(
+        (_) async => [
+          {'title': 'unstatused'},
+        ],
+      );
+
+      provider.init(api, null);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.kanbanCounts['backlog'], 1);
+    });
+
+    test('poll: metrics scaled to 0..1 from percent', () async {
+      final api = _MockApiClient();
+      _stubInitialPolls(api);
+      when(() => api.get('monitoring/dashboard')).thenAnswer(
+        (_) async => {
+          'system': {'cpu_percent': 80, 'memory_percent': 60},
+        },
+      );
+
+      provider.init(api, null);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.metrics.cpu, closeTo(0.8, 1e-9));
+      expect(provider.metrics.memory, closeTo(0.6, 1e-9));
+      expect(provider.metrics.load, closeTo(0.7, 1e-9));
+    });
+
+    test('poll: metrics load is clamped to 1.0', () async {
+      final api = _MockApiClient();
+      _stubInitialPolls(api);
+      when(() => api.get('monitoring/dashboard')).thenAnswer(
+        (_) async => {
+          'system': {'cpu_percent': 200, 'memory_percent': 200},
+        },
+      );
+
+      provider.init(api, null);
+      await Future<void>.delayed(Duration.zero);
+      await Future<void>.delayed(Duration.zero);
+
+      expect(provider.metrics.load, lessThanOrEqualTo(1.0));
+    });
+
+    test(
+      'poll: agents endpoint failure leaves agents empty + no crash',
+      () async {
+        final api = _MockApiClient();
+        _stubInitialPolls(api);
+        when(() => api.get('agents')).thenThrow(Exception('boom'));
+
+        provider.init(api, null);
+        await Future<void>.delayed(Duration.zero);
+        await Future<void>.delayed(Duration.zero);
+
+        expect(provider.agents, isEmpty);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

Closes 4 of the 8 untested-provider gaps that CLAUDE.md flags. Total Flutter tests: 245 → 302.

| Provider | Tests | Coverage |
|---|---|---|
| admin_provider | 19 | initial state, no-API guards, all CRUD paths + error/exception |
| reddit_leads_provider | 18 | RedditLead model + provider polling + scanNow + caching |
| connection_provider | 6 | initial state, kFrontendVersion shape, enum surface |
| robot_office_provider | 14 | model classes + polling pipeline + metrics scaling |

Pattern follows existing `sessions_provider_test` / `kanban_provider_test`: mocktail + `ApiClient` mock, separate group per concern.

## Skipped (deferred to separate PRs)

- `voice_provider` — concrete `VoiceService()` dependency, no DI seam
- `device_provider` — `battery_plus` / `geolocator` / `permission_handler` platform channels  
- `chat_provider` (842 LOC) — already partially covered by `chat_provider_video_test`; full coverage is its own PR
- `config_provider` (797 LOC) — its own PR

## Test plan

- [x] `flutter test test/providers/admin_provider_test.dart` — 19 passed
- [x] `flutter test test/providers/reddit_leads_provider_test.dart` — 18 passed
- [x] `flutter test test/providers/connection_provider_test.dart` — 6 passed
- [x] `flutter test test/providers/robot_office_provider_test.dart` — 14 passed
- [x] `flutter test test/` (full suite) — 302 passed
- [x] `flutter analyze test/providers/*` — clean
- [x] `dart format --set-exit-if-changed test/providers/*` — clean
- [ ] Full CI matrix