### PR TITLE
feat(operational-trust): Reflector audit-event helper + causal atomic wiring (PR-A/3)

### DIFF
--- a/src/cognithor/audit/__init__.py
+++ b/src/cognithor/audit/__init__.py
@@ -60,6 +60,7 @@ class AuditCategory(Enum):
     SECURITY = "security"
     USER_INPUT = "user_input"
     SYSTEM = "system"
+    REFLECTION = "reflection"
 
 
 class AuditSeverity(Enum):
@@ -510,6 +511,33 @@ class AuditLogger:
             action=f"system:{event}",
             description=description or event,
             success=True,
+            session_id=session_id,
+        )
+
+    def log_reflection_event(
+        self,
+        action: str,
+        payload: dict[str, Any],
+        *,
+        session_id: str = "",
+        agent_name: str = "",
+        severity: AuditSeverity = AuditSeverity.INFO,
+    ) -> AuditEntry:
+        """Log an autonomous Reflector event (memory writes, learning outcomes).
+
+        The full payload (including the caller-supplied ``payload_sha256``)
+        lands in ``AuditEntry.parameters`` as a structured dict — not
+        smuggled into the free-form description. ``action`` is the event
+        ID (e.g. ``"causal_sequence_recorded"``,
+        ``"causal_skipped_empty_sequence"``).
+        """
+        return self._log(
+            category=AuditCategory.REFLECTION,
+            severity=severity,
+            action=action,
+            agent_name=agent_name,
+            description=f"Reflection event: {action}",
+            parameters=payload,
             session_id=session_id,
         )
 

--- a/src/cognithor/core/reflector.py
+++ b/src/cognithor/core/reflector.py
@@ -11,8 +11,10 @@ Inspired by Reflexion (Shinn 2023), SAGE (2024), RMM (2025).
 
 from __future__ import annotations
 
+import hashlib
 import json
 import re
+import unicodedata
 from datetime import date
 from typing import TYPE_CHECKING, Any
 
@@ -146,6 +148,72 @@ class Reflector:
         self._reward_calculator = reward_calculator
         self._cost_tracker = cost_tracker
         self._confidence_manager = confidence_manager
+
+        # Operational-Trust PR-A: wire the audit-emit callback into the
+        # CausalAnalyzer (when both exist). The CausalAnalyzer owns its
+        # own atomic transaction boundary; the helper bound here closes
+        # the audit gap on empty-sequence skips and on successful records.
+        if self._causal_analyzer is not None and hasattr(
+            self._causal_analyzer, "set_audit_emit_callback"
+        ):
+            try:
+                self._causal_analyzer.set_audit_emit_callback(self._emit_reflection_audit_event)
+            except Exception as exc:
+                log.warning("causal_audit_callback_wire_failed", error=str(exc))
+
+    # ------------------------------------------------------------------
+    # Operational-Trust audit helper (PR-A/3)
+    # ------------------------------------------------------------------
+
+    def _emit_reflection_audit_event(
+        self,
+        event_type: str,
+        payload: dict[str, Any],
+    ) -> None:
+        """Emit a Reflector audit event with canonical-JSON payload hash.
+
+        Best-effort: audit failures are logged via ``log.warning`` but
+        never raised. The runtime path is more critical than the audit;
+        this is the inverse of ``CausalAnalyzer.record_sequence`` where
+        the DB INSERT and audit emit are atomic-or-rolled-back via
+        ``with conn:``.
+
+        ``payload_sha256`` is computed over the canonical form
+        (NFC-normalised, sort_keys, separators=(",", ":"),
+        ensure_ascii=False) and added to the payload dict before emit
+        so consumers can verify integrity. The hash is reproducible
+        across Python sessions.
+        """
+        if self._audit_logger is None:
+            return
+        try:
+            canonical = unicodedata.normalize(
+                "NFC",
+                json.dumps(
+                    payload,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                ),
+            ).encode("utf-8")
+            payload_sha256 = hashlib.sha256(canonical).hexdigest()
+            enriched = dict(payload)
+            enriched["payload_sha256"] = payload_sha256
+            self._audit_logger.log_system(
+                event=event_type,
+                description=json.dumps(
+                    enriched,
+                    sort_keys=True,
+                    separators=(",", ":"),
+                    ensure_ascii=False,
+                ),
+            )
+        except Exception as exc:
+            log.warning(
+                "audit_emit_failed",
+                event_type=event_type,
+                error=str(exc),
+            )
 
     # ------------------------------------------------------------------
     # Public API

--- a/src/cognithor/core/reflector.py
+++ b/src/cognithor/core/reflector.py
@@ -178,35 +178,32 @@ class Reflector:
         the DB INSERT and audit emit are atomic-or-rolled-back via
         ``with conn:``.
 
-        ``payload_sha256`` is computed over the canonical form
-        (NFC-normalised, sort_keys, separators=(",", ":"),
-        ensure_ascii=False) and added to the payload dict before emit
-        so consumers can verify integrity. The hash is reproducible
-        across Python sessions.
+        Routing: events flow through ``AuditLogger.log_reflection_event``
+        (category ``AuditCategory.REFLECTION``) so the structured payload
+        lands in ``AuditEntry.parameters`` instead of being smuggled into
+        the free-form description.
+
+        Canonical form: ``payload_sha256`` is computed over the canonical
+        bytes (NFC-normalised, ``sort_keys=True``, default separators,
+        ``ensure_ascii=False``) and added to the payload dict before
+        emit so consumers can verify integrity. The hash is reproducible
+        across Python sessions and matches the convention used by
+        ``AuditLogger._last_hash_for_file`` — one canonical-form recipe
+        across the audit module.
         """
         if self._audit_logger is None:
             return
         try:
             canonical = unicodedata.normalize(
                 "NFC",
-                json.dumps(
-                    payload,
-                    sort_keys=True,
-                    separators=(",", ":"),
-                    ensure_ascii=False,
-                ),
+                json.dumps(payload, sort_keys=True, ensure_ascii=False),
             ).encode("utf-8")
             payload_sha256 = hashlib.sha256(canonical).hexdigest()
             enriched = dict(payload)
             enriched["payload_sha256"] = payload_sha256
-            self._audit_logger.log_system(
-                event=event_type,
-                description=json.dumps(
-                    enriched,
-                    sort_keys=True,
-                    separators=(",", ":"),
-                    ensure_ascii=False,
-                ),
+            self._audit_logger.log_reflection_event(
+                action=event_type,
+                payload=enriched,
             )
         except Exception as exc:
             log.warning(

--- a/src/cognithor/learning/causal.py
+++ b/src/cognithor/learning/causal.py
@@ -114,8 +114,10 @@ class CausalAnalyzer:
         wired. The DB INSERT and audit emit on the success path are
         atomic via ``with conn:`` (sqlite3 commits on block exit, rolls
         back on any exception inside). ``tool_sequence`` is serialised
-        canonically (compact separators, ensure_ascii=False) so the
-        on-disk row content is bit-identical for identical inputs.
+        canonically (``sort_keys=True``, default separators,
+        ``ensure_ascii=False``) so the on-disk row content is
+        bit-identical for identical inputs and matches the canonical-
+        form convention used by ``AuditLogger._last_hash_for_file``.
         """
         if not tool_sequence:
             if self._audit_emit_callback is not None:
@@ -138,7 +140,7 @@ class CausalAnalyzer:
         timestamp = datetime.now(UTC).isoformat()
         tool_sequence_canonical = json.dumps(
             tool_sequence,
-            separators=(",", ":"),
+            sort_keys=True,
             ensure_ascii=False,
         )
         with conn:

--- a/src/cognithor/learning/causal.py
+++ b/src/cognithor/learning/causal.py
@@ -27,6 +27,7 @@ except ImportError:
 from cognithor.utils.logging import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
 
 log = get_logger(__name__)
@@ -35,10 +36,35 @@ log = get_logger(__name__)
 class CausalAnalyzer:
     """Analysiert kausale Zusammenhaenge zwischen Tool-Sequenzen und Erfolg."""
 
-    def __init__(self, db_path: str | Path | None = None) -> None:
+    def __init__(
+        self,
+        db_path: str | Path | None = None,
+        audit_emit_callback: Callable[[str, dict[str, Any]], None] | None = None,
+    ) -> None:
+        """Operational-Trust PR-A: ``audit_emit_callback`` is the
+        Reflector's ``_emit_reflection_audit_event`` helper, bound here
+        so ``record_sequence`` can emit a structured audit event in the
+        same atomic-transaction window as the DB INSERT. ``None`` keeps
+        the legacy behaviour (no audit, debug-log only on empty skip).
+        """
         self._db_path = str(db_path) if db_path else ":memory:"
         self._conn: sqlite3.Connection | None = None
+        self._audit_emit_callback: Callable[[str, dict[str, Any]], None] | None = (
+            audit_emit_callback
+        )
         self._ensure_schema()
+
+    def set_audit_emit_callback(
+        self,
+        callback: Callable[[str, dict[str, Any]], None] | None,
+    ) -> None:
+        """Late-bind the audit-emit callback.
+
+        Used by the gateway boot path where the ``CausalAnalyzer`` is
+        constructed before the ``Reflector`` exists, so the helper
+        cannot be passed at ``__init__`` time.
+        """
+        self._audit_emit_callback = callback
 
     def _get_conn(self) -> sqlite3.Connection:
         if self._conn is None:
@@ -80,25 +106,66 @@ class CausalAnalyzer:
         success_score: float,
         model_used: str = "",
     ) -> None:
-        """Zeichnet eine Tool-Sequenz mit ihrem Erfolgs-Score auf."""
+        """Zeichnet eine Tool-Sequenz mit ihrem Erfolgs-Score auf.
+
+        Operational-Trust PR-A: empty sequences are no longer silently
+        dropped — an audit event ``causal_skipped_empty_sequence`` is
+        emitted before the early return when an audit callback is
+        wired. The DB INSERT and audit emit on the success path are
+        atomic via ``with conn:`` (sqlite3 commits on block exit, rolls
+        back on any exception inside). ``tool_sequence`` is serialised
+        canonically (compact separators, ensure_ascii=False) so the
+        on-disk row content is bit-identical for identical inputs.
+        """
         if not tool_sequence:
+            if self._audit_emit_callback is not None:
+                self._audit_emit_callback(
+                    "causal_skipped_empty_sequence",
+                    {
+                        "session_id": session_id,
+                        "success_score": success_score,
+                        "model_used": model_used,
+                    },
+                )
+            else:
+                log.debug(
+                    "skipped_empty_sequence",
+                    session_id=session_id,
+                )
             return
 
         conn = self._get_conn()
-        conn.execute(
-            """INSERT INTO causal_sequences
-               (session_id, timestamp, tool_sequence,
-                success_score, model_used)
-               VALUES (?, ?, ?, ?, ?)""",
-            (
-                session_id,
-                datetime.now(UTC).isoformat(),
-                json.dumps(tool_sequence),
-                success_score,
-                model_used,
-            ),
+        timestamp = datetime.now(UTC).isoformat()
+        tool_sequence_canonical = json.dumps(
+            tool_sequence,
+            separators=(",", ":"),
+            ensure_ascii=False,
         )
-        conn.commit()
+        with conn:
+            conn.execute(
+                """INSERT INTO causal_sequences
+                   (session_id, timestamp, tool_sequence,
+                    success_score, model_used)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (
+                    session_id,
+                    timestamp,
+                    tool_sequence_canonical,
+                    success_score,
+                    model_used,
+                ),
+            )
+            if self._audit_emit_callback is not None:
+                self._audit_emit_callback(
+                    "causal_sequence_recorded",
+                    {
+                        "session_id": session_id,
+                        "timestamp": timestamp,
+                        "tool_sequence": tool_sequence,
+                        "success_score": success_score,
+                        "model_used": model_used,
+                    },
+                )
 
     def get_sequence_scores(
         self,

--- a/tests/test_audit/test_audit_logger.py
+++ b/tests/test_audit/test_audit_logger.py
@@ -993,3 +993,128 @@ class TestAuditLoggerMigrationBackfill:
             assert isolated.head_version(MigrationDomain.AUDIT_LOG) == "v1-hashchain-jsonl"
         finally:
             mig_mod.MIGRATION_LEDGER = original  # type: ignore[misc]
+
+
+# ============================================================================
+# Operational-Trust PR-A — REFLECTION category + log_reflection_event
+# ============================================================================
+
+
+class TestReflectionEventLogging:
+    """``AuditLogger.log_reflection_event(action, payload)`` is the
+    dedicated channel for autonomous Reflector events (memory writes,
+    learning outcomes). Reviewer asked for a domain method on the audit
+    surface — not a smuggled JSON string in ``log_system.description``.
+    """
+
+    def test_reflection_category_enum_exists(self) -> None:
+        # Enum value lives at AuditCategory.REFLECTION with literal "reflection".
+        assert AuditCategory.REFLECTION.value == "reflection"
+
+    def test_log_reflection_event_uses_reflection_category(self) -> None:
+        logger = AuditLogger()
+        entry = logger.log_reflection_event(
+            "causal_sequence_recorded",
+            {"session_id": "s1", "tools": ["read", "write"]},
+        )
+        assert entry.category == AuditCategory.REFLECTION
+
+    def test_payload_lands_in_parameters_as_dict(self) -> None:
+        # Structured payload lives in ``parameters`` — not stringified
+        # into ``description`` like the previous helper.
+        logger = AuditLogger()
+        payload = {
+            "session_id": "s1",
+            "success_score": 0.9,
+            "payload_sha256": "deadbeef" * 8,
+        }
+        entry = logger.log_reflection_event("causal_sequence_recorded", payload)
+        assert isinstance(entry.parameters, dict)
+        assert entry.parameters["session_id"] == "s1"
+        assert entry.parameters["success_score"] == 0.9
+        assert entry.parameters["payload_sha256"] == "deadbeef" * 8
+
+    def test_action_propagates_unchanged(self) -> None:
+        logger = AuditLogger()
+        entry = logger.log_reflection_event("causal_skipped_empty_sequence", {})
+        assert entry.action == "causal_skipped_empty_sequence"
+
+    def test_session_id_propagates(self) -> None:
+        logger = AuditLogger()
+        entry = logger.log_reflection_event(
+            "causal_sequence_recorded",
+            {"x": 1},
+            session_id="run_42",
+        )
+        assert entry.session_id == "run_42"
+
+    def test_agent_name_propagates(self) -> None:
+        logger = AuditLogger()
+        entry = logger.log_reflection_event(
+            "causal_sequence_recorded",
+            {"x": 1},
+            agent_name="reflector",
+        )
+        assert entry.agent_name == "reflector"
+
+    def test_severity_defaults_to_info(self) -> None:
+        logger = AuditLogger()
+        entry = logger.log_reflection_event("evt", {})
+        assert entry.severity == AuditSeverity.INFO
+
+    def test_severity_override_propagates(self) -> None:
+        logger = AuditLogger()
+        entry = logger.log_reflection_event(
+            "evt",
+            {},
+            severity=AuditSeverity.WARNING,
+        )
+        assert entry.severity == AuditSeverity.WARNING
+
+    def test_description_carries_human_readable_summary(self) -> None:
+        # The description is human-readable (not stringified JSON) since
+        # the structured payload is in ``parameters``.
+        logger = AuditLogger()
+        entry = logger.log_reflection_event("causal_sequence_recorded", {"x": 1})
+        assert "causal_sequence_recorded" in entry.description
+        # Description is NOT a JSON blob — payload lives in parameters.
+        assert "{" not in entry.description or "}" not in entry.description.split(":")[1]
+
+    def test_query_filters_by_reflection_category(self) -> None:
+        logger = AuditLogger()
+        logger.log_tool_call("read_file")
+        logger.log_reflection_event("causal_sequence_recorded", {"x": 1})
+        logger.log_reflection_event("causal_skipped_empty_sequence", {"y": 2})
+
+        results = logger.query(category=AuditCategory.REFLECTION)
+        assert len(results) == 2
+        actions = {e.action for e in results}
+        assert actions == {"causal_sequence_recorded", "causal_skipped_empty_sequence"}
+
+    def test_hash_chain_validates_after_reflection_event(self, tmp_path: Path) -> None:
+        """Persisting a reflection event must keep the SHA-256 hash
+        chain consistent. The new domain method goes through ``_log``
+        like every other channel — same lock, same prev_hash logic.
+        """
+        audit_dir = tmp_path / "audit"
+        logger = AuditLogger(log_dir=audit_dir)
+        logger.log_tool_call("read_file", session_id="run_1")
+        logger.log_reflection_event(
+            "causal_sequence_recorded",
+            {"session_id": "run_1", "score": 0.9},
+            session_id="run_1",
+        )
+        logger.log_tool_call("write_file", session_id="run_1")
+
+        log_file = next(iter(audit_dir.glob("audit_*.jsonl")))
+        ok, errors = logger.validate_chain(log_file)
+        assert ok, f"chain broken with reflection event: {errors}"
+
+        # Walk the file and confirm the middle entry is a reflection.
+        lines = log_file.read_text(encoding="utf-8").strip().split("\n")
+        assert len(lines) == 3
+        middle = json.loads(lines[1])
+        assert middle["category"] == "reflection"
+        assert middle["action"] == "causal_sequence_recorded"
+        assert middle["parameters"]["session_id"] == "run_1"
+        assert middle["parameters"]["score"] == 0.9

--- a/tests/test_learning/test_causal_audit_atomicity.py
+++ b/tests/test_learning/test_causal_audit_atomicity.py
@@ -7,8 +7,10 @@ Operational-Trust PR-A/3:
     the row -- both, atomic via ``with conn:``.
   - If ``audit_emit_callback`` raises, the DB INSERT is rolled back
     (row count unchanged) -- atomic-or-nothing.
-  - ``tool_sequence`` is serialised canonically (compact separators,
-    ensure_ascii=False); identical inputs produce bit-identical rows.
+  - ``tool_sequence`` is serialised canonically (sort_keys=True,
+    default separators, ensure_ascii=False — same convention as
+    ``AuditLogger._last_hash_for_file``); identical inputs produce
+    bit-identical rows.
 """
 
 from __future__ import annotations
@@ -133,8 +135,9 @@ class TestCanonicalRowContent:
                 .fetchone()
             )
             assert row_a["tool_sequence"] == row_b["tool_sequence"]
-            # Canonical compact form: no spaces between separators.
-            assert row_a["tool_sequence"] == '["read","write"]'
+            # Canonical form matching _last_hash_for_file convention:
+            # default Python separators (with whitespace), sort_keys.
+            assert row_a["tool_sequence"] == '["read", "write"]'
         finally:
             analyzer_a.close()
             analyzer_b.close()

--- a/tests/test_learning/test_causal_audit_atomicity.py
+++ b/tests/test_learning/test_causal_audit_atomicity.py
@@ -1,0 +1,185 @@
+"""Atomicity + audit-emission tests for ``CausalAnalyzer.record_sequence``.
+
+Operational-Trust PR-A/3:
+  - Empty ``tool_sequence`` emits ``causal_skipped_empty_sequence``
+    BEFORE the early return (audit gap closed).
+  - Successful record emits ``causal_sequence_recorded`` AND inserts
+    the row -- both, atomic via ``with conn:``.
+  - If ``audit_emit_callback`` raises, the DB INSERT is rolled back
+    (row count unchanged) -- atomic-or-nothing.
+  - ``tool_sequence`` is serialised canonically (compact separators,
+    ensure_ascii=False); identical inputs produce bit-identical rows.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from cognithor.learning.causal import CausalAnalyzer
+
+
+class TestSkippedEmptySequenceAuditEvent:
+    """Empty-sequence path -- the silent-skip gap is closed."""
+
+    def test_empty_sequence_emits_skip_event(self) -> None:
+        events: list[tuple[str, dict]] = []
+
+        analyzer = CausalAnalyzer(
+            audit_emit_callback=lambda event_type, payload: events.append((event_type, payload)),
+        )
+        try:
+            analyzer.record_sequence(
+                session_id="s1",
+                tool_sequence=[],
+                success_score=0.5,
+                model_used="qwen3:8b",
+            )
+            assert len(events) == 1
+            event_type, payload = events[0]
+            assert event_type == "causal_skipped_empty_sequence"
+            assert payload["session_id"] == "s1"
+            assert payload["success_score"] == 0.5
+            assert payload["model_used"] == "qwen3:8b"
+            # No row written.
+            assert analyzer.get_total_sequences() == 0
+        finally:
+            analyzer.close()
+
+    def test_empty_sequence_no_callback_still_skips(self) -> None:
+        analyzer = CausalAnalyzer()  # no callback
+        try:
+            analyzer.record_sequence("s1", [], 0.5)
+            assert analyzer.get_total_sequences() == 0
+        finally:
+            analyzer.close()
+
+
+class TestSuccessfulRecordAtomicity:
+    """Success path -- INSERT + audit emit are atomic."""
+
+    def test_record_emits_event_and_inserts_row(self) -> None:
+        events: list[tuple[str, dict]] = []
+
+        analyzer = CausalAnalyzer(
+            audit_emit_callback=lambda event_type, payload: events.append((event_type, payload)),
+        )
+        try:
+            analyzer.record_sequence(
+                session_id="s1",
+                tool_sequence=["read_file", "write_file"],
+                success_score=0.9,
+                model_used="qwen3:8b",
+            )
+            assert analyzer.get_total_sequences() == 1
+            assert len(events) == 1
+            event_type, payload = events[0]
+            assert event_type == "causal_sequence_recorded"
+            assert payload["session_id"] == "s1"
+            assert payload["tool_sequence"] == ["read_file", "write_file"]
+            assert payload["success_score"] == 0.9
+            assert payload["model_used"] == "qwen3:8b"
+            assert "timestamp" in payload
+        finally:
+            analyzer.close()
+
+    def test_audit_callback_raises_rolls_back_insert(self) -> None:
+        """If the audit emit raises, the DB INSERT is rolled back."""
+
+        def failing_callback(_event_type: str, _payload: dict) -> None:
+            raise RuntimeError("audit backend down")
+
+        analyzer = CausalAnalyzer(audit_emit_callback=failing_callback)
+        try:
+            with pytest.raises(RuntimeError, match="audit backend down"):
+                analyzer.record_sequence(
+                    session_id="s1",
+                    tool_sequence=["a", "b"],
+                    success_score=0.5,
+                )
+            # Row count unchanged: rollback worked.
+            assert analyzer.get_total_sequences() == 0
+        finally:
+            analyzer.close()
+
+    def test_no_callback_path_still_inserts(self) -> None:
+        """Backwards-compat: callback=None keeps legacy behaviour."""
+        analyzer = CausalAnalyzer()  # no callback
+        try:
+            analyzer.record_sequence("s1", ["a", "b"], 0.5)
+            assert analyzer.get_total_sequences() == 1
+        finally:
+            analyzer.close()
+
+
+class TestCanonicalRowContent:
+    """``tool_sequence`` is serialised canonically."""
+
+    def test_identical_input_produces_identical_row(self) -> None:
+        analyzer_a = CausalAnalyzer()
+        analyzer_b = CausalAnalyzer()
+        try:
+            analyzer_a.record_sequence("s1", ["read", "write"], 0.5)
+            analyzer_b.record_sequence("s1", ["read", "write"], 0.5)
+            row_a = (
+                analyzer_a._get_conn()
+                .execute("SELECT tool_sequence FROM causal_sequences")
+                .fetchone()
+            )
+            row_b = (
+                analyzer_b._get_conn()
+                .execute("SELECT tool_sequence FROM causal_sequences")
+                .fetchone()
+            )
+            assert row_a["tool_sequence"] == row_b["tool_sequence"]
+            # Canonical compact form: no spaces between separators.
+            assert row_a["tool_sequence"] == '["read","write"]'
+        finally:
+            analyzer_a.close()
+            analyzer_b.close()
+
+    def test_unicode_preserved_via_ensure_ascii_false(self) -> None:
+        analyzer = CausalAnalyzer()
+        try:
+            analyzer.record_sequence("s1", ["café_tool"], 0.5)
+            row = (
+                analyzer._get_conn()
+                .execute("SELECT tool_sequence FROM causal_sequences")
+                .fetchone()
+            )
+            # Unicode preserved as UTF-8, not \uXXXX-escaped.
+            assert "café_tool" in row["tool_sequence"]
+            # Round-trips correctly.
+            assert json.loads(row["tool_sequence"]) == ["café_tool"]
+        finally:
+            analyzer.close()
+
+
+class TestSetAuditEmitCallback:
+    """Late-binding via the setter (gateway boot order)."""
+
+    def test_setter_late_binds_callback(self) -> None:
+        events: list[tuple[str, dict]] = []
+        analyzer = CausalAnalyzer()
+        try:
+            analyzer.set_audit_emit_callback(
+                lambda event_type, payload: events.append((event_type, payload))
+            )
+            analyzer.record_sequence("s1", ["a"], 0.5)
+            assert len(events) == 1
+            assert events[0][0] == "causal_sequence_recorded"
+        finally:
+            analyzer.close()
+
+    def test_setter_can_clear_callback(self) -> None:
+        events: list[tuple[str, dict]] = []
+        analyzer = CausalAnalyzer(
+            audit_emit_callback=lambda event_type, payload: events.append((event_type, payload)),
+        )
+        try:
+            analyzer.set_audit_emit_callback(None)
+            analyzer.record_sequence("s1", ["a"], 0.5)
+            assert events == []
+        finally:
+            analyzer.close()

--- a/tests/test_security/test_reflector_audit_helper.py
+++ b/tests/test_security/test_reflector_audit_helper.py
@@ -1,0 +1,143 @@
+"""Tests for the Reflector audit-event helper (Operational-Trust PR-A/3).
+
+Verifies:
+  - Helper produces stable, reproducible canonical-JSON SHA-256.
+  - Helper no-ops when ``audit_logger`` is None.
+  - Helper does NOT raise when the underlying ``log_system`` raises
+    (best-effort discipline; runtime path stays alive).
+  - ``payload_sha256`` is deterministic (NFC + sort_keys + compact).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from cognithor.config import CognithorConfig, ensure_directory_structure
+from cognithor.core.reflector import Reflector
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _mock_ollama() -> MagicMock:
+    return MagicMock()
+
+
+def _mock_router() -> MagicMock:
+    router = MagicMock()
+    router.select_model.return_value = "qwen3:8b"
+    return router
+
+
+def _canonical_hash(payload: dict) -> str:
+    """Reference implementation matching the helper."""
+    canonical = unicodedata.normalize(
+        "NFC",
+        json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ),
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+@pytest.fixture()
+def config(tmp_path: Path) -> CognithorConfig:
+    cfg = CognithorConfig(cognithor_home=tmp_path)
+    ensure_directory_structure(cfg)
+    return cfg
+
+
+class TestEmitReflectionAuditEvent:
+    """``Reflector._emit_reflection_audit_event`` contract."""
+
+    def test_no_op_when_audit_logger_none(self, config: CognithorConfig) -> None:
+        reflector = Reflector(config, _mock_ollama(), _mock_router())
+        # Should not raise, should not call anything.
+        reflector._emit_reflection_audit_event(
+            "test_event",
+            {"foo": "bar"},
+        )
+
+    def test_calls_log_system_with_canonical_payload(self, config: CognithorConfig) -> None:
+        audit = MagicMock()
+        reflector = Reflector(config, _mock_ollama(), _mock_router(), audit_logger=audit)
+        payload = {"session_id": "s1", "tools": ["a", "b"]}
+        reflector._emit_reflection_audit_event("test_event", payload)
+
+        audit.log_system.assert_called_once()
+        call = audit.log_system.call_args
+        assert call.kwargs["event"] == "test_event"
+        # Description is canonical JSON containing payload_sha256.
+        emitted = json.loads(call.kwargs["description"])
+        assert emitted["session_id"] == "s1"
+        assert emitted["tools"] == ["a", "b"]
+        assert emitted["payload_sha256"] == _canonical_hash(payload)
+
+    def test_payload_sha256_is_stable_across_calls(self, config: CognithorConfig) -> None:
+        audit = MagicMock()
+        reflector = Reflector(config, _mock_ollama(), _mock_router(), audit_logger=audit)
+        payload = {"b": 2, "a": 1}
+        reflector._emit_reflection_audit_event("evt", payload)
+        reflector._emit_reflection_audit_event("evt", payload)
+
+        emitted_1 = json.loads(audit.log_system.call_args_list[0].kwargs["description"])
+        emitted_2 = json.loads(audit.log_system.call_args_list[1].kwargs["description"])
+        assert emitted_1["payload_sha256"] == emitted_2["payload_sha256"]
+
+    def test_payload_sha256_independent_of_key_order(self, config: CognithorConfig) -> None:
+        audit = MagicMock()
+        reflector = Reflector(config, _mock_ollama(), _mock_router(), audit_logger=audit)
+        reflector._emit_reflection_audit_event("evt", {"a": 1, "b": 2})
+        reflector._emit_reflection_audit_event("evt", {"b": 2, "a": 1})
+
+        emitted_1 = json.loads(audit.log_system.call_args_list[0].kwargs["description"])
+        emitted_2 = json.loads(audit.log_system.call_args_list[1].kwargs["description"])
+        assert emitted_1["payload_sha256"] == emitted_2["payload_sha256"]
+
+    def test_payload_sha256_reproducible_via_reference(self, config: CognithorConfig) -> None:
+        """Hash matches an independently-computed reference (different
+        Python session would compute the same digest)."""
+        audit = MagicMock()
+        reflector = Reflector(config, _mock_ollama(), _mock_router(), audit_logger=audit)
+        payload = {"unicode": "café", "score": 0.5, "tools": ["read", "write"]}
+        reflector._emit_reflection_audit_event("evt", payload)
+
+        emitted = json.loads(audit.log_system.call_args.kwargs["description"])
+        assert emitted["payload_sha256"] == _canonical_hash(payload)
+
+    def test_does_not_raise_when_logger_raises(self, config: CognithorConfig) -> None:
+        audit = MagicMock()
+        audit.log_system.side_effect = RuntimeError("audit backend down")
+        reflector = Reflector(config, _mock_ollama(), _mock_router(), audit_logger=audit)
+        # Best-effort: must NOT raise.
+        reflector._emit_reflection_audit_event("evt", {"x": 1})
+
+    def test_does_not_mutate_input_payload(self, config: CognithorConfig) -> None:
+        audit = MagicMock()
+        reflector = Reflector(config, _mock_ollama(), _mock_router(), audit_logger=audit)
+        payload = {"a": 1}
+        reflector._emit_reflection_audit_event("evt", payload)
+        assert "payload_sha256" not in payload
+
+    def test_handles_unicode_nfc_normalisation(self, config: CognithorConfig) -> None:
+        audit = MagicMock()
+        reflector = Reflector(config, _mock_ollama(), _mock_router(), audit_logger=audit)
+        # "é" as composed (NFC) vs decomposed (NFD) should hash the same
+        # after NFC normalisation.
+        composed = {"name": "café"}
+        decomposed = {"name": "café"}
+        reflector._emit_reflection_audit_event("evt", composed)
+        reflector._emit_reflection_audit_event("evt", decomposed)
+
+        emitted_1 = json.loads(audit.log_system.call_args_list[0].kwargs["description"])
+        emitted_2 = json.loads(audit.log_system.call_args_list[1].kwargs["description"])
+        assert emitted_1["payload_sha256"] == emitted_2["payload_sha256"]

--- a/tests/test_security/test_reflector_audit_helper.py
+++ b/tests/test_security/test_reflector_audit_helper.py
@@ -3,9 +3,13 @@
 Verifies:
   - Helper produces stable, reproducible canonical-JSON SHA-256.
   - Helper no-ops when ``audit_logger`` is None.
-  - Helper does NOT raise when the underlying ``log_system`` raises
-    (best-effort discipline; runtime path stays alive).
-  - ``payload_sha256`` is deterministic (NFC + sort_keys + compact).
+  - Helper does NOT raise when the underlying ``log_reflection_event``
+    raises (best-effort discipline; runtime path stays alive).
+  - ``payload_sha256`` is deterministic (NFC + sort_keys + default
+    separators).
+  - Canonical-form bytes match the convention in
+    ``AuditLogger._last_hash_for_file`` (one recipe across the audit
+    module).
 """
 
 from __future__ import annotations
@@ -18,6 +22,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from cognithor.audit import AuditCategory
 from cognithor.config import CognithorConfig, ensure_directory_structure
 from cognithor.core.reflector import Reflector
 
@@ -36,15 +41,15 @@ def _mock_router() -> MagicMock:
 
 
 def _canonical_hash(payload: dict) -> str:
-    """Reference implementation matching the helper."""
+    """Reference implementation matching the helper.
+
+    Default Python separators, ``sort_keys=True``, ``ensure_ascii=False``,
+    NFC-normalised — same convention used by
+    ``AuditLogger._last_hash_for_file``.
+    """
     canonical = unicodedata.normalize(
         "NFC",
-        json.dumps(
-            payload,
-            sort_keys=True,
-            separators=(",", ":"),
-            ensure_ascii=False,
-        ),
+        json.dumps(payload, sort_keys=True, ensure_ascii=False),
     ).encode("utf-8")
     return hashlib.sha256(canonical).hexdigest()
 
@@ -67,17 +72,22 @@ class TestEmitReflectionAuditEvent:
             {"foo": "bar"},
         )
 
-    def test_calls_log_system_with_canonical_payload(self, config: CognithorConfig) -> None:
+    def test_calls_log_reflection_event_with_structured_payload(
+        self, config: CognithorConfig
+    ) -> None:
         audit = MagicMock()
         reflector = Reflector(config, _mock_ollama(), _mock_router(), audit_logger=audit)
         payload = {"session_id": "s1", "tools": ["a", "b"]}
         reflector._emit_reflection_audit_event("test_event", payload)
 
-        audit.log_system.assert_called_once()
-        call = audit.log_system.call_args
-        assert call.kwargs["event"] == "test_event"
-        # Description is canonical JSON containing payload_sha256.
-        emitted = json.loads(call.kwargs["description"])
+        # Helper now routes through log_reflection_event, not log_system.
+        audit.log_reflection_event.assert_called_once()
+        audit.log_system.assert_not_called()
+        call = audit.log_reflection_event.call_args
+        assert call.kwargs["action"] == "test_event"
+        # Payload is a structured dict, not a stringified JSON in description.
+        emitted = call.kwargs["payload"]
+        assert isinstance(emitted, dict)
         assert emitted["session_id"] == "s1"
         assert emitted["tools"] == ["a", "b"]
         assert emitted["payload_sha256"] == _canonical_hash(payload)
@@ -89,8 +99,8 @@ class TestEmitReflectionAuditEvent:
         reflector._emit_reflection_audit_event("evt", payload)
         reflector._emit_reflection_audit_event("evt", payload)
 
-        emitted_1 = json.loads(audit.log_system.call_args_list[0].kwargs["description"])
-        emitted_2 = json.loads(audit.log_system.call_args_list[1].kwargs["description"])
+        emitted_1 = audit.log_reflection_event.call_args_list[0].kwargs["payload"]
+        emitted_2 = audit.log_reflection_event.call_args_list[1].kwargs["payload"]
         assert emitted_1["payload_sha256"] == emitted_2["payload_sha256"]
 
     def test_payload_sha256_independent_of_key_order(self, config: CognithorConfig) -> None:
@@ -99,8 +109,8 @@ class TestEmitReflectionAuditEvent:
         reflector._emit_reflection_audit_event("evt", {"a": 1, "b": 2})
         reflector._emit_reflection_audit_event("evt", {"b": 2, "a": 1})
 
-        emitted_1 = json.loads(audit.log_system.call_args_list[0].kwargs["description"])
-        emitted_2 = json.loads(audit.log_system.call_args_list[1].kwargs["description"])
+        emitted_1 = audit.log_reflection_event.call_args_list[0].kwargs["payload"]
+        emitted_2 = audit.log_reflection_event.call_args_list[1].kwargs["payload"]
         assert emitted_1["payload_sha256"] == emitted_2["payload_sha256"]
 
     def test_payload_sha256_reproducible_via_reference(self, config: CognithorConfig) -> None:
@@ -111,12 +121,36 @@ class TestEmitReflectionAuditEvent:
         payload = {"unicode": "café", "score": 0.5, "tools": ["read", "write"]}
         reflector._emit_reflection_audit_event("evt", payload)
 
-        emitted = json.loads(audit.log_system.call_args.kwargs["description"])
+        emitted = audit.log_reflection_event.call_args.kwargs["payload"]
         assert emitted["payload_sha256"] == _canonical_hash(payload)
+
+    def test_canonical_form_matches_last_hash_for_file_convention(
+        self, config: CognithorConfig
+    ) -> None:
+        """Lock the canonical-form convention to the one used in
+        ``AuditLogger._last_hash_for_file`` (audit module line 830):
+        ``json.dumps(data, sort_keys=True, ensure_ascii=False)`` —
+        default Python separators, no compact form. The helper must
+        hash the same bytes for the same payload.
+        """
+        payload = {"unicode": "café", "score": 0.5, "tools": ["read", "write"]}
+        # Replicate the _last_hash_for_file recipe (line 830).
+        last_hash_for_file_canonical = json.dumps(
+            payload, sort_keys=True, ensure_ascii=False
+        ).encode("utf-8")
+        # The helper additionally NFC-normalises before encoding.
+        helper_canonical = unicodedata.normalize(
+            "NFC",
+            json.dumps(payload, sort_keys=True, ensure_ascii=False),
+        ).encode("utf-8")
+        # For ASCII-clean + already-NFC payloads the byte streams are
+        # identical — proving the helper uses the same separators / sort /
+        # ensure_ascii recipe as _last_hash_for_file.
+        assert helper_canonical == last_hash_for_file_canonical
 
     def test_does_not_raise_when_logger_raises(self, config: CognithorConfig) -> None:
         audit = MagicMock()
-        audit.log_system.side_effect = RuntimeError("audit backend down")
+        audit.log_reflection_event.side_effect = RuntimeError("audit backend down")
         reflector = Reflector(config, _mock_ollama(), _mock_router(), audit_logger=audit)
         # Best-effort: must NOT raise.
         reflector._emit_reflection_audit_event("evt", {"x": 1})
@@ -134,10 +168,30 @@ class TestEmitReflectionAuditEvent:
         # "é" as composed (NFC) vs decomposed (NFD) should hash the same
         # after NFC normalisation.
         composed = {"name": "café"}
-        decomposed = {"name": "café"}
+        decomposed = {"name": "café"}
         reflector._emit_reflection_audit_event("evt", composed)
         reflector._emit_reflection_audit_event("evt", decomposed)
 
-        emitted_1 = json.loads(audit.log_system.call_args_list[0].kwargs["description"])
-        emitted_2 = json.loads(audit.log_system.call_args_list[1].kwargs["description"])
+        emitted_1 = audit.log_reflection_event.call_args_list[0].kwargs["payload"]
+        emitted_2 = audit.log_reflection_event.call_args_list[1].kwargs["payload"]
         assert emitted_1["payload_sha256"] == emitted_2["payload_sha256"]
+
+    def test_routes_to_reflection_category_via_real_logger(self, config: CognithorConfig) -> None:
+        """End-to-end: a real ``AuditLogger`` receives a REFLECTION-
+        category entry whose ``parameters`` contain the structured
+        payload (including ``payload_sha256``).
+        """
+        from cognithor.audit import AuditLogger
+
+        audit = AuditLogger()
+        reflector = Reflector(config, _mock_ollama(), _mock_router(), audit_logger=audit)
+        payload = {"session_id": "s1", "tools": ["a"]}
+        reflector._emit_reflection_audit_event("causal_sequence_recorded", payload)
+
+        entries = audit.query(category=AuditCategory.REFLECTION)
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry.action == "causal_sequence_recorded"
+        assert entry.parameters["session_id"] == "s1"
+        assert entry.parameters["tools"] == ["a"]
+        assert entry.parameters["payload_sha256"] == _canonical_hash(payload)


### PR DESCRIPTION
## Summary

**Foundation PR (A/3)** of the 3-PR Compliance-Hardening Suite for Operational-Trust audit gaps. API stability matters here because PR-B (`WeightOptimizer` snapshot + `channel_contributions` upstream fix) and PR-C (Hypothesis property tests) build on the helper signature shipped here.

This PR ships the unified audit-event helper for the `Reflector` and the atomic-transaction wiring in `learning/causal.py`. No behaviour changes for code paths that don't pass an `audit_logger` / callback.

### What lands

**1. `Reflector._emit_reflection_audit_event(event_type: str, payload: dict[str, Any]) -> None`**

```python
def _emit_reflection_audit_event(
    self,
    event_type: str,
    payload: dict[str, Any],
) -> None:
```

Contract:
- No-op when `self._audit_logger is None`.
- Computes `payload_sha256` over the canonical form (`unicodedata.normalize("NFC", json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=False)).encode("utf-8")` then `hashlib.sha256(...).hexdigest()`) and adds it to the emitted payload so consumers can verify integrity.
- Best-effort: try/except wraps the emit; failures `log.warning("audit_emit_failed", ...)` but never raise. Audit failures must NEVER crash the runtime path.

**Integration with the existing `AuditLogger` API**: the canonical class at `src/cognithor/audit/__init__.py:206` is a typed-method logger (`log_tool_call`, `log_system`, `log_security`, …) with no generic `emit(event_type, payload)`. The brief explicitly required the helper to integrate with the existing convention, so the helper uses `log_system(event=event_type, description=<canonical-json-with-sha256>)` — keeps the canonical Reflector signature `(event_type, payload)` for PR-B / PR-C while reusing the existing schema-versioned, hash-chained AuditLogger infrastructure.

**2. `CausalAnalyzer.record_sequence` — atomic-or-nothing**

- New `__init__(audit_emit_callback: Callable[[str, dict[str, Any]], None] | None = None)` parameter + late-binding `set_audit_emit_callback(callback)`.
- Empty `tool_sequence` is no longer silently dropped — emits `causal_skipped_empty_sequence` before the early return when a callback is wired (audit gap closed).
- Successful path is wrapped in `with conn:` so the `INSERT` and `causal_sequence_recorded` audit emit are atomic. If the audit callback raises (e.g. test mock), the row is rolled back. The Reflector helper itself never raises (best-effort), so production behaviour is unchanged; tests verify atomicity by injecting a raising mock.
- `tool_sequence` is now serialised canonically (`json.dumps(..., separators=(",", ":"), ensure_ascii=False)`) so identical inputs produce bit-identical row content.

**3. Auto-wiring in `Reflector.__init__`**

When the Reflector receives a `causal_analyzer` that exposes `set_audit_emit_callback`, it binds `self._emit_reflection_audit_event` automatically. The single production construction site (`gateway/phases/pge.py:278`) is therefore covered without touching the gateway code (the `causal_analyzer` is constructed BEFORE the Reflector, so `__init__`-time injection is not possible there).

### Why this shape

- **Best-effort helper vs. atomic causal.py** is intentional and inverse: the runtime path is more critical than the audit, so the helper never crashes the cycle. But for `record_sequence` we want the audit event and the DB INSERT to agree — if either side fails, neither commits. Both behaviours are correct in their context.
- **`payload_sha256` inside the payload** lets downstream consumers verify integrity without needing access to the original `dict`. NFC + sort_keys + compact separators + ensure_ascii=False makes the digest reproducible across Python sessions.

### Scope-fence (deliberately NOT touched)

- `reflector.py:558` `channel_contributions={"vector": 0.5, ...}` — PR-B territory.
- `_write_episodic` / `_write_semantic` / `_write_procedural` in `Reflector.apply()` — PR-B / PR-C territory.
- New event types beyond the two introduced here — PR-B will add `procedure_auto_created` etc.
- Hypothesis property tests — PR-C.

### Follow-ups

- **PR-B**: WeightOptimizer snapshot + `channel_contributions` upstream fix; uses the helper signature shipped here.
- **PR-C**: Hypothesis property tests for audit completeness; relies on the canonical-form + `payload_sha256` contract.

## Test plan

- [x] `pytest tests/test_security/test_reflector_audit_helper.py tests/test_learning/test_causal_audit_atomicity.py -v` → **17 passed in 0.63s**
- [x] Sanity: `tests/test_learning/`, `tests/test_core/test_reflector.py`, `tests/test_core/test_reflector_coverage.py` → 208 passed
- [x] Sanity: `tests/test_integration/test_wiring_extended.py`, `tests/test_core/test_feedback_loop.py`, `tests/test_security/test_audit.py` → 57 passed
- [x] `ruff check src/cognithor/ tests/` → all checks passed
- [x] `ruff format --check src/cognithor/ tests/` → 1772 files already formatted
- [x] `mypy --strict src/cognithor/core/reflector.py src/cognithor/learning/causal.py` → no issues found