### PR TITLE
fix(extension): close 3 Dependabot CVEs via npm overrides

### DIFF
--- a/extensions/vscode/package-lock.json
+++ b/extensions/vscode/package-lock.json
@@ -2582,9 +2582,9 @@
       }
     },
     "node_modules/diff": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
-      "integrity": "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw==",
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-9.0.0.tgz",
+      "integrity": "sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -3185,9 +3185,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.1.tgz",
-      "integrity": "sha512-h2r7rcm6Ee/J8o0LD5djLuFVcfbZxhvho4vvsbeV0aMvXjUgqv4YpxpkEx0d68l6+IleVfLAdVEfhR7QNMkGHQ==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -5444,16 +5444,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -5823,13 +5813,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+      "integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/setimmediate": {
@@ -6015,16 +6005,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/diff": {
-      "version": "8.0.4",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-8.0.4.tgz",
-      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.3.1"
       }
     },
     "node_modules/slash": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -192,5 +192,9 @@
   "dependencies": {
     "ws": "^8.18.0"
   },
-  "extensionDependencies": []
+  "extensionDependencies": [],
+  "overrides": {
+    "serialize-javascript": ">=7.0.5",
+    "diff": ">=9.0.0"
+  }
 }


### PR DESCRIPTION
## Summary

Closes the three open Dependabot alerts on the repo (all in ``extensions/vscode/package-lock.json``, which is the only npm tree in this monorepo):

| # | Package | Severity | Advisory |
|---|---|---|---|
| #10 | serialize-javascript ≤7.0.4 | HIGH | GHSA-5c6j-r48x-rmvq — RCE via ``RegExp.flags`` + ``Date.prototype.toISOString`` |
| #11 | serialize-javascript ≤7.0.4 | MEDIUM | GHSA-qj8w-gfj5-8c6v — CPU-exhaustion DoS |
| #12 | fast-uri | HIGH | host confusion via percent-encoded authority delimiters |

All three are transitive deps under ``devDependencies`` (mocha → serialize-javascript ; @vscode/vsce → @secretlint → ajv → fast-uri).

## Why ``npm audit fix --force`` doesn't work

That command would *downgrade* mocha to 11.3.0, which the npm advisory database still lists as affected (range ``8.0.0 – 12.0.0-beta-3`` — every mocha 11.x). The fix has to come from pinning the transitive deps directly, not from churning mocha.

## Fix

Two-line ``overrides`` block in ``package.json``:

```json
"overrides": {
  "serialize-javascript": ">=7.0.5",
  "diff": ">=9.0.0"
}
```

- ``serialize-javascript ≥7.0.5`` — advisory says ≤7.0.4 affected
- ``diff ≥9.0.0`` — advisory says 6.0.0 – 8.0.2 affected; mocha 11.7.5 still resolves to ``diff@7.0.0`` transitively, so the override is needed even though that one wasn't a separate alert

mocha 11.7.5 stays — the runtime API is compatible with the overridden deps.

## Test plan

- [x] ``npm audit`` → **0 vulnerabilities** (was 4: 1 low, 3 high)
- [x] ``npm run typecheck`` → clean
- [x] ``npm run compile`` → ``dist/extension.js`` 154 kB bundles cleanly
- [x] ``npm run test:unit`` → **31 / 31 passing** (mocha + diff overrides don't break the suite)
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)