### PR TITLE
test(flutter): cover last 4 untested providers (~39 tests)

### DIFF
--- a/flutter_app/test/providers/chat_provider_test.dart
+++ b/flutter_app/test/providers/chat_provider_test.dart
@@ -1,0 +1,288 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:cognithor_ui/providers/chat_provider.dart';
+import 'package:cognithor_ui/services/api_client.dart';
+import 'package:cognithor_ui/services/websocket_service.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+class _MockWsService extends Mock implements WebSocketService {}
+
+/// Captures the listener map that ChatProvider registers via [WebSocketService.on],
+/// so tests can drive inbound WS messages without a real socket.
+class _ListenerCapture {
+  final Map<String, List<WsMessageCallback>> listeners = {};
+
+  void wireOn(_MockWsService ws) {
+    when(() => ws.on(any(), any())).thenAnswer((inv) {
+      final type = inv.positionalArguments[0] as String;
+      final cb = inv.positionalArguments[1] as WsMessageCallback;
+      listeners.putIfAbsent(type, () => []).add(cb);
+    });
+  }
+
+  void emit(String type, Map<String, dynamic> msg) {
+    for (final cb in listeners[type] ?? const <WsMessageCallback>[]) {
+      cb(msg);
+    }
+  }
+}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+    registerFallbackValue((Map<String, dynamic> _) {});
+  });
+
+  group('ChatProvider', () {
+    test('default state is empty / not streaming', () {
+      final p = ChatProvider();
+      expect(p.messages, isEmpty);
+      expect(p.isStreaming, isFalse);
+      expect(p.isWaitingForResponse, isFalse);
+      expect(p.activeTool, isNull);
+      expect(p.statusText, isEmpty);
+      expect(p.pendingApproval, isNull);
+      expect(p.pipeline, isEmpty);
+      expect(p.canvasHtml, isNull);
+      expect(p.canvasTitle, isNull);
+      expect(p.planDetail, isNull);
+      expect(p.preFlightData, isNull);
+      expect(p.pendingVideoAttachment, isNull);
+      expect(p.pendingFeedbackFollowup, isNull);
+      expect(p.streamingText, isEmpty);
+      expect(p.lastError, isNull);
+      expect(p.agentLog, isEmpty);
+    });
+
+    test('sendMessage without WS appends a user message and notifies', () {
+      final p = ChatProvider();
+      var notified = 0;
+      p.addListener(() => notified++);
+
+      p.sendMessage('hello');
+
+      expect(p.messages.length, 1);
+      expect(p.messages.single.role, MessageRole.user);
+      expect(p.messages.single.text, 'hello');
+      expect(p.isWaitingForResponse, isTrue);
+      expect(notified, 1);
+    });
+
+    test(
+      'sendMessage forwards the pending video attachment to WS metadata',
+      () {
+        final ws = _MockWsService();
+        final cap = _ListenerCapture()..wireOn(ws);
+        // Silence other on-registrations.
+        cap;
+        when(
+          () => ws.sendMessage(any(), metadata: any(named: 'metadata')),
+        ).thenReturn(null);
+        final p = ChatProvider()..attach(ws);
+
+        // Simulate URL-paste of an mp4 → pendingVideoAttachment populated.
+        p.handlePastedTextForVideoUrl('https://x.com/clip.mp4');
+        p.sendMessage('look at this');
+
+        // Captured by mock:
+        final captured = verify(
+          () => ws.sendMessage(
+            captureAny(),
+            metadata: captureAny(named: 'metadata'),
+          ),
+        ).captured;
+        expect(captured.first, 'look at this');
+        final meta = captured.last as Map<String, dynamic>?;
+        expect(meta, isNotNull);
+        expect(meta!['video_attachment'], isNotNull);
+        expect(p.pendingVideoAttachment, isNull); // consumed
+      },
+    );
+
+    test('clearChat resets every observable field', () {
+      final p = ChatProvider();
+      p.sendMessage('first');
+      p.handlePastedTextForVideoUrl('https://x.com/a.mp4');
+
+      p.clearChat();
+
+      expect(p.messages, isEmpty);
+      expect(p.pendingVideoAttachment, isNull);
+      expect(p.statusText, isEmpty);
+      expect(p.pipeline, isEmpty);
+      expect(p.canvasHtml, isNull);
+      expect(p.planDetail, isNull);
+      expect(p.preFlightData, isNull);
+      expect(p.agentLog, isEmpty);
+    });
+
+    test('loadFromHistory replaces messages and parses roles', () {
+      final p = ChatProvider();
+      p.loadFromHistory([
+        {'role': 'user', 'content': 'hi'},
+        {'role': 'assistant', 'content': 'hello'},
+        {'role': 'system', 'content': 'note'},
+        {'role': 'unknown', 'content': 'fallback'}, // → system
+      ]);
+
+      expect(p.messages.length, 4);
+      expect(p.messages[0].role, MessageRole.user);
+      expect(p.messages[1].role, MessageRole.assistant);
+      expect(p.messages[2].role, MessageRole.system);
+      expect(p.messages[3].role, MessageRole.system);
+    });
+
+    test('clearPendingVideo nulls the pending attachment', () {
+      final p = ChatProvider();
+      p.handlePastedTextForVideoUrl('https://x.com/a.mp4');
+      expect(p.pendingVideoAttachment, isNotNull);
+      p.clearPendingVideo();
+      expect(p.pendingVideoAttachment, isNull);
+    });
+
+    test(
+      'dismissCanvas / dismissPlan / dismissPreFlight clear their fields',
+      () {
+        final ws = _MockWsService();
+        final cap = _ListenerCapture()..wireOn(ws);
+        final p = ChatProvider()..attach(ws);
+
+        // Drive plan/canvas/preflight via inbound WS messages.
+        cap.emit(WsType.canvasPush, {'html': '<b>x</b>', 'title': 'demo'});
+        cap.emit(WsType.planDetail, {'goal': 'g'});
+        cap.emit(WsType.statusUpdate, {
+          'type': 'pre_flight',
+          'text': '{"goal":"x","steps":[],"timeout":3}',
+        });
+
+        expect(p.canvasHtml, '<b>x</b>');
+        expect(p.canvasTitle, 'demo');
+        expect(p.planDetail, isNotNull);
+        expect(p.preFlightData, isNotNull);
+
+        p.dismissCanvas();
+        p.dismissPlan();
+        p.dismissPreFlight();
+
+        expect(p.canvasHtml, isNull);
+        expect(p.canvasTitle, isNull);
+        expect(p.planDetail, isNull);
+        expect(p.preFlightData, isNull);
+      },
+    );
+
+    test('streamToken → streamEnd produces a single assistant message', () {
+      final ws = _MockWsService();
+      final cap = _ListenerCapture()..wireOn(ws);
+      final p = ChatProvider()..attach(ws);
+
+      cap.emit(WsType.streamToken, {'token': 'Hel'});
+      cap.emit(WsType.streamToken, {'token': 'lo!'});
+      expect(p.isStreaming, isTrue);
+      expect(p.streamingText, 'Hello!');
+
+      cap.emit(WsType.streamEnd, {});
+      expect(p.isStreaming, isFalse);
+      expect(p.messages.last.role, MessageRole.assistant);
+      expect(p.messages.last.text, 'Hello!');
+      expect(p.streamingText, isEmpty);
+    });
+
+    test('assistantMessage handler appends + clears waiting state', () {
+      final ws = _MockWsService();
+      final cap = _ListenerCapture()..wireOn(ws);
+      final p = ChatProvider()..attach(ws);
+      p.isWaitingForResponse = true;
+
+      cap.emit(WsType.assistantMessage, {
+        'text': 'response text',
+        'metadata': {'k': 'v'},
+        'agent_name': 'planner',
+      });
+
+      expect(p.messages.last.role, MessageRole.assistant);
+      expect(p.messages.last.text, 'response text');
+      expect(p.messages.last.agentName, 'planner');
+      expect(p.isWaitingForResponse, isFalse);
+    });
+
+    test('error message is appended as system message + streaming reset', () {
+      final ws = _MockWsService();
+      final cap = _ListenerCapture()..wireOn(ws);
+      final p = ChatProvider()..attach(ws);
+
+      cap.emit(WsType.streamToken, {'token': 'partial'});
+      cap.emit(WsType.error, {'error': 'boom'});
+
+      expect(p.isStreaming, isFalse);
+      expect(p.messages.last.role, MessageRole.system);
+      expect(p.messages.last.text, 'boom');
+    });
+
+    test('toolStart + toolResult tracks activeTool', () {
+      final ws = _MockWsService();
+      final cap = _ListenerCapture()..wireOn(ws);
+      final p = ChatProvider()..attach(ws);
+
+      cap.emit(WsType.toolStart, {'tool': 'web.search'});
+      expect(p.activeTool, 'web.search');
+
+      cap.emit(WsType.toolResult, {'result': 'ok'});
+      expect(p.activeTool, isNull);
+    });
+
+    test(
+      'respondApproval uses REST and clears pendingApproval on ok',
+      () async {
+        final ws = _MockWsService();
+        final api = _MockApiClient();
+        when(() => ws.apiClient).thenReturn(api);
+        final cap = _ListenerCapture()..wireOn(ws);
+        final p = ChatProvider()..attach(ws);
+
+        cap.emit(WsType.approvalRequest, {
+          'request_id': 'r1',
+          'tool': 'fs.write',
+          'reason': 'risky',
+          'params': {'path': '/tmp/x'},
+        });
+        expect(p.pendingApproval, isNotNull);
+
+        when(
+          () => api.post(any(), any()),
+        ).thenAnswer((_) async => {'ok': true});
+
+        await p.respondApproval(true);
+
+        expect(p.pendingApproval, isNull);
+        expect(p.lastError, isNull);
+      },
+    );
+
+    test('retryLastResponse pops last assistant + resends last user text', () {
+      final ws = _MockWsService();
+      final cap = _ListenerCapture()..wireOn(ws);
+      when(
+        () => ws.sendMessage(any(), metadata: any(named: 'metadata')),
+      ).thenReturn(null);
+      final p = ChatProvider()..attach(ws);
+
+      p.sendMessage('first user');
+      cap.emit(WsType.assistantMessage, {'text': 'first answer'});
+      expect(p.messages.length, 2);
+
+      p.retryLastResponse();
+      // Assistant removed, user kept.
+      expect(p.messages.length, 1);
+      expect(p.messages.last.role, MessageRole.user);
+      // ws.sendMessage was called twice in total: once via sendMessage(), once via retry.
+      final all = verify(
+        () => ws.sendMessage(captureAny(), metadata: any(named: 'metadata')),
+      ).captured;
+      expect(all.length, 2);
+      expect(all, ['first user', 'first user']);
+    });
+  });
+}

--- a/flutter_app/test/providers/config_provider_test.dart
+++ b/flutter_app/test/providers/config_provider_test.dart
@@ -1,0 +1,172 @@
+import 'dart:convert';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:cognithor_ui/providers/config_provider.dart';
+import 'package:cognithor_ui/services/api_client.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(<String, dynamic>{});
+  });
+
+  group('ConfigProvider', () {
+    late _MockApiClient api;
+    late ConfigProvider p;
+
+    setUp(() {
+      api = _MockApiClient();
+      p = ConfigProvider()..setApi(api);
+    });
+
+    test('initial state has defaults injected after loadAll', () async {
+      when(() => api.get(any())).thenAnswer((_) async => {});
+
+      await p.loadAll();
+
+      // Defaults are merged in, so cfg should NOT be empty.
+      expect(p.cfg, isNotEmpty);
+      expect(p.cfg['language'], 'de');
+      expect(p.cfg['llm_backend_type'], 'ollama');
+      expect(p.loading, isFalse);
+      expect(p.error, isNull);
+    });
+
+    test(
+      'loadAll surfaces error from /config but still merges defaults',
+      () async {
+        when(() => api.get(any())).thenAnswer((_) async => {});
+        when(() => api.get('config')).thenThrow(Exception('boom'));
+
+        await p.loadAll();
+
+        expect(p.error, contains('boom'));
+        expect(p.cfg['language'], 'de'); // defaults still applied
+        expect(p.loading, isFalse);
+      },
+    );
+
+    test('loadAll honours overlay values from server', () async {
+      when(() => api.get(any())).thenAnswer((_) async => {});
+      when(() => api.get('config')).thenAnswer(
+        (_) async => {
+          'owner_name': 'Alex',
+          'language': 'en',
+          'ollama': {'base_url': 'http://other:11434'},
+        },
+      );
+
+      await p.loadAll();
+
+      expect(p.cfg['owner_name'], 'Alex');
+      expect(p.cfg['language'], 'en');
+      // Deep merge: overlay key wins, untouched defaults preserved.
+      final ollama = p.cfg['ollama'] as Map<String, dynamic>;
+      expect(ollama['base_url'], 'http://other:11434');
+      expect(ollama['timeout_seconds'], 120); // from defaults
+    });
+
+    test('getPath / set traverse and mutate via dot-path', () {
+      p.set('models.planner.name', 'qwen3:14b');
+
+      expect(p.getPath('models.planner.name'), 'qwen3:14b');
+      expect(p.getPath('does.not.exist'), isNull);
+    });
+
+    test('hasChanges flips when cfg mutated after a snapshot', () async {
+      when(() => api.get(any())).thenAnswer((_) async => {});
+      when(
+        () => api.get('config'),
+      ).thenAnswer((_) async => {'owner_name': 'A'});
+
+      await p.loadAll();
+      expect(p.hasChanges, isFalse);
+
+      p.set('owner_name', 'B');
+      expect(p.hasChanges, isTrue);
+    });
+
+    test('discard restores last saved snapshot', () async {
+      when(() => api.get(any())).thenAnswer((_) async => {});
+      when(
+        () => api.get('config'),
+      ).thenAnswer((_) async => {'owner_name': 'A'});
+
+      await p.loadAll();
+      p.set('owner_name', 'modified');
+      expect(p.cfg['owner_name'], 'modified');
+
+      p.discard();
+      expect(p.cfg['owner_name'], 'A');
+      expect(p.hasChanges, isFalse);
+    });
+
+    test('addAgent / updateAgent / removeAgent mutate list and notify', () {
+      var notified = 0;
+      p.addListener(() => notified++);
+
+      p.addAgent({'name': 'planner'});
+      expect(p.agents, hasLength(1));
+
+      p.updateAgent(0, {'name': 'planner', 'temperature': 0.5});
+      expect(p.agents.first['temperature'], 0.5);
+
+      p.removeAgent(0);
+      expect(p.agents, isEmpty);
+
+      // Out-of-range guards: must not throw.
+      p.updateAgent(99, {});
+      p.removeAgent(99);
+
+      expect(notified, greaterThanOrEqualTo(3));
+    });
+
+    test('exportJson + importJson round-trips state', () async {
+      when(() => api.get(any())).thenAnswer((_) async => {});
+      when(
+        () => api.get('config'),
+      ).thenAnswer((_) async => {'owner_name': 'A'});
+      await p.loadAll();
+      p.addAgent({'name': 'planner'});
+
+      final exported = p.exportJson();
+      final fresh = ConfigProvider()..setApi(api);
+      await fresh.importJson(exported);
+
+      expect(fresh.cfg['owner_name'], 'A');
+      expect(fresh.agents.single['name'], 'planner');
+    });
+
+    test('importJson with malformed JSON sets an error', () async {
+      await p.importJson('not json {');
+      expect(p.error, contains('Invalid JSON'));
+    });
+
+    test('leadsEngineEnabled reflects social toggles', () {
+      // Default cfg has no `social` map → false
+      expect(p.leadsEngineEnabled, isFalse);
+
+      p.set('social.reddit_scan_enabled', true);
+      expect(p.leadsEngineEnabled, isTrue);
+
+      p.set('social.reddit_scan_enabled', false);
+      p.set('social.rss_enabled', true);
+      expect(p.leadsEngineEnabled, isTrue);
+    });
+
+    test(
+      'importJson accepts a bare config blob (no top-level wrapper)',
+      () async {
+        final raw = jsonEncode({'owner_name': 'Bare', 'language': 'fr'});
+        await p.importJson(raw);
+        expect(p.cfg['owner_name'], 'Bare');
+        expect(p.cfg['language'], 'fr');
+        // Defaults still merged
+        expect(p.cfg['llm_backend_type'], 'ollama');
+      },
+    );
+  });
+}

--- a/flutter_app/test/providers/device_provider_test.dart
+++ b/flutter_app/test/providers/device_provider_test.dart
@@ -1,0 +1,115 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import 'package:cognithor_ui/providers/device_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('DeviceProvider', () {
+    test('initial state — every toggle is off and every datum null', () {
+      final p = DeviceProvider();
+      expect(p.locationEnabled, isFalse);
+      expect(p.cameraEnabled, isFalse);
+      expect(p.microphoneEnabled, isFalse);
+      expect(p.photosEnabled, isFalse);
+      expect(p.lastPosition, isNull);
+      expect(p.batteryLevel, isNull);
+      expect(p.networkType, isNull);
+      expect(p.deviceInfo, isNull);
+    });
+
+    test('enablePermission flips the matching toggle and notifies', () {
+      final p = DeviceProvider();
+      var notified = 0;
+      p.addListener(() => notified++);
+
+      p.enablePermission(Permission.location);
+      expect(p.locationEnabled, isTrue);
+
+      p.enablePermission(Permission.camera);
+      expect(p.cameraEnabled, isTrue);
+
+      p.enablePermission(Permission.microphone);
+      expect(p.microphoneEnabled, isTrue);
+
+      p.enablePermission(Permission.photos);
+      expect(p.photosEnabled, isTrue);
+
+      // Unrecognized permissions are a no-op (default branch in switch).
+      p.enablePermission(Permission.contacts);
+
+      expect(notified, 5);
+    });
+
+    test('disablePermission turns toggles off again', () {
+      final p = DeviceProvider();
+      p
+        ..enablePermission(Permission.location)
+        ..enablePermission(Permission.camera)
+        ..enablePermission(Permission.microphone)
+        ..enablePermission(Permission.photos);
+
+      expect(p.locationEnabled, isTrue);
+
+      p
+        ..disablePermission(Permission.location)
+        ..disablePermission(Permission.camera)
+        ..disablePermission(Permission.microphone)
+        ..disablePermission(Permission.photos);
+
+      expect(p.locationEnabled, isFalse);
+      expect(p.cameraEnabled, isFalse);
+      expect(p.microphoneEnabled, isFalse);
+      expect(p.photosEnabled, isFalse);
+    });
+
+    test('getDeviceContext is empty when nothing is enabled', () {
+      final p = DeviceProvider();
+      expect(p.getDeviceContext(), isEmpty);
+    });
+
+    test('getDeviceContext only includes battery/network when populated', () {
+      final p = DeviceProvider();
+      // We can't easily set lastPosition (final getter on Position), but we
+      // can verify the conditional shape via the other fields:
+      // batteryLevel + networkType + deviceInfo are public mutable.
+      p.batteryLevel = 88;
+      p.networkType = 'wifi';
+      p.deviceInfo = {'model': 'pc'};
+
+      final ctx = p.getDeviceContext();
+      expect(ctx['battery'], 88);
+      expect(ctx['network'], 'wifi');
+      expect(ctx['device'], {'model': 'pc'});
+      // Location absent because locationEnabled is false.
+      expect(ctx.containsKey('location'), isFalse);
+    });
+
+    test('recordAudio stub returns null without throwing', () async {
+      final p = DeviceProvider();
+      final result = await p.recordAudio();
+      expect(result, isNull);
+    });
+
+    test(
+      'getCurrentLocation returns null when permission is disabled',
+      () async {
+        final p = DeviceProvider();
+        // locationEnabled is false by default → fast-path null without
+        // touching the Geolocator platform plugin.
+        final pos = await p.getCurrentLocation();
+        expect(pos, isNull);
+      },
+    );
+
+    test(
+      'capturePhoto / pickPhoto return null when their permissions are off',
+      () async {
+        final p = DeviceProvider();
+        expect(await p.capturePhoto(), isNull);
+        expect(await p.pickPhoto(), isNull);
+      },
+    );
+  });
+}

--- a/flutter_app/test/providers/voice_provider_test.dart
+++ b/flutter_app/test/providers/voice_provider_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:cognithor_ui/providers/voice_provider.dart';
+import 'package:cognithor_ui/services/api_client.dart';
+import 'package:cognithor_ui/services/voice_service.dart';
+
+class _MockApiClient extends Mock implements ApiClient {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('VoiceProvider', () {
+    test('constructs with VoiceState.off and inactive', () {
+      final p = VoiceProvider();
+      expect(p.state, VoiceState.off);
+      expect(p.isActive, isFalse);
+      expect(p.lastTranscript, isEmpty);
+      expect(p.errorMessage, isNull);
+    });
+
+    test('constructor accepts an apiClient and a sendToChat callback', () {
+      final api = _MockApiClient();
+      String? captured;
+      final p = VoiceProvider(
+        apiClient: api,
+        sendToChat: (text) => captured = text,
+      );
+      expect(p.apiClient, same(api));
+      // Callback installed but not called yet.
+      expect(captured, isNull);
+    });
+
+    test('speakResponse with no apiClient is a silent no-op', () async {
+      final p = VoiceProvider();
+      // Should not throw; just logs via debugPrint.
+      await p.speakResponse('hello');
+      // State must remain off (no playback was attempted).
+      expect(p.state, VoiceState.off);
+    });
+
+    test(
+      'speakResponse uses the provider apiClient when none passed',
+      () async {
+        final api = _MockApiClient();
+        when(() => api.synthesizeSpeech(any())).thenAnswer((_) async => null);
+
+        final p = VoiceProvider(apiClient: api);
+        await p.speakResponse('hi');
+
+        verify(() => api.synthesizeSpeech('hi')).called(1);
+      },
+    );
+
+    test('speakResponse prefers explicit api argument over field', () async {
+      final fallback = _MockApiClient();
+      final preferred = _MockApiClient();
+      when(
+        () => preferred.synthesizeSpeech(any()),
+      ).thenAnswer((_) async => null);
+
+      final p = VoiceProvider(apiClient: fallback);
+      await p.speakResponse('hi', preferred);
+
+      verify(() => preferred.synthesizeSpeech('hi')).called(1);
+      verifyNever(() => fallback.synthesizeSpeech(any()));
+    });
+
+    test('speakResponse swallows synthesizeSpeech exception', () async {
+      final api = _MockApiClient();
+      when(
+        () => api.synthesizeSpeech(any()),
+      ).thenThrow(Exception('network down'));
+
+      final p = VoiceProvider(apiClient: api);
+      // Must not propagate.
+      await p.speakResponse('hi');
+
+      expect(p.state, VoiceState.off);
+    });
+
+    test('speakResponse with empty bytes returns without playback', () async {
+      final api = _MockApiClient();
+      when(() => api.synthesizeSpeech(any())).thenAnswer((_) async => <int>[]);
+
+      final p = VoiceProvider(apiClient: api);
+      await p.speakResponse('hi');
+      // Empty bytes → playTts is not called → state stays off.
+      expect(p.state, VoiceState.off);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Closes the Flutter provider coverage gap: 23 of 27 providers had unit-test coverage; the remaining 4 (`chat`, `config`, `device`, `voice`) were untested. After this PR every provider has a `*_test.dart` file alongside it.

39 new tests covering the four providers, 481 tests pass in the full Flutter suite.

## Per-provider counts

- `chat_provider_test.dart`: **13 tests** — default state, send/clear/load-from-history, video URL paste / clear, dismiss canvas/plan/preflight, stream-token/stream-end, assistant message handler, error handler, tool-start/tool-result, REST approval response, retryLastResponse. Mocks both `ApiClient` and `WebSocketService` and replays inbound WS frames via a captured listener map.
- `config_provider_test.dart`: **11 tests** — defaults injection, error path on `/config`, deep-merge of overlay, dot-path get/set, hasChanges + discard, agent CRUD with out-of-range guards, exportJson + importJson round-trip, malformed JSON, leadsEngineEnabled flag flips, bare config-blob import.
- `device_provider_test.dart`: **8 tests** — initial state, enable/disable for all 4 permission toggles, getDeviceContext shape (empty + populated), recordAudio stub, fast-path returns of getCurrentLocation / capturePhoto / pickPhoto when the matching permission is off (avoids platform-channel calls).
- `voice_provider_test.dart`: **7 tests** — construction, optional apiClient + sendToChat callback wiring, speakResponse with no client / fallback to provider field / explicit-arg precedence / exception swallow / empty-bytes short-circuit.

## Test plan

- [x] `dart format --output=none --set-exit-if-changed lib/ test/ integration_test/` — clean
- [x] `dart analyze test/providers/` — no issues
- [x] `flutter test test/providers/{chat,config,device,voice}_provider_test.dart` — 39/39 pass
- [x] `flutter test test/` — 481/481 pass