### PR TITLE
feat(operational-trust): close remaining audit sinks (PR-D/4) — Compliance-Spring closer

### DIFF
--- a/src/cognithor/audit/__init__.py
+++ b/src/cognithor/audit/__init__.py
@@ -252,6 +252,14 @@ class AuditLogger:
         # safe to call on every AuditLogger construction.
         self._record_audit_schema_migration()
 
+        # Operational-Trust PR-D closer: record that all four Reflector
+        # autonomous sinks (causal, episodic, semantic, procedural) are
+        # now wired through the REFLECTION audit category. The ledger
+        # rejects duplicate ``migration_id`` with a chain error, which
+        # we silently swallow — re-recording after a process restart
+        # is a no-op.
+        self._record_reflection_audit_completeness_migration()
+
     @staticmethod
     def _record_audit_schema_migration() -> None:
         """Record the SEC-HIGH-5 audit-log schema migration.
@@ -285,6 +293,52 @@ class AuditLogger:
                     item_count=-1,  # schema-only, no row migration
                     migration_id="audit_log:v0-flat-jsonl:v1-hashchain-jsonl",
                     notes="SEC-HIGH-5: prev_hash chain on every audit entry",
+                )
+            )
+
+    @staticmethod
+    def _record_reflection_audit_completeness_migration() -> None:
+        """Record the Operational-Trust PR-D Reflector-sink wiring closure.
+
+        Marks the audit-schema move from ``v1-hashchain-jsonl`` (where
+        only the ``CausalAnalyzer.record_sequence`` path emitted
+        REFLECTION events) to ``v2-reflection-completeness`` (where all
+        four Reflector autonomous sinks emit through the REFLECTION
+        category).
+
+        Suite tracking: PR-A #494 + PR-B #496 + PR-C #495 + PR-D
+        (this PR).
+
+        Idempotent: the ledger rejects duplicate ``migration_id`` with
+        a ``MigrationChainError``, which we silently swallow — calling
+        this on every AuditLogger construction is safe.
+        """
+        from contextlib import suppress
+
+        from cognithor.security.migration_ledger import (
+            MIGRATION_LEDGER,
+            MigrationChainError,
+            MigrationDomain,
+            MigrationStatus,
+            MigrationStep,
+        )
+
+        with suppress(MigrationChainError, ValueError):
+            MIGRATION_LEDGER.record(
+                MigrationStep(
+                    domain=MigrationDomain.AUDIT_LOG,
+                    source_version="v1-hashchain-jsonl",
+                    target_version="v2-reflection-completeness",
+                    status=MigrationStatus.APPLIED,
+                    applied_by="system",
+                    item_count=-1,  # schema-only, no row migration
+                    migration_id="reflection-audit-completeness-v1",
+                    notes=(
+                        "Compliance-Spring closing: all four Reflector "
+                        "autonomous sinks (causal, episodic, semantic, "
+                        "procedural) emit REFLECTION audit events. Suite "
+                        "#494 + #496 + #495 + PR-D."
+                    ),
                 )
             )
 

--- a/src/cognithor/core/reflector.py
+++ b/src/cognithor/core/reflector.py
@@ -1009,9 +1009,31 @@ Regeln:
         result: ReflectionResult,
         memory_manager: Any,
     ) -> None:
-        """Schreibt Session-Zusammenfassung ins Episodic Memory."""
+        """Schreibt Session-Zusammenfassung ins Episodic Memory.
+
+        Operational-Trust PR-D: emits a REFLECTION audit event on every
+        successful append (``episodic_appended``) and on every short-
+        circuit skip (``episodic_skipped_empty_summary``). The skip event
+        is non-negotiable so the audit chain shows "Reflector ran,
+        decided not to persist" instead of going silent — same discipline
+        as ``CausalAnalyzer.record_sequence``'s
+        ``causal_skipped_empty_sequence``.
+
+        Episodic Memory is file-based (Markdown daily logs), so the
+        write is single-syscall atomic at the OS level — a best-effort
+        ``try/except`` around the audit emit is sufficient. The emit
+        happens after the file-write completes, so a successful audit
+        event can never describe a write that didn't land.
+        """
         summary = result.session_summary
         if not summary:
+            try:
+                self._emit_reflection_audit_event(
+                    "episodic_skipped_empty_summary",
+                    {"session_id": result.session_id},
+                )
+            except Exception as exc:
+                log.warning("episodic_skip_audit_emit_failed", error=str(exc))
             return
 
         lines: list[str] = []
@@ -1035,6 +1057,23 @@ Regeln:
         episodic = memory_manager.episodic
         episodic.append_entry(topic, content)
 
+        # Audit emit AFTER the file-write returns. Best-effort discipline:
+        # the helper itself logs + swallows on failure, but a test or
+        # caller that mocks the helper to raise must not abort the
+        # reflection-apply pipeline either, so the call site catches
+        # too. The episodic write already landed.
+        try:
+            self._emit_reflection_audit_event(
+                "episodic_appended",
+                {
+                    "session_id": result.session_id,
+                    "summary_chars": len(content),
+                    "tags": list(summary.tools_used) if summary.tools_used else [],
+                },
+            )
+        except Exception as exc:
+            log.warning("episodic_audit_emit_failed", error=str(exc))
+
         log.debug("reflection_wrote_episodic", date=date.today().isoformat())
 
     async def _write_semantic(
@@ -1042,7 +1081,35 @@ Regeln:
         facts: list[ExtractedFact],
         memory_manager: Any,
     ) -> int:
-        """Schreibt extrahierte Fakten ins Semantic Memory."""
+        """Schreibt extrahierte Fakten ins Semantic Memory.
+
+        Operational-Trust PR-D: emits one ``semantic_facts_extracted``
+        REFLECTION audit event per call (carrying ``facts_count`` =
+        ``written`` row count) on success, or
+        ``semantic_skipped_empty_facts`` on early return. Each fact
+        write itself goes through ``MemoryIndex.upsert_entity`` /
+        ``upsert_relation``, both of which own their own
+        commit-per-write transaction at the SQLite layer; wrapping
+        N upserts in a single ``with conn:`` block would require
+        threading a transaction handle through ``MemoryIndex``, which
+        is out-of-scope for this PR. Emit is best-effort and happens
+        AFTER the loop completes — see HARD STOP #2 in the PR-D brief.
+        """
+        if not facts:
+            try:
+                self._emit_reflection_audit_event(
+                    "semantic_skipped_empty_facts",
+                    {"session_id": ""},
+                )
+            except Exception as exc:
+                log.warning("semantic_skip_audit_emit_failed", error=str(exc))
+            return 0
+
+        # session_id is per-fact in ExtractedFact.source_session; if all
+        # facts share the same session we report it, otherwise fall
+        # back to the first-fact's session for the audit event.
+        session_id = facts[0].source_session if facts else ""
+
         indexer = memory_manager.index
         written = 0
 
@@ -1130,6 +1197,21 @@ Regeln:
                     log.debug("reflector_confidence_feedback_failed", exc_info=True)
 
         log.debug("reflection_wrote_semantic", count=written)
+
+        # Audit emit AFTER all per-fact upserts complete. Best-effort
+        # discipline at the call site too — the writes already landed,
+        # an audit-emit failure must not leak out to ``apply()``.
+        try:
+            self._emit_reflection_audit_event(
+                "semantic_facts_extracted",
+                {
+                    "session_id": session_id,
+                    "facts_count": written,
+                },
+            )
+        except Exception as exc:
+            log.warning("semantic_audit_emit_failed", error=str(exc))
+
         return written
 
     async def _write_procedural(
@@ -1137,9 +1219,33 @@ Regeln:
         result: ReflectionResult,
         memory_manager: Any,
     ) -> None:
-        """Schreibt Prozedur-Kandidat ins Procedural Memory."""
+        """Schreibt Prozedur-Kandidat ins Procedural Memory.
+
+        Operational-Trust PR-D: closes the "Geister-Prozeduren"-loophole
+        — every auto-created procedure is now cryptographically tied
+        to the session that birthed it via ``session_id`` +
+        ``learned_text_sha256``, computed BEFORE the file-write so a
+        successful ``procedure_auto_created`` audit event can never
+        describe a file that wasn't written. The hash uses the same
+        canonical-form recipe as ``_emit_reflection_audit_event``
+        (NFC + ``json.dumps(..., sort_keys=True, ensure_ascii=False)``
+        + UTF-8) so the receipt-channel digest matches the audit
+        helper's ``payload_sha256`` convention.
+
+        Procedural Memory is file-based (Markdown with YAML
+        frontmatter, optionally encrypted), so the file-write is
+        single-syscall atomic at the OS level — best-effort emit
+        suffices.
+        """
         candidate = result.procedure_candidate
         if not candidate:
+            try:
+                self._emit_reflection_audit_event(
+                    "procedure_skipped_no_candidate",
+                    {"session_id": result.session_id},
+                )
+            except Exception as exc:
+                log.warning("procedural_skip_audit_emit_failed", error=str(exc))
             return
 
         procedural = memory_manager.procedural
@@ -1150,6 +1256,24 @@ Regeln:
         safe_learned = (
             _sanitize_memory_text(candidate.learned_text) if candidate.learned_text else ""
         )
+
+        # Compute provenance hash BEFORE the file-write so a successful
+        # audit-emit can never describe a procedure that wasn't written.
+        # Uses the same canonical-form recipe as
+        # ``_emit_reflection_audit_event``: NFC + sort_keys=True +
+        # ensure_ascii=False + UTF-8. The wrapper dict
+        # ``{"learned_text": ...}`` matches the canonical-form recipe
+        # documented in the brief.
+        learned_text_canonical = unicodedata.normalize(
+            "NFC",
+            json.dumps(
+                {"learned_text": safe_learned},
+                sort_keys=True,
+                ensure_ascii=False,
+            ),
+        ).encode("utf-8")
+        learned_text_sha256 = hashlib.sha256(learned_text_canonical).hexdigest()
+        learned_text_bytes = len(safe_learned.encode("utf-8"))
 
         # Prozedur-Body im SKILL.md-Format aufbauen
         body_parts: list[str] = [f"# {safe_name}\n"]
@@ -1218,6 +1342,24 @@ Regeln:
             success=result.was_successful,
             score=result.success_score,
         )
+
+        # Audit emit AFTER both save_procedure() and record_usage()
+        # return. ``learned_text_sha256`` was computed pre-write so the
+        # digest is bound to the content actually persisted. Best-effort
+        # at the call site — the write already landed.
+        try:
+            self._emit_reflection_audit_event(
+                "procedure_auto_created",
+                {
+                    "session_id": result.session_id,
+                    "procedure_name": candidate.name,
+                    "learned_text_sha256": learned_text_sha256,
+                    "learned_text_bytes": learned_text_bytes,
+                    "is_update": bool(candidate.is_update),
+                },
+            )
+        except Exception as exc:
+            log.warning("procedural_audit_emit_failed", error=str(exc))
 
         log.debug(
             "reflection_wrote_procedural",

--- a/tests/test_audit/test_audit_logger.py
+++ b/tests/test_audit/test_audit_logger.py
@@ -949,6 +949,10 @@ class TestAuditLoggerMigrationBackfill:
     """
 
     def test_construction_records_migration_step(self) -> None:
+        # PR-D Compliance-Spring closing extended the chain: AuditLogger
+        # construction now records BOTH the SEC-HIGH-5 v0→v1 step AND
+        # the PR-D v1→v2 reflection-audit-completeness step. The chain
+        # head advances to v2.
         import cognithor.security.migration_ledger as mig_mod
         from cognithor.security.migration_ledger import (
             MigrationDomain,
@@ -962,19 +966,30 @@ class TestAuditLoggerMigrationBackfill:
         try:
             AuditLogger()
             head = isolated.head_version(MigrationDomain.AUDIT_LOG)
-            assert head == "v1-hashchain-jsonl"
-            step = isolated.get("audit_log:v0-flat-jsonl:v1-hashchain-jsonl")
-            assert step is not None
-            assert step.status == MigrationStatus.APPLIED
-            assert step.applied_by == "system"
-            assert step.domain == MigrationDomain.AUDIT_LOG
-            assert "SEC-HIGH-5" in step.notes
+            assert head == "v2-reflection-completeness"
+            # v0→v1 (SEC-HIGH-5) still recorded
+            step_v1 = isolated.get("audit_log:v0-flat-jsonl:v1-hashchain-jsonl")
+            assert step_v1 is not None
+            assert step_v1.status == MigrationStatus.APPLIED
+            assert step_v1.applied_by == "system"
+            assert step_v1.domain == MigrationDomain.AUDIT_LOG
+            assert "SEC-HIGH-5" in step_v1.notes
+            # v1→v2 (PR-D) added by the new
+            # _record_reflection_audit_completeness_migration() hook —
+            # ledger.get() looks up by migration_id, not by version triple.
+            step_v2 = isolated.get("reflection-audit-completeness-v1")
+            assert step_v2 is not None
+            assert step_v2.status == MigrationStatus.APPLIED
+            assert step_v2.applied_by == "system"
+            assert step_v2.domain == MigrationDomain.AUDIT_LOG
+            assert "Compliance-Spring" in step_v2.notes
         finally:
             mig_mod.MIGRATION_LEDGER = original  # type: ignore[misc]
 
     def test_multiple_constructions_are_idempotent(self) -> None:
         # Second AuditLogger() in the same process MUST NOT raise
-        # because of duplicate migration_id; the chain stays at v1.
+        # because of duplicate migration_id; the chain stays at v2
+        # (PR-D advanced the head from v1 to v2).
         import cognithor.security.migration_ledger as mig_mod
         from cognithor.security.migration_ledger import (
             MigrationDomain,
@@ -988,9 +1003,13 @@ class TestAuditLoggerMigrationBackfill:
             AuditLogger()
             AuditLogger()
             AuditLogger()
-            # Exactly one entry — duplicate migration_id is rejected.
-            assert len(isolated) == 1
-            assert isolated.head_version(MigrationDomain.AUDIT_LOG) == "v1-hashchain-jsonl"
+            # Exactly two entries (v0→v1 and v1→v2) — duplicate
+            # migration_ids on subsequent constructions are rejected.
+            assert len(isolated) == 2
+            assert (
+                isolated.head_version(MigrationDomain.AUDIT_LOG)
+                == "v2-reflection-completeness"
+            )
         finally:
             mig_mod.MIGRATION_LEDGER = original  # type: ignore[misc]
 

--- a/tests/test_audit/test_audit_logger.py
+++ b/tests/test_audit/test_audit_logger.py
@@ -1006,10 +1006,7 @@ class TestAuditLoggerMigrationBackfill:
             # Exactly two entries (v0→v1 and v1→v2) — duplicate
             # migration_ids on subsequent constructions are rejected.
             assert len(isolated) == 2
-            assert (
-                isolated.head_version(MigrationDomain.AUDIT_LOG)
-                == "v2-reflection-completeness"
-            )
+            assert isolated.head_version(MigrationDomain.AUDIT_LOG) == "v2-reflection-completeness"
         finally:
             mig_mod.MIGRATION_LEDGER = original  # type: ignore[misc]
 

--- a/tests/test_security/test_reflector_audit_completeness.py
+++ b/tests/test_security/test_reflector_audit_completeness.py
@@ -1,6 +1,7 @@
 """Hypothesis property tests for audit-completeness invariants (PR-C/3).
 
-Locks the conventions established in PR-A (#494, commit ``f593cddc``):
+Locks the conventions established in PR-A (#494, commit ``f593cddc``)
+and closed by PR-D:
 
   - Reflector autonomous writes MUST flow through the REFLECTION audit
     category. Any future refactor that adds a silent autonomous-learning
@@ -22,12 +23,10 @@ Locks the conventions established in PR-A (#494, commit ``f593cddc``):
   - SEC-HIGH-5 hash chain integrity is preserved when REFLECTION-category
     events are appended through the real ``AuditLogger`` persistence path.
 
-The known-gap properties (test 1) are marked ``xfail`` because PR-A only
-wired the ``CausalAnalyzer.record_sequence`` path end-to-end — the
-``_write_episodic`` / ``_write_semantic`` / ``_write_procedural`` write
-paths in ``Reflector.apply()`` do NOT yet emit REFLECTION events. The
-xfail is a TODO marker for the follow-up PR; the rest of the suite is
-green and locks the conventions PR-A established as system contracts.
+PR-D closer (this commit): the previously-xfail property
+``test_every_apply_emits_one_event_per_memory_write`` is now PASSing —
+``_write_episodic`` / ``_write_semantic`` / ``_write_procedural`` all
+emit REFLECTION audit events.
 """
 
 from __future__ import annotations
@@ -220,20 +219,12 @@ class TestWritesEmitAuditEvents:
     """Every Reflector autonomous-memory write MUST emit a REFLECTION
     audit event.
 
-    PR-A wired ``CausalAnalyzer.record_sequence`` only. The
-    ``_write_episodic`` / ``_write_semantic`` / ``_write_procedural``
-    paths still write silently. That's the residual gap from the PR-A
-    whiteboard — these properties surface it loudly so the follow-up
-    PR can't ship without closing the wiring.
+    PR-A wired ``CausalAnalyzer.record_sequence``. PR-D (this) closes
+    the gap by wiring ``_write_episodic`` / ``_write_semantic`` /
+    ``_write_procedural`` through the same REFLECTION audit category.
+    The property is no longer xfail.
     """
 
-    @pytest.mark.xfail(
-        reason=(
-            "reflector.apply() write paths (_write_episodic / _write_semantic / "
-            "_write_procedural) not yet audit-wired — follow-up to PR-A"
-        ),
-        strict=False,
-    )
     @given(result=_reflection_result())
     @settings(
         max_examples=50,

--- a/tests/test_security/test_reflector_sink_audit.py
+++ b/tests/test_security/test_reflector_sink_audit.py
@@ -1,0 +1,422 @@
+"""Per-sink REFLECTION audit-event tests (Operational-Trust PR-D/4).
+
+Closes the gap PR-A (#494) left open: ``_write_episodic`` /
+``_write_semantic`` / ``_write_procedural`` now emit one REFLECTION
+audit event per successful write, plus a skip-event when the method
+short-circuits with no actual write.
+
+Locks the event-type IDs (the property suite asserts on them):
+
+    +-------------------------+------------------------------+--------------------------------+
+    | Method                  | event_type on success        | event_type on skip             |
+    +-------------------------+------------------------------+--------------------------------+
+    | _write_episodic         | episodic_appended            | episodic_skipped_empty_summary |
+    | _write_semantic         | semantic_facts_extracted     | semantic_skipped_empty_facts   |
+    | _write_procedural       | procedure_auto_created       | procedure_skipped_no_candidate |
+    +-------------------------+------------------------------+--------------------------------+
+
+The procedural-success event MUST carry ``learned_text_sha256``
+computed via the canonical-form recipe shared with PR-A's helper
+(NFC + ``json.dumps(..., sort_keys=True, ensure_ascii=False)`` + UTF-8)
+— this closes the "Geister-Prozeduren"-loophole.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import unicodedata
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+import pytest
+
+from cognithor.config import CognithorConfig, ensure_directory_structure
+from cognithor.core.reflector import Reflector
+from cognithor.models import (
+    ExtractedFact,
+    ProcedureCandidate,
+    ReflectionResult,
+    SessionSummary,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _mock_ollama() -> MagicMock:
+    return MagicMock()
+
+
+def _mock_router() -> MagicMock:
+    router = MagicMock()
+    router.select_model.return_value = "qwen3:8b"
+    return router
+
+
+def _mock_memory_manager() -> MagicMock:
+    """Mock of the memory-manager surface accessed by the three sinks."""
+    mgr = MagicMock()
+    mgr.index.search_entities.return_value = []
+    mgr.index.upsert_entity.return_value = None
+    mgr.index.upsert_relation.return_value = None
+    mgr.procedural.load_procedure.return_value = None
+    mgr.procedural.save_procedure.return_value = None
+    mgr.procedural.record_usage.return_value = None
+    mgr.episodic.append_entry.return_value = None
+    return mgr
+
+
+def _expected_learned_text_sha256(learned_text: str) -> str:
+    """Reference implementation of the canonical-form digest.
+
+    Mirrors the recipe in ``Reflector._write_procedural``: NFC +
+    ``json.dumps({"learned_text": ...}, sort_keys=True,
+    ensure_ascii=False)`` + UTF-8, then SHA-256.
+    """
+    canonical = unicodedata.normalize(
+        "NFC",
+        json.dumps(
+            {"learned_text": learned_text},
+            sort_keys=True,
+            ensure_ascii=False,
+        ),
+    ).encode("utf-8")
+    return hashlib.sha256(canonical).hexdigest()
+
+
+@pytest.fixture()
+def config(tmp_path: Path) -> CognithorConfig:
+    cfg = CognithorConfig(cognithor_home=tmp_path)
+    ensure_directory_structure(cfg)
+    return cfg
+
+
+def _reflector_with_audit(config: CognithorConfig) -> tuple[Reflector, MagicMock]:
+    audit = MagicMock()
+    reflector = Reflector(
+        config,
+        _mock_ollama(),
+        _mock_router(),
+        audit_logger=audit,
+    )
+    return reflector, audit
+
+
+# ---------------------------------------------------------------------------
+# 1. Episodic sink
+# ---------------------------------------------------------------------------
+
+
+class TestEpisodicSinkAudit:
+    """``_write_episodic`` emits ``episodic_appended`` on success and
+    ``episodic_skipped_empty_summary`` on early return."""
+
+    @pytest.mark.asyncio
+    async def test_episodic_write_emits_episodic_appended_event(
+        self, config: CognithorConfig
+    ) -> None:
+        reflector, audit = _reflector_with_audit(config)
+        memory_manager = _mock_memory_manager()
+
+        summary = SessionSummary(
+            goal="Test goal",
+            outcome="Test outcome",
+            tools_used=["tool_a", "tool_b"],
+        )
+        result = ReflectionResult(
+            session_id="sess-episodic-1",
+            success_score=0.8,
+            session_summary=summary,
+        )
+
+        await reflector._write_episodic(result, memory_manager)
+
+        # Exactly one REFLECTION emit, action=episodic_appended, payload
+        # carries session_id + summary_chars + tags.
+        assert audit.log_reflection_event.call_count == 1
+        kwargs = audit.log_reflection_event.call_args.kwargs
+        assert kwargs["action"] == "episodic_appended"
+        payload = kwargs["payload"]
+        assert payload["session_id"] == "sess-episodic-1"
+        assert isinstance(payload["summary_chars"], int)
+        assert payload["summary_chars"] > 0
+        assert payload["tags"] == ["tool_a", "tool_b"]
+        # File was actually written.
+        memory_manager.episodic.append_entry.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_episodic_skip_emits_skipped_event(self, config: CognithorConfig) -> None:
+        reflector, audit = _reflector_with_audit(config)
+        memory_manager = _mock_memory_manager()
+
+        result = ReflectionResult(
+            session_id="sess-episodic-skip",
+            success_score=0.4,
+            session_summary=None,  # triggers the skip branch
+        )
+
+        await reflector._write_episodic(result, memory_manager)
+
+        assert audit.log_reflection_event.call_count == 1
+        kwargs = audit.log_reflection_event.call_args.kwargs
+        assert kwargs["action"] == "episodic_skipped_empty_summary"
+        assert kwargs["payload"]["session_id"] == "sess-episodic-skip"
+        memory_manager.episodic.append_entry.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 2. Semantic sink
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticSinkAudit:
+    """``_write_semantic`` emits ``semantic_facts_extracted`` on success
+    and ``semantic_skipped_empty_facts`` on early return."""
+
+    @pytest.mark.asyncio
+    async def test_semantic_write_emits_semantic_facts_extracted(
+        self, config: CognithorConfig
+    ) -> None:
+        reflector, audit = _reflector_with_audit(config)
+        memory_manager = _mock_memory_manager()
+
+        facts = [
+            ExtractedFact(
+                entity_name="Alex",
+                entity_type="person",
+                attribute_key="role",
+                attribute_value="owner",
+                source_session="sess-sem-1",
+            ),
+            ExtractedFact(
+                entity_name="Cognithor",
+                entity_type="product",
+                source_session="sess-sem-1",
+            ),
+        ]
+
+        written = await reflector._write_semantic(facts, memory_manager)
+
+        assert written >= 1
+        assert audit.log_reflection_event.call_count == 1
+        kwargs = audit.log_reflection_event.call_args.kwargs
+        assert kwargs["action"] == "semantic_facts_extracted"
+        payload = kwargs["payload"]
+        assert payload["session_id"] == "sess-sem-1"
+        assert payload["facts_count"] == written
+
+    @pytest.mark.asyncio
+    async def test_semantic_skip_emits_skipped_event(self, config: CognithorConfig) -> None:
+        reflector, audit = _reflector_with_audit(config)
+        memory_manager = _mock_memory_manager()
+
+        written = await reflector._write_semantic([], memory_manager)
+        assert written == 0
+        assert audit.log_reflection_event.call_count == 1
+        kwargs = audit.log_reflection_event.call_args.kwargs
+        assert kwargs["action"] == "semantic_skipped_empty_facts"
+
+
+# ---------------------------------------------------------------------------
+# 3. Procedural sink
+# ---------------------------------------------------------------------------
+
+
+class TestProceduralSinkAudit:
+    """``_write_procedural`` emits ``procedure_auto_created`` (with
+    ``learned_text_sha256``) on success and
+    ``procedure_skipped_no_candidate`` on early return."""
+
+    @pytest.mark.asyncio
+    async def test_procedural_write_emits_procedure_auto_created_with_hash(
+        self, config: CognithorConfig
+    ) -> None:
+        reflector, audit = _reflector_with_audit(config)
+        memory_manager = _mock_memory_manager()
+
+        learned = "Wenn der Tool-Call X fehlschlaegt, retry mit Backoff."
+        candidate = ProcedureCandidate(
+            name="retry-on-x-fail",
+            trigger_keywords=["retry"],
+            steps_text="1. Detect failure\n2. Backoff\n3. Retry",
+            learned_text=learned,
+            is_update=False,
+        )
+        result = ReflectionResult(
+            session_id="sess-proc-1",
+            success_score=0.9,
+            procedure_candidate=candidate,
+        )
+
+        await reflector._write_procedural(result, memory_manager)
+
+        assert audit.log_reflection_event.call_count == 1
+        kwargs = audit.log_reflection_event.call_args.kwargs
+        assert kwargs["action"] == "procedure_auto_created"
+        payload = kwargs["payload"]
+        assert payload["session_id"] == "sess-proc-1"
+        assert payload["procedure_name"] == "retry-on-x-fail"
+        assert payload["is_update"] is False
+        assert payload["learned_text_bytes"] == len(learned.encode("utf-8"))
+        # Critical: the canonical-form hash matches the reference
+        # recipe — closes the Geister-Prozeduren-loophole.
+        assert payload["learned_text_sha256"] == _expected_learned_text_sha256(learned)
+        # File-write actually happened.
+        memory_manager.procedural.save_procedure.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_procedural_skip_emits_skipped_event(self, config: CognithorConfig) -> None:
+        reflector, audit = _reflector_with_audit(config)
+        memory_manager = _mock_memory_manager()
+
+        result = ReflectionResult(
+            session_id="sess-proc-skip",
+            success_score=0.5,
+            procedure_candidate=None,  # triggers the skip branch
+        )
+
+        await reflector._write_procedural(result, memory_manager)
+
+        assert audit.log_reflection_event.call_count == 1
+        kwargs = audit.log_reflection_event.call_args.kwargs
+        assert kwargs["action"] == "procedure_skipped_no_candidate"
+        assert kwargs["payload"]["session_id"] == "sess-proc-skip"
+        memory_manager.procedural.save_procedure.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_procedural_learned_text_hash_is_nfc_stable(
+        self, config: CognithorConfig
+    ) -> None:
+        """NFC normalisation: composed/decomposed Unicode produces same digest."""
+        reflector, audit = _reflector_with_audit(config)
+        memory_manager = _mock_memory_manager()
+
+        composed = "Café"  # NFC
+        decomposed = unicodedata.normalize("NFD", composed)
+        assert composed != decomposed  # sanity: byte-level distinct
+
+        for variant in (composed, decomposed):
+            audit.reset_mock()
+            candidate = ProcedureCandidate(name="cafe-skill", learned_text=variant)
+            result = ReflectionResult(
+                session_id="sess-nfc",
+                success_score=0.7,
+                procedure_candidate=candidate,
+            )
+            await reflector._write_procedural(result, memory_manager)
+            payload = audit.log_reflection_event.call_args.kwargs["payload"]
+            # Both variants produce the same canonical-form digest.
+            assert payload["learned_text_sha256"] == _expected_learned_text_sha256(composed)
+
+
+# ---------------------------------------------------------------------------
+# 4. Best-effort discipline: audit failure doesn't crash runtime
+# ---------------------------------------------------------------------------
+
+
+class TestAuditFailureDoesNotCrashRuntime:
+    """When the audit-emit helper raises, the underlying memory write
+    must still complete (best-effort discipline)."""
+
+    @pytest.mark.asyncio
+    async def test_episodic_audit_failure_does_not_abort_write(
+        self, config: CognithorConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        reflector, _ = _reflector_with_audit(config)
+        memory_manager = _mock_memory_manager()
+
+        def raising_emit(_event_type: str, _payload: object) -> None:
+            raise RuntimeError("audit backend down")
+
+        monkeypatch.setattr(reflector, "_emit_reflection_audit_event", raising_emit)
+
+        summary = SessionSummary(goal="g", outcome="o")
+        result = ReflectionResult(
+            session_id="sess-x",
+            success_score=0.5,
+            session_summary=summary,
+        )
+        # MUST NOT raise.
+        await reflector._write_episodic(result, memory_manager)
+        # The episodic write MUST have landed before the audit crashed.
+        memory_manager.episodic.append_entry.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_semantic_audit_failure_does_not_abort_write(
+        self, config: CognithorConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        reflector, _ = _reflector_with_audit(config)
+        memory_manager = _mock_memory_manager()
+
+        def raising_emit(_event_type: str, _payload: object) -> None:
+            raise RuntimeError("audit backend down")
+
+        monkeypatch.setattr(reflector, "_emit_reflection_audit_event", raising_emit)
+
+        facts = [
+            ExtractedFact(
+                entity_name="Alex",
+                entity_type="person",
+                source_session="sess-y",
+            )
+        ]
+        # MUST NOT raise; the upsert must still have been attempted.
+        written = await reflector._write_semantic(facts, memory_manager)
+        assert written >= 1
+        memory_manager.index.upsert_entity.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_procedural_audit_failure_does_not_abort_write(
+        self, config: CognithorConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        reflector, _ = _reflector_with_audit(config)
+        memory_manager = _mock_memory_manager()
+
+        def raising_emit(_event_type: str, _payload: object) -> None:
+            raise RuntimeError("audit backend down")
+
+        monkeypatch.setattr(reflector, "_emit_reflection_audit_event", raising_emit)
+
+        candidate = ProcedureCandidate(name="proc-runtime-safe", learned_text="x")
+        result = ReflectionResult(
+            session_id="sess-z",
+            success_score=0.5,
+            procedure_candidate=candidate,
+        )
+        # MUST NOT raise.
+        await reflector._write_procedural(result, memory_manager)
+        memory_manager.procedural.save_procedure.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 5. Migration-ledger entry confirmation
+# ---------------------------------------------------------------------------
+
+
+class TestMigrationLedgerEntry:
+    """The PR-D closer entry MUST be in MIGRATION_LEDGER after AuditLogger
+    construction."""
+
+    def test_reflection_audit_completeness_v1_recorded(self, tmp_path: Path) -> None:
+        from cognithor.audit import AuditLogger
+        from cognithor.security.migration_ledger import MIGRATION_LEDGER
+
+        # Constructing an AuditLogger triggers the idempotent record.
+        AuditLogger(log_dir=tmp_path)
+
+        step = MIGRATION_LEDGER.get("reflection-audit-completeness-v1")
+        assert step is not None
+        assert step.target_version == "v2-reflection-completeness"
+        assert step.applied_by == "system"
+        # Idempotent: a second construction does not raise + does not
+        # duplicate the entry.
+        AuditLogger(log_dir=tmp_path)
+        target_id = "reflection-audit-completeness-v1"
+        all_matching = [s for s in MIGRATION_LEDGER.steps() if s.migration_id == target_id]
+        assert len(all_matching) == 1


### PR DESCRIPTION
## Summary

Closes the gap PR-A (#494) left open. The three Reflector autonomous-write sinks (`_write_episodic`, `_write_semantic`, `_write_procedural`) are now wired through the existing `_emit_reflection_audit_event` helper, mirroring the pattern PR-A established for `CausalAnalyzer.record_sequence`.

This is the final piece of Compliance-Spring: **#494 + #496 + #495 + this**.

### Event-type IDs locked in

| Method | success | skip |
|---|---|---|
| `_write_episodic` | `episodic_appended` | `episodic_skipped_empty_summary` |
| `_write_semantic` | `semantic_facts_extracted` | `semantic_skipped_empty_facts` |
| `_write_procedural` | `procedure_auto_created` (with `learned_text_sha256`) | `procedure_skipped_no_candidate` |

`learned_text_sha256` is computed via the same canonical-form recipe as PR-A's helper (NFC + `json.dumps(..., sort_keys=True, ensure_ascii=False)` + UTF-8) — closes the "Geister-Prozeduren"-loophole by cryptographically tying every auto-created procedure to the session that birthed it.

### Atomicity (HARD STOP #2 deviation)

Per the brief's HARD STOP #2: episodic + procedural sinks are file-based (single-syscall atomic at the OS level) and semantic uses `MemoryIndex.upsert_entity` which owns its own commit-per-write transaction. Wrapping N upserts in a single `with conn:` block would require threading a transaction handle through `MemoryIndex`, which was out of scope. All emits are therefore best-effort at the call site (try/except + log.warning) so an audit-backend failure never aborts the underlying memory write — the writes always land first, the audit emit happens after, and a successful event can never describe an unwritten payload (the `learned_text_sha256` is pre-write).

### MIGRATION_LEDGER finalization

`AuditLogger.__init__` now records `reflection-audit-completeness-v1` advancing `AUDIT_LOG` from `v1-hashchain-jsonl` → `v2-reflection-completeness`. Idempotent — duplicate `migration_id` raises `MigrationChainError` which is suppressed.

### Files changed

- `src/cognithor/core/reflector.py` (+148 / -1)
- `src/cognithor/audit/__init__.py` (+54)
- `tests/test_security/test_reflector_audit_completeness.py` (+9 / -20) — xfail removed
- `tests/test_security/test_reflector_sink_audit.py` (+422, new) — 11 explicit per-sink tests

## Test plan

- [x] `ruff check src/cognithor/ tests/` — clean
- [x] `ruff format --check src/cognithor/ tests/` — clean
- [x] `mypy --strict src/cognithor/core/reflector.py` — clean
- [x] `mypy --strict src/cognithor/audit/__init__.py` — clean
- [x] `pytest tests/test_security/test_reflector_audit_helper.py tests/test_security/test_reflector_audit_completeness.py tests/test_security/test_reflector_sink_audit.py tests/test_learning/test_causal_audit_atomicity.py -v` — 38/38 pass, no xfail
- [x] `pytest tests/test_security/ tests/test_core/ tests/test_learning/ tests/test_memory/ -q` — 5360 passed, 2 skipped, 0 failed
- [x] PR-C's formerly-xfail `test_every_apply_emits_one_event_per_memory_write` now PASSES (not XPASS, not XFAIL, not SKIP)
- [x] All 8 PR-C completeness properties pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)