### PR TITLE
fix(manifest): migrate num_speculative_tokens → speculative_config (vLLM 0.20+)

### DIFF
--- a/manifest/v2/tiers.yaml
+++ b/manifest/v2/tiers.yaml
@@ -35,7 +35,10 @@ tiers:
       enforce_eager: true
       cpu_offload_gb: 4
       max_model_len: 16384
-      num_speculative_tokens: 1
+      # vLLM 0.20+ replaced --num-speculative-tokens with --speculative-config
+      # (JSON). MTP-speculative on NVFP4 wants 1 speculative token per step.
+      speculative_config:
+        num_speculative_tokens: 1
       enable_prefix_caching: true
     model_set:
       planner: "qwen3.6-27b-text-nvfp4-mtp"

--- a/src/cognithor/system/apply_engine.py
+++ b/src/cognithor/system/apply_engine.py
@@ -176,7 +176,7 @@ def _is_default_or_missing(cfg: dict[str, Any], path: tuple[str, ...]) -> bool:
 _SCHEMA_KNOWN_ROLES = {"planner", "executor", "coder", "embedding"}
 
 # Plain VLLMConfig fields (per src/cognithor/config.py:2567 VLLMConfig).
-# `enable_prefix_caching` + `num_speculative_tokens` exist only as
+# `enable_prefix_caching` + `speculative_config` exist only as
 # `vlm_*`-prefixed VLM-specific fields; for the L6 apply they go to the
 # sidecar `vllm_extras` so the runtime orchestrator can pick them up
 # without us mis-mapping into the wrong field name.
@@ -212,13 +212,26 @@ def _merge_solution(
     bc = tier.backend_config
     if tier.backend == "vllm" and bc.docker_image:
         cfg.setdefault("vllm", {})
+        # vLLM 0.20+ deprecation: ``--num-speculative-tokens N`` was replaced
+        # by ``--speculative-config '{"num_speculative_tokens": N, ...}'``.
+        # If the manifest still ships the legacy field, transform it into
+        # the new shape so the sidecar always reflects what vLLM 0.20+
+        # actually accepts.
+        speculative_config = bc.speculative_config
+        if speculative_config is None and bc.num_speculative_tokens is not None:
+            log.warning(
+                "manifest_num_speculative_tokens_deprecated",
+                tier_id=tier.id,
+                migrated_to="speculative_config",
+            )
+            speculative_config = {"num_speculative_tokens": bc.num_speculative_tokens}
         for field, value in {
             "docker_image": bc.docker_image,
             "gpu_memory_utilization": bc.gpu_memory_utilization,
             "enforce_eager": bc.enforce_eager,
             "cpu_offload_gb": bc.cpu_offload_gb,
             "max_model_len": bc.max_model_len,
-            "num_speculative_tokens": bc.num_speculative_tokens,
+            "speculative_config": speculative_config,
             "enable_prefix_caching": bc.enable_prefix_caching,
         }.items():
             if value is None:

--- a/src/cognithor/system/manifest_models.py
+++ b/src/cognithor/system/manifest_models.py
@@ -81,6 +81,15 @@ class BackendConfig(BaseModel):
     enforce_eager: bool | None = None
     cpu_offload_gb: int | None = None
     max_model_len: int | None = None
+    # Speculative decoding config — JSON shape matching vLLM 0.20+ CLI
+    # ``--speculative-config``. Example: ``{"num_speculative_tokens": 1,
+    # "method": "ngram"}``.
+    speculative_config: dict[str, Any] | None = None
+    # DEPRECATED: vLLM 0.20+ replaced ``--num-speculative-tokens N`` with
+    # ``--speculative-config '{"num_speculative_tokens": N, ...}'``.
+    # apply_engine auto-migrates this field into ``speculative_config``
+    # when the new field is unset; new manifests should use
+    # ``speculative_config`` directly.
     num_speculative_tokens: int | None = None
     enable_prefix_caching: bool | None = None
 

--- a/tests/test_system/test_hardware_aware_runtime.py
+++ b/tests/test_system/test_hardware_aware_runtime.py
@@ -551,6 +551,51 @@ class TestApplyEngine:
         assert data["manifest_version"] == apply_setup["manifest"].manifest_version
         assert "system_profile_hash" in data
 
+    def test_apply_emits_speculative_config_dict_not_legacy_field(self, apply_setup) -> None:
+        """vLLM 0.20+ wants ``--speculative-config '{"num_speculative_tokens": N}'``,
+        not the legacy ``--num-speculative-tokens N``. Sidecar's vllm_extras
+        must carry the JSON shape so the runtime tier-launcher emits the
+        right CLI flag (TODO-020 / Bug #1 from 2026-05-09 smoke-test)."""
+        # Find the NVFP4 tier (which has speculative_config in the manifest)
+        manifest = apply_setup["manifest"]
+        nvfp4_tier = next(
+            (t for t in manifest.tiers if t.id == "enterprise-vllm-nvfp4-blackwell"),
+            None,
+        )
+        if nvfp4_tier is None:
+            pytest.skip("manifest fixture lacks enterprise-vllm-nvfp4-blackwell tier")
+
+        # Skip if the tier isn't runnable in apply_setup (cap mismatch)
+        if apply_setup["solution"].tier_id != "enterprise-vllm-nvfp4-blackwell":
+            pytest.skip("apply_setup fixture is on a non-NVFP4 tier")
+
+        apply_solution(
+            solution=apply_setup["solution"],
+            manifest=manifest,
+            capabilities=apply_setup["caps"],
+            objective=apply_setup["objective"],
+            config_path=apply_setup["config_path"],
+            user_confirmed=True,
+        )
+        sidecar = apply_setup["config_path"].parent / ".hardware_aware.json"
+        import json
+
+        data = json.loads(sidecar.read_text(encoding="utf-8"))
+        extras = data.get("vllm_extras", {})
+        assert "speculative_config" in extras, (
+            f"speculative_config missing from vllm_extras — got keys: {list(extras.keys())}"
+        )
+        spec = extras["speculative_config"]
+        assert isinstance(spec, dict), (
+            f"speculative_config must be dict (vLLM 0.20+ JSON shape), got {type(spec)}"
+        )
+        assert spec.get("num_speculative_tokens") == 1
+        # Legacy flat field must NOT leak into the sidecar
+        assert "num_speculative_tokens" not in extras, (
+            "Legacy num_speculative_tokens leaked into vllm_extras — "
+            "tier-launcher would emit deprecated --num-speculative-tokens flag"
+        )
+
     def test_apply_writes_marker(self, apply_setup) -> None:
         result = apply_solution(
             solution=apply_setup["solution"],


### PR DESCRIPTION
## Summary

Real bug found during yesterday's vLLM smoke-test (TODO-003 from session memory). vLLM 0.20 deprecated ``--num-speculative-tokens N`` in favour of ``--speculative-config '{"num_speculative_tokens": N, ...}'`` (JSON shape). The manifest still pinned the legacy flat field, and ``apply_engine`` propagated it 1:1 to the sidecar's ``vllm_extras``. Any tier-launcher feeding ``vllm_extras`` to the vLLM CLI would emit the deprecated flag and the engine would refuse to start with:

```
api_server.py: error: unrecognized arguments: --num-speculative-tokens
```

## Migration

| Layer | Before | After |
|---|---|---|
| ``BackendConfig`` (manifest_models.py) | ``num_speculative_tokens: int \| None`` | adds ``speculative_config: dict[str, Any] \| None``; legacy field retained but documented deprecated |
| ``manifest/v2/tiers.yaml`` (NVFP4 tier) | ``num_speculative_tokens: 1`` | ``speculative_config: {num_speculative_tokens: 1}`` |
| ``apply_engine._merge_solution`` | passes legacy field through to vllm_extras | prefers ``speculative_config``; auto-migrates legacy with one-shot ``manifest_num_speculative_tokens_deprecated`` warning |

Sidecar ``vllm_extras`` shape after this PR for the NVFP4 tier:

```json
"vllm_extras": {
    "speculative_config": {"num_speculative_tokens": 1},
    "enable_prefix_caching": true
}
```

## Test plan

- [x] New ``test_apply_emits_speculative_config_dict_not_legacy_field`` asserts (a) ``speculative_config`` is present + dict-shaped in vllm_extras, (b) legacy flat field does NOT leak through.
- [x] ``pytest tests/test_system/ -q`` → **42 / 42 green** (was 41 + 1 new).
- [x] ``mypy --strict src/cognithor/system/manifest_models.py src/cognithor/system/apply_engine.py`` → 0
- [x] ``ruff check`` + ``ruff format --check`` → clean
- [ ] CI green on this branch

## ⚠️ Owner note: manifest signature

``manifest/v2/manifest.sig`` is invalidated by the YAML change. Before the next online-refresh of the manifest, run:

```
python scripts/sign_manifest.py sign --key F:\cognithor-keys\manifest_targets.key.pem
```

and commit the new ``manifest.sig``. The embedded fallback path uses the bundled YAML directly, so this PR alone doesn't break local ``cognithor doctor`` — only the online-refresh would fail the sig check until re-signing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)