### PR TITLE
test(backend): deep coverage for agent_vault + post_processing (~30 tests)

### DIFF
--- a/tests/test_gateway/test_post_processing_deep.py
+++ b/tests/test_gateway/test_post_processing_deep.py
@@ -1,0 +1,587 @@
+"""Deep coverage for cognithor.gateway.post_processing.
+
+The module is the post-PGE pipeline: reflection, skill-tracking,
+telemetry, profiler, run-recording, reflexion, evolution, session
+analysis, pattern documentation, and key-tool persistence.
+
+The functions take the live ``Gateway`` instance and read internal
+state through it, so most tests instantiate ``Gateway.__new__(Gateway)``
+and inject only the attributes the function under test reads.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cognithor.gateway import post_processing
+from cognithor.gateway.gateway import Gateway
+from cognithor.gateway.post_processing import (
+    maybe_record_pattern,
+    persist_key_tool_results,
+    persist_session,
+    run_post_processing,
+)
+from cognithor.models import (
+    AgentResult,
+    Message,
+    MessageRole,
+    SessionContext,
+    ToolResult,
+    WorkingMemory,
+)
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _bare_gateway() -> Gateway:
+    """A Gateway shell without running __init__.
+
+    Sets only the attributes that post_processing functions touch
+    when they probe via ``hasattr(gw, "_x")`` / ``getattr(gw, "_x", None)``.
+    """
+    gw = Gateway.__new__(Gateway)
+    # Defaults used everywhere — None means "feature off"
+    gw._reflector = None  # type: ignore[attr-defined]
+    gw._memory_manager = None  # type: ignore[attr-defined]
+    gw._skill_registry = None  # type: ignore[attr-defined]
+    gw._skill_generator = None  # type: ignore[attr-defined]
+    gw._task_telemetry = None  # type: ignore[attr-defined]
+    gw._task_profiler = None  # type: ignore[attr-defined]
+    gw._run_recorder = None  # type: ignore[attr-defined]
+    gw._strategy_memory = None  # type: ignore[attr-defined]
+    gw._reflexion_memory = None  # type: ignore[attr-defined]
+    gw._session_analyzer = None  # type: ignore[attr-defined]
+    gw._evolution_orchestrator = None  # type: ignore[attr-defined]
+    gw._prompt_evolution = None  # type: ignore[attr-defined]
+    gw._trace_store = None  # type: ignore[attr-defined]
+    gw._planner = None  # type: ignore[attr-defined]
+    gw._session_store = None  # type: ignore[attr-defined]
+    gw._deep_learner = None  # type: ignore[attr-defined]
+    gw._evolution_loop = None  # type: ignore[attr-defined]
+    gw._config = None  # type: ignore[attr-defined]
+    gw._pattern_record_timestamps = []  # type: ignore[attr-defined]
+    return gw
+
+
+def _session(channel: str = "cli") -> SessionContext:
+    return SessionContext(session_id="sess-12345678", channel=channel)
+
+
+def _wm_with_user(text: str) -> WorkingMemory:
+    wm = WorkingMemory()
+    wm.add_message(Message(role=MessageRole.USER, content=text))
+    return wm
+
+
+def _ok_tool(tool_name: str = "web_search", content: str = "out") -> ToolResult:
+    return ToolResult(tool_name=tool_name, content=content, is_error=False)
+
+
+def _err_tool(tool_name: str = "read_file", error_type: str = "FileNotFound") -> ToolResult:
+    return ToolResult(
+        tool_name=tool_name,
+        content="boom",
+        is_error=True,
+        error_type=error_type,
+        error_message="boom-msg",
+    )
+
+
+def _agent_result(
+    *,
+    success: bool = True,
+    tool_results: list[ToolResult] | None = None,
+    response: str = "Done",
+) -> AgentResult:
+    return AgentResult(
+        response=response,
+        success=success,
+        tool_results=tool_results or [],
+        total_duration_ms=100,
+        model_used="qwen3:32b",
+    )
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# run_post_processing — branch coverage
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRunPostProcessing:
+    @pytest.mark.asyncio
+    async def test_no_subsystems_is_noop(self) -> None:
+        gw = _bare_gateway()
+        await run_post_processing(
+            gw,
+            _session(),
+            _wm_with_user("hello"),
+            _agent_result(),
+            None,
+            None,
+        )
+
+    @pytest.mark.asyncio
+    async def test_reflector_runs_when_should_reflect_true(self) -> None:
+        gw = _bare_gateway()
+        reflection = MagicMock()
+        reflection.success_score = 0.9
+        gw._reflector = MagicMock()  # type: ignore[attr-defined]
+        gw._reflector.should_reflect.return_value = True
+        gw._reflector.reflect = AsyncMock(return_value=reflection)
+        result = _agent_result()
+        await run_post_processing(gw, _session(), _wm_with_user("q"), result, None, None)
+        gw._reflector.reflect.assert_awaited_once()
+        assert result.reflection is reflection
+
+    @pytest.mark.asyncio
+    async def test_reflector_skipped_when_should_reflect_false(self) -> None:
+        gw = _bare_gateway()
+        gw._reflector = MagicMock()  # type: ignore[attr-defined]
+        gw._reflector.should_reflect.return_value = False
+        gw._reflector.reflect = AsyncMock()
+        await run_post_processing(gw, _session(), _wm_with_user("q"), _agent_result(), None, None)
+        gw._reflector.reflect.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_reflector_exception_is_swallowed(self) -> None:
+        gw = _bare_gateway()
+        gw._reflector = MagicMock()  # type: ignore[attr-defined]
+        gw._reflector.should_reflect.return_value = True
+        gw._reflector.reflect = AsyncMock(side_effect=RuntimeError("boom"))
+        # MUST NOT raise — reflection failure can never break post-processing
+        await run_post_processing(gw, _session(), _wm_with_user("q"), _agent_result(), None, None)
+
+    @pytest.mark.asyncio
+    async def test_low_score_triggers_evolution_gap_injection(self) -> None:
+        gw = _bare_gateway()
+        reflection = MagicMock()
+        reflection.success_score = 0.1  # below 0.5 threshold
+        gw._reflector = MagicMock()  # type: ignore[attr-defined]
+        gw._reflector.should_reflect.return_value = True
+        gw._reflector.reflect = AsyncMock(return_value=reflection)
+        gw._reflector.apply = AsyncMock(return_value={"episodic": 1})
+        gw._memory_manager = MagicMock()  # type: ignore[attr-defined]
+        gw._deep_learner = MagicMock()  # type: ignore[attr-defined]
+        gw._evolution_loop = MagicMock()  # type: ignore[attr-defined]
+        cfg = MagicMock()
+        cfg.evolution.learning_goals = []
+        gw._config = cfg  # type: ignore[attr-defined]
+
+        wm = _wm_with_user("how do I X")
+        await run_post_processing(gw, _session(), wm, _agent_result(), None, None)
+        # A gap goal was appended
+        assert len(cfg.evolution.learning_goals) == 1
+        assert "Schwache Antwort" in cfg.evolution.learning_goals[0]
+
+    @pytest.mark.asyncio
+    async def test_strategy_memory_records_when_tools_used(self) -> None:
+        gw = _bare_gateway()
+        gw._strategy_memory = MagicMock()  # type: ignore[attr-defined]
+        result = _agent_result(tool_results=[_ok_tool("web_search"), _ok_tool("web_fetch")])
+        await run_post_processing(gw, _session(), _wm_with_user("q"), result, None, None)
+        gw._strategy_memory.record.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_strategy_memory_skipped_when_no_tools(self) -> None:
+        gw = _bare_gateway()
+        gw._strategy_memory = MagicMock()  # type: ignore[attr-defined]
+        await run_post_processing(gw, _session(), _wm_with_user("q"), _agent_result(), None, None)
+        gw._strategy_memory.record.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_skill_registry_records_usage_for_active_skill(self) -> None:
+        gw = _bare_gateway()
+        gw._skill_registry = MagicMock()  # type: ignore[attr-defined]
+        active_skill = MagicMock()
+        active_skill.skill.slug = "my-skill"
+        active_skill.procedure_name = "proc-1"
+        await run_post_processing(
+            gw, _session(), _wm_with_user("q"), _agent_result(), active_skill, None
+        )
+        gw._skill_registry.record_usage.assert_called_once()
+        call_kwargs = gw._skill_registry.record_usage.call_args.kwargs
+        assert call_kwargs["success"] is True
+        # No reflection → falls back to 0.8 for success
+        assert call_kwargs["score"] == 0.8
+
+    @pytest.mark.asyncio
+    async def test_task_telemetry_extracts_first_error(self) -> None:
+        gw = _bare_gateway()
+        gw._task_telemetry = MagicMock()  # type: ignore[attr-defined]
+        result = _agent_result(
+            success=False,
+            tool_results=[_ok_tool("a"), _err_tool("b", "TimeoutError")],
+        )
+        await run_post_processing(gw, _session(), _wm_with_user("q"), result, None, None)
+        kwargs = gw._task_telemetry.record_task.call_args.kwargs
+        assert kwargs["error_type"] == "TimeoutError"
+        assert kwargs["success"] is False
+        assert kwargs["tool_calls"] == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_task_profiler_finishes_with_score(self) -> None:
+        gw = _bare_gateway()
+        gw._task_profiler = MagicMock()  # type: ignore[attr-defined]
+        await run_post_processing(
+            gw, _session(), _wm_with_user("q"), _agent_result(success=False), None, None
+        )
+        kwargs = gw._task_profiler.finish_task.call_args.kwargs
+        assert kwargs["session_id"] == "sess-12345678"
+        # No reflection + failure → 0.3
+        assert kwargs["success_score"] == 0.3
+
+    @pytest.mark.asyncio
+    async def test_run_recorder_only_called_when_run_id_present(self) -> None:
+        gw = _bare_gateway()
+        gw._run_recorder = MagicMock()  # type: ignore[attr-defined]
+        await run_post_processing(gw, _session(), _wm_with_user("q"), _agent_result(), None, None)
+        gw._run_recorder.finish_run.assert_not_called()
+        await run_post_processing(
+            gw, _session(), _wm_with_user("q"), _agent_result(), None, "RUN-1"
+        )
+        gw._run_recorder.finish_run.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_response_truncated_to_500_chars_in_run_recorder(self) -> None:
+        gw = _bare_gateway()
+        gw._run_recorder = MagicMock()  # type: ignore[attr-defined]
+        big = "x" * 1000
+        await run_post_processing(
+            gw,
+            _session(),
+            _wm_with_user("q"),
+            _agent_result(response=big),
+            None,
+            "RUN-1",
+        )
+        kwargs = gw._run_recorder.finish_run.call_args.kwargs
+        assert len(kwargs["final_response"]) == 500
+
+    @pytest.mark.asyncio
+    async def test_reflexion_records_unknown_error(self) -> None:
+        gw = _bare_gateway()
+        rm = MagicMock()
+        rm.get_solution.return_value = None
+        gw._reflexion_memory = rm  # type: ignore[attr-defined]
+        result = _agent_result(success=False, tool_results=[_err_tool("read_file")])
+        await run_post_processing(
+            gw, _session(), _wm_with_user("read /etc/passwd"), result, None, None
+        )
+        rm.record_error.assert_called_once()
+        assert rm.get_solution.called
+
+    @pytest.mark.asyncio
+    async def test_reflexion_logs_known_solution_without_recording(self) -> None:
+        gw = _bare_gateway()
+        rm = MagicMock()
+        rm.get_solution.return_value = MagicMock(prevention_rule="check-existence")
+        gw._reflexion_memory = rm  # type: ignore[attr-defined]
+        result = _agent_result(success=False, tool_results=[_err_tool("read_file")])
+        await run_post_processing(gw, _session(), _wm_with_user("q"), result, None, None)
+        rm.record_error.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# maybe_record_pattern (branch coverage beyond test_pattern_documentation.py)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestMaybeRecordPattern:
+    def test_no_user_message_skips_recording(self) -> None:
+        gw = _bare_gateway()
+        gw._memory_manager = MagicMock()  # type: ignore[attr-defined]
+        procedural = MagicMock()
+        procedural.search_procedures.return_value = ""
+        gw._memory_manager.procedural = procedural
+        wm = WorkingMemory()  # no user message
+        maybe_record_pattern(
+            gw,
+            _session(),
+            wm,
+            _agent_result(tool_results=[_ok_tool("web_search")]),
+        )
+        procedural.save_procedure.assert_not_called()
+
+    def test_only_stopwords_skips_recording(self) -> None:
+        gw = _bare_gateway()
+        gw._memory_manager = MagicMock()  # type: ignore[attr-defined]
+        procedural = MagicMock()
+        procedural.search_procedures.return_value = ""
+        gw._memory_manager.procedural = procedural
+        # All words ≤3 chars or in stopword list
+        maybe_record_pattern(
+            gw,
+            _session(),
+            _wm_with_user("the and for"),
+            _agent_result(tool_results=[_ok_tool("web_search")]),
+        )
+        procedural.save_procedure.assert_not_called()
+
+    def test_pattern_recorded_with_keywords_and_tools(self) -> None:
+        gw = _bare_gateway()
+        gw._memory_manager = MagicMock()  # type: ignore[attr-defined]
+        procedural = MagicMock()
+        procedural.search_procedures.return_value = ""
+        gw._memory_manager.procedural = procedural
+        gw._pattern_record_timestamps = []  # type: ignore[attr-defined]
+
+        maybe_record_pattern(
+            gw,
+            _session(),
+            _wm_with_user("Search Python tutorials online today"),
+            _agent_result(tool_results=[_ok_tool("web_search"), _ok_tool("search_and_read")]),
+        )
+        procedural.save_procedure.assert_called_once()
+        kwargs = procedural.save_procedure.call_args.kwargs
+        body: str = kwargs["body"]
+        assert "web_search" in body
+        assert "search_and_read" in body
+        # Timestamp pushed for rate limiting
+        assert len(gw._pattern_record_timestamps) == 1
+
+    def test_no_memory_manager_is_noop(self) -> None:
+        gw = _bare_gateway()
+        # Must not raise
+        maybe_record_pattern(
+            gw,
+            _session(),
+            _wm_with_user("Search Python tutorials online today"),
+            _agent_result(tool_results=[_ok_tool("web_search")]),
+        )
+
+    def test_internal_exception_is_swallowed(self) -> None:
+        gw = _bare_gateway()
+        gw._memory_manager = MagicMock()  # type: ignore[attr-defined]
+        procedural = MagicMock()
+        procedural.search_procedures.side_effect = RuntimeError("blow up")
+        gw._memory_manager.procedural = procedural
+        # Must not raise even though search_procedures throws
+        maybe_record_pattern(
+            gw,
+            _session(),
+            _wm_with_user("Search Python tutorials online today"),
+            _agent_result(tool_results=[_ok_tool("web_search")]),
+        )
+
+    def test_tool_result_without_tool_name_filtered(self) -> None:
+        gw = _bare_gateway()
+        gw._memory_manager = MagicMock()  # type: ignore[attr-defined]
+        procedural = MagicMock()
+        procedural.search_procedures.return_value = ""
+        gw._memory_manager.procedural = procedural
+        gw._pattern_record_timestamps = []  # type: ignore[attr-defined]
+        # ToolResult with empty tool_name → filtered out
+        empty = ToolResult(tool_name="", content="x", is_error=False)
+        maybe_record_pattern(
+            gw,
+            _session(),
+            _wm_with_user("Search Python tutorials online today"),
+            _agent_result(tool_results=[empty]),
+        )
+        procedural.save_procedure.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# persist_session
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPersistSession:
+    @pytest.mark.asyncio
+    async def test_no_session_store_is_noop(self) -> None:
+        gw = _bare_gateway()
+        await persist_session(gw, _session(), _wm_with_user("q"))
+        # No exception → fine
+
+    @pytest.mark.asyncio
+    async def test_normal_session_persists_session_and_history(self) -> None:
+        gw = _bare_gateway()
+        gw._session_store = MagicMock()  # type: ignore[attr-defined]
+        # Disable auto_title attribute completely so the second branch
+        # doesn't fire
+        del gw._session_store.auto_title
+        wm = _wm_with_user("hello world")
+        await persist_session(gw, _session(), wm)
+        gw._session_store.save_session.assert_called_once()
+        gw._session_store.save_chat_history.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_incognito_only_saves_metadata(self) -> None:
+        gw = _bare_gateway()
+        gw._session_store = MagicMock()  # type: ignore[attr-defined]
+        sess = SessionContext(session_id="x", channel="cli", incognito=True)
+        await persist_session(gw, sess, _wm_with_user("q"))
+        gw._session_store.save_session.assert_called_once()
+        # Chat history is NEVER persisted in incognito mode
+        gw._session_store.save_chat_history.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_session_store_save_exception_is_swallowed(self) -> None:
+        gw = _bare_gateway()
+        gw._session_store = MagicMock()  # type: ignore[attr-defined]
+        gw._session_store.save_session.side_effect = RuntimeError("disk full")
+        # Must not raise
+        await persist_session(gw, _session(), _wm_with_user("q"))
+
+    @pytest.mark.asyncio
+    async def test_auto_title_called_when_available(self) -> None:
+        gw = _bare_gateway()
+        store = MagicMock()
+        store.auto_title = MagicMock()
+        gw._session_store = store  # type: ignore[attr-defined]
+        await persist_session(gw, _session(), _wm_with_user("q"))
+        store.auto_title.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_auto_title_exception_is_swallowed(self) -> None:
+        gw = _bare_gateway()
+        store = MagicMock()
+        store.auto_title.side_effect = RuntimeError("boom")
+        gw._session_store = store  # type: ignore[attr-defined]
+        # Must not raise
+        await persist_session(gw, _session(), _wm_with_user("q"))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# persist_key_tool_results
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPersistKeyToolResults:
+    def test_empty_results_is_noop(self) -> None:
+        gw = _bare_gateway()
+        gw._CONTEXT_TOOLS = Gateway._CONTEXT_TOOLS  # type: ignore[attr-defined]
+        gw._CONTEXT_RESULT_LIMIT = Gateway._CONTEXT_RESULT_LIMIT  # type: ignore[attr-defined]
+        wm = WorkingMemory()
+        persist_key_tool_results(gw, wm, [])
+        assert wm.chat_history == []
+
+    def test_failed_result_skipped(self) -> None:
+        gw = _bare_gateway()
+        gw._CONTEXT_TOOLS = Gateway._CONTEXT_TOOLS  # type: ignore[attr-defined]
+        gw._CONTEXT_RESULT_LIMIT = Gateway._CONTEXT_RESULT_LIMIT  # type: ignore[attr-defined]
+        wm = WorkingMemory()
+        persist_key_tool_results(gw, wm, [_err_tool("web_search")])
+        assert wm.chat_history == []
+
+    def test_non_context_tool_skipped(self) -> None:
+        gw = _bare_gateway()
+        gw._CONTEXT_TOOLS = Gateway._CONTEXT_TOOLS  # type: ignore[attr-defined]
+        gw._CONTEXT_RESULT_LIMIT = Gateway._CONTEXT_RESULT_LIMIT  # type: ignore[attr-defined]
+        wm = WorkingMemory()
+        # "list_files" not in CONTEXT_TOOLS
+        persist_key_tool_results(gw, wm, [_ok_tool("list_files", "blob")])
+        assert wm.chat_history == []
+
+    def test_empty_content_skipped(self) -> None:
+        gw = _bare_gateway()
+        gw._CONTEXT_TOOLS = Gateway._CONTEXT_TOOLS  # type: ignore[attr-defined]
+        gw._CONTEXT_RESULT_LIMIT = Gateway._CONTEXT_RESULT_LIMIT  # type: ignore[attr-defined]
+        wm = WorkingMemory()
+        persist_key_tool_results(gw, wm, [_ok_tool("web_search", "   ")])
+        assert wm.chat_history == []
+
+    def test_context_tool_persisted_as_tool_message(self) -> None:
+        gw = _bare_gateway()
+        gw._CONTEXT_TOOLS = Gateway._CONTEXT_TOOLS  # type: ignore[attr-defined]
+        gw._CONTEXT_RESULT_LIMIT = Gateway._CONTEXT_RESULT_LIMIT  # type: ignore[attr-defined]
+        wm = WorkingMemory()
+        persist_key_tool_results(gw, wm, [_ok_tool("web_search", "found 3 results")])
+        assert len(wm.chat_history) == 1
+        msg = wm.chat_history[0]
+        assert msg.role == MessageRole.TOOL
+        assert msg.name == "web_search"
+        assert msg.content == "found 3 results"
+
+    def test_oversized_content_truncated_with_marker(self) -> None:
+        gw = _bare_gateway()
+        gw._CONTEXT_TOOLS = Gateway._CONTEXT_TOOLS  # type: ignore[attr-defined]
+        # Force a tiny limit so we don't have to build a 4001-char fixture
+        gw._CONTEXT_RESULT_LIMIT = 10  # type: ignore[attr-defined]
+        wm = WorkingMemory()
+        persist_key_tool_results(gw, wm, [_ok_tool("web_search", "0123456789ABCDEF")])
+        msg = wm.chat_history[0]
+        assert msg.content.startswith("0123456789")
+        assert "[... gekürzt]" in msg.content
+
+    def test_multiple_results_all_persisted_in_order(self) -> None:
+        gw = _bare_gateway()
+        gw._CONTEXT_TOOLS = Gateway._CONTEXT_TOOLS  # type: ignore[attr-defined]
+        gw._CONTEXT_RESULT_LIMIT = Gateway._CONTEXT_RESULT_LIMIT  # type: ignore[attr-defined]
+        wm = WorkingMemory()
+        persist_key_tool_results(
+            gw,
+            wm,
+            [
+                _ok_tool("web_search", "first"),
+                _ok_tool("web_fetch", "second"),
+                _err_tool("web_search"),  # skipped
+                _ok_tool("not_in_context", "skipped"),  # skipped
+                _ok_tool("media_extract_text", "third"),
+            ],
+        )
+        assert [m.name for m in wm.chat_history] == [
+            "web_search",
+            "web_fetch",
+            "media_extract_text",
+        ]
+        assert [m.content for m in wm.chat_history] == ["first", "second", "third"]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Integration touchpoint: _maybe_record_pattern delegation
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_gateway_method_delegates_to_post_processing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``Gateway._maybe_record_pattern`` is a thin wrapper around
+    ``post_processing.maybe_record_pattern`` — verify it forwards args."""
+    captured: dict[str, Any] = {}
+
+    def fake_mrp(gw: Any, session: Any, wm: Any, agent_result: Any) -> None:
+        captured["gw"] = gw
+        captured["session"] = session
+        captured["wm"] = wm
+        captured["ar"] = agent_result
+
+    monkeypatch.setattr(post_processing, "maybe_record_pattern", fake_mrp)
+    gw = _bare_gateway()
+    sess = _session()
+    wm = _wm_with_user("q")
+    ar = _agent_result()
+    gw._maybe_record_pattern(sess, wm, ar)
+    assert captured == {"gw": gw, "session": sess, "wm": wm, "ar": ar}
+
+
+def test_pattern_rate_limit_prunes_old_timestamps_in_place() -> None:
+    """Old timestamps (>1h) should be pruned from
+    ``gw._pattern_record_timestamps`` even when the rest of the
+    function bails out before recording."""
+    gw = _bare_gateway()
+    gw._memory_manager = MagicMock()  # type: ignore[attr-defined]
+    procedural = MagicMock()
+    procedural.search_procedures.return_value = ""
+    gw._memory_manager.procedural = procedural
+    now = time.monotonic()
+    # Two old + one recent
+    gw._pattern_record_timestamps = [  # type: ignore[attr-defined]
+        now - 7200,
+        now - 7300,
+        now - 10,
+    ]
+    maybe_record_pattern(
+        gw,
+        _session(),
+        _wm_with_user("Find latest research articles online"),
+        _agent_result(tool_results=[_ok_tool("web_search")]),
+    )
+    # Old ones gone; the recent one stays plus the freshly-appended record.
+    assert all(now - ts < 3600 for ts in gw._pattern_record_timestamps)

--- a/tests/test_security/test_agent_vault_deep.py
+++ b/tests/test_security/test_agent_vault_deep.py
@@ -1,0 +1,618 @@
+"""Deep coverage for cognithor.security.agent_vault.
+
+Covers happy-path, edge cases, error paths, and inter-class
+isolation invariants for ``AgentSecret``, ``AgentVault``,
+``VaultRotator``, ``IsolatedSessionStore``, ``SessionFirewall``,
+and ``AgentVaultManager``.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from cognithor.security.agent_vault import (
+    AgentSecret,
+    AgentSession,
+    AgentVault,
+    AgentVaultManager,
+    IsolatedSessionStore,
+    RotationPolicy,
+    SecretStatus,
+    SecretType,
+    SessionFirewall,
+    VaultRotator,
+    _load_or_create_master_secret,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AgentSecret
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAgentSecret:
+    def test_to_dict_omits_encrypted_value(self) -> None:
+        secret = AgentSecret(
+            secret_id="SEC-x-0001",
+            agent_id="agent-x",
+            name="api",
+            secret_type=SecretType.API_KEY,
+            _encrypted_value="cipher",
+        )
+        d = secret.to_dict()
+        assert "secret_id" in d
+        assert "_encrypted_value" not in d
+        # Type field uses the StrEnum value, not the python attr name
+        assert d["type"] == "api_key"
+        assert d["status"] == "active"
+
+    def test_is_active_property(self) -> None:
+        active = AgentSecret(secret_id="s", agent_id="a", name="n", secret_type=SecretType.API_KEY)
+        rotated = AgentSecret(
+            secret_id="s",
+            agent_id="a",
+            name="n",
+            secret_type=SecretType.API_KEY,
+            status=SecretStatus.ROTATED,
+        )
+        assert active.is_active is True
+        assert rotated.is_active is False
+
+    @pytest.mark.parametrize(
+        ("expires_at", "expected"),
+        [
+            ("", False),  # No expiry → never expired
+            ("9999-12-31T23:59:59Z", False),  # Far future
+            ("1970-01-01T00:00:00Z", True),  # Far past
+        ],
+    )
+    def test_is_expired(self, expires_at: str, expected: bool) -> None:
+        secret = AgentSecret(
+            secret_id="s",
+            agent_id="a",
+            name="n",
+            secret_type=SecretType.API_KEY,
+            expires_at=expires_at,
+        )
+        assert secret.is_expired is expected
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AgentVault — happy path + edge cases
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestAgentVaultBasic:
+    def test_store_and_retrieve_round_trip(self) -> None:
+        vault = AgentVault("agent-rt", master_secret=b"deterministic")
+        secret = vault.store("api", "ghp_abcd1234")
+        assert vault.retrieve(secret.secret_id) == "ghp_abcd1234"
+
+    def test_secret_id_is_namespaced_to_agent(self) -> None:
+        vault = AgentVault("agent-z", master_secret=b"m")
+        s1 = vault.store("a", "x")
+        s2 = vault.store("b", "y")
+        assert s1.secret_id.startswith("SEC-")
+        # Counter increments: 0001 → 0002
+        assert s1.secret_id.endswith("0001")
+        assert s2.secret_id.endswith("0002")
+
+    def test_store_encrypted_value_differs_from_plaintext(self) -> None:
+        vault = AgentVault("agent-1", master_secret=b"secret")
+        secret = vault.store("api", "plaintext-secret")
+        # The encrypted blob is base64 Fernet — must differ from the
+        # plaintext and not contain it.
+        assert secret._encrypted_value != "plaintext-secret"
+        assert "plaintext-secret" not in secret._encrypted_value
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "",
+            "x",
+            "a" * 100_000,
+            "über-secret-mit-Ümlauten-😀",
+            "\x00\x01\x02binary-ish",
+        ],
+        ids=["empty", "single_char", "large_100k", "unicode_emoji", "control_chars"],
+    )
+    def test_round_trip_preserves_arbitrary_strings(self, value: str) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        s = vault.store("k", value)
+        assert vault.retrieve(s.secret_id) == value
+
+    def test_retrieve_missing_id_returns_none_and_logs(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        assert vault.retrieve("does-not-exist") is None
+        # Failed lookups still produce an access-log entry
+        log = vault.access_log()
+        assert any(e["action"] == "retrieve_failed" for e in log)
+
+    def test_retrieve_after_revoke_returns_none(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        s = vault.store("k", "v")
+        assert vault.revoke(s.secret_id) is True
+        # Revoked secret is removed from the store entirely
+        assert vault.retrieve(s.secret_id) is None
+
+    def test_revoke_unknown_returns_false(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        assert vault.revoke("SEC-nonexistent-9999") is False
+
+    def test_rotate_changes_value_keeps_id_and_increments_counter(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        s = vault.store("k", "v1")
+        original_id = s.secret_id
+        rotated = vault.rotate(s.secret_id, "v2")
+        assert rotated is not None
+        assert rotated.secret_id == original_id
+        assert rotated.rotation_count == 1
+        assert rotated.last_rotated  # non-empty timestamp
+        assert vault.retrieve(s.secret_id) == "v2"
+
+    def test_rotate_unknown_returns_none(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        assert vault.rotate("SEC-missing-0001", "v") is None
+
+    def test_ttl_secret_has_expiry_set_in_future(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        s = vault.store("k", "v", ttl_hours=24)
+        assert s.expires_at != ""
+        # Format is ISO Z, lexicographically sortable
+        assert s.expires_at > time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    def test_ttl_zero_means_no_expiry(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        s = vault.store("k", "v", ttl_hours=0)
+        assert s.expires_at == ""
+
+    def test_decrypt_invalid_fernet_raises_value_error(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        s = vault.store("k", "v")
+        # Tamper with the cipher: replace with random Fernet-shaped bytes
+        # that won't authenticate
+        s._encrypted_value = "gAAAAABxxxinvalidtokendata"
+        with pytest.raises(ValueError, match="Decryption failed"):
+            vault.retrieve(s.secret_id)
+
+    def test_active_and_all_secrets_diverge_after_revoke(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        s1 = vault.store("a", "v1")
+        s2 = vault.store("b", "v2")
+        assert len(vault.active_secrets()) == 2
+        vault.revoke(s1.secret_id)
+        active = vault.active_secrets()
+        all_ = vault.all_secrets()
+        # Revoke deletes the secret entirely → both lists shrink
+        assert len(active) == 1
+        assert len(all_) == 1
+        assert active[0].secret_id == s2.secret_id
+
+    def test_expire_check_marks_only_overdue(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        # Long-lived secret
+        live = vault.store("live", "v", ttl_hours=24)
+        # Past-dated secret (manually backdate)
+        past = vault.store("past", "v")
+        past.expires_at = "1970-01-01T00:00:00Z"
+        expired = vault.expire_check()
+        assert past in expired
+        assert live not in expired
+        assert past.status is SecretStatus.EXPIRED
+        assert live.status is SecretStatus.ACTIVE
+
+    def test_access_log_returns_recent_first(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        s = vault.store("k", "v")
+        vault.retrieve(s.secret_id)
+        vault.retrieve(s.secret_id)
+        log = vault.access_log(limit=10)
+        # Most recent first
+        assert log[0]["action"] == "retrieve"
+        # Each entry carries agent_id + timestamp
+        assert all(e["agent_id"] == "agent" for e in log)
+        assert all("timestamp" in e for e in log)
+
+    def test_stats_counts_by_status(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        a = vault.store("a", "v")
+        b = vault.store("b", "v")
+        c = vault.store("c", "v")
+        # Mark b expired manually
+        b.status = SecretStatus.EXPIRED
+        # Revoke c (deletes it from the dict)
+        vault.revoke(c.secret_id)
+        stats = vault.stats()
+        assert stats["agent_id"] == "agent"
+        # a is active, b is expired, c is gone (revoked)
+        assert stats["total_secrets"] == 2
+        assert stats["active"] == 1
+        assert stats["expired"] == 1
+        # access_events counts every store/retrieve/revoke logged
+        assert stats["access_events"] >= 4
+        # Sanity-check we exercised the unused secret
+        _ = a.secret_id
+
+    def test_two_vaults_with_same_master_secret_share_keys(self) -> None:
+        # Key derivation is deterministic from agent_id + master_secret.
+        v1 = AgentVault("agent-x", master_secret=b"m")
+        v2 = AgentVault("agent-x", master_secret=b"m")
+        s = v1.store("k", "v")
+        # v2 has independent _secrets dict but the same fernet key, so
+        # it can decrypt v1's ciphertext directly:
+        assert v2._decrypt(s._encrypted_value) == "v"
+
+    def test_two_vaults_with_different_master_secrets_cannot_decrypt(self) -> None:
+        v1 = AgentVault("agent-x", master_secret=b"m1")
+        v2 = AgentVault("agent-x", master_secret=b"m2")
+        s = v1.store("k", "v")
+        with pytest.raises(ValueError, match="Decryption failed"):
+            v2._decrypt(s._encrypted_value)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# VaultRotator
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestVaultRotator:
+    def test_default_policies_loaded(self) -> None:
+        r = VaultRotator()
+        # Should have one policy per default entry
+        assert r.policy_count == len(VaultRotator.DEFAULT_POLICIES)
+        # API_KEY is one of the defaults
+        assert r.get_policy(SecretType.API_KEY) is not None
+
+    def test_no_defaults_skips_loading(self) -> None:
+        r = VaultRotator(load_defaults=False)
+        assert r.policy_count == 0
+        assert r.get_policy(SecretType.API_KEY) is None
+
+    def test_add_policy_overrides_existing(self) -> None:
+        r = VaultRotator()
+        new_policy = RotationPolicy(
+            "ROT-API",  # same id as the default API_KEY policy
+            SecretType.API_KEY,
+            rotation_interval_hours=1,
+            max_age_hours=2,
+        )
+        r.add_policy(new_policy)
+        # Same id → replaces, count unchanged
+        assert r.policy_count == len(VaultRotator.DEFAULT_POLICIES)
+        # get_policy returns the new one for API_KEY
+        got = r.get_policy(SecretType.API_KEY)
+        assert got is not None
+        assert got.rotation_interval_hours == 1
+
+    def test_check_rotation_for_fresh_secret_returns_empty(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        vault.store("k", "v", secret_type=SecretType.API_KEY)
+        r = VaultRotator()
+        assert r.check_rotation_needed(vault) == []
+
+    def test_check_rotation_for_aged_secret(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        s = vault.store("k", "v", secret_type=SecretType.TOKEN)
+        # Token policy: rotate every 24h. Backdate to 25h ago.
+        s.created_at = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - 25 * 3600))
+        s.last_rotated = ""
+        r = VaultRotator()
+        needs = r.check_rotation_needed(vault)
+        assert s in needs
+
+    def test_check_rotation_skips_disabled_policy(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        vault.store("k", "v", secret_type=SecretType.API_KEY)
+        r = VaultRotator(load_defaults=False)
+        r.add_policy(
+            RotationPolicy(
+                "ROT-API-OFF",
+                SecretType.API_KEY,
+                rotation_interval_hours=1,
+                auto_rotate=False,
+            )
+        )
+        # auto_rotate=False → should never propose rotation
+        assert r.check_rotation_needed(vault) == []
+
+    def test_check_rotation_handles_corrupt_timestamp(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        s = vault.store("k", "v", secret_type=SecretType.TOKEN)
+        s.created_at = "not-a-valid-iso-timestamp"
+        s.last_rotated = ""
+        r = VaultRotator()
+        # Falls back to now_ts → age == 0 → no rotation
+        assert r.check_rotation_needed(vault) == []
+
+    def test_auto_rotate_writes_log_entries(self) -> None:
+        vault = AgentVault("agent", master_secret=b"m")
+        s = vault.store("k", "v", secret_type=SecretType.API_KEY)
+        r = VaultRotator()
+        ids = r.auto_rotate(vault)
+        assert s.secret_id in ids
+        stats = r.stats()
+        assert stats["total_rotations"] == 1
+        # The new value differs from the stored "v"
+        assert vault.retrieve(s.secret_id) != "v"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# IsolatedSessionStore
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestIsolatedSessionStore:
+    def test_create_and_get_session(self) -> None:
+        store = IsolatedSessionStore()
+        s = store.create_session("agent-1", tenant_id="tenant-x")
+        got = store.get_session("agent-1", s.session_id)
+        assert got is s
+        assert got.tenant_id == "tenant-x"
+        assert got.is_active is True
+
+    def test_get_session_for_unknown_agent_returns_none(self) -> None:
+        store = IsolatedSessionStore()
+        assert store.get_session("nobody", "SESS-x") is None
+
+    def test_close_session_marks_inactive_keeps_record(self) -> None:
+        store = IsolatedSessionStore()
+        s = store.create_session("agent-1")
+        assert store.close_session("agent-1", s.session_id) is True
+        # Still retrievable, but inactive
+        got = store.get_session("agent-1", s.session_id)
+        assert got is not None
+        assert got.is_active is False
+
+    @pytest.mark.parametrize(
+        ("agent", "session"),
+        [
+            ("nobody", "any-sess"),  # unknown agent
+            ("agent-1", "missing-sess"),  # known agent, unknown session
+        ],
+    )
+    def test_close_session_unknown_returns_false(self, agent: str, session: str) -> None:
+        store = IsolatedSessionStore()
+        store.create_session("agent-1")
+        assert store.close_session(agent, session) is False
+
+    def test_destroy_session_removes_record(self) -> None:
+        store = IsolatedSessionStore()
+        s = store.create_session("agent-1")
+        assert store.destroy_session("agent-1", s.session_id) is True
+        assert store.get_session("agent-1", s.session_id) is None
+        assert store.destroy_session("agent-1", s.session_id) is False
+
+    def test_destroy_session_unknown_agent(self) -> None:
+        store = IsolatedSessionStore()
+        assert store.destroy_session("nobody", "any") is False
+
+    def test_active_vs_all_after_close(self) -> None:
+        store = IsolatedSessionStore()
+        s1 = store.create_session("agent-1")
+        s2 = store.create_session("agent-1")
+        store.close_session("agent-1", s1.session_id)
+        all_sess = store.agent_sessions("agent-1")
+        active_sess = store.active_sessions("agent-1")
+        assert len(all_sess) == 2
+        assert len(active_sess) == 1
+        assert active_sess[0].session_id == s2.session_id
+
+    def test_purge_agent_returns_count_and_clears(self) -> None:
+        store = IsolatedSessionStore()
+        store.create_session("a")
+        store.create_session("a")
+        store.create_session("b")
+        n = store.purge_agent("a")
+        assert n == 2
+        assert store.agent_sessions("a") == []
+        # Other agent untouched
+        assert len(store.agent_sessions("b")) == 1
+
+    def test_purge_unknown_agent_returns_zero(self) -> None:
+        store = IsolatedSessionStore()
+        assert store.purge_agent("nobody") == 0
+
+    def test_stats_aggregate(self) -> None:
+        store = IsolatedSessionStore()
+        store.create_session("a")
+        s2 = store.create_session("a")
+        store.create_session("b")
+        store.close_session("a", s2.session_id)
+        stats = store.stats()
+        assert stats["agent_stores"] == 2
+        assert stats["total_sessions"] == 3
+        assert stats["active_sessions"] == 2
+
+    def test_session_to_dict_lists_data_keys(self) -> None:
+        store = IsolatedSessionStore()
+        s = store.create_session("a", data={"role": "user", "lang": "de"})
+        d = s.to_dict()
+        assert set(d["data_keys"]) == {"role", "lang"}
+        assert d["active"] is True
+        assert d["agent_id"] == "a"
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SessionFirewall
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestSessionFirewall:
+    def test_same_agent_authorized(self) -> None:
+        fw = SessionFirewall(IsolatedSessionStore())
+        assert fw.authorize("agent-1", "agent-1", "SESS-x") is True
+        assert fw.violation_count == 0
+
+    def test_cross_agent_blocked_and_logged(self) -> None:
+        fw = SessionFirewall(IsolatedSessionStore())
+        assert fw.authorize("attacker", "victim", "SESS-x") is False
+        assert fw.violation_count == 1
+        v = fw.violations()[0]
+        assert v["requester"] == "attacker"
+        assert v["target"] == "victim"
+        assert v["action"] == "BLOCKED"
+
+    def test_violations_returns_recent_first(self) -> None:
+        fw = SessionFirewall(IsolatedSessionStore())
+        fw.authorize("att1", "victim", "S1")
+        fw.authorize("att2", "victim", "S2")
+        violations = fw.violations(limit=10)
+        # Most recent first
+        assert violations[0]["requester"] == "att2"
+        assert violations[1]["requester"] == "att1"
+
+    def test_stats_counts_unique_attackers(self) -> None:
+        fw = SessionFirewall(IsolatedSessionStore())
+        fw.authorize("att1", "victim", "S1")
+        fw.authorize("att1", "victim", "S2")  # same attacker again
+        fw.authorize("att2", "victim", "S3")
+        stats = fw.stats()
+        assert stats["total_violations"] == 3
+        assert stats["unique_attackers"] == 2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AgentVaultManager (uses tmp_path to avoid touching ~/.cognithor/)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def vault_manager(tmp_path: Path) -> AgentVaultManager:
+    """AgentVaultManager with master-secret in tmp_path (no ~/.cognithor write)."""
+    return AgentVaultManager(master_secret_path=str(tmp_path / "vault_master.key"))
+
+
+class TestAgentVaultManager:
+    def test_create_vault_persists_in_manager(self, vault_manager: AgentVaultManager) -> None:
+        v = vault_manager.create_vault("agent-1")
+        assert vault_manager.get_vault("agent-1") is v
+        assert vault_manager.vault_count == 1
+
+    def test_get_unknown_vault_returns_none(self, vault_manager: AgentVaultManager) -> None:
+        assert vault_manager.get_vault("nobody") is None
+
+    def test_destroy_vault_revokes_secrets_and_purges_sessions(
+        self, vault_manager: AgentVaultManager
+    ) -> None:
+        v = vault_manager.create_vault("agent-1")
+        v.store("k", "secret-value")
+        vault_manager.sessions.create_session("agent-1")
+        assert vault_manager.destroy_vault("agent-1") is True
+        # Vault gone
+        assert vault_manager.get_vault("agent-1") is None
+        # Sessions purged
+        assert vault_manager.sessions.agent_sessions("agent-1") == []
+
+    def test_destroy_unknown_vault_returns_false(self, vault_manager: AgentVaultManager) -> None:
+        assert vault_manager.destroy_vault("nobody") is False
+
+    def test_rotate_all_returns_per_agent_results(self, vault_manager: AgentVaultManager) -> None:
+        v_a = vault_manager.create_vault("agent-a")
+        v_b = vault_manager.create_vault("agent-b")
+        v_a.store("k", "v", secret_type=SecretType.API_KEY)
+        v_b.store("k", "v", secret_type=SecretType.API_KEY)
+        results = vault_manager.rotate_all()
+        # Both agents had at least one secret rotated
+        assert "agent-a" in results
+        assert "agent-b" in results
+        assert len(results["agent-a"]) == 1
+        assert len(results["agent-b"]) == 1
+
+    def test_stats_aggregates_all_subsystems(self, vault_manager: AgentVaultManager) -> None:
+        v = vault_manager.create_vault("agent-1")
+        v.store("k", "v")
+        vault_manager.sessions.create_session("agent-1")
+        # Trigger a firewall violation
+        vault_manager.firewall.authorize("att", "agent-1", "S1")
+        stats = vault_manager.stats()
+        assert stats["total_vaults"] == 1
+        assert stats["total_secrets"] == 1
+        assert stats["sessions"]["total_sessions"] == 1
+        assert stats["firewall"]["total_violations"] == 1
+        assert stats["rotation"]["policies"] == len(VaultRotator.DEFAULT_POLICIES)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _load_or_create_master_secret (file-system contract)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestLoadOrCreateMasterSecret:
+    def test_creates_32_byte_file_when_missing(self, tmp_path: Path) -> None:
+        key_file = tmp_path / "vault_master.key"
+        assert not key_file.exists()
+        secret = _load_or_create_master_secret(str(key_file))
+        assert key_file.exists()
+        assert len(secret) == 32
+        # File on disk matches what we got back
+        assert key_file.read_bytes()[:32] == secret
+
+    def test_loads_existing_secret_unchanged(self, tmp_path: Path) -> None:
+        key_file = tmp_path / "vault_master.key"
+        original = b"x" * 32 + b"trailing-data-ignored"
+        key_file.write_bytes(original)
+        secret = _load_or_create_master_secret(str(key_file))
+        # Returns first 32 bytes only
+        assert secret == b"x" * 32
+        # File content untouched
+        assert key_file.read_bytes() == original
+
+    def test_truncated_file_is_regenerated(self, tmp_path: Path) -> None:
+        key_file = tmp_path / "vault_master.key"
+        key_file.write_bytes(b"too-short")
+        secret = _load_or_create_master_secret(str(key_file))
+        # Regenerated to full 32 bytes
+        assert len(secret) == 32
+        assert key_file.read_bytes()[:32] == secret
+
+    def test_uses_cognithor_home_env_when_no_path(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Steer the default path to tmp_path so we don't touch ~/.cognithor/
+        monkeypatch.setenv("COGNITHOR_HOME", str(tmp_path))
+        secret = _load_or_create_master_secret(None)
+        assert (tmp_path / "vault_master.key").exists()
+        assert len(secret) == 32
+
+    def test_two_calls_with_same_path_return_same_secret(self, tmp_path: Path) -> None:
+        path = str(tmp_path / "vault_master.key")
+        s1 = _load_or_create_master_secret(path)
+        s2 = _load_or_create_master_secret(path)
+        assert s1 == s2
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# RotationPolicy.to_dict (small but worth one assertion)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRotationPolicy:
+    def test_to_dict_uses_enum_value(self) -> None:
+        p = RotationPolicy("ROT-X", SecretType.PASSWORD)
+        d = p.to_dict()
+        assert d["type"] == "password"
+        assert d["policy_id"] == "ROT-X"
+        assert d["auto"] is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# AgentSession dataclass — quick sanity
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def test_agent_session_default_data_factory_is_independent() -> None:
+    """Ensure ``data: dict[str, Any] = field(default_factory=dict)``
+    does not leak state between instances (classic mutable-default bug)."""
+    s1 = AgentSession(session_id="A", agent_id="a")
+    s2 = AgentSession(session_id="B", agent_id="a")
+    s1.data["x"] = 1
+    assert "x" not in s2.data
+    # mypy --strict needs this dict to be Any-valued
+    s2.data["y"] = "str"
+    typed: dict[str, Any] = s1.data
+    assert typed["x"] == 1


### PR DESCRIPTION
## Summary

Two previously-thin backend modules now have deep branch-coverage tests. Total: **99 new tests** (target was ~30; doubled-up via parametrize). All green locally and clean on `ruff check` + `ruff format --check`.

| File | Tests | Coverage |
|---|---|---|
| `tests/test_security/test_agent_vault_deep.py` | **64** | AgentSecret + AgentVault (round-trip, unicode/emoji/100k payloads, tampered-cipher ValueError, revoke/rotate/expire, deterministic key-derivation, cross-master-secret isolation), VaultRotator (default policies, override, fresh/aged/disabled/corrupt-timestamp), IsolatedSessionStore (create/close/destroy/purge/active-vs-all), SessionFirewall (allow/deny/log), AgentVaultManager (create/destroy/rotate_all/stats), `_load_or_create_master_secret` (create + load + truncate + COGNITHOR_HOME env), RotationPolicy.to_dict, AgentSession.data factory independence |
| `tests/test_gateway/test_post_processing_deep.py` | **35** | `run_post_processing` branches (reflector exception, low-score → evolution gap, strategy_memory, skill_registry, task_telemetry first-error pickup, task_profiler, run_recorder + 500-char truncation, reflexion known/unknown), `maybe_record_pattern` (no user message, only-stopwords, persistence, no memory_manager, internal exception swallow, missing tool_name filter, rate-limit pruning), `persist_session` (no store, normal vs incognito, auto_title, exception swallow), `persist_key_tool_results` (empty/failed/non-context/empty-content/normal/oversized-truncation/multi-ordering), `Gateway._maybe_record_pattern` delegation |

Pattern follows the existing `test_pattern_documentation.py` and `test_vault_provenance.py`: instantiate `Gateway.__new__(Gateway)` and seed only the attributes the function under test reads, mock everything else.

## Test plan

- [x] `pytest tests/test_security/test_agent_vault_deep.py tests/test_gateway/test_post_processing_deep.py -v` — 99 passed in ~3s
- [x] `pytest tests/test_security/ -q` — 1571 passed, 1 skipped (no regressions)
- [x] `pytest tests/test_gateway/ -q` — 358 passed (no regressions)
- [x] `ruff check src/cognithor/ tests/` — clean
- [x] `ruff format --check src/cognithor/ tests/` — clean
- [ ] Full CI matrix

## Notes

- `mypy --strict` per-test-file currently flags `import-untyped` for `cognithor.*` because the editable install lacks a `py.typed` marker. CI only runs mypy against `src/cognithor/` (workflow `ci.yml` line 77), so this is consistent with the existing `tests/test_security/test_vault_provenance.py` pattern. No source changes were made.