### PR TITLE
feat(pre-commit): dart format hook for flutter_app/ (mirror CI gate)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,3 +75,30 @@ repos:
         types: [python]
         files: ^(src/cognithor/channels/program_synthesis/|tests/test_channels/test_program_synthesis/)
         pass_filenames: false
+
+      # Mirror of CI's "Flutter (analyze + test) — Dart format check" step
+      # so commits don't bring format drift into PRs that then surface as
+      # red CI on push (the recurring incident from 2026-05-08:
+      # 5 .dart files in the HW-Aware push were unformatted, masked
+      # behind the failing Lint job, only surfaced once Lint went green).
+      # Skipped automatically when Flutter SDK is absent — operators
+      # without Flutter can still commit non-Flutter changes.
+      - id: dart-format-flutter
+        name: dart format --set-exit-if-changed (flutter_app/)
+        entry: |
+          bash -c '
+            if ! command -v dart >/dev/null 2>&1; then
+              echo "[dart-format] dart not on PATH — skipping. Install Flutter to enable."
+              exit 0
+            fi
+            dart format --output=none --set-exit-if-changed "$@" || {
+              echo ""
+              echo "[dart-format] Drift detected. Run:"
+              echo "  cd flutter_app && dart format lib/ test/ integration_test/"
+              echo "and re-stage."
+              exit 1
+            }
+          ' --
+        language: system
+        files: ^flutter_app/.*\.dart$
+        pass_filenames: true


### PR DESCRIPTION
## Summary

Mirrors CI's ``Flutter (analyze + test) — Dart format check`` step into the local pre-commit chain.

Triggered by the 2026-05-08 HW-Aware push: 5 ``.dart`` files in ``flutter_app/lib/screens/onboarding/`` / ``splash`` / ``vllm_setup`` + ``test/providers/`` shipped without ``dart format`` because the local pre-commit-config didn't have a Dart hook. CI's format-check was masked behind a failing Lint job and only turned red once Lint went green, requiring a follow-up commit (``a8180cb8`` in PR #503). This hook stops that recurring.

## What the hook does

- Runs ``dart format --output=none --set-exit-if-changed`` on every staged ``.dart`` file under ``flutter_app/`` (regex ``^flutter_app/.*\.dart$``).
- Skips cleanly when ``dart`` isn't on PATH, so non-Flutter operators can still commit non-Flutter changes without installing Flutter.
- On format drift, prints the exact ``cd flutter_app && dart format lib/ test/ integration_test/`` line the user should run to fix.

## Setup (one-time per clone, unchanged)

```bash
pip install pre-commit
pre-commit install
```

## Test plan

- [x] ``yaml.safe_load(.pre-commit-config.yaml)`` parses → 11 hooks (was 10), new ``dart-format-flutter`` registered
- [x] Hook fires on staged ``flutter_app/**/*.dart`` paths only; other diffs (Python, YAML, MD) unaffected
- [x] Pre-existing hooks (ruff, mypy-strict-pse, pytest-pse, etc.) continue working — single additive change
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)