### PR TITLE
test(backend): deep coverage for mcp/browser + mcp/database_tools (~50 tests)

### DIFF
--- a/tests/test_mcp/test_browser_deep.py
+++ b/tests/test_mcp/test_browser_deep.py
@@ -1,0 +1,556 @@
+"""Deep coverage for ``cognithor.mcp.browser``.
+
+The browser tool is security-sensitive: its public surface includes the SSRF
+guards that decide whether the agent's outbound HTTP requests reach an
+internal address. PR #479 (PASS-4 SEC-CRIT-1) introduced the DNS-resolution
+layer (`_validate_resolved_host`) on top of the existing hostname-string
+check (`_validate_url`). This file exercises both layers exhaustively
+plus the navigation, screenshot, click, fill, JS, page-info, and
+registration paths.
+
+Continuation of Wave-1/2 backend deep coverage (PRs #486, #488).
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from cognithor.mcp.browser import (
+    BROWSER_TOOL_SCHEMAS,
+    BrowserResult,
+    BrowserTool,
+    BrowserToolError,
+    register_browser_tools,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helpers
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+def _mock_page(
+    *,
+    url: str = "https://example.com",
+    title: str = "Example Domain",
+    body: str = "Hello, world.",
+) -> Any:
+    """Build an AsyncMock playwright page that returns the given values."""
+    page = AsyncMock()
+    page.url = url
+    page.title = AsyncMock(return_value=title)
+    page.inner_text = AsyncMock(return_value=body)
+    page.goto = AsyncMock(return_value=MagicMock(status=200))
+    page.click = AsyncMock()
+    page.fill = AsyncMock()
+    page.evaluate = AsyncMock(return_value=None)
+    page.screenshot = AsyncMock()
+    page.wait_for_load_state = AsyncMock()
+    page.set_default_timeout = MagicMock()
+    return page
+
+
+def _initialized_tool(tmp_path: Path, page: Any | None = None) -> BrowserTool:
+    """Build a BrowserTool with `_initialized=True` and a mock page."""
+    tool = BrowserTool(workspace_dir=tmp_path)
+    tool._initialized = True
+    tool._page = page or _mock_page()
+    return tool
+
+
+def _addrinfo(ip: str, family: int = socket.AF_INET) -> list[tuple[Any, ...]]:
+    """Build a fake `socket.getaddrinfo` reply for the given IP."""
+    if family == socket.AF_INET:
+        return [(family, socket.SOCK_STREAM, 0, "", (ip, 0))]
+    # IPv6
+    return [(family, socket.SOCK_STREAM, 0, "", (ip, 0, 0, 0))]
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Module surface / dataclass / exception
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestBrowserResultDataclass:
+    def test_default_is_success(self) -> None:
+        r = BrowserResult()
+        assert r.success is True
+        assert r.text == ""
+        assert r.url == ""
+        assert r.title == ""
+        assert r.screenshot_path is None
+        assert r.error is None
+
+    def test_failure_carries_error(self) -> None:
+        r = BrowserResult(success=False, url="x", error="boom")
+        assert r.success is False
+        assert r.error == "boom"
+
+    def test_browser_tool_error_is_exception(self) -> None:
+        # Sanity: explicit exception export.
+        with pytest.raises(BrowserToolError):
+            raise BrowserToolError("synthetic")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _validate_url — hostname-string SSRF guard
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestValidateUrlSchemes:
+    @pytest.mark.parametrize(
+        "url",
+        ["http://example.com/", "https://example.com/", "https://sub.example.com/path?q=1"],
+    )
+    def test_http_https_accepted(self, url: str) -> None:
+        assert BrowserTool._validate_url(url) is None
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.com/file",
+            "file:///etc/passwd",
+            "javascript:alert(1)",
+            "data:text/html,<script>alert(1)</script>",
+            "gopher://example.com/",
+            "ws://example.com/socket",
+            "wss://example.com/socket",
+        ],
+    )
+    def test_non_http_schemes_refused(self, url: str) -> None:
+        err = BrowserTool._validate_url(url)
+        assert err is not None
+
+
+class TestValidateUrlHostnameBlocks:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://localhost/admin",
+            "http://127.0.0.1/",
+            "http://0.0.0.0/",
+            "http://169.254.169.254/latest/meta-data/",  # AWS IMDS
+            "http://metadata.google.internal/computeMetadata/v1/",
+            "http://[::1]/",
+        ],
+    )
+    def test_blocked_hostnames(self, url: str) -> None:
+        err = BrowserTool._validate_url(url)
+        assert err is not None
+
+    @pytest.mark.parametrize(
+        "url,family",
+        [
+            ("http://10.0.0.1/", "10/8"),
+            ("http://10.255.255.255/", "10/8"),
+            ("http://172.16.0.1/", "172.16/12"),
+            ("http://172.31.255.255/", "172.16/12"),
+            ("http://192.168.0.1/", "192.168/16"),
+            ("http://192.168.255.255/", "192.168/16"),
+        ],
+    )
+    def test_rfc1918_ranges_refused(self, url: str, family: str) -> None:
+        err = BrowserTool._validate_url(url)
+        assert err is not None, f"{url} ({family}) should be blocked"
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://[fc00::1]/",
+            "http://[fd12:3456:789a::1]/",
+            "http://[fe80::1]/",
+        ],
+    )
+    def test_ipv6_private_refused(self, url: str) -> None:
+        err = BrowserTool._validate_url(url)
+        assert err is not None
+
+    def test_no_hostname_refused(self) -> None:
+        err = BrowserTool._validate_url("https:///nopath")
+        assert err is not None
+
+    def test_172_15_is_not_private(self) -> None:
+        # Boundary: 172.15/16 is NOT in RFC1918 range (172.16-31).
+        # The string-only check must let it through (DNS layer may still block).
+        assert BrowserTool._validate_url("http://172.15.0.1/") is None
+
+    def test_172_32_is_not_private(self) -> None:
+        # Other side of the boundary.
+        assert BrowserTool._validate_url("http://172.32.0.1/") is None
+
+    def test_hostname_case_insensitive(self) -> None:
+        # ``LOCALHOST`` should still be caught.
+        err = BrowserTool._validate_url("http://LOCALHOST/")
+        assert err is not None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _validate_resolved_host — DNS-layer SSRF guard (PASS-4 SEC-CRIT-1)
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestValidateResolvedHost:
+    @pytest.mark.asyncio
+    async def test_literal_ip_skipped(self) -> None:
+        # Literal IPs already pass through ``_validate_url``; resolution is
+        # short-circuited so no socket call needed.
+        assert await BrowserTool._validate_resolved_host("http://93.184.216.34/") is None
+
+    @pytest.mark.asyncio
+    async def test_no_hostname_refused(self) -> None:
+        err = await BrowserTool._validate_resolved_host("https:///")
+        assert err is not None
+
+    @pytest.mark.asyncio
+    async def test_resolves_to_loopback_blocked(self) -> None:
+        # DNS-rebinding: hostname is innocuous but resolves to 127.x.
+        async def fake_getaddrinfo(*_: Any, **__: Any) -> list[tuple[Any, ...]]:
+            return _addrinfo("127.0.0.1")
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.getaddrinfo = AsyncMock(side_effect=fake_getaddrinfo)
+            err = await BrowserTool._validate_resolved_host("http://inner.evil.com/")
+        assert err is not None
+
+    @pytest.mark.asyncio
+    async def test_resolves_to_rfc1918_blocked(self) -> None:
+        async def fake_getaddrinfo(*_: Any, **__: Any) -> list[tuple[Any, ...]]:
+            return _addrinfo("10.0.0.1")
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.getaddrinfo = AsyncMock(side_effect=fake_getaddrinfo)
+            err = await BrowserTool._validate_resolved_host("http://intranet.example/")
+        assert err is not None
+
+    @pytest.mark.asyncio
+    async def test_resolves_to_link_local_blocked(self) -> None:
+        async def fake_getaddrinfo(*_: Any, **__: Any) -> list[tuple[Any, ...]]:
+            return _addrinfo("169.254.1.1")
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.getaddrinfo = AsyncMock(side_effect=fake_getaddrinfo)
+            err = await BrowserTool._validate_resolved_host("http://aws-meta.evil/")
+        assert err is not None
+
+    @pytest.mark.asyncio
+    async def test_resolves_to_ipv6_loopback_blocked(self) -> None:
+        async def fake_getaddrinfo(*_: Any, **__: Any) -> list[tuple[Any, ...]]:
+            return _addrinfo("::1", family=socket.AF_INET6)
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.getaddrinfo = AsyncMock(side_effect=fake_getaddrinfo)
+            err = await BrowserTool._validate_resolved_host("http://v6loop.evil/")
+        assert err is not None
+
+    @pytest.mark.asyncio
+    async def test_ipv6_zone_id_stripped(self) -> None:
+        # `fe80::1%eth0` style addresses with zone IDs: the impl strips the
+        # zone before parsing so the ``ipaddress`` module accepts it.
+        async def fake_getaddrinfo(*_: Any, **__: Any) -> list[tuple[Any, ...]]:
+            return [(socket.AF_INET6, socket.SOCK_STREAM, 0, "", ("fe80::1%eth0", 0, 0, 0))]
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.getaddrinfo = AsyncMock(side_effect=fake_getaddrinfo)
+            err = await BrowserTool._validate_resolved_host("http://link-local.evil/")
+        assert err is not None
+
+    @pytest.mark.asyncio
+    async def test_resolution_failure_is_passed_through(self) -> None:
+        # NXDOMAIN must NOT be reported as an SSRF block — the navigate call
+        # surfaces the real error so users can debug.
+        async def fake_getaddrinfo(*_: Any, **__: Any) -> list[tuple[Any, ...]]:
+            raise OSError("nodename nor servname provided")
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.getaddrinfo = AsyncMock(side_effect=fake_getaddrinfo)
+            err = await BrowserTool._validate_resolved_host("http://nx.example.invalid/")
+        assert err is None
+
+    @pytest.mark.asyncio
+    async def test_public_ip_passes(self) -> None:
+        # 93.184.216.34 (example.com) is global — must pass.
+        async def fake_getaddrinfo(*_: Any, **__: Any) -> list[tuple[Any, ...]]:
+            return _addrinfo("93.184.216.34")
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.getaddrinfo = AsyncMock(side_effect=fake_getaddrinfo)
+            err = await BrowserTool._validate_resolved_host("http://example.com/")
+        assert err is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# navigate() — SSRF + happy path + truncation + error paths
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestNavigate:
+    @pytest.mark.asyncio
+    async def test_uninitialised_returns_error(self, tmp_path: Path) -> None:
+        tool = BrowserTool(workspace_dir=tmp_path)
+        result = await tool.navigate("https://example.com/")
+        assert result.success is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "ftp://example.com/",
+            "javascript:alert(1)",
+            "file:///etc/passwd",
+            "http://localhost/",
+            "http://127.0.0.1/",
+            "http://169.254.169.254/",
+            "http://10.0.0.1/",
+            "http://192.168.1.1/",
+        ],
+    )
+    async def test_string_layer_ssrf_blocked(self, tmp_path: Path, url: str) -> None:
+        tool = _initialized_tool(tmp_path)
+        result = await tool.navigate(url)
+        assert result.success is False
+        # The page mock should never have been touched.
+        tool._page.goto.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_dns_layer_ssrf_blocked(self, tmp_path: Path) -> None:
+        tool = _initialized_tool(tmp_path)
+
+        async def fake_getaddrinfo(*_: Any, **__: Any) -> list[tuple[Any, ...]]:
+            return _addrinfo("127.0.0.1")
+
+        with patch("asyncio.get_running_loop") as mock_loop:
+            mock_loop.return_value.getaddrinfo = AsyncMock(side_effect=fake_getaddrinfo)
+            result = await tool.navigate("http://rebind.evil.test/")
+
+        assert result.success is False
+        tool._page.goto.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_happy_path_extracts_text(self, tmp_path: Path) -> None:
+        page = _mock_page(body="The quick brown fox.")
+        tool = _initialized_tool(tmp_path, page)
+        result = await tool.navigate("https://example.com/")
+        assert result.success is True
+        assert "fox" in result.text
+        assert result.title == "Example Domain"
+
+    @pytest.mark.asyncio
+    async def test_extract_text_false_skips_inner_text(self, tmp_path: Path) -> None:
+        page = _mock_page()
+        tool = _initialized_tool(tmp_path, page)
+        result = await tool.navigate("https://example.com/", extract_text=False)
+        assert result.success is True
+        assert result.text == ""
+        page.inner_text.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_long_text_truncated(self, tmp_path: Path) -> None:
+        # max_text_length defaults to 8000; produce double that.
+        long_body = "A" * 16_000
+        page = _mock_page(body=long_body)
+        tool = _initialized_tool(tmp_path, page)
+        result = await tool.navigate("https://example.com/")
+        assert result.success is True
+        assert len(result.text) < len(long_body)
+
+    @pytest.mark.asyncio
+    async def test_goto_exception_returns_error(self, tmp_path: Path) -> None:
+        page = _mock_page()
+        page.goto = AsyncMock(side_effect=RuntimeError("connection reset"))
+        tool = _initialized_tool(tmp_path, page)
+        result = await tool.navigate("https://example.com/")
+        assert result.success is False
+        # The exception type leaks into the error string but the actual
+        # message ("connection reset") must NOT — we don't want to leak
+        # internal stack info to the LLM.
+        assert "connection reset" not in (result.error or "")
+
+    @pytest.mark.asyncio
+    async def test_goto_returns_none_response(self, tmp_path: Path) -> None:
+        # ``goto`` may return ``None`` for about:blank etc; module reads
+        # ``response.status`` only when truthy.
+        page = _mock_page()
+        page.goto = AsyncMock(return_value=None)
+        tool = _initialized_tool(tmp_path, page)
+        result = await tool.navigate("https://example.com/")
+        assert result.success is True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# screenshot() / click() / fill() / execute_js()
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestScreenshot:
+    @pytest.mark.asyncio
+    async def test_default_path_uses_workspace(self, tmp_path: Path) -> None:
+        tool = _initialized_tool(tmp_path)
+        result = await tool.screenshot()
+        assert result.success is True
+        assert result.screenshot_path is not None
+        # Auto-generated path must live in the workspace dir.
+        assert str(tmp_path) in (result.screenshot_path or "")
+
+    @pytest.mark.asyncio
+    async def test_explicit_path_used(self, tmp_path: Path) -> None:
+        out = tmp_path / "shot.png"
+        tool = _initialized_tool(tmp_path)
+        result = await tool.screenshot(path=str(out))
+        assert result.success is True
+        assert result.screenshot_path == str(out)
+        tool._page.screenshot.assert_awaited_once_with(path=str(out), full_page=False)
+
+    @pytest.mark.asyncio
+    async def test_full_page_passed_through(self, tmp_path: Path) -> None:
+        tool = _initialized_tool(tmp_path)
+        await tool.screenshot(path=str(tmp_path / "full.png"), full_page=True)
+        tool._page.screenshot.assert_awaited_once_with(
+            path=str(tmp_path / "full.png"), full_page=True
+        )
+
+
+class TestExecuteJs:
+    @pytest.mark.asyncio
+    async def test_long_script_refused(self, tmp_path: Path) -> None:
+        tool = _initialized_tool(tmp_path)
+        tool._max_js_length = 50
+        result = await tool.execute_js("a" * 200)
+        assert result.success is False
+        assert tool._page.evaluate.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_long_result_truncated(self, tmp_path: Path) -> None:
+        page = _mock_page()
+        # Produce a string longer than the configured limit.
+        page.evaluate = AsyncMock(return_value="X" * 20_000)
+        tool = _initialized_tool(tmp_path, page)
+        tool._max_text_length = 100
+        result = await tool.execute_js("longString()")
+        assert result.success is True
+        # Truncated payload + suffix marker — definitely shorter than 20k.
+        assert len(result.text) < 1_000
+
+    @pytest.mark.asyncio
+    async def test_js_exception_surfaces(self, tmp_path: Path) -> None:
+        page = _mock_page()
+        page.evaluate = AsyncMock(side_effect=RuntimeError("boom"))
+        tool = _initialized_tool(tmp_path, page)
+        result = await tool.execute_js("1+1")
+        assert result.success is False
+        # Error type leaks but raw message must not.
+        assert "boom" not in (result.error or "")
+
+
+class TestClickFillPageInfo:
+    @pytest.mark.asyncio
+    async def test_click_passes_selector(self, tmp_path: Path) -> None:
+        tool = _initialized_tool(tmp_path)
+        result = await tool.click("#submit")
+        assert result.success is True
+        tool._page.click.assert_awaited_once_with("#submit")
+
+    @pytest.mark.asyncio
+    async def test_fill_passes_selector_and_value(self, tmp_path: Path) -> None:
+        tool = _initialized_tool(tmp_path)
+        result = await tool.fill("#email", "user@example.com")
+        assert result.success is True
+        tool._page.fill.assert_awaited_once_with("#email", "user@example.com")
+
+    @pytest.mark.asyncio
+    async def test_page_info_collects_links_and_inputs(self, tmp_path: Path) -> None:
+        page = _mock_page(title="Search Page")
+        page.evaluate = AsyncMock(
+            side_effect=[
+                [{"text": "Home", "href": "https://example.com/"}],
+                [
+                    {
+                        "tag": "input",
+                        "type": "text",
+                        "name": "q",
+                        "id": "search",
+                        "text": "",
+                    }
+                ],
+            ]
+        )
+        tool = _initialized_tool(tmp_path, page)
+        result = await tool.get_page_info()
+        assert result.success is True
+        assert "Home" in result.text
+        assert "search" in result.text
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# initialize() / close() lifecycle
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_initialize_idempotent_when_initialized(self, tmp_path: Path) -> None:
+        tool = BrowserTool(workspace_dir=tmp_path)
+        tool._initialized = True
+        assert await tool.initialize() is True
+
+    @pytest.mark.asyncio
+    async def test_initialize_returns_false_when_playwright_missing(self, tmp_path: Path) -> None:
+        tool = BrowserTool(workspace_dir=tmp_path)
+        # Force the late `from playwright.async_api import async_playwright`
+        # to fail — register `None` shim modules which Python imports as
+        # missing-attr ImportError.
+        with patch.dict("sys.modules", {"playwright": None, "playwright.async_api": None}):
+            assert await tool.initialize() is False
+        assert tool._initialized is False
+
+    @pytest.mark.asyncio
+    async def test_close_when_uninitialised_is_safe(self) -> None:
+        tool = BrowserTool()
+        await tool.close()  # must not raise
+        assert tool._initialized is False
+
+    @pytest.mark.asyncio
+    async def test_close_resets_handles(self, tmp_path: Path) -> None:
+        tool = BrowserTool(workspace_dir=tmp_path)
+        tool._initialized = True
+        tool._page = AsyncMock()
+        tool._context = AsyncMock()
+        tool._browser = AsyncMock()
+        tool._playwright = AsyncMock()
+        await tool.close()
+        assert tool._initialized is False
+        assert tool._page is None
+        assert tool._context is None
+        assert tool._browser is None
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# register_browser_tools — wires up BROWSER_TOOL_SCHEMAS to a client
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRegistration:
+    def test_register_returns_browsertool(self) -> None:
+        client = MagicMock()
+        tool = register_browser_tools(client)
+        assert isinstance(tool, BrowserTool)
+
+    def test_register_calls_client_for_each_schema(self) -> None:
+        client = MagicMock()
+        register_browser_tools(client)
+        assert client.register_builtin_handler.call_count == len(BROWSER_TOOL_SCHEMAS)
+        registered = {call.args[0] for call in client.register_builtin_handler.call_args_list}
+        assert registered == set(BROWSER_TOOL_SCHEMAS.keys())
+
+    def test_schemas_cover_all_public_handlers(self) -> None:
+        # Every schema must declare a description and an inputSchema.
+        for name, schema in BROWSER_TOOL_SCHEMAS.items():
+            assert schema["description"], f"{name} missing description"
+            assert "inputSchema" in schema, f"{name} missing inputSchema"
+            assert schema["inputSchema"]["type"] == "object"

--- a/tests/test_mcp/test_database_tools_deep.py
+++ b/tests/test_mcp/test_database_tools_deep.py
@@ -1,0 +1,595 @@
+"""Deep coverage for ``cognithor.mcp.database_tools``.
+
+The module is security-sensitive: it owns the SQL execution layer that the
+agent can reach via ``db_query`` / ``db_schema`` / ``db_execute`` /
+``db_connect``. Audit-PR10 (audit-MED-3) hardened ``_check_injection`` to
+run regardless of whether ``params`` were supplied (smuggling defence).
+PR #479 P4-D added DROP-blocking + path-validation polish.
+
+This file exercises:
+  * ``_check_injection`` — every pattern + smuggling-with-params.
+  * Path validation — workspace/home roots, traversal, non-existent files.
+  * ``db_query`` — happy-path, params, limit clamping, read-only blocking,
+    empty SQL.
+  * ``db_schema`` — list mode, table mode, invalid identifier, missing table.
+  * ``db_execute`` — INSERT/UPDATE/DELETE rowcount, DROP block, empty SQL.
+  * ``db_connect`` — version + counts + size formatting.
+  * ``_format_table`` + ``_truncate`` — ASCII rendering edge-cases.
+  * ``_is_pg_connection_string`` — heuristic.
+  * ``register_database_tools`` — all four handlers + schemas.
+
+Continuation of Wave-1/2 backend deep coverage (PRs #486, #488).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from cognithor.config import CognithorConfig, SecurityConfig, ensure_directory_structure
+from cognithor.mcp.database_tools import (
+    _MAX_ROW_LIMIT,
+    DatabaseError,
+    DatabaseTools,
+    _check_injection,
+    _format_table,
+    _is_pg_connection_string,
+    _truncate,
+    register_database_tools,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixtures
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def config(tmp_path: Path) -> CognithorConfig:
+    cfg = CognithorConfig(
+        cognithor_home=tmp_path / ".cognithor",
+        security=SecurityConfig(allowed_paths=[str(tmp_path)]),
+    )
+    ensure_directory_structure(cfg)
+    return cfg
+
+
+@pytest.fixture()
+def db_tools(config: CognithorConfig) -> DatabaseTools:
+    return DatabaseTools(config)
+
+
+@pytest.fixture()
+def sample_db(tmp_path: Path) -> Path:
+    """Create an unencrypted SQLite test DB with two tables and rows."""
+    db_path = tmp_path / "sample.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL, age INTEGER, email TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO users (name, age, email) VALUES "
+        "('Alice', 30, 'alice@example.com'),"
+        "('Bob', 25, 'bob@example.com'),"
+        "('Charlie', 35, 'charlie@example.com'),"
+        "('Dave', 40, 'dave@example.com')"
+    )
+    conn.execute(
+        "CREATE TABLE orders (id INTEGER PRIMARY KEY, user_id INTEGER, product TEXT, amount REAL)"
+    )
+    conn.execute(
+        "INSERT INTO orders (user_id, product, amount) VALUES "
+        "(1, 'Widget', 9.99),"
+        "(2, 'Gadget', 19.99)"
+    )
+    conn.execute("CREATE INDEX idx_users_name ON users(name)")
+    conn.execute("CREATE VIEW active_users AS SELECT * FROM users WHERE age > 0")
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+class _MockMCPClient:
+    def __init__(self) -> None:
+        self.registered: dict[str, dict[str, Any]] = {}
+
+    def register_builtin_handler(
+        self,
+        name: str,
+        handler: object,
+        *,
+        description: str = "",
+        input_schema: dict[str, Any] | None = None,
+    ) -> None:
+        self.registered[name] = {
+            "handler": handler,
+            "description": description,
+            "input_schema": input_schema,
+        }
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _check_injection — SQL-injection pattern detector
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestCheckInjection:
+    @pytest.mark.parametrize(
+        "sql",
+        [
+            "SELECT 1; DROP TABLE users",
+            "SELECT 1;DELETE FROM x",
+            "SELECT 1; UPDATE x SET y=1",
+            "SELECT 1; INSERT INTO x VALUES (1)",
+            "SELECT 1; ALTER TABLE x ADD col INT",
+            "SELECT 1; CREATE TABLE evil (id INT)",
+            "SELECT 1; EXEC xp_cmdshell",
+        ],
+    )
+    def test_multistatement_attacks_caught(self, sql: str) -> None:
+        with pytest.raises(DatabaseError, match="injection"):
+            _check_injection(sql, None)
+
+    def test_union_select_caught(self) -> None:
+        with pytest.raises(DatabaseError, match="injection"):
+            _check_injection("SELECT * FROM users UNION SELECT * FROM secrets", None)
+
+    def test_comment_terminator_caught(self) -> None:
+        with pytest.raises(DatabaseError, match="injection"):
+            _check_injection("SELECT * FROM users WHERE id = 1 --", None)
+
+    def test_smuggling_with_params_still_caught(self) -> None:
+        # audit-MED-3: parameterised callers must NOT be exempt.
+        # Even with placeholders, the SQL string itself must be clean.
+        with pytest.raises(DatabaseError, match="injection"):
+            _check_injection("SELECT * FROM users WHERE id = ?; DROP TABLE x", [1])
+
+    def test_smuggling_union_with_params(self) -> None:
+        with pytest.raises(DatabaseError, match="injection"):
+            _check_injection(
+                "SELECT name FROM users WHERE id = ? UNION SELECT password FROM admin",
+                [1],
+            )
+
+    def test_normal_queries_pass(self) -> None:
+        # Plain queries with or without params must NOT trigger.
+        _check_injection("SELECT * FROM users", None)
+        _check_injection("SELECT * FROM users WHERE name = ?", ["Alice"])
+        _check_injection("SELECT id, name FROM users WHERE age BETWEEN ? AND ?", [25, 40])
+
+    def test_case_insensitive(self) -> None:
+        # Pattern uses re.IGNORECASE — lowercase smuggling still caught.
+        with pytest.raises(DatabaseError, match="injection"):
+            _check_injection("select 1; drop table users", None)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _is_pg_connection_string — routing heuristic
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPGHeuristic:
+    @pytest.mark.parametrize(
+        "connstr",
+        [
+            "postgresql://user:pass@host/db",
+            "postgres://user:pass@host:5432/db",
+            "POSTGRESQL://user@host/db",
+            "  postgresql://leading-space-stripped/  ",
+        ],
+    )
+    def test_pg_strings(self, connstr: str) -> None:
+        assert _is_pg_connection_string(connstr) is True
+
+    @pytest.mark.parametrize(
+        "connstr",
+        [
+            "/tmp/db.sqlite",
+            "C:\\Users\\foo\\db.sqlite",
+            "mysql://user@host/db",
+            "sqlite:///path/to.db",
+            "",
+        ],
+    )
+    def test_non_pg_strings(self, connstr: str) -> None:
+        assert _is_pg_connection_string(connstr) is False
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# _truncate / _format_table — ASCII rendering
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestTruncate:
+    def test_short_value_unchanged(self) -> None:
+        assert _truncate("hello") == "hello"
+
+    def test_exact_length_unchanged(self) -> None:
+        s = "x" * 200
+        assert _truncate(s, 200) == s
+
+    def test_long_value_truncated_with_ellipsis(self) -> None:
+        s = "x" * 250
+        out = _truncate(s, 200)
+        assert len(out) == 200
+        assert out.endswith("...")
+
+
+class TestFormatTable:
+    def test_no_columns_emits_rows_affected(self) -> None:
+        assert "5 rows affected" in _format_table([], [], 5)
+
+    def test_simple_two_column_table(self) -> None:
+        out = _format_table(["name", "age"], [("Alice", 30), ("Bob", 25)], 2)
+        assert "Alice" in out
+        assert "Bob" in out
+        assert "(2 rows)" in out
+
+    def test_one_row_singular_label(self) -> None:
+        out = _format_table(["id"], [(1,)], 1)
+        assert "(1 row)" in out
+
+    def test_zero_rows_plural_label(self) -> None:
+        out = _format_table(["id"], [], 0)
+        assert "(0 rows)" in out
+
+    def test_none_cells_render_null(self) -> None:
+        out = _format_table(["id", "name"], [(1, None)], 1)
+        assert "NULL" in out
+
+    def test_long_cell_truncated(self) -> None:
+        long_value = "x" * 500
+        out = _format_table(["data"], [(long_value,)], 1)
+        assert "..." in out
+        assert long_value not in out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Path validation — workspace + traversal + missing
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestPathValidation:
+    @pytest.mark.asyncio
+    async def test_outside_allowed_roots_blocked(self, db_tools: DatabaseTools) -> None:
+        with pytest.raises(DatabaseError, match="Zugriff verweigert"):
+            await db_tools.db_query("/etc/passwd", "SELECT 1")
+
+    @pytest.mark.asyncio
+    async def test_traversal_blocked(self, db_tools: DatabaseTools, tmp_path: Path) -> None:
+        # Path that resolves outside the allowed root.
+        with pytest.raises(DatabaseError, match="Zugriff verweigert"):
+            await db_tools.db_query(
+                str(tmp_path / ".." / ".." / ".." / "etc" / "shadow"), "SELECT 1"
+            )
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_db_inside_allowed_root(
+        self, db_tools: DatabaseTools, tmp_path: Path
+    ) -> None:
+        # Allowed root, but the file does not exist.
+        with pytest.raises(DatabaseError, match="nicht gefunden"):
+            await db_tools.db_query(str(tmp_path / "ghost.db"), "SELECT 1")
+
+    @pytest.mark.asyncio
+    async def test_workspace_dir_is_implicitly_allowed(self, config: CognithorConfig) -> None:
+        # Even if not in allowed_paths, workspace is auto-added.
+        wk_db = config.workspace_dir / "wk.db"
+        wk_db.parent.mkdir(parents=True, exist_ok=True)
+        sqlite3.connect(str(wk_db)).close()
+        tools = DatabaseTools(config)
+        # Should not raise an "access denied" — it should run.
+        result = await tools.db_query(str(wk_db), "SELECT 1 AS one")
+        assert "one" in result
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# db_query — happy paths + read-only enforcement + clamping
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDbQuery:
+    @pytest.mark.asyncio
+    async def test_select_all(self, db_tools: DatabaseTools, sample_db: Path) -> None:
+        out = await db_tools.db_query(str(sample_db), "SELECT name FROM users")
+        for name in ("Alice", "Bob", "Charlie", "Dave"):
+            assert name in out
+
+    @pytest.mark.asyncio
+    async def test_positional_param_filter(self, db_tools: DatabaseTools, sample_db: Path) -> None:
+        out = await db_tools.db_query(
+            str(sample_db),
+            "SELECT name FROM users WHERE age >= ? AND age <= ?",
+            params=[28, 36],
+        )
+        assert "Alice" in out
+        assert "Charlie" in out
+        assert "Bob" not in out  # 25 < 28
+        assert "Dave" not in out  # 40 > 36
+
+    @pytest.mark.asyncio
+    async def test_named_param_via_dict_unsupported_falls_through(
+        self, db_tools: DatabaseTools, sample_db: Path
+    ) -> None:
+        # The handler accepts list-of-params; sqlite3 with `?`-style
+        # placeholders does not support named binding. Confirm with a
+        # standard positional query that string injection is unnecessary
+        # because parameterisation works.
+        out = await db_tools.db_query(
+            str(sample_db),
+            "SELECT name FROM users WHERE name = ?",
+            params=["Alice'; DROP TABLE users;--"],
+        )
+        # No row matches the literal string — query returns 0 rows but
+        # the DROP smuggle never runs (placeholder, not concatenation).
+        assert "Alice'" not in out  # would only appear if the DROP ran
+        assert "(0 rows)" in out
+
+    @pytest.mark.asyncio
+    async def test_empty_sql_returns_friendly_error(
+        self, db_tools: DatabaseTools, sample_db: Path
+    ) -> None:
+        out = await db_tools.db_query(str(sample_db), "   ")
+        assert "Fehler" in out or "kein sql" in out.lower()
+
+    @pytest.mark.asyncio
+    async def test_limit_clamped_to_max(self, db_tools: DatabaseTools, sample_db: Path) -> None:
+        # Limit above _MAX_ROW_LIMIT silently clamps; the query runs.
+        out = await db_tools.db_query(
+            str(sample_db),
+            "SELECT name FROM users",
+            limit=_MAX_ROW_LIMIT + 100_000,
+        )
+        # Sample DB has 4 rows, all should appear.
+        assert "Alice" in out and "Dave" in out
+
+    @pytest.mark.asyncio
+    async def test_limit_clamped_to_one_when_zero(
+        self, db_tools: DatabaseTools, sample_db: Path
+    ) -> None:
+        # The handler does max(1, min(limit, MAX)) — 0 becomes 1.
+        out = await db_tools.db_query(str(sample_db), "SELECT name FROM users", limit=0)
+        # With clamp to 1, exactly one row + a "more rows available" note.
+        assert "1 row" in out
+        assert "more rows available" in out
+
+    @pytest.mark.asyncio
+    async def test_readonly_blocks_insert(self, db_tools: DatabaseTools, sample_db: Path) -> None:
+        with pytest.raises(DatabaseError):
+            await db_tools.db_query(
+                str(sample_db), "INSERT INTO users (name, age) VALUES ('Eve', 28)"
+            )
+
+    @pytest.mark.asyncio
+    async def test_readonly_blocks_update(self, db_tools: DatabaseTools, sample_db: Path) -> None:
+        with pytest.raises(DatabaseError):
+            await db_tools.db_query(str(sample_db), "UPDATE users SET age=99 WHERE name='Alice'")
+
+    @pytest.mark.asyncio
+    async def test_invalid_sql_surfaces_database_error(
+        self, db_tools: DatabaseTools, sample_db: Path
+    ) -> None:
+        with pytest.raises(DatabaseError):
+            await db_tools.db_query(str(sample_db), "SELECT * FROM nonexistent_table")
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# db_schema — list mode + table mode + invalid identifier
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDbSchema:
+    @pytest.mark.asyncio
+    async def test_list_includes_tables_and_views(
+        self, db_tools: DatabaseTools, sample_db: Path
+    ) -> None:
+        out = await db_tools.db_schema(str(sample_db))
+        assert "users" in out
+        assert "orders" in out
+        assert "active_users" in out  # view
+
+    @pytest.mark.asyncio
+    async def test_table_mode_lists_columns(self, db_tools: DatabaseTools, sample_db: Path) -> None:
+        out = await db_tools.db_schema(str(sample_db), table="users")
+        for col in ("id", "name", "age", "email"):
+            assert col in out
+
+    @pytest.mark.asyncio
+    async def test_table_mode_marks_primary_key(
+        self, db_tools: DatabaseTools, sample_db: Path
+    ) -> None:
+        out = await db_tools.db_schema(str(sample_db), table="users")
+        # PK column header + "YES" in id row.
+        assert "PK" in out
+        # We can't easily anchor a regex on the row but YES must appear.
+        assert "YES" in out
+
+    @pytest.mark.asyncio
+    async def test_table_mode_lists_indexes(self, db_tools: DatabaseTools, sample_db: Path) -> None:
+        out = await db_tools.db_schema(str(sample_db), table="users")
+        assert "idx_users_name" in out
+
+    @pytest.mark.asyncio
+    async def test_missing_table_raises(self, db_tools: DatabaseTools, sample_db: Path) -> None:
+        with pytest.raises(DatabaseError, match="nicht gefunden"):
+            await db_tools.db_schema(str(sample_db), table="not_a_table")
+
+    @pytest.mark.asyncio
+    async def test_invalid_identifier_blocks_attack(
+        self, db_tools: DatabaseTools, sample_db: Path
+    ) -> None:
+        # A `;`-laden identifier must not slip through PRAGMA. The regex
+        # `_SAFE_IDENTIFIER_RE` permits only `[A-Za-z_][A-Za-z0-9_ ]*`.
+        with pytest.raises(DatabaseError, match="Ungueltiger Tabellenname"):
+            await db_tools.db_schema(str(sample_db), table="users; DROP TABLE users;")
+
+    @pytest.mark.asyncio
+    async def test_invalid_identifier_with_quote_blocked(
+        self, db_tools: DatabaseTools, sample_db: Path
+    ) -> None:
+        with pytest.raises(DatabaseError, match="Ungueltiger Tabellenname"):
+            await db_tools.db_schema(str(sample_db), table='users" OR 1=1 --')
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# db_execute — write paths + DROP block + empty SQL
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDbExecute:
+    @pytest.mark.asyncio
+    async def test_insert_returns_rows_affected(
+        self, db_tools: DatabaseTools, sample_db: Path
+    ) -> None:
+        out = await db_tools.db_execute(
+            str(sample_db),
+            "INSERT INTO users (name, age, email) VALUES (?, ?, ?)",
+            params=["Eve", 28, "eve@example.com"],
+        )
+        assert "1" in out
+        # Followup read confirms write actually committed.
+        check = await db_tools.db_query(
+            str(sample_db), "SELECT name FROM users WHERE name = ?", params=["Eve"]
+        )
+        assert "Eve" in check
+
+    @pytest.mark.asyncio
+    async def test_update_returns_rows_affected(
+        self, db_tools: DatabaseTools, sample_db: Path
+    ) -> None:
+        out = await db_tools.db_execute(
+            str(sample_db),
+            "UPDATE users SET age = ? WHERE name = ?",
+            params=[31, "Alice"],
+        )
+        assert "1" in out
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_rows_affected(
+        self, db_tools: DatabaseTools, sample_db: Path
+    ) -> None:
+        out = await db_tools.db_execute(
+            str(sample_db), "DELETE FROM users WHERE name = ?", params=["Bob"]
+        )
+        assert "1" in out
+
+    @pytest.mark.asyncio
+    async def test_drop_blocked(self, db_tools: DatabaseTools, sample_db: Path) -> None:
+        with pytest.raises(DatabaseError, match="DROP"):
+            await db_tools.db_execute(str(sample_db), "DROP TABLE users")
+
+    @pytest.mark.asyncio
+    async def test_drop_blocked_case_insensitive(
+        self, db_tools: DatabaseTools, sample_db: Path
+    ) -> None:
+        # Mixed-case DROP — the strip().upper() check is case-insensitive.
+        with pytest.raises(DatabaseError, match="DROP"):
+            await db_tools.db_execute(str(sample_db), "  drop table users")
+
+    @pytest.mark.asyncio
+    async def test_empty_sql_returns_friendly_error(
+        self, db_tools: DatabaseTools, sample_db: Path
+    ) -> None:
+        out = await db_tools.db_execute(str(sample_db), "  \n  ")
+        assert "Fehler" in out or "kein sql" in out.lower()
+
+    @pytest.mark.asyncio
+    async def test_create_table_succeeds(self, db_tools: DatabaseTools, sample_db: Path) -> None:
+        out = await db_tools.db_execute(
+            str(sample_db), "CREATE TABLE notes (id INTEGER PRIMARY KEY, body TEXT)"
+        )
+        # SQLite returns rowcount=-1 for DDL; "Erfolgreich" is the prefix.
+        assert "Erfolg" in out or "row" in out.lower() or "-1" in out
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# db_connect — version + counts + size
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestDbConnect:
+    @pytest.mark.asyncio
+    async def test_returns_sqlite_metadata(self, db_tools: DatabaseTools, sample_db: Path) -> None:
+        out = await db_tools.db_connect(str(sample_db))
+        assert "SQLite" in out
+        assert "Tabellen:" in out
+        assert "Views:" in out
+
+    @pytest.mark.asyncio
+    async def test_size_label_kb(self, db_tools: DatabaseTools, sample_db: Path) -> None:
+        # Sample DB is small but >1 KB.
+        out = await db_tools.db_connect(str(sample_db))
+        # Either "B", "KB" or "MB" must appear.
+        assert any(unit in out for unit in (" B", "KB", "MB"))
+
+    @pytest.mark.asyncio
+    async def test_missing_db_raises(self, db_tools: DatabaseTools, tmp_path: Path) -> None:
+        with pytest.raises(DatabaseError, match="nicht gefunden"):
+            await db_tools.db_connect(str(tmp_path / "missing.db"))
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error masking — credentials in connection strings must NOT leak
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestErrorMasking:
+    @pytest.mark.asyncio
+    async def test_outside_root_error_does_not_leak_full_filesystem(
+        self, db_tools: DatabaseTools
+    ) -> None:
+        # Confirm the error mentions the path the caller passed (so they
+        # know what was rejected) but not random other absolute paths.
+        try:
+            await db_tools.db_query("/etc/passwd", "SELECT 1")
+        except DatabaseError as exc:
+            assert "/etc/passwd" in str(exc)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# register_database_tools — wiring test
+# ─────────────────────────────────────────────────────────────────────────────
+
+
+class TestRegistration:
+    def test_all_four_tools_registered(self, config: CognithorConfig) -> None:
+        client = _MockMCPClient()
+        tools = register_database_tools(client, config)
+        assert isinstance(tools, DatabaseTools)
+        assert set(client.registered.keys()) == {
+            "db_query",
+            "db_schema",
+            "db_execute",
+            "db_connect",
+        }
+
+    @pytest.mark.parametrize("name", ["db_query", "db_schema", "db_execute", "db_connect"])
+    def test_each_handler_callable(self, config: CognithorConfig, name: str) -> None:
+        client = _MockMCPClient()
+        register_database_tools(client, config)
+        assert callable(client.registered[name]["handler"])
+
+    def test_query_schema_requires_database_and_sql(self, config: CognithorConfig) -> None:
+        client = _MockMCPClient()
+        register_database_tools(client, config)
+        schema = client.registered["db_query"]["input_schema"]
+        assert schema is not None
+        assert set(schema["required"]) == {"database", "sql"}
+
+    def test_connect_schema_requires_database_only(self, config: CognithorConfig) -> None:
+        client = _MockMCPClient()
+        register_database_tools(client, config)
+        schema = client.registered["db_connect"]["input_schema"]
+        assert schema is not None
+        assert schema["required"] == ["database"]
+
+    def test_descriptions_non_empty(self, config: CognithorConfig) -> None:
+        client = _MockMCPClient()
+        register_database_tools(client, config)
+        for name, entry in client.registered.items():
+            assert entry["description"], f"{name} missing description"


### PR DESCRIPTION
## Summary
- `test_browser_deep.py` (72 tests) covers URL scheme allowlist, hostname-string SSRF blocks (loopback, IMDS, RFC1918, IPv6 ULA/link-local), the new DNS-resolution layer from PR #479 / PASS-4 SEC-CRIT-1 (DNS-rebinding into 127.x / 10.x / 169.254.x / ::1, IPv6 zone-id stripping, NXDOMAIN pass-through), navigation happy-path + truncation, screenshot/click/fill/JS edge-cases, lifecycle, and registration wiring.
- `test_database_tools_deep.py` (70 tests) covers `_check_injection` against multi-statement / UNION / comment-terminator smuggling (with and without `params` — audit-MED-3), `_is_pg_connection_string` heuristic, ASCII rendering edge-cases, allowed-roots path validation + traversal blocking, `db_query` happy-path / clamping / read-only enforcement / invalid SQL, `db_schema` list+table modes + invalid-identifier defence, `db_execute` write paths + DROP-block (case-insensitive), `db_connect` metadata, error-masking, and full registration wiring.
- Total: 142 tests, all green locally; full `tests/test_mcp/` (1365 tests) passes; `ruff check src/ tests/` + `ruff format --check src/ tests/` clean.

Continuation of Wave-1/2 backend deep coverage (PRs #486, #488).

## Test plan
- [x] `ruff check src/cognithor/ tests/`
- [x] `ruff format --check src/cognithor/ tests/`
- [x] `pytest tests/test_mcp/test_browser_deep.py tests/test_mcp/test_database_tools_deep.py -v` (142 passed)
- [x] `pytest tests/test_mcp/ -q` (1365 passed)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)