### PR TITLE
test(vscode): receipt_view + ws_client + mcp_bridge unit suites (~15 tests)

### DIFF
--- a/extensions/vscode/test/unit/mcp_bridge.test.ts
+++ b/extensions/vscode/test/unit/mcp_bridge.test.ts
@@ -1,0 +1,251 @@
+import { strict as assert } from "assert";
+import { EventEmitter, Readable, Writable } from "stream";
+import * as Module from "module";
+import * as actualChildProcess from "child_process";
+
+/**
+ * Hijack `child_process.spawn` before mcp_bridge.ts imports it.
+ * The require hook returns a wrapper that delegates `spawn` to a
+ * fake-process factory under our control. All other exports stay
+ * real so transitive `child_process.exec` etc. (used by VS Code
+ * dependencies indirectly) keep working.
+ */
+
+interface SpawnRecord {
+  command: string;
+  args: readonly string[];
+  options: actualChildProcess.SpawnOptions;
+  child: FakeChildProcess;
+}
+
+const spawnLog: SpawnRecord[] = [];
+
+class FakeStdin extends Writable {
+  public lines: string[] = [];
+  override _write(
+    chunk: Buffer | string,
+    _enc: BufferEncoding,
+    cb: (err?: Error | null) => void,
+  ): void {
+    const text = typeof chunk === "string" ? chunk : chunk.toString("utf-8");
+    // mcp_bridge writes one JSON-RPC message per line.
+    for (const line of text.split("\n")) {
+      if (line !== "") this.lines.push(line);
+    }
+    cb();
+  }
+}
+
+class FakeStdout extends Readable {
+  override _read(): void {
+    /* push happens externally via .push() */
+  }
+  pushLine(line: string): void {
+    this.push(line + "\n");
+  }
+}
+
+class FakeChildProcess extends EventEmitter {
+  public stdin = new FakeStdin();
+  public stdout = new FakeStdout();
+  public stderr = new FakeStdout();
+  public killed = false;
+  public lastSignal: string | null = null;
+  public pid = 12345;
+  kill(signal?: string): boolean {
+    this.killed = true;
+    this.lastSignal = signal ?? "SIGTERM";
+    return true;
+  }
+}
+
+function fakeSpawn(
+  command: string,
+  args?: readonly string[],
+  options?: actualChildProcess.SpawnOptions,
+): FakeChildProcess {
+  const child = new FakeChildProcess();
+  spawnLog.push({
+    command,
+    args: args ?? [],
+    options: options ?? {},
+    child,
+  });
+  return child;
+}
+
+interface ProtoRequire {
+  (this: NodeJS.Module, id: string): unknown;
+}
+const proto = (Module as unknown as { prototype: { require: ProtoRequire } }).prototype;
+const originalRequire = proto.require;
+proto.require = function (this: NodeJS.Module, id: string): unknown {
+  if (id === "child_process") {
+    return {
+      ...actualChildProcess,
+      spawn: fakeSpawn,
+    };
+  }
+  return originalRequire.call(this, id);
+};
+
+// Now load the SUT under the hook.
+import {
+  DEFAULT_BRIDGE_CONFIG,
+  McpBridge,
+  readBridgeConfig,
+  type BridgeConfig,
+} from "../../src/mcp_bridge";
+import { setConfig, resetConfig } from "./vscode-mock";
+
+const fastConfig: BridgeConfig = {
+  ...DEFAULT_BRIDGE_CONFIG,
+  cliPath: "fake-cognithor",
+  heartbeatMs: 60_000, // long — heartbeat won't fire in any test
+  pongTimeoutMs: 1_000,
+  restartBackoffMs: 50,
+  maxRestarts: 2,
+  requestTimeoutMs: 1_000,
+};
+
+function lastChild(): FakeChildProcess {
+  return spawnLog[spawnLog.length - 1]!.child;
+}
+
+function flushIo(times = 4): Promise<void> {
+  return new Promise((resolve) => {
+    let n = times;
+    const tick = (): void => {
+      if (n-- <= 0) {
+        resolve();
+        return;
+      }
+      setImmediate(tick);
+    };
+    tick();
+  });
+}
+
+describe("McpBridge", () => {
+  beforeEach(() => {
+    spawnLog.length = 0;
+  });
+
+  it("spawns the configured CLI with `mcp --stdio` args and reaches onReady after handshake", async () => {
+    const bridge = new McpBridge(fastConfig);
+    let ready = false;
+    bridge.onReady(() => {
+      ready = true;
+    });
+    const startPromise = bridge.start();
+    await flushIo();
+    const rec = spawnLog[0]!;
+    assert.equal(rec.command, "fake-cognithor");
+    assert.deepEqual(rec.args, ["mcp", "--stdio"]);
+    // The handshake call serialised one JSON-RPC `initialize` message.
+    const initLine = rec.child.stdin.lines[0]!;
+    const parsed = JSON.parse(initLine) as Record<string, unknown>;
+    assert.equal(parsed.method, "initialize");
+    assert.equal(parsed.jsonrpc, "2.0");
+    assert.equal(parsed.id, 1);
+    // Respond so handshake completes.
+    rec.child.stdout.pushLine(JSON.stringify({ jsonrpc: "2.0", id: 1, result: { ok: true } }));
+    await startPromise;
+    assert.equal(ready, true);
+    const stopPromise = bridge.stop();
+    rec.child.emit("exit", 0);
+    await stopPromise;
+  });
+
+  it("call() correlates response by id and resolves with the result", async () => {
+    const bridge = new McpBridge(fastConfig);
+    const startPromise = bridge.start();
+    await flushIo();
+    const child = lastChild();
+    child.stdout.pushLine(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }));
+    await startPromise;
+    // Now make a real call and satisfy it.
+    const callPromise = bridge.call("video_render", { run_id: "r1" });
+    await flushIo();
+    const lastLine = child.stdin.lines[child.stdin.lines.length - 1]!;
+    const sent = JSON.parse(lastLine) as Record<string, unknown>;
+    assert.equal(sent.method, "video_render");
+    assert.equal(sent.id, 2);
+    child.stdout.pushLine(
+      JSON.stringify({ jsonrpc: "2.0", id: 2, result: { mp4_path: "/tmp/x.mp4" } }),
+    );
+    const result = (await callPromise) as { mp4_path: string };
+    assert.equal(result.mp4_path, "/tmp/x.mp4");
+    const stopPromise = bridge.stop();
+    child.emit("exit", 0);
+    await stopPromise;
+  });
+
+  it("call() rejects when the server returns a JSON-RPC error", async () => {
+    const bridge = new McpBridge(fastConfig);
+    const startPromise = bridge.start();
+    await flushIo();
+    const child = lastChild();
+    child.stdout.pushLine(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }));
+    await startPromise;
+    const callPromise = bridge.call("broken_tool");
+    await flushIo();
+    child.stdout.pushLine(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        error: { code: -32602, message: "invalid params" },
+      }),
+    );
+    await assert.rejects(callPromise, /invalid params/);
+    const stopPromise = bridge.stop();
+    child.emit("exit", 0);
+    await stopPromise;
+  });
+
+  it("ignores malformed stdout lines, surfaces them via onLog, and keeps working", async () => {
+    const bridge = new McpBridge(fastConfig);
+    const logs: string[] = [];
+    bridge.onLog((s) => logs.push(s));
+    const startPromise = bridge.start();
+    await flushIo();
+    const child = lastChild();
+    child.stdout.pushLine("this is not json");
+    child.stdout.pushLine(""); // blank — explicitly skipped
+    child.stdout.pushLine(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }));
+    await startPromise;
+    assert.ok(
+      logs.some((l) => l.startsWith("malformed stdout line")),
+      "malformed line should surface via onLog",
+    );
+    const stopPromise = bridge.stop();
+    child.emit("exit", 0);
+    await stopPromise;
+  });
+
+  it("stop() rejects in-flight requests and SIGTERMs the child", async () => {
+    const bridge = new McpBridge(fastConfig);
+    const startPromise = bridge.start();
+    await flushIo();
+    const child = lastChild();
+    child.stdout.pushLine(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }));
+    await startPromise;
+    const inflight = bridge.call("never_resolves");
+    await flushIo();
+    // Make stop() resolve quickly by emitting `exit` immediately.
+    const stopPromise = bridge.stop();
+    child.emit("exit", 0);
+    await stopPromise;
+    assert.equal(child.lastSignal, "SIGTERM");
+    await assert.rejects(inflight, /MCP bridge stopped/);
+  });
+
+  it("readBridgeConfig pulls cliPath from workspace settings, defaults the rest", () => {
+    resetConfig();
+    setConfig({ "cognithor.cliPath": "/usr/local/bin/cognithor" });
+    const cfg = readBridgeConfig();
+    assert.equal(cfg.cliPath, "/usr/local/bin/cognithor");
+    assert.equal(cfg.heartbeatMs, DEFAULT_BRIDGE_CONFIG.heartbeatMs);
+    assert.equal(cfg.maxRestarts, DEFAULT_BRIDGE_CONFIG.maxRestarts);
+  });
+});

--- a/extensions/vscode/test/unit/receipt_view.test.ts
+++ b/extensions/vscode/test/unit/receipt_view.test.ts
@@ -1,0 +1,165 @@
+import { strict as assert } from "assert";
+import * as http from "node:http";
+import * as sinon from "sinon";
+import { FakeMemento, FakeWebviewPanel, getMock, resetConfig, resetMockSpies, setConfig } from "./vscode-mock";
+
+import {
+  readReceiptConfig,
+  ReceiptTreeProvider,
+  ReceiptViewer,
+} from "../../src/receipt_view";
+
+interface CapturedRequest {
+  path: string;
+  host: string;
+  port: number;
+  method: string;
+  headers: Record<string, string>;
+}
+
+function startStubServer(
+  responder: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+): Promise<{ port: number; close: () => Promise<void>; requests: CapturedRequest[] }> {
+  const requests: CapturedRequest[] = [];
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      requests.push({
+        path: req.url ?? "",
+        host: "127.0.0.1",
+        port: (server.address() as { port: number }).port,
+        method: req.method ?? "GET",
+        headers: req.headers as Record<string, string>,
+      });
+      responder(req, res);
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const port = (server.address() as { port: number }).port;
+      resolve({
+        port,
+        close: () =>
+          new Promise<void>((res) => {
+            server.close(() => res());
+          }),
+        requests,
+      });
+    });
+  });
+}
+
+describe("ReceiptViewer + ReceiptTreeProvider", () => {
+  beforeEach(() => {
+    resetConfig();
+    resetMockSpies();
+  });
+
+  it("readReceiptConfig pulls host/port/includeTrust from workspace settings", () => {
+    setConfig({
+      "cognithor.apiHost": "10.0.0.5",
+      "cognithor.apiPort": 9999,
+      "cognithor.receiptIncludeTrust": false,
+    });
+    const cfg = readReceiptConfig();
+    assert.equal(cfg.apiHost, "10.0.0.5");
+    assert.equal(cfg.apiPort, 9999);
+    assert.equal(cfg.includeTrust, false);
+  });
+
+  it("show() warns and bails on empty trace id without firing HTTP", async () => {
+    const memento = new FakeMemento();
+    const viewer = new ReceiptViewer(memento as never);
+    const mock = getMock();
+    await viewer.show("   ");
+    const warnStub = mock.window.showWarningMessage as sinon.SinonStub;
+    assert.equal(warnStub.callCount, 1, "empty id should trigger warning");
+    assert.equal(
+      (mock.window.createWebviewPanel as sinon.SinonStub).callCount,
+      0,
+      "empty id must not open a webview",
+    );
+  });
+
+  it("show() fetches receipt, opens a webview with rendered HTML, and remembers the trace id", async () => {
+    const stub = await startStubServer((_req, res) => {
+      res.statusCode = 200;
+      res.setHeader("content-type", "application/json");
+      res.end(JSON.stringify({ trace_id: "tr_abc", decisions: [] }));
+    });
+    const memento = new FakeMemento();
+    const viewer = new ReceiptViewer(memento as never);
+    const mock = getMock();
+    try {
+      await viewer.show("tr_abc", {
+        apiHost: "127.0.0.1",
+        apiPort: stub.port,
+        includeTrust: true,
+      });
+    } finally {
+      await stub.close();
+    }
+    const createCalls = (mock.window.createWebviewPanel as sinon.SinonStub).getCalls();
+    assert.equal(createCalls.length, 1, "expected exactly one webview panel");
+    const panel = createCalls[0]!.returnValue as FakeWebviewPanel;
+    assert.ok(
+      panel.webview.html.includes("Run receipt for trace tr_abc"),
+      "rendered HTML should heading for parsed receipt",
+    );
+    assert.ok(panel.webview.html.includes("HTTP 200"), "status should appear in meta");
+    assert.deepEqual(memento.store["cognithor.receiptTraceIds"], ["tr_abc"]);
+    // include_trust=true should be on the wire.
+    assert.equal(stub.requests.length, 1);
+    assert.ok(stub.requests[0]!.path.endsWith("?include_trust=true"));
+    assert.ok(stub.requests[0]!.path.includes("tr_abc"));
+  });
+
+  it("show() surfaces a fetch error via showErrorMessage and does not record the trace id", async () => {
+    const memento = new FakeMemento();
+    const viewer = new ReceiptViewer(memento as never);
+    const mock = getMock();
+    await viewer.show("tr_dead", {
+      // unused port; immediate ECONNREFUSED.
+      apiHost: "127.0.0.1",
+      apiPort: 1,
+      includeTrust: false,
+    });
+    const errStub = mock.window.showErrorMessage as sinon.SinonStub;
+    assert.equal(errStub.callCount, 1, "fetch failure should surface an error toast");
+    const msg = errStub.firstCall.args[0] as string;
+    assert.ok(msg.startsWith("Cognithor: receipt fetch failed"), `unexpected: ${msg}`);
+    assert.equal(
+      memento.store["cognithor.receiptTraceIds"],
+      undefined,
+      "failed fetch must not pollute history",
+    );
+  });
+
+  it("ReceiptViewer.rememberTraceId deduplicates and caps at MAX_HISTORY", async () => {
+    const memento = new FakeMemento();
+    const viewer = new ReceiptViewer(memento as never);
+    for (let i = 0; i < 25; i++) {
+      await viewer.rememberTraceId(`tr_${i}`);
+    }
+    // Re-add an existing one to confirm dedup + reorder.
+    await viewer.rememberTraceId("tr_5");
+    const stored = memento.store["cognithor.receiptTraceIds"] as string[];
+    assert.equal(stored.length, 20, "should cap at 20 entries");
+    assert.equal(stored[0], "tr_5", "most-recent should bubble to head");
+    // No duplicates.
+    assert.equal(new Set(stored).size, stored.length);
+  });
+
+  it("ReceiptTreeProvider exposes recent ids as TreeItems and refresh fires the change event", () => {
+    const memento = new FakeMemento();
+    memento.store["cognithor.receiptTraceIds"] = ["tr_first", "tr_second"];
+    const viewer = new ReceiptViewer(memento as never);
+    const provider = new ReceiptTreeProvider(viewer);
+    const children = provider.getChildren();
+    assert.equal(children.length, 2);
+    assert.equal((children[0] as { label: string }).label, "tr_first");
+    let fired = 0;
+    provider.onDidChangeTreeData(() => {
+      fired += 1;
+    });
+    provider.refresh();
+    assert.equal(fired, 1, "refresh() should fire onDidChangeTreeData exactly once");
+  });
+});

--- a/extensions/vscode/test/unit/vscode-mock.ts
+++ b/extensions/vscode/test/unit/vscode-mock.ts
@@ -73,6 +73,97 @@ class OutputChannel {
   }
 }
 
+class ThemeIcon {
+  constructor(public readonly id: string) {}
+}
+
+const treeItemCollapsibleState = { None: 0, Collapsed: 1, Expanded: 2 };
+const viewColumn = { Active: -1, Beside: -2, One: 1, Two: 2, Three: 3 };
+
+class TreeItem {
+  public tooltip: unknown;
+  public contextValue: unknown;
+  public iconPath: unknown;
+  public command: unknown;
+  constructor(
+    public readonly label: string,
+    public readonly collapsibleState: number = treeItemCollapsibleState.None,
+  ) {}
+}
+
+type EventEmitterListener<T> = (e: T) => void;
+
+class EventEmitter<T> {
+  public listeners: EventEmitterListener<T>[] = [];
+  public disposed = false;
+  readonly event = (listener: EventEmitterListener<T>): { dispose: () => void } => {
+    this.listeners.push(listener);
+    return {
+      dispose: () => {
+        const idx = this.listeners.indexOf(listener);
+        if (idx !== -1) this.listeners.splice(idx, 1);
+      },
+    };
+  };
+  fire(payload: T): void {
+    for (const l of [...this.listeners]) l(payload);
+  }
+  dispose(): void {
+    this.disposed = true;
+    this.listeners = [];
+  }
+}
+
+class FakeWebview {
+  public html = "";
+}
+
+class FakeWebviewPanel {
+  public webview = new FakeWebview();
+  public title: string;
+  public visible = true;
+  public disposed = false;
+  public revealCalls: { column: number; preserveFocus: boolean }[] = [];
+  private disposeCallbacks: Array<() => void> = [];
+  constructor(
+    public readonly viewType: string,
+    title: string,
+    public readonly viewColumn: number,
+    public readonly options: Record<string, unknown>,
+  ) {
+    this.title = title;
+  }
+  reveal(column?: number, preserveFocus?: boolean): void {
+    this.revealCalls.push({ column: column ?? -1, preserveFocus: preserveFocus ?? false });
+    this.visible = true;
+  }
+  onDidDispose(cb: () => void): { dispose: () => void } {
+    this.disposeCallbacks.push(cb);
+    return { dispose: () => undefined };
+  }
+  dispose(): void {
+    this.disposed = true;
+    this.visible = false;
+    for (const cb of this.disposeCallbacks) cb();
+  }
+}
+
+class FakeMemento {
+  public store: Record<string, unknown> = {};
+  get<T>(key: string, defaultValue?: T): T | undefined {
+    if (key in this.store) return this.store[key] as T;
+    return defaultValue;
+  }
+  update(key: string, value: unknown): Promise<void> {
+    if (value === undefined) {
+      delete this.store[key];
+    } else {
+      this.store[key] = value;
+    }
+    return Promise.resolve();
+  }
+}
+
 interface ConfigStore {
   [key: string]: unknown;
 }
@@ -106,6 +197,14 @@ const window = {
   showErrorMessage: sinon.stub().resolves(undefined),
   showInformationMessage: sinon.stub().resolves(undefined),
   onDidChangeActiveTextEditor: sinon.stub().returns({ dispose: () => undefined }),
+  createWebviewPanel: sinon.stub().callsFake(
+    (
+      viewType: string,
+      title: string,
+      column: number,
+      options: Record<string, unknown> = {},
+    ) => new FakeWebviewPanel(viewType, title, column, options),
+  ),
 };
 
 const workspace = {
@@ -125,6 +224,11 @@ const vscodeMock = {
   MarkdownString,
   OverviewRulerLane: overviewRulerLane,
   StatusBarAlignment: statusBarAlignment,
+  ThemeIcon,
+  TreeItem,
+  TreeItemCollapsibleState: treeItemCollapsibleState,
+  ViewColumn: viewColumn,
+  EventEmitter,
   window,
   workspace,
   languages,
@@ -149,7 +253,12 @@ export function resetMockSpies(): void {
   (workspace.onDidChangeConfiguration as sinon.SinonStub).resetHistory();
   (window.onDidChangeActiveTextEditor as sinon.SinonStub).resetHistory();
   (languages.registerHoverProvider as sinon.SinonStub).resetHistory();
+  (window.createWebviewPanel as sinon.SinonStub).resetHistory();
+  (window.showWarningMessage as sinon.SinonStub).resetHistory();
+  (window.showErrorMessage as sinon.SinonStub).resetHistory();
 }
+
+export { FakeMemento, FakeWebviewPanel };
 
 // Node 20 made `Module._resolveFilename` non-writable in some
 // contexts, so instead of swapping the resolver we override the

--- a/extensions/vscode/test/unit/ws_client.test.ts
+++ b/extensions/vscode/test/unit/ws_client.test.ts
@@ -1,0 +1,194 @@
+import { strict as assert } from "assert";
+import { EventEmitter } from "events";
+import * as Module from "module";
+
+/**
+ * Hijack the `ws` module before `ws_client.ts` imports it.
+ * We register a require hook here that returns a fake WebSocket
+ * class (and mark it as the default export so esModuleInterop's
+ * `import WebSocket from "ws"` resolves to our fake constructor).
+ */
+
+interface FakeSendCall {
+  data: unknown;
+}
+
+class FakeWebSocket extends EventEmitter {
+  static lastInstance: FakeWebSocket | null = null;
+  static instances: FakeWebSocket[] = [];
+
+  public readonly url: string;
+  public readonly options: Record<string, unknown>;
+  public readonly sends: FakeSendCall[] = [];
+  public terminated = false;
+  public closed: { code: number; reason: string } | null = null;
+
+  constructor(url: string, options: Record<string, unknown> = {}) {
+    super();
+    this.url = url;
+    this.options = options;
+    FakeWebSocket.lastInstance = this;
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: unknown): void {
+    this.sends.push({ data });
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  close(code: number, reason: string): void {
+    this.closed = { code, reason };
+  }
+
+  // Helpers used by tests:
+  fireOpen(): void {
+    this.emit("open");
+  }
+  fireMessage(data: unknown): void {
+    this.emit("message", data);
+  }
+  fireError(err: Error): void {
+    this.emit("error", err);
+  }
+  fireClose(code = 1000, reason = ""): void {
+    this.emit("close", code, Buffer.from(reason));
+  }
+}
+
+interface ProtoRequire {
+  (this: NodeJS.Module, id: string): unknown;
+}
+const proto = (Module as unknown as { prototype: { require: ProtoRequire } }).prototype;
+const originalRequire = proto.require;
+proto.require = function (this: NodeJS.Module, id: string): unknown {
+  if (id === "ws") {
+    // esModuleInterop reads either `default` or the function itself.
+    return Object.assign(FakeWebSocket as unknown as object, {
+      default: FakeWebSocket,
+      __esModule: true,
+    });
+  }
+  return originalRequire.call(this, id);
+};
+
+// Now require the SUT — its `import WebSocket from "ws"` resolves to FakeWebSocket.
+import { WsClient } from "../../src/ws_client";
+
+function newClient(): WsClient {
+  return new WsClient({
+    bind: "127.0.0.1",
+    port: 12345,
+    token: "fake-token",
+    connectTimeoutMs: 100,
+  });
+}
+
+describe("WsClient", () => {
+  beforeEach(() => {
+    FakeWebSocket.lastInstance = null;
+    FakeWebSocket.instances = [];
+  });
+
+  it("rejects runPlan() when neither planPath nor plan is provided", async () => {
+    const client = newClient();
+    await assert.rejects(client.runPlan({}), /requires either planPath or plan/);
+  });
+
+  it("opens with bearer auth and forwards plan_path on the wire", async () => {
+    const client = newClient();
+    const runPromise = client.runPlan({ planPath: "/abs/plan.json" });
+    // Allow microtasks to schedule the WS construction.
+    await new Promise((r) => setImmediate(r));
+    const ws = FakeWebSocket.lastInstance!;
+    assert.ok(ws, "expected a WebSocket instance");
+    assert.equal(ws.url, "ws://127.0.0.1:12345/");
+    assert.equal((ws.options.headers as Record<string, string>).Authorization, "Bearer fake-token");
+    ws.fireOpen();
+    await new Promise((r) => setImmediate(r));
+    assert.equal(ws.sends.length, 1);
+    const sent = JSON.parse(ws.sends[0]!.data as string) as Record<string, unknown>;
+    assert.equal(sent.type, "run_plan");
+    assert.equal(sent.plan_path, "/abs/plan.json");
+    ws.fireClose(1000, "");
+    await runPromise;
+  });
+
+  it("delivers parsed JSON event frames to onEvent listeners", async () => {
+    const client = newClient();
+    const events: Record<string, unknown>[] = [];
+    client.onEvent((e) => events.push(e));
+    const runPromise = client.runPlan({ plan: { steps: [] } });
+    await new Promise((r) => setImmediate(r));
+    const ws = FakeWebSocket.lastInstance!;
+    ws.fireOpen();
+    await new Promise((r) => setImmediate(r));
+    ws.fireMessage(Buffer.from(JSON.stringify({ type: "step_start", id: "s1" })));
+    ws.fireMessage('{"type":"step_end","id":"s1"}');
+    ws.fireClose(1000, "ok");
+    await runPromise;
+    assert.equal(events.length, 2);
+    assert.equal(events[0]!.type, "step_start");
+    assert.equal(events[1]!.type, "step_end");
+  });
+
+  it("emits onError for malformed JSON frames without aborting the stream", async () => {
+    const client = newClient();
+    const errors: Error[] = [];
+    const events: Record<string, unknown>[] = [];
+    client.onError((e) => errors.push(e));
+    client.onEvent((e) => events.push(e));
+    const runPromise = client.runPlan({ plan: {} });
+    await new Promise((r) => setImmediate(r));
+    const ws = FakeWebSocket.lastInstance!;
+    ws.fireOpen();
+    await new Promise((r) => setImmediate(r));
+    ws.fireMessage("{not valid json");
+    ws.fireMessage('{"type":"recovered"}');
+    ws.fireClose(1000, "");
+    await runPromise;
+    assert.equal(errors.length, 1, "exactly one parse error should surface");
+    assert.match(errors[0]!.message, /malformed event frame/);
+    assert.equal(events.length, 1, "post-error frames should still be delivered");
+    assert.equal(events[0]!.type, "recovered");
+  });
+
+  it("rejects runPlan() with a clear message when the open times out", async () => {
+    const client = new WsClient({
+      bind: "127.0.0.1",
+      port: 12345,
+      token: "tok",
+      connectTimeoutMs: 25,
+    });
+    await assert.rejects(client.runPlan({ plan: {} }), /WS open timeout/);
+    // The dangling socket was torn down — terminate should have been called.
+    const ws = FakeWebSocket.lastInstance!;
+    assert.ok(ws.terminated, "open-timeout must terminate the dangling socket");
+  });
+
+  it("close() is idempotent and a no-op when no connection is active", () => {
+    const client = newClient();
+    assert.doesNotThrow(() => client.close());
+    assert.doesNotThrow(() => client.close());
+  });
+
+  it("delivers CloseInfo with wasClean=true for code 1000 to onClose listeners", async () => {
+    const client = newClient();
+    const closes: { code: number; wasClean: boolean }[] = [];
+    client.onClose((info) => closes.push({ code: info.code, wasClean: info.wasClean }));
+    const runPromise = client.runPlan({ plan: {} });
+    await new Promise((r) => setImmediate(r));
+    const ws = FakeWebSocket.lastInstance!;
+    ws.fireOpen();
+    await new Promise((r) => setImmediate(r));
+    ws.fireClose(1000, "done");
+    const info = await runPromise;
+    assert.equal(info.code, 1000);
+    assert.equal(info.wasClean, true);
+    assert.equal(info.reason, "done");
+    assert.equal(closes.length, 1);
+    assert.equal(closes[0]!.wasClean, true);
+  });
+});


### PR DESCRIPTION
## Summary

Builds on the test infra that just landed in #485. Adds three more unit suites under `extensions/vscode/test/unit/` covering the remaining non-trivial extension modules.

| File | Tests | What it covers |
|---|---|---|
| `receipt_view.test.ts` | 6 | `readReceiptConfig` workspace read, empty-id warn path, full happy path against a real `http.Server` loopback stub (fetch -> webview render -> persist trace id), error-toast on fetch failure, `rememberTraceId` dedup + 20-cap, `ReceiptTreeProvider.refresh` event fire. |
| `ws_client.test.ts` | 7 | `Module.prototype.require` hook for `ws`, asserts `Bearer` auth header + plan_path on the wire, JSON event-frame parsing, `onError` for malformed frames without stream abort, open-timeout + socket teardown, idempotent `close()`, `CloseInfo.wasClean` for code 1000. |
| `mcp_bridge.test.ts` | 6 | `require` hook for `child_process.spawn`, asserts spawn args (`["mcp", "--stdio"]`), JSON-RPC handshake -> `onReady`, id-correlated `call()` request/response, JSON-RPC error rejection, malformed-stdout-line `onLog` + recovery, `stop()` rejects in-flight calls + SIGTERMs, `readBridgeConfig` cliPath read. |

`test/unit/vscode-mock.ts` is extended with the surface used by `receipt_view.ts`: `EventEmitter`, `TreeItem`, `ThemeIcon`, `ViewColumn`, `TreeItemCollapsibleState`, `FakeWebviewPanel`, `FakeMemento`, plus `window.createWebviewPanel`. Existing 12 tests are unaffected.

Both stubbing strategies (loopback `http.Server` for the receipt view, `Module.prototype.require` hooks for `ws` and `child_process`) keep the suite hermetic — no real CLI, no network egress.

## Test plan

- [x] `cd extensions/vscode && npm install` (existing deps unchanged)
- [x] `npm run compile` (tsc + esbuild, no diagnostics)
- [x] `npm run lint` (ESLint clean)
- [x] `npm run test:unit` -> **31 passing** (12 baseline + 19 new) in ~60ms

```
  CostGutterController            6 passing
  DecisionHoverProvider           6 passing
  McpBridge                       6 passing  <- new
  ReceiptViewer + ReceiptTreeProvider  6 passing  <- new
  WsClient                        7 passing  <- new

  31 passing (62ms)
```

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>