### PR TITLE
feat(scripts): launch_vllm_tier.py — bundles 2026-05-09 smoke-test workarounds

### DIFF
--- a/docs/runbooks/launch_vllm_tier.md
+++ b/docs/runbooks/launch_vllm_tier.md
@@ -1,0 +1,84 @@
+# Launch vLLM Tier (Hardware-Aware Runtime)
+
+`scripts/launch_vllm_tier.py` is the operator-side companion to `cognithor doctor --apply-recommendation` — once the apply-engine has written the sidecar (`~/.cognithor/.hardware_aware.json`) for a vLLM-backed tier, this script reads it and starts vLLM with the safe defaults discovered during the 2026-05-09 NVFP4 smoke-test.
+
+## Why this script exists
+
+vLLM 0.20 introduced six independent regression-traps for the NVFP4 + Blackwell + WSL2 combo. Each trap silently breaks an otherwise-correct tier-apply. The script bundles all six fixes; running `python -m vllm.entrypoints.openai.api_server …` directly without these is unlikely to produce a working server.
+
+| # | Trap | Fix the script applies |
+|---|---|---|
+| 1 | HF Hub HEAD-request fails when a community-uploaded model lacks `preprocessor_config.json` upstream — even if the local snapshot is intact | `HF_HUB_OFFLINE=1` + `TRANSFORMERS_OFFLINE=1`, plus auto-resolves the HF id to the cached snapshot path |
+| 2 | flashinfer 0.6.x reads `nvcc --version`; if the system nvcc is < 12.9 it refuses sm_120 even though PyTorch is built against CUDA 13 | `--force-cuda-arch 12.0f` env override (opt-in flag) |
+| 3 | `ninja` PATH-lookup hits a non-executable match in WSL `/mnt/c/...` interop dirs → `PermissionError` | PATH cleanup: prepends venv `bin/`, drops Windows-mnt entries |
+| 4 | `--cpu-offload-gb` triggers a uvloop deadlock during the first incoming request on WSL2 + vLLM 0.20; the API server stays bound but stops accepting connections | Off by default; explicit `--cpu-offload N` to enable |
+| 5 | `--num-speculative-tokens` was deprecated in vLLM 0.20+ | Reads `speculative_config` (dict) from sidecar `vllm_extras`, emits as `--speculative-config '{…}'` JSON |
+| 6 | `--host 127.0.0.1` makes the server unreachable from the Windows host through WSL2 port-forward | Defaults to `0.0.0.0`; pass `--host 127.0.0.1` to keep it WSL-internal |
+
+## Usage
+
+```bash
+# Resolve everything from the sidecar
+python scripts/launch_vllm_tier.py
+
+# Explicit model snapshot path + port
+python scripts/launch_vllm_tier.py \
+    --model ~/.cache/huggingface/hub/models--Qwen--Qwen3.6-27B-FP8/snapshots/abc123 \
+    --port 8000
+
+# Blackwell + nvcc 12.0 (most current Ubuntu WSL stacks)
+python scripts/launch_vllm_tier.py --force-cuda-arch 12.0f
+
+# Dry-run: print the constructed command + env, exec nothing
+python scripts/launch_vllm_tier.py --print-only
+
+# Override the venv path (default ~/vllm-env)
+python scripts/launch_vllm_tier.py --venv /opt/vllm-env
+
+# Pass through additional vLLM CLI args
+python scripts/launch_vllm_tier.py -- --tensor-parallel-size 2 --quantization fp8
+```
+
+## Sidecar fields the script reads
+
+```jsonc
+{
+  "vllm": {
+    "gpu_memory_utilization": 0.94,
+    "enforce_eager": true,
+    "max_model_len": 16384
+  },
+  "vllm_extras": {
+    "speculative_config": {"num_speculative_tokens": 1},
+    "enable_prefix_caching": true
+  },
+  "model_set_extras": {
+    "planner": {"name": "Qwen/Qwen3.6-27B-FP8"}
+  }
+}
+```
+
+CLI flags override sidecar values. If both the sidecar and CLI lack a value, vLLM defaults apply.
+
+## Smoke-test after launch
+
+`scripts/smoke_vllm_backend.py` is the existing smoke-test runner. Once `launch_vllm_tier.py` reports `Application startup complete`:
+
+```bash
+# from another shell — uses the default localhost:8000
+python scripts/smoke_vllm_backend.py
+```
+
+## When something still fails
+
+- `OSError: Can't load image processor for 'org/repo'` — the model repo is missing `preprocessor_config.json` upstream. Copy it from a sibling repo (e.g. official Qwen FP8 release) into the local snapshot, then `mv` the corresponding `.no_exist/<rev>/preprocessor_config.json` marker out of the way.
+- `RuntimeError: No supported CUDA architectures found for major versions [12]` — pass `--force-cuda-arch 12.0f`.
+- `PermissionError: [Errno 13] Permission denied: 'ninja'` — script already cleans PATH; if it still fails, your venv `bin/ninja` may be missing or non-executable. `chmod +x ~/vllm-env/bin/ninja`.
+- Server reaches `Application startup complete` but `curl` hangs — check the engine log for stalled JIT compilation; first-request fp4_gemm autotuning can take 1-3 min on RTX 5090. Increase HTTP client timeout.
+- `--num-speculative-tokens unrecognized` — the sidecar still has the legacy field. Fix in the manifest YAML (`speculative_config: {num_speculative_tokens: N}`) and rerun `cognithor doctor --apply-recommendation` to refresh the sidecar.
+
+## Related files
+
+- `manifest/v2/tiers.yaml` — tier definitions; `enterprise-vllm-nvfp4-blackwell` is the NVFP4 tier this script was designed against.
+- `src/cognithor/system/apply_engine.py` — emits the sidecar that this script reads.
+- `scripts/smoke_vllm_backend.py` — companion smoke-test that hits `/v1/models` and `/v1/chat/completions`.

--- a/scripts/launch_vllm_tier.py
+++ b/scripts/launch_vllm_tier.py
@@ -1,0 +1,392 @@
+#!/usr/bin/env python3
+# Licensed under the Apache License, Version 2.0 (see LICENSE).
+"""Launch the vLLM OpenAI-compatible server with the safe defaults
+encoded by the Hardware-Aware Runtime tier-apply (sidecar
+``~/.cognithor/.hardware_aware.json``).
+
+Bundles the workarounds discovered during the 2026-05-09 smoke-test of
+the Enterprise NVFP4 tier on RTX 5090 + vLLM 0.20:
+
+1. **HF Hub HEAD-bypass** — ``HF_HUB_OFFLINE=1`` +
+   ``TRANSFORMERS_OFFLINE=1`` so a community-uploaded NVFP4 repo that
+   lacks ``preprocessor_config.json`` upstream still loads from the
+   already-cached snapshot (transformers' default behaviour: HEAD
+   request to HF Hub *first*, fail before consulting local cache).
+
+2. **flashinfer sm_120 CUDA-arch override** —
+   ``FLASHINFER_CUDA_ARCH_LIST=12.0f``. flashinfer 0.6.x reads
+   ``nvcc --version`` to decide whether to allow Blackwell sm_120; if
+   the system nvcc is < 12.9 it errors out even though PyTorch is
+   built against CUDA 13. The env var bypasses the version probe and
+   pins the target arch directly with the ``f`` suffix vLLM 0.20+
+   expects.
+
+3. **PATH hygiene** — when the WSL ``$PATH`` includes the long chain
+   of ``/mnt/c/...`` Windows interop directories, Python's ``execvp``
+   for ``ninja`` (used by flashinfer JIT) can find a non-executable
+   match in one of those mounts and raise ``PermissionError`` instead
+   of falling through. We prepend the venv ``bin/`` and trim PATH to
+   pure-Linux directories.
+
+4. **No ``--cpu-offload-gb`` by default** — empirically triggers a
+   uvloop-deadlock during the first incoming request on WSL2 + vLLM
+   0.20; the API server stays bound but stops accepting connections.
+   Pass ``--cpu-offload N`` explicitly only if VRAM is genuinely
+   insufficient.
+
+5. **``--host 0.0.0.0`` by default** — exposes the server on the WSL
+   VM's network interface so Windows-host ``localhost:8000`` reaches
+   it via WSL2's port-forward. Pass ``--host 127.0.0.1`` to keep it
+   WSL-only.
+
+6. **``--speculative-config`` JSON** instead of the deprecated
+   ``--num-speculative-tokens N`` (vLLM ≥0.20 dropped the latter).
+
+Resolution order for the model path:
+
+* ``--model PATH`` — explicit path wins
+* sidecar ``model_set_extras.planner.model_id`` — the L6 apply-engine
+  emits the HF-format ID for the manifest-pinned model
+* ``--model HF_ID`` — fallback to plain HF Hub ID
+
+Usage::
+
+    # offline-resolve from sidecar, defaults from Manifest
+    python scripts/launch_vllm_tier.py
+
+    # explicit model path + custom port
+    python scripts/launch_vllm_tier.py \\
+        --model ~/models/Qwen3.6-27B-NVFP4 \\
+        --port 8000
+
+    # dry-run — print the constructed command, exec nothing
+    python scripts/launch_vllm_tier.py --print-only
+
+The script does NOT attempt to download models from HuggingFace —
+it expects the snapshot to already be in ``$HF_HOME/hub/...``. Use
+``huggingface-cli download`` separately to pre-cache.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+# ───────────────────────────────────────────────────────────────────
+# Sidecar resolution
+# ───────────────────────────────────────────────────────────────────
+
+
+def _sidecar_path() -> Path:
+    return Path.home() / ".cognithor" / ".hardware_aware.json"
+
+
+def _load_sidecar() -> dict[str, Any]:
+    p = _sidecar_path()
+    if not p.exists():
+        return {}
+    try:
+        return dict(json.loads(p.read_text(encoding="utf-8")))
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _resolve_hf_snapshot(hf_id: str, hf_home: Path) -> Path | None:
+    """Find the latest snapshot of ``org/repo`` under ``$HF_HOME/hub/``.
+
+    HF caches as ``models--{org}--{repo}/snapshots/{revision}/`` with a
+    ``refs/main`` symlink pointing at the active revision. We resolve
+    that symlink rather than picking the first directory, in case
+    multiple revisions are cached.
+    """
+    cache_root = hf_home / "hub" / f"models--{hf_id.replace('/', '--')}"
+    if not cache_root.exists():
+        return None
+
+    refs_main = cache_root / "refs" / "main"
+    if refs_main.exists():
+        try:
+            revision = refs_main.read_text(encoding="utf-8").strip()
+            snapshot = cache_root / "snapshots" / revision
+            if snapshot.exists():
+                return snapshot
+        except OSError:
+            pass
+
+    snapshots_dir = cache_root / "snapshots"
+    if snapshots_dir.exists():
+        revisions = list(snapshots_dir.iterdir())
+        if revisions:
+            return revisions[0]
+
+    return None
+
+
+# ───────────────────────────────────────────────────────────────────
+# Environment hardening
+# ───────────────────────────────────────────────────────────────────
+
+
+def _build_env(venv_bin: Path, *, force_arch: str | None) -> dict[str, str]:
+    """Construct the env dict that bypasses the 2026-05-09 smoke-test gotchas."""
+    base_env = dict(os.environ)
+
+    # Strip Windows-mnt entries from PATH; keep only Linux-standard dirs +
+    # the venv bin (which has the bundled `ninja` for flashinfer JIT).
+    cleaned_path = ":".join(
+        [
+            str(venv_bin),
+            "/usr/local/sbin",
+            "/usr/local/bin",
+            "/usr/sbin",
+            "/usr/bin",
+            "/sbin",
+            "/bin",
+        ]
+    )
+    base_env["PATH"] = cleaned_path
+
+    # HF Hub bypass — local cache only, no HEAD requests
+    base_env["HF_HUB_OFFLINE"] = "1"
+    base_env["TRANSFORMERS_OFFLINE"] = "1"
+
+    # flashinfer Blackwell override (only applied if user explicitly asks
+    # for it via --force-cuda-arch, since it's RTX 50-series-specific)
+    if force_arch:
+        base_env["FLASHINFER_CUDA_ARCH_LIST"] = force_arch
+
+    return base_env
+
+
+# ───────────────────────────────────────────────────────────────────
+# vLLM CLI command builder
+# ───────────────────────────────────────────────────────────────────
+
+
+def _build_vllm_cmd(
+    *,
+    python_bin: Path,
+    model_path: str,
+    served_name: str | None,
+    port: int,
+    host: str,
+    gpu_memory_utilization: float,
+    max_model_len: int | None,
+    enforce_eager: bool,
+    enable_prefix_caching: bool,
+    speculative_config: dict[str, Any] | None,
+    cpu_offload_gb: int | None,
+    extra_args: list[str],
+) -> list[str]:
+    cmd: list[str] = [
+        str(python_bin),
+        "-m",
+        "vllm.entrypoints.openai.api_server",
+        "--model",
+        model_path,
+        "--host",
+        host,
+        "--port",
+        str(port),
+        "--gpu-memory-utilization",
+        str(gpu_memory_utilization),
+    ]
+    if served_name:
+        cmd += ["--served-model-name", served_name]
+    if max_model_len is not None:
+        cmd += ["--max-model-len", str(max_model_len)]
+    if enforce_eager:
+        cmd += ["--enforce-eager"]
+    if enable_prefix_caching:
+        cmd += ["--enable-prefix-caching"]
+    if cpu_offload_gb is not None and cpu_offload_gb > 0:
+        cmd += ["--cpu-offload-gb", str(cpu_offload_gb)]
+    if speculative_config:
+        cmd += ["--speculative-config", json.dumps(speculative_config)]
+    cmd.extend(extra_args)
+    return cmd
+
+
+# ───────────────────────────────────────────────────────────────────
+# Main
+# ───────────────────────────────────────────────────────────────────
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Launch vLLM with the Hardware-Aware tier sidecar's safe defaults."
+    )
+    parser.add_argument(
+        "--model",
+        help="HF id (org/repo) or local snapshot path. Resolves from sidecar by default.",
+    )
+    parser.add_argument(
+        "--served-model-name",
+        help=(
+            "Public model ID surfaced via /v1/models. "
+            "Defaults to --model when an HF id, else falls through."
+        ),
+    )
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument(
+        "--host",
+        default="0.0.0.0",
+        help="0.0.0.0 (default, reachable from Windows host) or 127.0.0.1 (WSL-internal only).",
+    )
+    parser.add_argument("--gpu-memory-utilization", type=float)
+    parser.add_argument("--max-model-len", type=int)
+    parser.add_argument(
+        "--cpu-offload", type=int, default=0, help="Disabled by default (uvloop deadlock)."
+    )
+    parser.add_argument(
+        "--force-cuda-arch",
+        help="Set FLASHINFER_CUDA_ARCH_LIST (e.g. '12.0f' for Blackwell sm_120 with old nvcc).",
+    )
+    parser.add_argument("--no-eager", action="store_true", help="Override sidecar enforce_eager.")
+    parser.add_argument("--no-prefix-caching", action="store_true")
+    parser.add_argument(
+        "--venv",
+        default=str(Path.home() / "vllm-env"),
+        help="Path to vLLM venv. Looked up at $venv/bin/python and $venv/bin (for ninja).",
+    )
+    parser.add_argument(
+        "--hf-home",
+        default=os.environ.get("HF_HOME", str(Path.home() / ".cache" / "huggingface")),
+    )
+    parser.add_argument(
+        "--print-only",
+        action="store_true",
+        help="Print the constructed command + env without executing.",
+    )
+    parser.add_argument(
+        "vllm_args",
+        nargs=argparse.REMAINDER,
+        help="Trailing args passed verbatim to vllm.entrypoints (after --).",
+    )
+    args = parser.parse_args(argv)
+
+    venv_path = Path(args.venv).expanduser()
+    venv_bin = venv_path / "bin"
+    python_bin = venv_bin / "python"
+    # In --print-only mode the venv may not exist (e.g. running on the
+    # Windows host to inspect the command before sshing into WSL).
+    if not python_bin.exists() and not args.print_only:
+        print(f"[ERROR] vLLM venv python not found at {python_bin}", file=sys.stderr)
+        return 2
+
+    sidecar = _load_sidecar()
+    extras = sidecar.get("vllm_extras", {}) or {}
+    model_set_extras = sidecar.get("model_set_extras", {}) or {}
+
+    # Resolve model
+    if args.model:
+        model_arg: str = args.model
+    else:
+        planner = (model_set_extras.get("planner") or {}).get("name")
+        if not planner:
+            print(
+                "[ERROR] No --model given and sidecar lacks model_set_extras.planner.name. "
+                "Run `cognithor doctor --apply-recommendation` first.",
+                file=sys.stderr,
+            )
+            return 3
+        model_arg = planner
+
+    # If model_arg looks like an HF id, try to resolve to a local snapshot path so
+    # HF_HUB_OFFLINE doesn't fail trying to consult the registry for it.
+    served_name = args.served_model_name or (model_arg if "/" in model_arg else None)
+    if "/" in model_arg and not Path(model_arg).exists():
+        snapshot = _resolve_hf_snapshot(model_arg, Path(args.hf_home).expanduser())
+        if snapshot:
+            print(f"[info] resolved {model_arg} → {snapshot}", file=sys.stderr)
+            model_arg = str(snapshot)
+        else:
+            print(
+                f"[warn] {model_arg} not in HF cache at {args.hf_home}/hub/. "
+                "Server may fail with HF_HUB_OFFLINE=1.",
+                file=sys.stderr,
+            )
+
+    # GPU memory util — sidecar wins if not overridden
+    gpu_mem_util = args.gpu_memory_utilization
+    if gpu_mem_util is None:
+        gpu_mem_util = (sidecar.get("vllm") or {}).get("gpu_memory_utilization", 0.9)
+
+    # max_model_len
+    max_len = args.max_model_len
+    if max_len is None:
+        max_len = (sidecar.get("vllm") or {}).get("max_model_len")
+
+    # enforce_eager
+    sidecar_eager = (sidecar.get("vllm") or {}).get("enforce_eager", False)
+    enforce_eager = sidecar_eager and not args.no_eager
+
+    # prefix caching
+    prefix_caching = bool(extras.get("enable_prefix_caching", True)) and not args.no_prefix_caching
+
+    # speculative_config
+    spec_cfg = extras.get("speculative_config")
+    if not isinstance(spec_cfg, dict) or not spec_cfg:
+        spec_cfg = None
+
+    cpu_offload = args.cpu_offload if args.cpu_offload > 0 else None
+
+    # Build env + command
+    env = _build_env(venv_bin, force_arch=args.force_cuda_arch)
+    env["HF_HOME"] = str(Path(args.hf_home).expanduser())
+
+    cmd = _build_vllm_cmd(
+        python_bin=python_bin,
+        model_path=model_arg,
+        served_name=served_name,
+        port=args.port,
+        host=args.host,
+        gpu_memory_utilization=float(gpu_mem_util),
+        max_model_len=int(max_len) if max_len else None,
+        enforce_eager=bool(enforce_eager),
+        enable_prefix_caching=prefix_caching,
+        speculative_config=spec_cfg,
+        cpu_offload_gb=cpu_offload,
+        extra_args=[a for a in args.vllm_args if a != "--"],
+    )
+
+    if args.print_only:
+        print("ENV (overrides):")
+        for key in (
+            "HF_HOME",
+            "HF_HUB_OFFLINE",
+            "TRANSFORMERS_OFFLINE",
+            "PATH",
+            "FLASHINFER_CUDA_ARCH_LIST",
+        ):
+            if key in env:
+                print(f"  {key}={env[key]}")
+        print("\nCOMMAND:")
+        # shlex.quote the parts so the user can copy-paste
+        import shlex
+
+        print("  " + " ".join(shlex.quote(p) for p in cmd))
+        return 0
+
+    # exec
+    print(f"[launch] {' '.join(cmd[:6])} ...", file=sys.stderr)
+    try:
+        return subprocess.call(cmd, env=env)
+    except FileNotFoundError as exc:
+        print(f"[ERROR] {exc}", file=sys.stderr)
+        return 4
+    except KeyboardInterrupt:
+        return 130
+
+
+if __name__ == "__main__":
+    # ``shutil.which`` is imported but unused here; keeping the import so the
+    # module exposes the helper for tests/imports that may need it.
+    _ = shutil.which
+    sys.exit(main())

--- a/tests/test_scripts/test_launch_vllm_tier.py
+++ b/tests/test_scripts/test_launch_vllm_tier.py
@@ -1,0 +1,224 @@
+"""Tests for ``scripts/launch_vllm_tier.py`` — the operator-side vLLM
+launcher that bundles the 2026-05-09 smoke-test workarounds.
+
+We don't import the script as a module (it lives outside ``src/``);
+instead we ``runpy``-load it and call its helper functions directly
+so we get coverage without needing pytest plugins for script discovery.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def launcher_module():
+    """Load ``scripts/launch_vllm_tier.py`` as a module under a stable name."""
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / "scripts" / "launch_vllm_tier.py"
+    spec = importlib.util.spec_from_file_location("launch_vllm_tier", script_path)
+    assert spec and spec.loader, "spec_from_file_location failed"
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# ───────────────────────────────────────────────────────────────────
+# _build_env — env hardening
+# ───────────────────────────────────────────────────────────────────
+
+
+class TestBuildEnv:
+    def test_path_starts_with_venv_bin(self, launcher_module) -> None:
+        venv_bin = Path("/home/test/vllm-env/bin")
+        env = launcher_module._build_env(venv_bin, force_arch=None)
+        path_parts = env["PATH"].split(":")
+        assert path_parts[0] == str(venv_bin), (
+            "venv bin must be first in PATH for ninja JIT-compile to find the "
+            "bundled ninja before any /mnt/c/... Windows interop binary"
+        )
+
+    def test_path_excludes_windows_mnt(self, launcher_module) -> None:
+        venv_bin = Path("/home/test/vllm-env/bin")
+        env = launcher_module._build_env(venv_bin, force_arch=None)
+        for entry in env["PATH"].split(":"):
+            assert not entry.startswith("/mnt/c/"), (
+                f"Windows-mnt entry leaked into PATH: {entry!r}; flashinfer "
+                "ninja PATH-lookup may hit a non-executable .exe under the mnt"
+            )
+
+    def test_hf_offline_set(self, launcher_module) -> None:
+        env = launcher_module._build_env(Path("/x/bin"), force_arch=None)
+        assert env["HF_HUB_OFFLINE"] == "1"
+        assert env["TRANSFORMERS_OFFLINE"] == "1"
+
+    def test_force_cuda_arch_only_when_explicit(self, launcher_module) -> None:
+        e_off = launcher_module._build_env(Path("/x/bin"), force_arch=None)
+        assert "FLASHINFER_CUDA_ARCH_LIST" not in e_off, (
+            "force_arch=None must NOT set FLASHINFER_CUDA_ARCH_LIST — "
+            "the override is RTX-50-series-specific and shouldn't be on by default"
+        )
+        e_on = launcher_module._build_env(Path("/x/bin"), force_arch="12.0f")
+        assert e_on["FLASHINFER_CUDA_ARCH_LIST"] == "12.0f"
+
+
+# ───────────────────────────────────────────────────────────────────
+# _build_vllm_cmd — CLI assembly
+# ───────────────────────────────────────────────────────────────────
+
+
+def _make_cmd(launcher_module, **overrides: Any) -> list[str]:
+    """Helper: build a default-ish CLI command and return it."""
+    defaults: dict[str, Any] = {
+        "python_bin": Path("/x/bin/python"),
+        "model_path": "/snap/abc",
+        "served_name": "org/repo",
+        "port": 8000,
+        "host": "0.0.0.0",
+        "gpu_memory_utilization": 0.9,
+        "max_model_len": None,
+        "enforce_eager": False,
+        "enable_prefix_caching": False,
+        "speculative_config": None,
+        "cpu_offload_gb": None,
+        "extra_args": [],
+    }
+    defaults.update(overrides)
+    return launcher_module._build_vllm_cmd(**defaults)
+
+
+class TestBuildVllmCmd:
+    def test_minimal_args(self, launcher_module) -> None:
+        cmd = _make_cmd(launcher_module)
+        # cmd[0] is str(python_bin); on Windows the separator differs but the
+        # path components must round-trip through Path comparison.
+        assert Path(cmd[0]) == Path("/x/bin/python")
+        assert cmd[1:3] == ["-m", "vllm.entrypoints.openai.api_server"]
+        assert "--model" in cmd
+        assert Path(cmd[cmd.index("--model") + 1]) == Path("/snap/abc")
+        assert "--host" in cmd
+        assert cmd[cmd.index("--host") + 1] == "0.0.0.0"
+
+    def test_speculative_config_emitted_as_json(self, launcher_module) -> None:
+        """vLLM 0.20+ wants --speculative-config '{...}' (JSON), not the
+        deprecated --num-speculative-tokens N. Bug #1 / Manifest migration."""
+        spec = {"num_speculative_tokens": 1, "method": "ngram"}
+        cmd = _make_cmd(launcher_module, speculative_config=spec)
+        assert "--speculative-config" in cmd
+        emitted = cmd[cmd.index("--speculative-config") + 1]
+        # Must round-trip through JSON
+        parsed = json.loads(emitted)
+        assert parsed == spec
+
+    def test_no_num_speculative_tokens_flag_ever_emitted(self, launcher_module) -> None:
+        """The deprecated flag must never appear regardless of input shape."""
+        cmd = _make_cmd(
+            launcher_module,
+            speculative_config={"num_speculative_tokens": 1},
+        )
+        assert "--num-speculative-tokens" not in cmd
+
+    def test_cpu_offload_off_by_default(self, launcher_module) -> None:
+        """Bug #4 / uvloop deadlock: cpu-offload must NOT be on the cmd line
+        unless caller explicitly passed cpu_offload_gb > 0."""
+        cmd = _make_cmd(launcher_module, cpu_offload_gb=None)
+        assert "--cpu-offload-gb" not in cmd
+        cmd_zero = _make_cmd(launcher_module, cpu_offload_gb=0)
+        assert "--cpu-offload-gb" not in cmd_zero
+        cmd_explicit = _make_cmd(launcher_module, cpu_offload_gb=4)
+        assert "--cpu-offload-gb" in cmd_explicit
+        assert cmd_explicit[cmd_explicit.index("--cpu-offload-gb") + 1] == "4"
+
+    def test_enforce_eager_only_when_true(self, launcher_module) -> None:
+        cmd_off = _make_cmd(launcher_module, enforce_eager=False)
+        assert "--enforce-eager" not in cmd_off
+        cmd_on = _make_cmd(launcher_module, enforce_eager=True)
+        assert "--enforce-eager" in cmd_on
+
+    def test_max_model_len_none_omits_flag(self, launcher_module) -> None:
+        cmd = _make_cmd(launcher_module, max_model_len=None)
+        assert "--max-model-len" not in cmd
+        cmd_set = _make_cmd(launcher_module, max_model_len=16384)
+        assert cmd_set[cmd_set.index("--max-model-len") + 1] == "16384"
+
+    def test_extra_args_appended_verbatim(self, launcher_module) -> None:
+        cmd = _make_cmd(
+            launcher_module,
+            extra_args=["--tensor-parallel-size", "2", "--quantization", "fp8"],
+        )
+        # Trailing args must appear in order after our default ones
+        idx = cmd.index("--tensor-parallel-size")
+        assert cmd[idx + 1] == "2"
+        assert cmd[idx + 2] == "--quantization"
+        assert cmd[idx + 3] == "fp8"
+
+
+# ───────────────────────────────────────────────────────────────────
+# _resolve_hf_snapshot — cache-aware HF id → path resolution
+# ───────────────────────────────────────────────────────────────────
+
+
+class TestResolveHfSnapshot:
+    def test_returns_none_when_not_cached(self, launcher_module, tmp_path: Path) -> None:
+        result = launcher_module._resolve_hf_snapshot("foo/bar", tmp_path)
+        assert result is None
+
+    def test_resolves_via_refs_main(self, launcher_module, tmp_path: Path) -> None:
+        repo = tmp_path / "hub" / "models--foo--bar"
+        snap = repo / "snapshots" / "abc123"
+        snap.mkdir(parents=True)
+        (repo / "refs").mkdir(parents=True)
+        (repo / "refs" / "main").write_text("abc123\n", encoding="utf-8")
+        result = launcher_module._resolve_hf_snapshot("foo/bar", tmp_path)
+        assert result == snap
+
+    def test_falls_back_to_first_snapshot(self, launcher_module, tmp_path: Path) -> None:
+        repo = tmp_path / "hub" / "models--foo--bar"
+        snap = repo / "snapshots" / "deadbeef"
+        snap.mkdir(parents=True)
+        # No refs/main → fallback to listing snapshots/ and returning one
+        result = launcher_module._resolve_hf_snapshot("foo/bar", tmp_path)
+        assert result == snap
+
+    def test_handles_org_repo_with_dashes(self, launcher_module, tmp_path: Path) -> None:
+        # HF transforms "qwen-team/super-mix-7b" → "models--qwen-team--super-mix-7b"
+        repo = tmp_path / "hub" / "models--qwen-team--super-mix-7b"
+        snap = repo / "snapshots" / "v1"
+        snap.mkdir(parents=True)
+        (repo / "refs").mkdir(parents=True)
+        (repo / "refs" / "main").write_text("v1", encoding="utf-8")
+        result = launcher_module._resolve_hf_snapshot("qwen-team/super-mix-7b", tmp_path)
+        assert result == snap
+
+
+# ───────────────────────────────────────────────────────────────────
+# _load_sidecar — JSON robustness
+# ───────────────────────────────────────────────────────────────────
+
+
+class TestLoadSidecar:
+    def test_missing_file_returns_empty(self, launcher_module, tmp_path, monkeypatch) -> None:
+        monkeypatch.setattr(launcher_module, "_sidecar_path", lambda: tmp_path / "nope.json")
+        assert launcher_module._load_sidecar() == {}
+
+    def test_corrupt_json_returns_empty(self, launcher_module, tmp_path, monkeypatch) -> None:
+        bad = tmp_path / "sidecar.json"
+        bad.write_text("{not json", encoding="utf-8")
+        monkeypatch.setattr(launcher_module, "_sidecar_path", lambda: bad)
+        assert launcher_module._load_sidecar() == {}
+
+    def test_valid_sidecar_parsed(self, launcher_module, tmp_path, monkeypatch) -> None:
+        good = tmp_path / "sidecar.json"
+        good.write_text(
+            json.dumps({"recommended_tier": "x", "vllm_extras": {"a": 1}}),
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(launcher_module, "_sidecar_path", lambda: good)
+        data = launcher_module._load_sidecar()
+        assert data["recommended_tier"] == "x"
+        assert data["vllm_extras"] == {"a": 1}


### PR DESCRIPTION
## Summary

Operator-side companion to ``cognithor doctor --apply-recommendation``. Once the apply-engine writes the sidecar (``~/.cognithor/.hardware_aware.json``) for a vLLM-backed tier, this script reads the sidecar's ``vllm_extras`` + ``vllm`` blocks and starts vLLM with the safe defaults discovered during the 2026-05-09 NVFP4 smoke-test on RTX 5090.

Six independent vLLM-0.20-on-Blackwell traps are bundled. Running ``python -m vllm.entrypoints.openai.api_server …`` directly without these is unlikely to produce a working server; this script encodes the fixes once.

## The trap matrix

| # | Trap | Fix |
|---|---|---|
| 1 | HF Hub HEAD-request fails when community-uploaded NVFP4 repo lacks ``preprocessor_config.json`` upstream | ``HF_HUB_OFFLINE=1`` + ``TRANSFORMERS_OFFLINE=1`` + auto-resolves HF id to cached snapshot path |
| 2 | flashinfer 0.6.x rejects sm_120 when system nvcc is older than 12.9 (even though PyTorch is cu13) | opt-in ``--force-cuda-arch 12.0f`` env var |
| 3 | ``ninja`` PATH-lookup hits non-executable ``.exe`` in WSL ``/mnt/c/...`` mounts | PATH cleanup: venv bin first, drop Windows-mnt |
| 4 | ``--cpu-offload-gb`` triggers uvloop deadlock on first request (WSL2 + vLLM 0.20) | off by default; explicit ``--cpu-offload N`` to enable |
| 5 | ``--num-speculative-tokens`` deprecated in vLLM 0.20+ | reads ``speculative_config`` dict from sidecar, emits as ``--speculative-config '{…}'`` JSON |
| 6 | ``--host 127.0.0.1`` unreachable from Windows host through WSL2 port-forward | defaults to ``0.0.0.0`` |

Companion to the sibling PR ``fix(manifest): migrate num_speculative_tokens → speculative_config`` — that PR fixes Trap #5 in the apply-engine; this one consumes the corrected sidecar shape downstream.

## Files

- ``scripts/launch_vllm_tier.py`` — operator script (~350 LOC)
- ``docs/runbooks/launch_vllm_tier.md`` — runbook with the trap matrix, sidecar shape reference, smoke-test follow-up, and "when something still fails" triage
- ``tests/test_scripts/test_launch_vllm_tier.py`` — 18 unit tests covering env hardening, CLI assembly, HF-snapshot resolution, and sidecar JSON robustness

## Sidecar fields the script reads

```jsonc
{
  "vllm": {
    "gpu_memory_utilization": 0.94,
    "enforce_eager": true,
    "max_model_len": 16384
  },
  "vllm_extras": {
    "speculative_config": {"num_speculative_tokens": 1},
    "enable_prefix_caching": true
  },
  "model_set_extras": {
    "planner": {"name": "Qwen/Qwen3.6-27B-FP8"}
  }
}
```

## Usage

```bash
# Resolve everything from the sidecar
python scripts/launch_vllm_tier.py

# Explicit model + Blackwell override
python scripts/launch_vllm_tier.py \
    --model sakamakismile/Qwen3.6-27B-Text-NVFP4-MTP \
    --force-cuda-arch 12.0f

# Dry-run: print constructed cmd + env, exec nothing
python scripts/launch_vllm_tier.py --print-only

# Trailing args passed through to vLLM
python scripts/launch_vllm_tier.py -- --tensor-parallel-size 2
```

## Test plan

- [x] ``pytest tests/test_scripts/ -q`` → **18 / 18 green**
- [x] ``mypy --strict scripts/launch_vllm_tier.py`` → 0 issues
- [x] ``ruff check`` + ``ruff format --check`` → clean
- [x] ``python scripts/launch_vllm_tier.py --print-only --model … --force-cuda-arch 12.0f`` → prints expected env + command for review without executing
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)