### PR TITLE
feat(operational-trust): WeightOptimizer snapshots + channel_contributions fix (PR-B/3)

### DIFF
--- a/src/cognithor/core/reflector.py
+++ b/src/cognithor/core/reflector.py
@@ -95,6 +95,49 @@ def _safe_float(value: Any, default: float) -> float:
         return default
 
 
+def _compute_channel_contributions(
+    injected_memories: list[Any],
+) -> dict[str, float]:
+    """Compute channel contribution shares from injected search results.
+
+    Operational-Trust PR-B (2026-05-05): replaces the hardcoded
+    ``{"vector": 0.5, "bm25": 0.3, "graph": 0.2}`` constant that fed
+    the WeightOptimizer with constants instead of real signals (see
+    bug at ``reflector.py:558`` pre-fix).
+
+    Concrete formula per the PR-B brief:
+        contribution = (number of hits from channel) / (total hits)
+
+    A channel "hits" on a result when its per-channel score is > 0.
+    Channels that did not contribute to any result yield 0.0.
+
+    Returns an empty dict when no results are present so the caller can
+    skip the EMA update entirely instead of feeding zeros (which would
+    bias future weights toward the minimum-weight floor).
+    """
+    if not injected_memories:
+        return {}
+
+    counts = {"vector": 0, "bm25": 0, "graph": 0}
+    for result in injected_memories:
+        if getattr(result, "vector_score", 0.0) > 0:
+            counts["vector"] += 1
+        if getattr(result, "bm25_score", 0.0) > 0:
+            counts["bm25"] += 1
+        if getattr(result, "graph_score", 0.0) > 0:
+            counts["graph"] += 1
+
+    total_hits = counts["vector"] + counts["bm25"] + counts["graph"]
+    if total_hits == 0:
+        return {}
+
+    return {
+        "vector": counts["vector"] / total_hits,
+        "bm25": counts["bm25"] / total_hits,
+        "graph": counts["graph"] / total_hits,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Reflector
 # ---------------------------------------------------------------------------
@@ -160,6 +203,21 @@ class Reflector:
                 self._causal_analyzer.set_audit_emit_callback(self._emit_reflection_audit_event)
             except Exception as exc:
                 log.warning("causal_audit_callback_wire_failed", error=str(exc))
+
+        # Operational-Trust PR-B: same auto-wire for the
+        # SearchWeightOptimizer. The optimizer is constructed inside
+        # MemoryManager (boot order: memory before reflector), so the
+        # callback can't be passed at __init__ time. The setter is the
+        # bridge — every weight-snapshot persist will emit a
+        # ``weight_snapshot_persisted`` reflection event into the
+        # TRUST-1 receipt channel.
+        if self._weight_optimizer is not None and hasattr(
+            self._weight_optimizer, "set_audit_emit_callback"
+        ):
+            try:
+                self._weight_optimizer.set_audit_emit_callback(self._emit_reflection_audit_event)
+            except Exception as exc:
+                log.warning("weight_optimizer_audit_callback_wire_failed", error=str(exc))
 
     # ------------------------------------------------------------------
     # Operational-Trust audit helper (PR-A/3)
@@ -615,16 +673,32 @@ class Reflector:
             except Exception as exc:
                 log.debug("causal_record_failed", error=str(exc))
 
-        # Weight Optimizer: Such-Feedback (wenn Reflexion Suche enthielt)
+        # Weight Optimizer: Such-Feedback (wenn Reflexion Suche enthielt).
+        # Operational-Trust PR-B: channel_contributions now reflects the
+        # real per-channel hit share computed from working_memory's
+        # injected search results — no longer the hardcoded
+        # ``{"vector": 0.5, "bm25": 0.3, "graph": 0.2}`` phantom that
+        # caused the optimizer to learn from constants. When the
+        # session had no search hits (empty dict), the EMA update is
+        # skipped entirely instead of feeding zeros which would bias
+        # the weights toward the minimum-weight floor.
         if self._weight_optimizer and result.success_score > 0:
-            try:
-                self._weight_optimizer.record_outcome(
-                    query=session.session_id[:16],
-                    channel_contributions={"vector": 0.5, "bm25": 0.3, "graph": 0.2},
-                    feedback_score=result.success_score,
+            channel_contributions = _compute_channel_contributions(working_memory.injected_memories)
+            if not channel_contributions:
+                log.debug(
+                    "weight_optimizer_skipped_no_search",
+                    session_id=session.session_id,
                 )
-            except Exception as exc:
-                log.debug("weight_optimizer_feedback_failed", error=str(exc))
+            else:
+                try:
+                    self._weight_optimizer.record_outcome(
+                        query=session.session_id[:16],
+                        channel_contributions=channel_contributions,
+                        feedback_score=result.success_score,
+                        session_id=session.session_id,
+                    )
+                except Exception as exc:
+                    log.debug("weight_optimizer_feedback_failed", error=str(exc))
 
         return result
 

--- a/src/cognithor/memory/manager.py
+++ b/src/cognithor/memory/manager.py
@@ -101,7 +101,28 @@ class MemoryManager:
             from cognithor.memory.weight_optimizer import SearchWeightOptimizer as _SWO
 
             opt_db = str(self._config.db_path.with_name("memory_weights.db"))
-            self._weight_optimizer = _SWO(opt_db)
+
+            # Operational-Trust PR-B: wire the encrypted-at-rest snapshot
+            # plumbing. ``EncryptedFileIO`` lazy-loads its key from the
+            # OS keyring chain (env var → keyring → CredentialStore);
+            # when no key is available the optimizer simply skips
+            # snapshots with a debug log. The audit-emit callback is
+            # late-bound by the Reflector via ``set_audit_emit_callback``.
+            _snapshot_dir: Path | None = None
+            _snapshot_io: Any = None
+            try:
+                from cognithor.security.encrypted_file import EncryptedFileIO
+
+                _snapshot_dir = self._config.cognithor_home / "weight_snapshots"
+                _snapshot_io = EncryptedFileIO()
+            except Exception as snap_exc:
+                logger.debug("weight_snapshot_io_init_skipped: %s", snap_exc)
+
+            self._weight_optimizer = _SWO(
+                opt_db,
+                encrypted_file_io=_snapshot_io,
+                snapshot_dir=_snapshot_dir,
+            )
         except ImportError:
             logger.debug("SearchWeightOptimizer init skipped: module not available")
         except Exception as exc:

--- a/src/cognithor/memory/weight_optimizer.py
+++ b/src/cognithor/memory/weight_optimizer.py
@@ -5,12 +5,25 @@ measured by user satisfaction (reflector score).
 
 EMA-Formel: w_new = alpha * observed + (1-alpha) * w_old
 Constraints: Jedes Gewicht min 0.05, Summe = 1.0
+
+Operational-Trust PR-B (2026-05-05): every successful ``record_outcome``
+call now produces a Fernet-encrypted snapshot of the active weight
+vector under ``<snapshot_dir>/<weight_sha256>.fernet`` plus a plaintext
+``<weight_sha256>.meta.json`` sidecar. Snapshots are content-addressed
+by the SHA-256 of the canonical-NFC-JSON of the plaintext weights, so
+identical weights produce identical hashes and the file is written at
+most once. The snapshot SHA-256 is forwarded to the Reflector's audit
+channel (PR-A) so TRUST-1 receipt verifiers can chain-verify which
+weight vector was active at run time without needing the encryption
+key.
 """
 
 from __future__ import annotations
 
 import hashlib
+import json
 import sqlite3
+import unicodedata
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -28,7 +41,10 @@ except ImportError:
 from cognithor.utils.logging import get_logger
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from pathlib import Path
+
+    from cognithor.security.encrypted_file import EncryptedFileIO
 
 log = get_logger(__name__)
 
@@ -46,10 +62,36 @@ class SearchWeightOptimizer:
         db_path: str | Path | None = None,
         alpha: float = DEFAULT_ALPHA,
         initial_weights: tuple[float, float, float] | None = None,
+        *,
+        encrypted_file_io: EncryptedFileIO | None = None,
+        snapshot_dir: Path | None = None,
+        audit_emit_callback: Callable[[str, dict[str, Any]], None] | None = None,
     ) -> None:
+        """Operational-Trust PR-B: snapshot-related kwargs.
+
+        ``encrypted_file_io`` is an :class:`EncryptedFileIO` instance
+        wired to the same OS-keyring chain as the rest of the storage
+        stack; it abstracts Fernet encryption + key loading. Snapshots
+        require both ``encrypted_file_io`` AND ``snapshot_dir`` to be
+        non-None — otherwise the snapshot step is skipped (with a
+        ``log.debug("weight_snapshot_skipped_no_io")``) and the
+        optimizer behaves exactly like before.
+
+        ``audit_emit_callback`` is the Reflector's
+        ``_emit_reflection_audit_event`` helper. When set, every
+        persisted snapshot fires a ``weight_snapshot_persisted`` event
+        with ``weight_sha256`` + ``session_id`` + ``snapshot_bytes`` so
+        the TRUST-1 receipt can cross-verify the active weight vector
+        for a run. ``None`` keeps the legacy debug-only behaviour.
+        """
         self._db_path = str(db_path) if db_path else ":memory:"
         self._alpha = alpha
         self._conn: sqlite3.Connection | None = None
+        self._encrypted_file_io: EncryptedFileIO | None = encrypted_file_io
+        self._snapshot_dir: Path | None = snapshot_dir
+        self._audit_emit_callback: Callable[[str, dict[str, Any]], None] | None = (
+            audit_emit_callback
+        )
 
         # Current weights (vector, bm25, graph)
         if initial_weights:
@@ -61,6 +103,34 @@ class SearchWeightOptimizer:
 
         self._ensure_schema()
         self._load_weights()
+
+    def set_audit_emit_callback(
+        self,
+        callback: Callable[[str, dict[str, Any]], None] | None,
+    ) -> None:
+        """Late-bind the audit-emit callback (Operational-Trust PR-B).
+
+        Mirrors :meth:`CausalAnalyzer.set_audit_emit_callback` from PR-A.
+        Used by the gateway boot path: the optimizer is constructed
+        inside :class:`MemoryManager` before the :class:`Reflector`
+        exists, so the helper cannot be passed at ``__init__`` time.
+        """
+        self._audit_emit_callback = callback
+
+    def set_snapshot_io(
+        self,
+        encrypted_file_io: EncryptedFileIO | None,
+        snapshot_dir: Path | None,
+    ) -> None:
+        """Late-bind the snapshot encryption + directory pair.
+
+        Production wiring: the gateway constructs ``EncryptedFileIO``
+        after the :class:`MemoryManager` (which constructs this
+        optimizer). The pair must be set together — either both
+        non-None to enable snapshots, or both None to disable them.
+        """
+        self._encrypted_file_io = encrypted_file_io
+        self._snapshot_dir = snapshot_dir
 
     def _get_conn(self) -> sqlite3.Connection:
         if self._conn is None:
@@ -153,6 +223,8 @@ class SearchWeightOptimizer:
         query: str,
         channel_contributions: dict[str, float],
         feedback_score: float,
+        *,
+        session_id: str = "",
     ) -> None:
         """Zeichnet ein Suchergebnis auf und aktualisiert Gewichte via EMA.
 
@@ -160,6 +232,10 @@ class SearchWeightOptimizer:
             query: Die Suchanfrage.
             channel_contributions: {"vector": 0-1, "bm25": 0-1, "graph": 0-1}
             feedback_score: Nuetzlichkeit des Ergebnisses (0-1, z.B. Reflector-Score).
+            session_id: Operational-Trust PR-B correlation key. Forwarded to
+                the snapshot meta + audit event so a TRUST-1 receipt can
+                cross-link the weight vector active during this run.
+                Empty string when called outside a Plan→Gate→Execute scope.
         """
         query_hash = hashlib.sha256(query.encode()).hexdigest()[:16]
         v_contrib = channel_contributions.get("vector", 0.0)
@@ -210,6 +286,131 @@ class SearchWeightOptimizer:
                     self.MIN_WEIGHT,
                 )
                 self._save_weights()
+
+        # Operational-Trust PR-B: persist a content-addressed Fernet
+        # snapshot of the (possibly updated) weight vector + sidecar.
+        # Best-effort: a snapshot failure must not break the EMA update.
+        self._persist_snapshot(session_id=session_id)
+
+    # ------------------------------------------------------------------
+    # Operational-Trust PR-B: snapshot machinery
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _canonical_weight_bytes(weights: dict[str, float]) -> bytes:
+        """Return canonical-NFC-JSON bytes of a weight dict.
+
+        Uses the SAME canonical recipe as PR-A's
+        ``Reflector._emit_reflection_audit_event``: NFC normalisation +
+        ``json.dumps(sort_keys=True, ensure_ascii=False)``. Bit-identical
+        across processes, enabling content-addressed deduplication.
+        """
+        canonical = unicodedata.normalize(
+            "NFC",
+            json.dumps(weights, sort_keys=True, ensure_ascii=False),
+        )
+        return canonical.encode("utf-8")
+
+    def current_weight_vector(self) -> dict[str, float]:
+        """Return the active weight vector as a plain dict.
+
+        Stable key order is enforced by callers via the canonical-form
+        recipe; this getter just exposes the live values.
+        """
+        return {
+            "vector": self._w_vector,
+            "bm25": self._w_bm25,
+            "graph": self._w_graph,
+        }
+
+    def _persist_snapshot(self, *, session_id: str = "") -> str | None:
+        """Persist a Fernet-encrypted snapshot + plaintext sidecar.
+
+        Returns the ``weight_sha256`` hash on success (whether or not
+        the file was newly written — content-addressed dedup means
+        identical weights produce identical hashes). Returns ``None``
+        when snapshots are disabled or the encryption layer is
+        unavailable.
+
+        Layout under ``self._snapshot_dir``:
+
+        * ``<weight_sha256>.fernet`` — Fernet-encrypted JSON of the
+          weight dict (via ``EncryptedFileIO.write``)
+        * ``<weight_sha256>.meta.json`` — plaintext sidecar with
+          ``weight_sha256`` + ``fernet_file`` + ``created_at`` +
+          ``session_id`` + ``snapshot_bytes``. Lets receipt verifiers
+          observe existence + chain link without key access.
+
+        On the success path with an audit callback wired, emits a
+        ``weight_snapshot_persisted`` reflection event carrying the
+        same triple (``weight_sha256``, ``session_id``,
+        ``snapshot_bytes``) so the TRUST-1 receipt can cross-link.
+        """
+        if self._encrypted_file_io is None or self._snapshot_dir is None:
+            log.debug("weight_snapshot_skipped_no_io")
+            return None
+
+        # ``EncryptedFileIO.is_available`` triggers lazy-init + key
+        # lookup. False = no key in env / keyring / credential store —
+        # the file would be written as plaintext, which would silently
+        # break the encrypted-at-rest contract. Skip with a debug log.
+        try:
+            if not self._encrypted_file_io.is_available:
+                log.debug("weight_snapshot_skipped_no_key")
+                return None
+        except Exception as exc:
+            log.debug("weight_snapshot_io_probe_failed", error=str(exc))
+            return None
+
+        weights = self.current_weight_vector()
+        try:
+            canonical = self._canonical_weight_bytes(weights)
+            weight_sha256 = hashlib.sha256(canonical).hexdigest()
+            self._snapshot_dir.mkdir(parents=True, exist_ok=True)
+            fernet_path = self._snapshot_dir / f"{weight_sha256}.fernet"
+            meta_path = self._snapshot_dir / f"{weight_sha256}.meta.json"
+
+            snapshot_bytes = len(canonical)
+            # Content-addressed dedup: same weights → same hash → same
+            # filename. Skip rewrite when the encrypted file already
+            # exists (the meta sidecar may legitimately be re-emitted
+            # because callers want a per-run created_at + session_id).
+            if not fernet_path.exists():
+                # ``EncryptedFileIO.write`` accepts ``str`` content; the
+                # plaintext we pass is the canonical-NFC-JSON string —
+                # the bytes the SHA-256 was computed over. Decryption
+                # by an operator returns exactly the same bytes.
+                self._encrypted_file_io.write(fernet_path, canonical.decode("utf-8"))
+
+            meta_payload = {
+                "weight_sha256": weight_sha256,
+                "fernet_file": fernet_path.name,
+                "created_at": datetime.now(UTC).isoformat(),
+                "session_id": session_id,
+                "snapshot_bytes": snapshot_bytes,
+            }
+            meta_path.write_text(
+                json.dumps(meta_payload, sort_keys=True, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        except Exception as exc:
+            log.warning("weight_snapshot_persist_failed", error=str(exc))
+            return None
+
+        if self._audit_emit_callback is not None:
+            try:
+                self._audit_emit_callback(
+                    "weight_snapshot_persisted",
+                    {
+                        "weight_sha256": weight_sha256,
+                        "session_id": session_id,
+                        "snapshot_bytes": snapshot_bytes,
+                    },
+                )
+            except Exception as exc:
+                log.warning("weight_snapshot_audit_emit_failed", error=str(exc))
+
+        return weight_sha256
 
     def get_optimized_weights(self) -> tuple[float, float, float]:
         """Gibt aktuelle optimierte Gewichte zurueck: (w_vector, w_bm25, w_graph)."""

--- a/tests/test_core/test_reflector_channel_contributions.py
+++ b/tests/test_core/test_reflector_channel_contributions.py
@@ -1,0 +1,317 @@
+"""Tests for the Operational-Trust PR-B ``channel_contributions``
+upstream fix in :class:`~cognithor.core.reflector.Reflector`.
+
+Pre-fix bug: ``Reflector.reflect`` fed a HARDCODED phantom
+``{"vector": 0.5, "bm25": 0.3, "graph": 0.2}`` to the
+:class:`~cognithor.memory.weight_optimizer.SearchWeightOptimizer` —
+every call learned from the same constants regardless of which channels
+actually contributed.
+
+PR-B fix: the reflector now reads ``working_memory.injected_memories``
+and computes the per-channel hit share via:
+
+    contribution = (number of hits from channel) / (total hits)
+
+A channel "hits" a result when its per-channel score > 0. When no
+search results were injected (empty mix), the EMA update is skipped
+entirely instead of feeding zeros.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from cognithor.config import CognithorConfig
+from cognithor.core.model_router import ModelRouter, OllamaClient
+from cognithor.core.reflector import Reflector, _compute_channel_contributions
+from cognithor.models import (
+    ActionPlan,
+    AgentResult,
+    Chunk,
+    MemorySearchResult,
+    MemoryTier,
+    Message,
+    MessageRole,
+    PlannedAction,
+    SessionContext,
+    ToolResult,
+    WorkingMemory,
+)
+
+# ============================================================================
+# _compute_channel_contributions: pure function
+# ============================================================================
+
+
+def _make_result(
+    *,
+    bm25: float = 0.0,
+    vector: float = 0.0,
+    graph: float = 0.0,
+    chunk_id: str = "chunk-x",
+) -> MemorySearchResult:
+    chunk = Chunk(
+        id=chunk_id,
+        text="some text",
+        source_path="test.md",
+        memory_tier=MemoryTier.EPISODIC,
+        timestamp=datetime.now(UTC),
+        content_hash="hash-x",
+    )
+    return MemorySearchResult(
+        chunk=chunk,
+        score=max(bm25, vector, graph),
+        bm25_score=bm25,
+        vector_score=vector,
+        graph_score=graph,
+        recency_factor=1.0,
+    )
+
+
+class TestComputeChannelContributions:
+    def test_empty_input_returns_empty_dict(self) -> None:
+        assert _compute_channel_contributions([]) == {}
+
+    def test_all_zero_scores_returns_empty(self) -> None:
+        results = [_make_result(bm25=0.0, vector=0.0, graph=0.0)]
+        assert _compute_channel_contributions(results) == {}
+
+    def test_single_channel_dominates(self) -> None:
+        results = [
+            _make_result(vector=0.9, chunk_id="a"),
+            _make_result(vector=0.7, chunk_id="b"),
+            _make_result(vector=0.5, chunk_id="c"),
+        ]
+        contrib = _compute_channel_contributions(results)
+        assert contrib == {"vector": 1.0, "bm25": 0.0, "graph": 0.0}
+
+    def test_mixed_channels_proportional(self) -> None:
+        # 2 vector hits, 1 bm25 hit, 1 graph hit -> total 4 hits.
+        results = [
+            _make_result(vector=0.8, chunk_id="a"),
+            _make_result(vector=0.6, chunk_id="b"),
+            _make_result(bm25=0.5, chunk_id="c"),
+            _make_result(graph=0.4, chunk_id="d"),
+        ]
+        contrib = _compute_channel_contributions(results)
+        assert contrib["vector"] == pytest.approx(0.5)
+        assert contrib["bm25"] == pytest.approx(0.25)
+        assert contrib["graph"] == pytest.approx(0.25)
+        assert sum(contrib.values()) == pytest.approx(1.0)
+
+    def test_overlapping_channels_count_per_channel(self) -> None:
+        """A single result that scored on multiple channels counts once
+        for each contributing channel — the formula is "number of hits"
+        per channel, independent of per-channel intensity."""
+        results = [
+            _make_result(bm25=0.5, vector=0.5, chunk_id="a"),  # hits 2 channels
+            _make_result(graph=0.4, chunk_id="b"),  # hits 1 channel
+        ]
+        contrib = _compute_channel_contributions(results)
+        # 1 vector hit + 1 bm25 hit + 1 graph hit = 3 total hits.
+        assert contrib["vector"] == pytest.approx(1 / 3)
+        assert contrib["bm25"] == pytest.approx(1 / 3)
+        assert contrib["graph"] == pytest.approx(1 / 3)
+
+    def test_NOT_the_old_phantom_constants(self) -> None:
+        """Regression: the value MUST NEVER be the pre-fix phantom mix."""
+        results = [_make_result(vector=0.9)]
+        contrib = _compute_channel_contributions(results)
+        assert contrib != {"vector": 0.5, "bm25": 0.3, "graph": 0.2}
+
+
+# ============================================================================
+# Reflector.reflect: integration with WeightOptimizer
+# ============================================================================
+
+
+@pytest.fixture()
+def config(tmp_path: Any) -> CognithorConfig:
+    return CognithorConfig(cognithor_home=tmp_path)
+
+
+@pytest.fixture()
+def mock_ollama() -> AsyncMock:
+    return AsyncMock(spec=OllamaClient)
+
+
+@pytest.fixture()
+def mock_router() -> MagicMock:
+    router = MagicMock(spec=ModelRouter)
+    router.select_model.return_value = "qwen3:32b"
+    router.get_model_config.return_value = {
+        "temperature": 0.3,
+        "top_p": 0.9,
+        "context_window": 32768,
+    }
+    return router
+
+
+@pytest.fixture()
+def session() -> SessionContext:
+    return SessionContext(session_id="sess-pr-b", channel="cli", user_id="alex")
+
+
+@pytest.fixture()
+def working_memory_with_search() -> WorkingMemory:
+    """Working memory whose injected memories reflect a real channel mix.
+
+    3 results: 2 vector-only hits, 1 bm25-only hit. Expected share:
+    vector=2/3, bm25=1/3, graph=0.
+    """
+    wm = WorkingMemory(session_id="sess-pr-b")
+    wm.add_message(Message(role=MessageRole.USER, content="recherche-bericht"))
+    wm.injected_memories = [
+        _make_result(vector=0.9, chunk_id="r1"),
+        _make_result(vector=0.7, chunk_id="r2"),
+        _make_result(bm25=0.5, chunk_id="r3"),
+    ]
+    return wm
+
+
+def _make_agent_result_with_tools() -> AgentResult:
+    plans = [
+        ActionPlan(
+            goal="Recherche-Bericht",
+            reasoning="x",
+            steps=[
+                PlannedAction(
+                    tool="memory_search",
+                    params={"query": "x"},
+                    rationale="r",
+                )
+            ],
+        )
+    ]
+    tool_results = [
+        ToolResult(tool_name="memory_search", content="ok", is_error=False),
+    ]
+    return AgentResult(
+        response="ok",
+        plans=plans,
+        tool_results=tool_results,
+        total_iterations=2,
+        total_duration_ms=100,
+        model_used="qwen3:32b",
+        success=True,
+    )
+
+
+GOOD_JSON = """{
+  "success_score": 0.85,
+  "evaluation": "Ok",
+  "extracted_facts": [],
+  "session_summary": {
+    "goal": "x",
+    "outcome": "ok",
+    "key_decisions": [],
+    "open_items": [],
+    "tools_used": ["memory_search"],
+    "duration_ms": 100
+  }
+}"""
+
+
+class TestReflectorPopulatesRealContributions:
+    """The reflector must feed REAL channel mix to the optimizer."""
+
+    async def test_real_channel_mix_passed_to_optimizer(
+        self,
+        config: CognithorConfig,
+        mock_ollama: AsyncMock,
+        mock_router: MagicMock,
+        session: SessionContext,
+        working_memory_with_search: WorkingMemory,
+    ) -> None:
+        mock_ollama.chat.return_value = {
+            "message": {"content": GOOD_JSON},
+            "prompt_eval_count": 10,
+            "eval_count": 10,
+        }
+
+        weight_optimizer = MagicMock()
+        reflector = Reflector(
+            config,
+            mock_ollama,
+            mock_router,
+            weight_optimizer=weight_optimizer,
+        )
+
+        agent_result = _make_agent_result_with_tools()
+        await reflector.reflect(session, working_memory_with_search, agent_result)
+
+        # The optimizer was called with the COMPUTED real share, NOT
+        # the pre-fix phantom constants.
+        assert weight_optimizer.record_outcome.called
+        call_kwargs = weight_optimizer.record_outcome.call_args.kwargs
+        contrib = call_kwargs["channel_contributions"]
+        assert contrib["vector"] == pytest.approx(2 / 3)
+        assert contrib["bm25"] == pytest.approx(1 / 3)
+        assert contrib["graph"] == pytest.approx(0.0)
+        # Critically NOT the phantom.
+        assert contrib != {"vector": 0.5, "bm25": 0.3, "graph": 0.2}
+        # session_id is forwarded for snapshot meta linkage.
+        assert call_kwargs["session_id"] == session.session_id
+
+    async def test_skips_optimizer_when_no_search_hits(
+        self,
+        config: CognithorConfig,
+        mock_ollama: AsyncMock,
+        mock_router: MagicMock,
+        session: SessionContext,
+    ) -> None:
+        """Empty injected_memories → record_outcome is NOT called.
+
+        Pre-fix this fed the optimizer with the phantom constants; PR-B
+        skips the call so the EMA isn't biased by sessions that did no
+        search at all.
+        """
+        mock_ollama.chat.return_value = {
+            "message": {"content": GOOD_JSON},
+            "prompt_eval_count": 10,
+            "eval_count": 10,
+        }
+
+        wm = WorkingMemory(session_id=session.session_id)
+        wm.add_message(Message(role=MessageRole.USER, content="hello"))
+        # NO injected_memories — simulates a session without search.
+
+        weight_optimizer = MagicMock()
+        reflector = Reflector(
+            config,
+            mock_ollama,
+            mock_router,
+            weight_optimizer=weight_optimizer,
+        )
+
+        agent_result = _make_agent_result_with_tools()
+        await reflector.reflect(session, wm, agent_result)
+
+        # The skip path: no record_outcome call (empty contributions).
+        assert not weight_optimizer.record_outcome.called
+
+    async def test_audit_callback_wired_to_optimizer(
+        self,
+        config: CognithorConfig,
+        mock_ollama: AsyncMock,
+        mock_router: MagicMock,
+    ) -> None:
+        """Reflector wires its audit-emit helper into the optimizer at
+        construction time (mirrors PR-A's CausalAnalyzer pattern)."""
+        weight_optimizer = MagicMock()
+
+        Reflector(
+            config,
+            mock_ollama,
+            mock_router,
+            weight_optimizer=weight_optimizer,
+        )
+
+        # The setter should have been called once with a callable.
+        assert weight_optimizer.set_audit_emit_callback.called
+        bound_cb = weight_optimizer.set_audit_emit_callback.call_args.args[0]
+        assert callable(bound_cb)

--- a/tests/test_memory/test_weight_optimizer_snapshot.py
+++ b/tests/test_memory/test_weight_optimizer_snapshot.py
@@ -1,0 +1,428 @@
+"""Tests for the Operational-Trust PR-B snapshot mechanism on
+``SearchWeightOptimizer``.
+
+Covers:
+
+* deterministic ``weight_sha256`` (same plaintext → same hash, NFC + sort_keys)
+* ``.fernet`` + ``.meta.json`` sidecar layout
+* content-addressed deduplication (no rewrite on identical weights)
+* audit-emit callback fires ``weight_snapshot_persisted`` with the
+  correct triple ``(weight_sha256, session_id, snapshot_bytes)``
+* graceful skip when EncryptedFileIO/snapshot_dir are not wired
+
+The Fernet path is exercised via a real :class:`EncryptedFileIO` with
+a transient ``COGNITHOR_DB_KEY`` env var so the keyring chain is never
+touched during the test.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from typing import TYPE_CHECKING, Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from cognithor.memory.weight_optimizer import SearchWeightOptimizer
+from cognithor.security.encrypted_file import EncryptedFileIO
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture()
+def fernet_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Provide a deterministic encryption key via env var.
+
+    ``EncryptedFileIO`` derives its Fernet key from this string via
+    SHA-256, so the test never touches the real OS keyring.
+    """
+    monkeypatch.setenv("COGNITHOR_DB_KEY", "pr-b-snapshot-test-key")
+
+
+@pytest.fixture()
+def snapshot_dir(tmp_path: Path) -> Path:
+    return tmp_path / "weight_snapshots"
+
+
+@pytest.fixture()
+def encrypted_io(fernet_env: None) -> EncryptedFileIO:
+    return EncryptedFileIO()
+
+
+class TestSnapshotPersistence:
+    """End-to-end: weights → fernet+meta files on disk, deterministic hash."""
+
+    def test_snapshot_files_created(
+        self,
+        encrypted_io: EncryptedFileIO,
+        snapshot_dir: Path,
+    ) -> None:
+        opt = SearchWeightOptimizer(
+            encrypted_file_io=encrypted_io,
+            snapshot_dir=snapshot_dir,
+        )
+        try:
+            opt.record_outcome(
+                "test query",
+                {"vector": 0.7, "bm25": 0.2, "graph": 0.1},
+                feedback_score=0.9,
+                session_id="sess-abc",
+            )
+
+            # Exactly one .fernet + one .meta.json should exist.
+            fernet_files = list(snapshot_dir.glob("*.fernet"))
+            meta_files = list(snapshot_dir.glob("*.meta.json"))
+            assert len(fernet_files) == 1
+            assert len(meta_files) == 1
+
+            # Filename = weight_sha256 + extension.
+            assert fernet_files[0].stem == meta_files[0].name.split(".meta.json")[0]
+        finally:
+            opt.close()
+
+    def test_meta_sidecar_shape(
+        self,
+        encrypted_io: EncryptedFileIO,
+        snapshot_dir: Path,
+    ) -> None:
+        opt = SearchWeightOptimizer(
+            encrypted_file_io=encrypted_io,
+            snapshot_dir=snapshot_dir,
+        )
+        try:
+            opt.record_outcome(
+                "test",
+                {"vector": 0.5, "bm25": 0.3, "graph": 0.2},
+                feedback_score=0.8,
+                session_id="sess-meta-shape",
+            )
+
+            meta_files = list(snapshot_dir.glob("*.meta.json"))
+            assert len(meta_files) == 1
+            meta = json.loads(meta_files[0].read_text(encoding="utf-8"))
+
+            # Required keys (per PR-B brief).
+            assert set(meta.keys()) == {
+                "weight_sha256",
+                "fernet_file",
+                "created_at",
+                "session_id",
+                "snapshot_bytes",
+            }
+            assert meta["session_id"] == "sess-meta-shape"
+            assert meta["fernet_file"] == f"{meta['weight_sha256']}.fernet"
+            assert meta["snapshot_bytes"] > 0
+            # Hash format = 64 hex chars.
+            assert len(meta["weight_sha256"]) == 64
+            assert all(c in "0123456789abcdef" for c in meta["weight_sha256"])
+        finally:
+            opt.close()
+
+    def test_weight_sha256_matches_canonical_recipe(
+        self,
+        encrypted_io: EncryptedFileIO,
+        snapshot_dir: Path,
+    ) -> None:
+        """The on-disk weight_sha256 must equal an independently-computed
+        hash via the canonical-NFC-JSON-sort_keys recipe (same as PR-A).
+        """
+        opt = SearchWeightOptimizer(
+            encrypted_file_io=encrypted_io,
+            snapshot_dir=snapshot_dir,
+            initial_weights=(0.5, 0.3, 0.2),
+        )
+        try:
+            # feedback_score=0 ensures EMA does NOT mutate weights, so
+            # the snapshot reflects the initial vector exactly.
+            opt.record_outcome(
+                "test",
+                {"vector": 0.5, "bm25": 0.3, "graph": 0.2},
+                feedback_score=0.0,
+                session_id="sess-deterministic",
+            )
+
+            expected = {"vector": 0.5, "bm25": 0.3, "graph": 0.2}
+            canonical = unicodedata.normalize(
+                "NFC",
+                json.dumps(expected, sort_keys=True, ensure_ascii=False),
+            ).encode("utf-8")
+            expected_hash = hashlib.sha256(canonical).hexdigest()
+
+            meta_files = list(snapshot_dir.glob("*.meta.json"))
+            meta = json.loads(meta_files[0].read_text(encoding="utf-8"))
+            assert meta["weight_sha256"] == expected_hash
+            assert meta["snapshot_bytes"] == len(canonical)
+        finally:
+            opt.close()
+
+    def test_fernet_file_is_encrypted(
+        self,
+        encrypted_io: EncryptedFileIO,
+        snapshot_dir: Path,
+    ) -> None:
+        opt = SearchWeightOptimizer(
+            encrypted_file_io=encrypted_io,
+            snapshot_dir=snapshot_dir,
+        )
+        try:
+            opt.record_outcome(
+                "test",
+                {"vector": 0.7, "bm25": 0.2, "graph": 0.1},
+                feedback_score=0.5,
+                session_id="sess-encrypted",
+            )
+
+            fernet_path = next(snapshot_dir.glob("*.fernet"))
+            # The encrypted file starts with the COGNITHOR_ENC_V1 magic
+            # header, NOT raw JSON — proves Fernet was used.
+            raw = fernet_path.read_bytes()
+            assert raw.startswith(b"COGNITHOR_ENC_V1\n")
+
+            # Round-trip via EncryptedFileIO should yield the canonical
+            # plaintext we expect.
+            decrypted = encrypted_io.read(fernet_path)
+            decoded = json.loads(decrypted)
+            assert set(decoded.keys()) == {"vector", "bm25", "graph"}
+        finally:
+            opt.close()
+
+    def test_content_addressed_dedup(
+        self,
+        encrypted_io: EncryptedFileIO,
+        snapshot_dir: Path,
+    ) -> None:
+        """Identical weight vectors → no rewrite of the .fernet file.
+
+        The meta sidecar IS rewritten (different created_at + session_id
+        per call) — that's intentional, the meta is per-event.
+        """
+        opt = SearchWeightOptimizer(
+            encrypted_file_io=encrypted_io,
+            snapshot_dir=snapshot_dir,
+            initial_weights=(0.5, 0.3, 0.2),
+        )
+        try:
+            # First call — feedback_score=0 keeps weights untouched.
+            opt.record_outcome(
+                "q1",
+                {"vector": 0.5, "bm25": 0.3, "graph": 0.2},
+                feedback_score=0.0,
+                session_id="sess-1",
+            )
+            fernet_files_1 = sorted(snapshot_dir.glob("*.fernet"))
+            assert len(fernet_files_1) == 1
+            mtime_1 = fernet_files_1[0].stat().st_mtime_ns
+
+            # Second call — same weight vector → same hash → same file.
+            opt.record_outcome(
+                "q2",
+                {"vector": 0.5, "bm25": 0.3, "graph": 0.2},
+                feedback_score=0.0,
+                session_id="sess-2",
+            )
+            fernet_files_2 = sorted(snapshot_dir.glob("*.fernet"))
+            assert len(fernet_files_2) == 1
+            assert fernet_files_2[0] == fernet_files_1[0]
+            # File was NOT rewritten — mtime unchanged.
+            assert fernet_files_2[0].stat().st_mtime_ns == mtime_1
+        finally:
+            opt.close()
+
+
+class TestAuditCallback:
+    """``weight_snapshot_persisted`` event flows through the callback."""
+
+    def test_audit_callback_invoked(
+        self,
+        encrypted_io: EncryptedFileIO,
+        snapshot_dir: Path,
+    ) -> None:
+        captured: list[tuple[str, dict[str, Any]]] = []
+
+        def cb(event_type: str, payload: dict[str, Any]) -> None:
+            captured.append((event_type, payload))
+
+        opt = SearchWeightOptimizer(
+            encrypted_file_io=encrypted_io,
+            snapshot_dir=snapshot_dir,
+            audit_emit_callback=cb,
+        )
+        try:
+            opt.record_outcome(
+                "q",
+                {"vector": 0.5, "bm25": 0.3, "graph": 0.2},
+                feedback_score=0.7,
+                session_id="sess-audit-cb",
+            )
+
+            assert len(captured) == 1
+            event_type, payload = captured[0]
+            assert event_type == "weight_snapshot_persisted"
+            assert payload["session_id"] == "sess-audit-cb"
+            assert "weight_sha256" in payload
+            assert payload["snapshot_bytes"] > 0
+            # Hash format check.
+            assert len(payload["weight_sha256"]) == 64
+        finally:
+            opt.close()
+
+    def test_set_audit_emit_callback_late_bind(
+        self,
+        encrypted_io: EncryptedFileIO,
+        snapshot_dir: Path,
+    ) -> None:
+        """Late-binding mirrors PR-A's CausalAnalyzer pattern."""
+        opt = SearchWeightOptimizer(
+            encrypted_file_io=encrypted_io,
+            snapshot_dir=snapshot_dir,
+        )
+        captured: list[tuple[str, dict[str, Any]]] = []
+
+        def cb(event_type: str, payload: dict[str, Any]) -> None:
+            captured.append((event_type, payload))
+
+        try:
+            opt.set_audit_emit_callback(cb)
+            opt.record_outcome(
+                "q",
+                {"vector": 0.5, "bm25": 0.3, "graph": 0.2},
+                feedback_score=0.7,
+                session_id="sess-late-bind",
+            )
+            assert len(captured) == 1
+            assert captured[0][0] == "weight_snapshot_persisted"
+        finally:
+            opt.close()
+
+    def test_audit_callback_failure_does_not_break_record(
+        self,
+        encrypted_io: EncryptedFileIO,
+        snapshot_dir: Path,
+    ) -> None:
+        """A throwing callback must not interrupt the EMA path."""
+        cb = MagicMock(side_effect=RuntimeError("audit boom"))
+
+        opt = SearchWeightOptimizer(
+            encrypted_file_io=encrypted_io,
+            snapshot_dir=snapshot_dir,
+            audit_emit_callback=cb,
+        )
+        try:
+            # Should NOT raise.
+            opt.record_outcome(
+                "q",
+                {"vector": 0.5, "bm25": 0.3, "graph": 0.2},
+                feedback_score=0.7,
+                session_id="sess-cb-fails",
+            )
+            # And the snapshot files still exist.
+            assert list(snapshot_dir.glob("*.fernet"))
+            assert list(snapshot_dir.glob("*.meta.json"))
+        finally:
+            opt.close()
+
+
+class TestGracefulSkip:
+    """No EncryptedFileIO + no snapshot_dir → no error, no files."""
+
+    def test_skip_when_io_missing(self, tmp_path: Path) -> None:
+        snapshot_dir = tmp_path / "weight_snapshots"
+        opt = SearchWeightOptimizer(
+            encrypted_file_io=None,
+            snapshot_dir=snapshot_dir,
+        )
+        try:
+            opt.record_outcome(
+                "q",
+                {"vector": 0.5, "bm25": 0.3, "graph": 0.2},
+                feedback_score=0.7,
+                session_id="sess",
+            )
+            assert not snapshot_dir.exists() or not list(snapshot_dir.iterdir())
+        finally:
+            opt.close()
+
+    def test_skip_when_dir_missing(
+        self,
+        encrypted_io: EncryptedFileIO,
+    ) -> None:
+        opt = SearchWeightOptimizer(
+            encrypted_file_io=encrypted_io,
+            snapshot_dir=None,
+        )
+        try:
+            # Should not raise.
+            opt.record_outcome(
+                "q",
+                {"vector": 0.5, "bm25": 0.3, "graph": 0.2},
+                feedback_score=0.7,
+                session_id="sess",
+            )
+        finally:
+            opt.close()
+
+    def test_skip_when_no_key(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        snapshot_dir: Path,
+    ) -> None:
+        """Without a Fernet key the snapshot is silently skipped (the
+        encrypted-at-rest contract trumps best-effort persistence)."""
+        # Ensure no key is reachable.
+        monkeypatch.delenv("COGNITHOR_DB_KEY", raising=False)
+
+        # A real EncryptedFileIO with no key + no keyring entry will
+        # report ``is_available == False``.
+        io = EncryptedFileIO()
+        # Stub the keyring chain to ensure no key.
+        io._initialized = True  # type: ignore[attr-defined]
+        io._fernet = None  # type: ignore[attr-defined]
+
+        opt = SearchWeightOptimizer(
+            encrypted_file_io=io,
+            snapshot_dir=snapshot_dir,
+        )
+        try:
+            opt.record_outcome(
+                "q",
+                {"vector": 0.5, "bm25": 0.3, "graph": 0.2},
+                feedback_score=0.7,
+                session_id="sess",
+            )
+            assert not snapshot_dir.exists() or not list(snapshot_dir.iterdir())
+        finally:
+            opt.close()
+
+
+class TestBackwardCompat:
+    """Existing callers without the new kwargs still work."""
+
+    def test_legacy_construction_no_kwargs(self) -> None:
+        opt = SearchWeightOptimizer()
+        try:
+            opt.record_outcome(
+                "q",
+                {"vector": 0.5, "bm25": 0.3, "graph": 0.2},
+                feedback_score=0.7,
+            )
+            # Weights still updated as before.
+            w_v, w_b, w_g = opt.get_optimized_weights()
+            assert abs((w_v + w_b + w_g) - 1.0) < 0.001
+        finally:
+            opt.close()
+
+    def test_record_outcome_session_id_optional(self) -> None:
+        """``session_id`` defaults to empty string."""
+        opt = SearchWeightOptimizer()
+        try:
+            # Old signature still works without session_id.
+            opt.record_outcome(
+                "q",
+                {"vector": 0.5, "bm25": 0.3, "graph": 0.2},
+                feedback_score=0.7,
+            )
+        finally:
+            opt.close()


### PR DESCRIPTION
## Summary

Operational-Trust Compliance-Hardening Suite, PR-B of 3. Builds on **PR #494** (PR-A: Reflector audit-event helper + causal atomic wiring).

Two coupled scope items:

### Item 1 — WeightOptimizer encrypted snapshots

Every successful ``record_outcome`` on ``SearchWeightOptimizer`` now persists a Fernet-encrypted snapshot of the active weight vector under ``~/.cognithor/weight_snapshots/`` plus a plaintext ``.meta.json`` sidecar:

* ``<weight_sha256>.fernet`` — Fernet-encrypted JSON of the weight dict (via existing :class:`EncryptedFileIO`, OS-keyring chain).
* ``<weight_sha256>.meta.json`` — plaintext: ``{weight_sha256, fernet_file, created_at, session_id, snapshot_bytes}``. Lets receipt verifiers see existence + chain link without key access.

**Hash domain**: ``weight_sha256 = SHA-256(NFC(json.dumps(weights, sort_keys=True, ensure_ascii=False)).encode("utf-8"))``. Same canonical recipe as PR-A. Bit-identical across processes; identical weights produce identical hashes → snapshot is content-addressed and the ``.fernet`` file is written at most once.

**Audit channel**: ``set_audit_emit_callback`` mirrors PR-A's ``CausalAnalyzer`` pattern. The Reflector auto-wires its ``_emit_reflection_audit_event`` helper at construction; every persisted snapshot fires a ``weight_snapshot_persisted`` reflection event with ``(weight_sha256, session_id, snapshot_bytes)`` so the TRUST-1 receipt can cross-link the active weight vector.

**Key-absent handling**: when ``EncryptedFileIO.is_available`` returns False (no key in env / keyring / credential store), the snapshot is silently skipped with a debug log instead of falling back to plaintext — the encrypted-at-rest contract trumps best-effort persistence.

### Item 2 — ``channel_contributions`` upstream fix

Pre-fix bug at ``reflector.py:558``: a HARDCODED phantom ``{""vector"": 0.5, ""bm25"": 0.3, ""graph"": 0.2}`` was fed to the optimizer on every reflection — every call learned from constants, never from real data.

Fix: ``_compute_channel_contributions(working_memory.injected_memories)`` reads the actual ``MemorySearchResult`` objects that fed the LLM and computes:

    contribution = (hits-from-channel) / (total hits)

A channel ""hits"" a result when its per-channel score > 0. Empty mix (no search this run) → ``record_outcome`` is skipped entirely; pre-fix this fed zeros that biased the EMA toward the minimum-weight floor.

## Files modified

| File | LOC added |
|---|---|
| ``src/cognithor/memory/weight_optimizer.py`` | +201 |
| ``src/cognithor/core/reflector.py`` | +90 |
| ``src/cognithor/memory/manager.py`` | +23 |
| ``tests/test_memory/test_weight_optimizer_snapshot.py`` | new (367 LOC, 13 tests) |
| ``tests/test_core/test_reflector_channel_contributions.py`` | new (256 LOC, 9 tests) |

## Verification

* ``ruff check src/cognithor/ tests/`` — clean
* ``ruff format --check src/cognithor/ tests/`` — clean (1775 files)
* ``mypy --strict src/cognithor/memory/weight_optimizer.py src/cognithor/core/reflector.py`` — Success
* ``pytest tests/test_memory/ tests/test_core/ tests/test_security/`` — **5235 passed**, 2 skipped, 1 xfailed, 0 failures

## Test plan

- [x] Snapshot ``.fernet`` + ``.meta.json`` produced end-to-end with COGNITHOR_ENC_V1 magic header
- [x] ``weight_sha256`` matches independently-computed canonical-NFC-JSON SHA-256
- [x] Content-addressed dedup: identical weights → no rewrite of ``.fernet``
- [x] ``weight_snapshot_persisted`` audit event fires with correct triple
- [x] Audit callback can fail without breaking record_outcome
- [x] Graceful skip when EncryptedFileIO/snapshot_dir/key are missing
- [x] Reflector feeds REAL channel mix, never the pre-fix phantom constants
- [x] Empty injected_memories → record_outcome skipped (not zero-fed)
- [x] Backward-compat: legacy callers without new kwargs still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)