### PR TITLE
fix(system): mypy --strict zero-errors across HW-Aware modules

### DIFF
--- a/flutter_app/lib/providers/onboarding_provider.dart
+++ b/flutter_app/lib/providers/onboarding_provider.dart
@@ -61,15 +61,20 @@ class HardwareSolution {
       rationaleEn: j['rationale_en'] as String? ?? '',
       score: (j['score'] as num).toDouble(),
       scoreBreakdown: breakdown,
-      blockers: (j['blockers'] as List? ?? []).map((e) => e.toString()).toList(),
-      warnings: (j['warnings'] as List? ?? []).map((e) => e.toString()).toList(),
+      blockers: (j['blockers'] as List? ?? [])
+          .map((e) => e.toString())
+          .toList(),
+      warnings: (j['warnings'] as List? ?? [])
+          .map((e) => e.toString())
+          .toList(),
       isImmediatelyRunnable: j['is_immediately_runnable'] as bool? ?? false,
-      estimatedFirstResponseS:
-          (j['estimated_first_response_s'] as num? ?? 0).toDouble(),
+      estimatedFirstResponseS: (j['estimated_first_response_s'] as num? ?? 0)
+          .toDouble(),
       estimatedDiskGb: (j['estimated_disk_gb'] as num? ?? 0).toDouble(),
-      estimatedSetupMinutes: (j['estimated_setup_minutes'] as num? ?? 0).toInt(),
-      estimatedCostEurPerMonth:
-          (j['estimated_cost_eur_per_month'] as num? ?? 0).toDouble(),
+      estimatedSetupMinutes: (j['estimated_setup_minutes'] as num? ?? 0)
+          .toInt(),
+      estimatedCostEurPerMonth: (j['estimated_cost_eur_per_month'] as num? ?? 0)
+          .toDouble(),
       backend: j['backend'] as String? ?? '',
       modelSet: ms,
     );
@@ -178,7 +183,7 @@ enum WizardStage {
 
 class OnboardingProvider extends ChangeNotifier {
   OnboardingProvider({required this.apiBaseUrl, http.Client? httpClient})
-      : _http = httpClient ?? http.Client();
+    : _http = httpClient ?? http.Client();
 
   final String apiBaseUrl;
   final http.Client _http;
@@ -205,9 +210,9 @@ class OnboardingProvider extends ChangeNotifier {
   }
 
   Map<String, String> get _headers => {
-        'Content-Type': 'application/json',
-        if (_authToken != null) 'Authorization': 'Bearer $_authToken',
-      };
+    'Content-Type': 'application/json',
+    if (_authToken != null) 'Authorization': 'Bearer $_authToken',
+  };
 
   Future<void> detect() async {
     _stage = WizardStage.detecting;
@@ -225,8 +230,10 @@ class OnboardingProvider extends ChangeNotifier {
       );
 
       final cp = await _http
-          .get(Uri.parse('$apiBaseUrl/api/system/capabilities'),
-              headers: _headers)
+          .get(
+            Uri.parse('$apiBaseUrl/api/system/capabilities'),
+            headers: _headers,
+          )
           .timeout(const Duration(seconds: 15));
       if (cp.statusCode != 200) {
         throw Exception('capabilities HTTP ${cp.statusCode}');
@@ -248,12 +255,14 @@ class OnboardingProvider extends ChangeNotifier {
     _stage = WizardStage.loadingRecommendations;
     notifyListeners();
     try {
-      final r = await _http.get(
-        Uri.parse(
-          '$apiBaseUrl/api/system/recommendations?objective=$preset&max_solutions=5',
-        ),
-        headers: _headers,
-      ).timeout(const Duration(seconds: 20));
+      final r = await _http
+          .get(
+            Uri.parse(
+              '$apiBaseUrl/api/system/recommendations?objective=$preset&max_solutions=5',
+            ),
+            headers: _headers,
+          )
+          .timeout(const Duration(seconds: 20));
       if (r.statusCode != 200) {
         throw Exception('recommendations HTTP ${r.statusCode}');
       }
@@ -276,15 +285,17 @@ class OnboardingProvider extends ChangeNotifier {
     _errorMessage = null;
     notifyListeners();
     try {
-      final r = await _http.post(
-        Uri.parse('$apiBaseUrl/api/system/apply'),
-        headers: _headers,
-        body: jsonEncode({
-          'tier_id': tierId,
-          'objective_preset': _objectivePreset,
-          'user_confirmed': true,
-        }),
-      ).timeout(const Duration(seconds: 30));
+      final r = await _http
+          .post(
+            Uri.parse('$apiBaseUrl/api/system/apply'),
+            headers: _headers,
+            body: jsonEncode({
+              'tier_id': tierId,
+              'objective_preset': _objectivePreset,
+              'user_confirmed': true,
+            }),
+          )
+          .timeout(const Duration(seconds: 30));
       if (r.statusCode != 200) {
         throw Exception('apply HTTP ${r.statusCode}: ${r.body}');
       }

--- a/flutter_app/lib/screens/onboarding/hardware_wizard_screen.dart
+++ b/flutter_app/lib/screens/onboarding/hardware_wizard_screen.dart
@@ -35,9 +35,7 @@ class _HardwareWizardScreenState extends State<HardwareWizardScreen> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Cognithor · Hardware-Setup'),
-      ),
+      appBar: AppBar(title: const Text('Cognithor · Hardware-Setup')),
       body: Consumer<OnboardingProvider>(
         builder: (context, p, _) {
           // Auto-advance step based on stage
@@ -99,7 +97,6 @@ class _HardwareWizardScreenState extends State<HardwareWizardScreen> {
 // Step 1 — Detection
 // ─────────────────────────────────────────────────────────────────────────
 
-
 class _DetectionStep extends StatelessWidget {
   const _DetectionStep({required this.p});
   final OnboardingProvider p;
@@ -112,7 +109,8 @@ class _DetectionStep extends StatelessWidget {
         child: Row(
           children: [
             SizedBox(
-              width: 18, height: 18,
+              width: 18,
+              height: 18,
               child: CircularProgressIndicator(strokeWidth: 2),
             ),
             SizedBox(width: 12),
@@ -147,13 +145,13 @@ class _DetectionStep extends StatelessWidget {
                 final icon = status == 'ok'
                     ? Icons.check_circle_outline
                     : status == 'warn'
-                        ? Icons.error_outline
-                        : Icons.cancel_outlined;
+                    ? Icons.error_outline
+                    : Icons.cancel_outlined;
                 final color = status == 'ok'
                     ? Colors.green
                     : status == 'warn'
-                        ? Colors.orange
-                        : Colors.red;
+                    ? Colors.orange
+                    : Colors.red;
                 return Padding(
                   padding: const EdgeInsets.symmetric(vertical: 2),
                   child: Row(
@@ -162,10 +160,7 @@ class _DetectionStep extends StatelessWidget {
                       const SizedBox(width: 8),
                       SizedBox(
                         width: 110,
-                        child: Text(
-                          e.key,
-                          style: theme.textTheme.bodySmall,
-                        ),
+                        child: Text(e.key, style: theme.textTheme.bodySmall),
                       ),
                       Expanded(child: Text(value)),
                     ],
@@ -190,7 +185,11 @@ class _DetectionStep extends StatelessWidget {
               ),
               child: Row(
                 children: [
-                  const Icon(Icons.error_outline, size: 16, color: Colors.orange),
+                  const Icon(
+                    Icons.error_outline,
+                    size: 16,
+                    color: Colors.orange,
+                  ),
                   const SizedBox(width: 8),
                   Expanded(child: Text(w['message'] ?? '')),
                 ],
@@ -241,17 +240,32 @@ class _CapChip extends StatelessWidget {
 // Step 2 — Objective Preset
 // ─────────────────────────────────────────────────────────────────────────
 
-
 class _ObjectiveStep extends StatelessWidget {
   const _ObjectiveStep({required this.p});
   final OnboardingProvider p;
 
   static const _presets = [
-    ('balanced', 'Ausgewogen', 'Standard — gute Mischung aus Qualität, Speed, Cost und Privacy.'),
+    (
+      'balanced',
+      'Ausgewogen',
+      'Standard — gute Mischung aus Qualität, Speed, Cost und Privacy.',
+    ),
     ('quality', 'Beste Qualität', 'Maximale Antwort-Qualität, ggf. langsamer.'),
-    ('speed', 'Schnellste Antworten', 'Minimale Latenz — bevorzugt kleinere Modelle.'),
-    ('privacy', 'Maximale Privacy', 'Nur lokale Inferenz, keine Cloud-Anfragen.'),
-    ('cost', 'Geringste Kosten', 'Lokale Inferenz oder günstigster Cloud-Anbieter.'),
+    (
+      'speed',
+      'Schnellste Antworten',
+      'Minimale Latenz — bevorzugt kleinere Modelle.',
+    ),
+    (
+      'privacy',
+      'Maximale Privacy',
+      'Nur lokale Inferenz, keine Cloud-Anfragen.',
+    ),
+    (
+      'cost',
+      'Geringste Kosten',
+      'Lokale Inferenz oder günstigster Cloud-Anbieter.',
+    ),
   ];
 
   @override
@@ -266,7 +280,10 @@ class _ObjectiveStep extends StatelessWidget {
                 ? Theme.of(context).colorScheme.primaryContainer
                 : null,
             child: ListTile(
-              title: Text(title, style: const TextStyle(fontWeight: FontWeight.bold)),
+              title: Text(
+                title,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
               subtitle: Text(desc),
               trailing: p.objectivePreset == key
                   ? const Icon(Icons.check_circle, color: Colors.blue)
@@ -279,7 +296,8 @@ class _ObjectiveStep extends StatelessWidget {
           const Row(
             children: [
               SizedBox(
-                width: 16, height: 16,
+                width: 16,
+                height: 16,
                 child: CircularProgressIndicator(strokeWidth: 2),
               ),
               SizedBox(width: 12),
@@ -295,7 +313,6 @@ class _ObjectiveStep extends StatelessWidget {
 // ─────────────────────────────────────────────────────────────────────────
 // Step 3 — Solution selection
 // ─────────────────────────────────────────────────────────────────────────
-
 
 class _SolutionsStep extends StatelessWidget {
   const _SolutionsStep({required this.p});
@@ -423,7 +440,10 @@ class _ScoreBars extends StatelessWidget {
     return Row(
       children: [
         for (final (label, value, color) in entries) ...[
-          SizedBox(width: 14, child: Text(label, style: const TextStyle(fontSize: 11))),
+          SizedBox(
+            width: 14,
+            child: Text(label, style: const TextStyle(fontSize: 11)),
+          ),
           Expanded(
             child: Container(
               height: 8,
@@ -462,7 +482,6 @@ class _ScoreBars extends StatelessWidget {
 // Step 4 — Done / Apply Progress
 // ─────────────────────────────────────────────────────────────────────────
 
-
 class _DoneStep extends StatelessWidget {
   const _DoneStep({required this.p, required this.onCompleted});
   final OnboardingProvider p;
@@ -476,7 +495,8 @@ class _DoneStep extends StatelessWidget {
         child: Row(
           children: [
             SizedBox(
-              width: 18, height: 18,
+              width: 18,
+              height: 18,
               child: CircularProgressIndicator(strokeWidth: 2),
             ),
             SizedBox(width: 12),
@@ -533,7 +553,6 @@ class _DoneStep extends StatelessWidget {
 // Shared error block
 // ─────────────────────────────────────────────────────────────────────────
 
-
 class _ErrorBlock extends StatelessWidget {
   const _ErrorBlock({required this.message, required this.onRetry});
   final String message;
@@ -560,7 +579,10 @@ class _ErrorBlock extends StatelessWidget {
           const SizedBox(height: 6),
           Text(message),
           const SizedBox(height: 8),
-          OutlinedButton(onPressed: onRetry, child: const Text('Erneut versuchen')),
+          OutlinedButton(
+            onPressed: onRetry,
+            child: const Text('Erneut versuchen'),
+          ),
         ],
       ),
     );

--- a/flutter_app/lib/screens/splash_screen.dart
+++ b/flutter_app/lib/screens/splash_screen.dart
@@ -112,7 +112,10 @@ class _SplashScreenState extends State<SplashScreen> {
         if (token != null) 'Authorization': 'Bearer $token',
       };
       final r = await http
-          .get(Uri.parse('${conn.serverUrl}/api/system/health'), headers: headers)
+          .get(
+            Uri.parse('${conn.serverUrl}/api/system/health'),
+            headers: headers,
+          )
           .timeout(const Duration(seconds: 5));
       if (r.statusCode != 200) return false;
       final data = jsonDecode(r.body) as Map<String, dynamic>;

--- a/flutter_app/lib/screens/vllm_setup_screen.dart
+++ b/flutter_app/lib/screens/vllm_setup_screen.dart
@@ -364,7 +364,6 @@ class _ModelCardState extends State<_ModelCard> {
   }
 }
 
-
 /// VLM-Router quality preset selector. Reads + writes
 /// ``config.vllm.quality_default`` via /api/backends/vllm/quality-default.
 ///
@@ -487,7 +486,6 @@ class _VlmQualityCardState extends State<_VlmQualityCard> {
   }
 }
 
-
 class _TierDescription extends StatelessWidget {
   final Map<String, dynamic> tier;
   const _TierDescription({required this.tier});
@@ -520,9 +518,9 @@ class _TierDescription extends StatelessWidget {
             const SizedBox(height: 4),
             Text(
               'GPU footprint: ~$memory GiB (excl. KV cache)',
-              style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                fontStyle: FontStyle.italic,
-              ),
+              style: Theme.of(
+                context,
+              ).textTheme.bodySmall?.copyWith(fontStyle: FontStyle.italic),
             ),
           ],
         ],

--- a/flutter_app/test/providers/onboarding_provider_test.dart
+++ b/flutter_app/test/providers/onboarding_provider_test.dart
@@ -9,16 +9,25 @@ import 'package:http/testing.dart';
 
 import 'package:cognithor_ui/providers/onboarding_provider.dart';
 
-http.Response _ok(Object body) => http.Response(jsonEncode(body), 200,
-    headers: {'content-type': 'application/json'});
+http.Response _ok(Object body) => http.Response(
+  jsonEncode(body),
+  200,
+  headers: {'content-type': 'application/json'},
+);
 
-http.Response _bad(int code) =>
-    http.Response('{"detail":"err"}', code, headers: {'content-type': 'application/json'});
+http.Response _bad(int code) => http.Response(
+  '{"detail":"err"}',
+  code,
+  headers: {'content-type': 'application/json'},
+);
 
 void main() {
   group('OnboardingProvider', () {
     test('initial state is idle', () {
-      final p = OnboardingProvider(apiBaseUrl: 'http://x', httpClient: MockClient((req) async => _ok({})));
+      final p = OnboardingProvider(
+        apiBaseUrl: 'http://x',
+        httpClient: MockClient((req) async => _ok({})),
+      );
       expect(p.stage, WizardStage.idle);
       expect(p.solutions, isEmpty);
       expect(p.appliedTierId, isNull);
@@ -88,7 +97,10 @@ void main() {
                 'rationale_en': '...',
                 'score': 0.708,
                 'score_breakdown': {
-                  'quality': 0.83, 'speed': 0.25, 'cost': 1.0, 'privacy': 1.0,
+                  'quality': 0.83,
+                  'speed': 0.25,
+                  'cost': 1.0,
+                  'privacy': 1.0,
                 },
                 'blockers': [],
                 'warnings': [],
@@ -135,7 +147,8 @@ void main() {
             'config_path': '/home/u/.cognithor/config.yaml',
             'backup_path': null,
             'sidecar_path': '/home/u/.cognithor/.hardware_aware.json',
-            'initialized_marker_path': '/home/u/.cognithor/.cognithor_initialized',
+            'initialized_marker_path':
+                '/home/u/.cognithor/.cognithor_initialized',
             'capabilities_hash': 'sha256:abc',
           });
         }
@@ -148,15 +161,17 @@ void main() {
     });
 
     test('reset returns to idle', () async {
-      final mock = MockClient((req) async => _ok({
-            'success': true,
-            'selected_tier_id': 'x',
-            'config_path': '/c',
-            'backup_path': null,
-            'sidecar_path': '/s',
-            'initialized_marker_path': '/m',
-            'capabilities_hash': 'h',
-          }));
+      final mock = MockClient(
+        (req) async => _ok({
+          'success': true,
+          'selected_tier_id': 'x',
+          'config_path': '/c',
+          'backup_path': null,
+          'sidecar_path': '/s',
+          'initialized_marker_path': '/m',
+          'capabilities_hash': 'h',
+        }),
+      );
       final p = OnboardingProvider(apiBaseUrl: 'http://x', httpClient: mock);
       await p.apply('x');
       expect(p.stage, WizardStage.applied);
@@ -172,17 +187,27 @@ void main() {
         capturedAuth = req.headers['Authorization'];
         if (req.url.path == '/api/system/profile') {
           return _ok({
-            'detected_at': 't', 'tier': 'x', 'recommended_mode': 'm',
-            'sanity_warnings': [], 'components': {},
+            'detected_at': 't',
+            'tier': 'x',
+            'recommended_mode': 'm',
+            'sanity_warnings': [],
+            'components': {},
           });
         }
         if (req.url.path == '/api/system/capabilities') {
           return _ok({
-            'can_run_nvfp4': false, 'can_run_fp8_marlin': false,
-            'can_run_gguf_cuda': false, 'can_run_gguf_metal': false,
-            'can_run_vllm_container': false, 'can_run_ollama_native': true,
-            'vram_class': 'none', 'ram_class': 'low', 'disk_class': 'low',
-            'has_internet': true, 'profile_hash': 'h', 'multi_gpu_count': 1,
+            'can_run_nvfp4': false,
+            'can_run_fp8_marlin': false,
+            'can_run_gguf_cuda': false,
+            'can_run_gguf_metal': false,
+            'can_run_vllm_container': false,
+            'can_run_ollama_native': true,
+            'vram_class': 'none',
+            'ram_class': 'low',
+            'disk_class': 'low',
+            'has_internet': true,
+            'profile_hash': 'h',
+            'multi_gpu_count': 1,
           });
         }
         return _bad(404);
@@ -212,9 +237,12 @@ void main() {
         'estimated_cost_eur_per_month': 0,
         'backend': 'ollama',
         'model_set': {
-          'planner': 'qwen', 'executor': 'qwen-fast',
-          'coder': 'qwen', 'embedding': 'qwen-emb',
-          'formulate': 'qwen-fast', 'fast_path_validator': 'qwen-fast',
+          'planner': 'qwen',
+          'executor': 'qwen-fast',
+          'coder': 'qwen',
+          'embedding': 'qwen-emb',
+          'formulate': 'qwen-fast',
+          'fast_path_validator': 'qwen-fast',
         },
       });
       expect(s.tierId, 't');

--- a/src/cognithor/api/system_api.py
+++ b/src/cognithor/api/system_api.py
@@ -45,7 +45,7 @@ system_router = APIRouter(prefix="/api/system", tags=["system"])
 # ── Module-level cache (rebuilt per request — fast enough) ─────────────────
 
 
-def _detect() -> tuple[Any, Any, tuple]:
+def _detect() -> tuple[Any, Any, tuple[Any, ...]]:
     detector = SystemDetector()
     profile = detector.run_full_scan()
     caps = map_to_capabilities(profile)
@@ -60,8 +60,8 @@ class ProfileResponse(BaseModel):
     detected_at: str
     tier: str
     recommended_mode: str
-    sanity_warnings: list[dict] = Field(default_factory=list)
-    components: dict[str, dict] = Field(default_factory=dict)
+    sanity_warnings: list[dict[str, Any]] = Field(default_factory=list)
+    components: dict[str, dict[str, Any]] = Field(default_factory=dict)
 
 
 class CapabilitiesResponse(BaseModel):
@@ -139,7 +139,7 @@ class HealthResponse(BaseModel):
     manifest_version: str | None
     drift_detected: bool
     drift_components: list[str]
-    sanity_warnings: list[dict]
+    sanity_warnings: list[dict[str, Any]]
     last_capabilities_hash: str | None
     current_capabilities_hash: str
 
@@ -305,7 +305,7 @@ async def post_apply(req: ApplyRequest) -> ApplyResponse:
 
 
 @system_router.post("/refresh-manifest")
-async def post_refresh_manifest() -> dict:
+async def post_refresh_manifest() -> dict[str, Any]:
     loader = ManifestLoader()
     try:
         manifest, source = loader.load(prefer_online=True, force_refresh=True)
@@ -386,26 +386,26 @@ async def get_health() -> HealthResponse:
 
 
 @system_router.get("/perf")
-async def get_perf_summary() -> dict:
+async def get_perf_summary() -> dict[str, Any]:
     """Per-model rolling performance summary (last 24 h)."""
     tracker = get_default_tracker()
     return {"window_s": 86400, "models": tracker.model_summary(window_s=86400)}
 
 
 @system_router.post("/dismiss-hardware-drift")
-async def post_dismiss_hardware_drift() -> dict:
+async def post_dismiss_hardware_drift() -> dict[str, Any]:
     DriftDetector().dismiss_hardware_banner()
     return {"ok": True}
 
 
 @system_router.post("/dismiss-performance-drift")
-async def post_dismiss_performance_drift() -> dict:
+async def post_dismiss_performance_drift() -> dict[str, Any]:
     DriftDetector().dismiss_performance_banner()
     return {"ok": True}
 
 
 @system_router.post("/rollback")
-async def post_rollback() -> dict:
+async def post_rollback() -> dict[str, Any]:
     restored = rollback_last()
     if restored is None:
         raise HTTPException(status_code=404, detail="No backups available")
@@ -413,5 +413,5 @@ async def post_rollback() -> dict:
 
 
 @system_router.get("/backups")
-async def get_backups() -> dict:
+async def get_backups() -> dict[str, Any]:
     return {"backups": [str(p) for p in list_backups()]}

--- a/src/cognithor/system/apply_engine.py
+++ b/src/cognithor/system/apply_engine.py
@@ -23,7 +23,10 @@ import tempfile
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 import yaml
 
@@ -49,7 +52,7 @@ _LOCK_PATH = Path.home() / ".cognithor" / ".wizard.lock"
 
 
 @contextlib.contextmanager
-def _file_lock(timeout_s: float = 5.0):
+def _file_lock(timeout_s: float = 5.0) -> Iterator[None]:
     """Cross-platform exclusive file-lock around the apply pipeline.
 
     POSIX: fcntl.LOCK_EX | LOCK_NB.
@@ -115,7 +118,7 @@ class ApplyResult:
 _LATEST_SCHEMA_VERSION = 2
 
 
-def _migrate_v1_to_v2(cfg: dict) -> dict:
+def _migrate_v1_to_v2(cfg: dict[str, Any]) -> dict[str, Any]:
     """v1 → v2: bookkeeping fields (`__schema_version`, `__recommended_*`)
     were originally written into config.yaml. v2 moves them to the
     `~/.cognithor/.hardware_aware.json` sidecar so config.yaml stays
@@ -135,7 +138,7 @@ def _migrate_v1_to_v2(cfg: dict) -> dict:
 _SCHEMA_MIGRATIONS = {1: _migrate_v1_to_v2}
 
 
-def _migrate_to_latest(cfg: dict) -> dict:
+def _migrate_to_latest(cfg: dict[str, Any]) -> dict[str, Any]:
     """Apply v1→v2→… migrations idempotently. Schema-version tracking moved
     to sidecar in v2 — migrations now just clean up legacy keys."""
     cur = 1 if "__schema_version" in cfg else _LATEST_SCHEMA_VERSION
@@ -151,7 +154,7 @@ def _migrate_to_latest(cfg: dict) -> dict:
 # ── Merge ──────────────────────────────────────────────────────────────────
 
 
-def _is_default_or_missing(cfg: dict, path: tuple[str, ...]) -> bool:
+def _is_default_or_missing(cfg: dict[str, Any], path: tuple[str, ...]) -> bool:
     """True iff the field at `path` is missing or matches the Cognithor
     code-default. Used to decide whether to overwrite vs respect User-Override."""
     cur: Any = cfg
@@ -189,8 +192,8 @@ _SCHEMA_KNOWN_VLLM_FIELDS = {
 
 
 def _merge_solution(
-    cfg: dict, solution: Solution, tier: Tier, manifest: Manifest
-) -> tuple[dict, dict]:
+    cfg: dict[str, Any], solution: Solution, tier: Tier, manifest: Manifest
+) -> tuple[dict[str, Any], dict[str, Any]]:
     """Idempotent merge — never overwrite User-Overrides.
 
     Returns (config_yaml_dict, sidecar_dict) where sidecar_dict carries
@@ -230,7 +233,7 @@ def _merge_solution(
 
     # Models — per role, only set if not already user-defined
     cfg.setdefault("models", {})
-    sidecar_models: dict[str, dict] = {}
+    sidecar_models: dict[str, dict[str, Any]] = {}
     backend_id_field = tier.backend
     for role in ("planner", "executor", "coder", "embedding", "formulate", "fast_path_validator"):
         model_id = getattr(tier.model_set, role)
@@ -299,7 +302,7 @@ def list_backups(config_path: Path | None = None) -> list[Path]:
 # ── Atomic write ───────────────────────────────────────────────────────────
 
 
-def _atomic_write_yaml(path: Path, data: dict) -> None:
+def _atomic_write_yaml(path: Path, data: dict[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     fd, tmp_str = tempfile.mkstemp(prefix=path.name + ".", suffix=".tmp", dir=str(path.parent))
     tmp_path = Path(tmp_str)
@@ -317,7 +320,7 @@ def _atomic_write_yaml(path: Path, data: dict) -> None:
 # ── Pydantic validation pre-flight ─────────────────────────────────────────
 
 
-def _validate_against_schema(cfg: dict) -> None:
+def _validate_against_schema(cfg: dict[str, Any]) -> None:
     """Build a CognithorConfig from the merged dict to catch schema bugs.
 
     We don't keep the result — just verify it parses. Validation errors
@@ -383,7 +386,7 @@ def apply_solution(
 
     with _file_lock(timeout_s=5.0):
         # Read existing config (or {})
-        existing: dict = {}
+        existing: dict[str, Any] = {}
         if config_path.exists():
             try:
                 existing = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}

--- a/src/cognithor/system/capabilities.py
+++ b/src/cognithor/system/capabilities.py
@@ -11,7 +11,7 @@ zero-code).
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 from cognithor.system.detector import SystemProfile
 
@@ -328,7 +328,7 @@ def _hash_profile(profile: SystemProfile) -> str:
     import hashlib
     import json
 
-    relevant: dict = {}
+    relevant: dict[str, dict[str, Any]] = {}
     for key in ("os", "cpu", "ram", "gpu", "disk", "docker", "wsl2", "rocm", "container"):
         if key in profile.results:
             data = dict(profile.results[key].raw_data)

--- a/src/cognithor/system/detector.py
+++ b/src/cognithor/system/detector.py
@@ -381,7 +381,7 @@ class SystemDetector:
                 **kwargs,
             )
             if r.returncode == 0 and r.stdout.strip():
-                v = r.stdout.strip().splitlines()[0].replace(",", ".").strip()
+                v: str = r.stdout.strip().splitlines()[0].replace(",", ".").strip()
                 if re.fullmatch(r"\d+\.\d+", v):
                     return v
         except (FileNotFoundError, subprocess.TimeoutExpired):

--- a/src/cognithor/system/manifest_models.py
+++ b/src/cognithor/system/manifest_models.py
@@ -12,7 +12,7 @@ All field names match the YAML keys so loading is a straight
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
@@ -132,8 +132,8 @@ class PricingManifest(BaseModel):
     manifest_version: str
     expires_utc: str | None = None
     providers: dict[str, dict[str, PricingEntry]] = Field(default_factory=dict)
-    local_inference: dict = Field(default_factory=dict)
-    default_usage_profile: dict = Field(default_factory=dict)
+    local_inference: dict[str, Any] = Field(default_factory=dict)
+    default_usage_profile: dict[str, Any] = Field(default_factory=dict)
 
 
 class Recall(BaseModel):

--- a/src/cognithor/system/perf_tracker.py
+++ b/src/cognithor/system/perf_tracker.py
@@ -20,6 +20,7 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 from threading import Lock
+from typing import Any
 
 from cognithor.utils.logging import get_logger
 
@@ -50,7 +51,7 @@ class PerfRecord:
             return 0.0
         return (self.completion_tokens * 1000.0) / self.total_ms
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, Any]:
         return {
             "ts": round(self.timestamp, 3),
             "model_id": self.model_id,
@@ -65,7 +66,7 @@ class PerfRecord:
         }
 
     @classmethod
-    def from_dict(cls, d: dict) -> PerfRecord:
+    def from_dict(cls, d: dict[str, Any]) -> PerfRecord:
         return cls(
             timestamp=float(d.get("ts", 0)),
             model_id=str(d.get("model_id", "")),
@@ -146,7 +147,7 @@ class PerfTracker:
         samples.sort()
         return float(samples[len(samples) // 2])
 
-    def model_summary(self, *, window_s: float = 86400) -> dict[str, dict]:
+    def model_summary(self, *, window_s: float = 86400) -> dict[str, dict[str, Any]]:
         cutoff = time.time() - window_s
         out: dict[str, list[PerfRecord]] = {}
         with self._lock:

--- a/src/cognithor/system/solver.py
+++ b/src/cognithor/system/solver.py
@@ -157,9 +157,9 @@ def _estimate_monthly_cost_eur(tier: Tier, pricing: PricingManifest | None) -> f
     if tier.backend in ("ollama", "vllm", "lmstudio", "llama_cpp"):
         return 0.0  # electricity not in this scope; covered separately
     profile = pricing.default_usage_profile or {}
-    rpd = profile.get("requests_per_day", 80)
-    avg_in = profile.get("avg_input_tokens", 1500)
-    avg_out = profile.get("avg_output_tokens", 800)
+    rpd = int(profile.get("requests_per_day", 80))
+    avg_in = int(profile.get("avg_input_tokens", 1500))
+    avg_out = int(profile.get("avg_output_tokens", 800))
 
     provider_pricing = pricing.providers.get(tier.backend, {})
     if not provider_pricing:


### PR DESCRIPTION
## Summary

The HW-Aware-Runtime push (#241/`2bd04765` and predecessors) left **28 mypy errors** in 7 files that broke the `mypy --strict src/cognithor/` CI gate on main.

This PR brings the gate back to zero. Run-time behaviour unchanged.

## What was wrong

| File | Errors | Cause |
|---|---|---|
| `system/perf_tracker.py` | 3 | `dict` without parameters in `to_dict`, `from_dict`, `model_summary` |
| `system/detector.py` | 1 | `r.stdout` is `Any` because subprocess `kwargs: dict[str, Any]` widens `CompletedProcess` |
| `system/capabilities.py` | 1 | `relevant: dict = {}` in `_hash_profile` |
| `system/manifest_models.py` | 2 | `local_inference: dict` and `default_usage_profile: dict` on `PricingManifest` |
| `system/solver.py` | 1 | Pydantic `dict[str, Any]` widened the cost calc to `Any` |
| `system/apply_engine.py` | 10 | Bare `dict` on every helper signature + `_file_lock` missing return annotation |
| `api/system_api.py` | 10 | Bare `tuple` / `dict` on `_detect()` and 8 endpoint handlers |

## Fix shape

- Parameterise every bare `dict` / `tuple` (`dict[str, Any]`, `tuple[Any, ...]`) — matches the Pydantic free-form YAML payload + the `_detect()` triple shape
- `apply_engine._file_lock` → `Iterator[None]` (gated under `TYPE_CHECKING` so ruff `TC003` stays happy with `from __future__ import annotations`)
- `detector._detect_cuda_runtime_version` → annotate local `v: str` to discharge the inherited `Any` from subprocess
- `solver._estimate_monthly_cost_eur` → cast `rpd` / `avg_in` / `avg_out` to `int` on read

## Test plan

- [x] `mypy --strict src/cognithor/` → **830 source files, 0 errors** (was 28)
- [x] `ruff check src/cognithor/system/ src/cognithor/api/system_api.py` → clean
- [x] `ruff format --check` → clean
- [x] `pytest tests/test_system/ -q` → 35 / 35 green
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)