### PR TITLE
feat(pse): idempotent Sprint-26 domain registration + gateway-boot tests

### DIFF
--- a/src/cognithor/channels/program_synthesis/domains/__init__.py
+++ b/src/cognithor/channels/program_synthesis/domains/__init__.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 from cognithor.channels.program_synthesis.domains._register_all import (
     SPRINT26_DOMAIN_NAMES,
     register_all_sprint26_domains,
+    register_missing_sprint26_domains,
 )
 from cognithor.channels.program_synthesis.domains.base import (
     Domain,
@@ -72,4 +73,5 @@ __all__ = [
     "Scorecard",
     "ScorecardEntry",
     "register_all_sprint26_domains",
+    "register_missing_sprint26_domains",
 ]

--- a/src/cognithor/channels/program_synthesis/domains/_register_all.py
+++ b/src/cognithor/channels/program_synthesis/domains/_register_all.py
@@ -18,11 +18,21 @@ Calling the wrapper twice on the same registry raises
 ``DomainAlreadyRegisteredError`` from the underlying registry — the
 wrapper does NOT swallow that, because a double-init usually points
 at a real wiring bug.
+
+For idempotent gateway-boot wiring (which may run more than once in
+the same Python process — test fixtures, hot-reload), use
+:func:`register_missing_sprint26_domains` instead. It registers only
+the Sprint-26 domains not yet present in the registry and returns the
+list of names it actually registered, so the caller can log
+appropriately.
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 from cognithor.channels.program_synthesis.domains.ast_dsl import (
     register_ast_domain,
@@ -67,6 +77,20 @@ SPRINT26_DOMAIN_NAMES: tuple[str, ...] = (
 )
 
 
+# Name → registrar function mapping in the SPRINT26_DOMAIN_NAMES order.
+# Used by both ``register_all_sprint26_domains`` (registers all) and
+# ``register_missing_sprint26_domains`` (registers only the gaps).
+_SPRINT26_REGISTRARS: tuple[tuple[str, Callable[[DomainRegistry], None]], ...] = (
+    ("sql", register_sql_domain),
+    ("json", register_json_domain),
+    ("datetime", register_datetime_domain),
+    ("ast", register_ast_domain),
+    ("bytes", register_bytes_domain),
+    ("float", register_float_domain),
+    ("image_v2", register_image_v2_domain),
+)
+
+
 def register_all_sprint26_domains(registry: DomainRegistry) -> None:
     """Register every Sprint-26 domain into ``registry``.
 
@@ -77,12 +101,39 @@ def register_all_sprint26_domains(registry: DomainRegistry) -> None:
 
     Raises ``DomainAlreadyRegisteredError`` when invoked twice with
     the same name — that's a wiring bug worth surfacing rather than
-    silently no-oping.
+    silently no-oping. Gateway-boot wiring that may run more than once
+    in the same process (test fixtures, hot-reload) should use
+    :func:`register_missing_sprint26_domains` instead.
     """
-    register_sql_domain(registry)
-    register_json_domain(registry)
-    register_datetime_domain(registry)
-    register_ast_domain(registry)
-    register_bytes_domain(registry)
-    register_float_domain(registry)
-    register_image_v2_domain(registry)
+    for _name, register_fn in _SPRINT26_REGISTRARS:
+        register_fn(registry)
+
+
+def register_missing_sprint26_domains(registry: DomainRegistry) -> list[str]:
+    """Register only the Sprint-26 domains not yet present in ``registry``.
+
+    Idempotent: calling twice on a fully-populated registry returns
+    ``[]`` and mutates nothing. Calling on a partially-populated
+    registry fills only the gaps and returns the names that were
+    actually registered, in Owner-D3 order.
+
+    The intended caller is the gateway boot path, which runs once per
+    Python process under normal operation but may run multiple times
+    in test fixtures and hot-reload paths. Compared to
+    ``register_all_sprint26_domains``, this function never raises
+    ``DomainAlreadyRegisteredError`` because it pre-checks before
+    each registration.
+
+    Foreign domain names (anything outside ``SPRINT26_DOMAIN_NAMES``)
+    are ignored — this function only manages the Sprint-26 catalog.
+
+    Returns:
+        The Sprint-26 names that were actually registered by THIS call.
+    """
+    newly_registered: list[str] = []
+    for name, register_fn in _SPRINT26_REGISTRARS:
+        if name in registry:
+            continue
+        register_fn(registry)
+        newly_registered.append(name)
+    return newly_registered

--- a/src/cognithor/gateway/phases/tools.py
+++ b/src/cognithor/gateway/phases/tools.py
@@ -203,22 +203,26 @@ async def init_tools(
     # json, datetime, ast, bytes, float, image_v2) into the canonical
     # DOMAIN_REGISTRY. The synthesis pipeline reads from this
     # registry; without this call the registry stays empty and every
-    # cross-domain query falls back to the free-form path. Defensive
-    # wrapper because re-running the gateway in a single Python
-    # process (test fixtures, hot-reload) hits the
-    # DomainAlreadyRegisteredError guard — that's not fatal here.
+    # cross-domain query falls back to the free-form path.
+    #
+    # ``register_missing_sprint26_domains`` is set-based + idempotent:
+    # safe to call on a fresh, partial, or fully-populated registry,
+    # so re-runs (test fixtures, hot-reload) and partial-init recovery
+    # don't raise. Returns the names actually registered by THIS call,
+    # which we surface in the audit log so reviewers can tell first-
+    # boot from re-boot at a glance.
     try:
         from cognithor.channels.program_synthesis.domains import (
             DOMAIN_REGISTRY,
-            SPRINT26_DOMAIN_NAMES,
-            register_all_sprint26_domains,
+            register_missing_sprint26_domains,
         )
 
-        if len(DOMAIN_REGISTRY) == 0:
-            register_all_sprint26_domains(DOMAIN_REGISTRY)
+        newly_registered = register_missing_sprint26_domains(DOMAIN_REGISTRY)
+        if newly_registered:
             log.info(
                 "pse_sprint26_domains_registered",
-                domains=list(SPRINT26_DOMAIN_NAMES),
+                domains=newly_registered,
+                total=len(DOMAIN_REGISTRY),
             )
         else:
             log.debug(

--- a/tests/test_gateway/test_phases_coverage.py
+++ b/tests/test_gateway/test_phases_coverage.py
@@ -227,6 +227,253 @@ class TestToolsPhase:
 
 
 # ============================================================================
+# phases/tools.py — Sprint-26 PSE domain registration wiring
+#
+# These tests cover the integration point added in Sprint-26 where
+# init_tools centralises registration of the seven Domain-Expansion
+# catalogs (sql, json, datetime, ast, bytes, float, image_v2) into
+# the canonical DOMAIN_REGISTRY. Without this wiring the registry
+# stays empty at runtime and every cross-domain synthesis query falls
+# back to the free-form path.
+#
+# Each test uses a fresh in-process DomainRegistry monkey-patched
+# into BOTH the module that exports it AND the registry submodule, so
+# the function-local ``from … import DOMAIN_REGISTRY`` inside
+# init_tools picks up the test's instance instead of the global
+# singleton (which other tests in the session may have populated).
+# ============================================================================
+
+
+class TestToolsPhaseSprint26Registration:
+    @pytest.fixture
+    def fresh_domain_registry(self, monkeypatch):
+        """Inject a clean DomainRegistry for the duration of this test."""
+        from cognithor.channels.program_synthesis.domains.registry import (
+            DomainRegistry,
+        )
+
+        fresh = DomainRegistry()
+        # Patch BOTH locations — the package re-exports DOMAIN_REGISTRY
+        # at the package level for ergonomics, and init_tools imports
+        # via the package re-export.
+        monkeypatch.setattr(
+            "cognithor.channels.program_synthesis.domains.registry.DOMAIN_REGISTRY",
+            fresh,
+        )
+        monkeypatch.setattr(
+            "cognithor.channels.program_synthesis.domains.DOMAIN_REGISTRY",
+            fresh,
+        )
+        return fresh
+
+    @pytest.mark.asyncio
+    async def test_init_tools_registers_all_seven_sprint26_domains(
+        self, config: CognithorConfig, fresh_domain_registry
+    ) -> None:
+        """After init_tools runs against an empty registry, all 7
+        Sprint-26 domains must be present (Owner-D3 catalog complete)."""
+        from cognithor.channels.program_synthesis.domains import (
+            SPRINT26_DOMAIN_NAMES,
+        )
+        from cognithor.gateway.phases.tools import init_tools
+
+        assert len(fresh_domain_registry) == 0, "fixture must start empty"
+
+        await init_tools(config, mcp_client=MagicMock(), memory_manager=MagicMock())
+
+        for name in SPRINT26_DOMAIN_NAMES:
+            assert name in fresh_domain_registry, (
+                f"Sprint-26 domain {name!r} missing after init_tools"
+            )
+        assert len(fresh_domain_registry) == 7
+
+    @pytest.mark.asyncio
+    async def test_init_tools_idempotent_on_double_boot(
+        self, config: CognithorConfig, fresh_domain_registry
+    ) -> None:
+        """Running init_tools twice in the same process (test fixtures,
+        hot-reload) must NOT raise DomainAlreadyRegisteredError. The
+        idempotent path is what register_missing_sprint26_domains
+        guarantees."""
+        from cognithor.gateway.phases.tools import init_tools
+
+        await init_tools(config, mcp_client=MagicMock(), memory_manager=MagicMock())
+        # Second boot must not raise
+        await init_tools(config, mcp_client=MagicMock(), memory_manager=MagicMock())
+        # Registry stayed at 7 — no duplicates
+        assert len(fresh_domain_registry) == 7
+
+    @pytest.mark.asyncio
+    async def test_init_tools_partial_registry_fills_gaps(
+        self, config: CognithorConfig, fresh_domain_registry
+    ) -> None:
+        """If the registry was partially pre-seeded (rare but possible
+        with multi-process test runners or hand-crafted fixtures),
+        init_tools must fill the gaps without error and reach the
+        expected 7-domain steady state."""
+        from cognithor.channels.program_synthesis.domains.sql import (
+            register_sql_domain,
+        )
+        from cognithor.gateway.phases.tools import init_tools
+
+        register_sql_domain(fresh_domain_registry)
+        assert len(fresh_domain_registry) == 1
+
+        await init_tools(config, mcp_client=MagicMock(), memory_manager=MagicMock())
+
+        from cognithor.channels.program_synthesis.domains import (
+            SPRINT26_DOMAIN_NAMES,
+        )
+
+        for name in SPRINT26_DOMAIN_NAMES:
+            assert name in fresh_domain_registry
+        assert len(fresh_domain_registry) == 7
+
+    @pytest.mark.asyncio
+    async def test_init_tools_preserves_owner_d3_priority_order(
+        self, config: CognithorConfig, fresh_domain_registry
+    ) -> None:
+        """Owner-Decision D3 fixes the registration order: SQL → JSON
+        → Datetime → AST → BinaryData → Float → Image-Boost. The
+        public scorecard depends on this ordering, so the gateway-boot
+        path must preserve it (even though name-lookup wouldn't care)."""
+        from cognithor.channels.program_synthesis.domains import (
+            SPRINT26_DOMAIN_NAMES,
+        )
+        from cognithor.gateway.phases.tools import init_tools
+
+        await init_tools(config, mcp_client=MagicMock(), memory_manager=MagicMock())
+
+        # Iterate over the registry in registration order — registry's
+        # internal _metadata dict preserves insertion order (PEP 468).
+        registered_in_order = list(fresh_domain_registry._metadata.keys())
+        # Filter to just the Sprint-26 names (in case other things land
+        # in the registry alongside)
+        sprint26_only = [n for n in registered_in_order if n in set(SPRINT26_DOMAIN_NAMES)]
+        assert tuple(sprint26_only) == SPRINT26_DOMAIN_NAMES
+
+    @pytest.mark.asyncio
+    async def test_init_tools_logs_newly_registered_names(
+        self,
+        config: CognithorConfig,
+        fresh_domain_registry,
+    ) -> None:
+        """First-boot must emit ``pse_sprint26_domains_registered`` with
+        the names actually registered. Reviewers can then tell first-
+        boot from re-boot at a glance in audit logs.
+
+        The project uses structlog, which does NOT propagate to
+        pytest's caplog. We patch the module-level ``log.info`` instead
+        to capture structured events directly.
+        """
+        from cognithor.channels.program_synthesis.domains import (
+            SPRINT26_DOMAIN_NAMES,
+        )
+        from cognithor.gateway.phases import tools as tools_module
+
+        captured: list[tuple[str, dict]] = []
+
+        original_info = tools_module.log.info
+
+        def capture_info(event: str, **kwargs):  # type: ignore[no-untyped-def]
+            captured.append((event, kwargs))
+            return original_info(event, **kwargs)
+
+        with patch.object(tools_module.log, "info", side_effect=capture_info):
+            await tools_module.init_tools(
+                config, mcp_client=MagicMock(), memory_manager=MagicMock()
+            )
+
+        # Find the Sprint-26 registered event among all captured info events
+        sprint26_events = [
+            (event, kwargs)
+            for event, kwargs in captured
+            if event == "pse_sprint26_domains_registered"
+        ]
+        assert sprint26_events, (
+            f"expected ``pse_sprint26_domains_registered`` event, got events: "
+            f"{[e for e, _ in captured]}"
+        )
+        event, kwargs = sprint26_events[0]
+        # The wiring forwards the helper's return value (list of newly
+        # registered names) under the ``domains`` key — that's the
+        # contract the audit-log readers depend on.
+        assert "domains" in kwargs, f"event {event!r} missing ``domains`` kwarg: {kwargs}"
+        assert set(kwargs["domains"]) == set(SPRINT26_DOMAIN_NAMES)
+        # And the ``total`` field must reflect the registry size after
+        # this call so log readers don't have to count.
+        assert kwargs.get("total") == 7
+
+    @pytest.mark.asyncio
+    async def test_init_tools_swallows_pse_import_error(
+        self, config: CognithorConfig, monkeypatch
+    ) -> None:
+        """If the program_synthesis channel import path raises (e.g.
+        the package is shipped without optional deps in a constrained
+        deploy), init_tools must continue and complete — Sprint-26
+        registration is best-effort, not gateway-fatal."""
+        import sys
+
+        from cognithor.gateway.phases.tools import init_tools
+
+        # Block the import that the inner try/except depends on
+        if isinstance(__builtins__, dict):
+            original_import = __builtins__["__import__"]
+        else:
+            original_import = __builtins__.__import__
+
+        def raising_import(name, *args, **kwargs):  # type: ignore[no-untyped-def]
+            if name == "cognithor.channels.program_synthesis.domains" or name.startswith(
+                "cognithor.channels.program_synthesis.domains."
+            ):
+                raise ImportError(f"forced-fail: {name}")
+            return original_import(name, *args, **kwargs)
+
+        # Drop any cached imports first so the next import attempt
+        # actually goes through __import__
+        for mod_name in list(sys.modules):
+            if mod_name.startswith("cognithor.channels.program_synthesis.domains"):
+                del sys.modules[mod_name]
+
+        if isinstance(__builtins__, dict):
+            monkeypatch.setitem(__builtins__, "__import__", raising_import)
+        else:
+            monkeypatch.setattr(__builtins__, "__import__", raising_import)
+
+        # Must NOT raise — the inner try/except absorbs ImportError
+        result = await init_tools(config, mcp_client=MagicMock(), memory_manager=MagicMock())
+        # init_tools still returns the result dict for the rest of the
+        # tool subsystems (mcp_bridge, telemetry_hub, etc.)
+        assert isinstance(result, dict)
+
+    @pytest.mark.asyncio
+    async def test_init_tools_does_not_register_duplicate_on_repeat_full_boot(
+        self, config: CognithorConfig, fresh_domain_registry
+    ) -> None:
+        """Repeated boots leave the registry at exactly 7 domains —
+        no duplicate factories, no spurious metadata entries."""
+        from cognithor.gateway.phases.tools import init_tools
+
+        for _ in range(3):
+            await init_tools(config, mcp_client=MagicMock(), memory_manager=MagicMock())
+
+        assert len(fresh_domain_registry) == 7
+        # Each metadata block should be the canonical singleton — id()
+        # comparison after multiple boots confirms no replacement happened.
+        from cognithor.channels.program_synthesis.domains import (
+            SPRINT26_DOMAIN_NAMES,
+        )
+
+        first_ids = {n: id(fresh_domain_registry.metadata(n)) for n in SPRINT26_DOMAIN_NAMES}
+        # Trigger another boot
+        await init_tools(config, mcp_client=MagicMock(), memory_manager=MagicMock())
+        for n in SPRINT26_DOMAIN_NAMES:
+            assert id(fresh_domain_registry.metadata(n)) == first_ids[n], (
+                f"metadata for {n!r} was replaced — registration is not idempotent"
+            )
+
+
+# ============================================================================
 # phases/pge.py
 # ============================================================================
 

--- a/tests/test_pse/test_domains/test_register_all.py
+++ b/tests/test_pse/test_domains/test_register_all.py
@@ -1,4 +1,5 @@
-"""Tests for ``register_all_sprint26_domains``."""
+"""Tests for ``register_all_sprint26_domains`` and the idempotent
+``register_missing_sprint26_domains`` companion."""
 
 from __future__ import annotations
 
@@ -8,6 +9,7 @@ from cognithor.channels.program_synthesis.domains import (
     SPRINT26_DOMAIN_NAMES,
     DomainRegistry,
     register_all_sprint26_domains,
+    register_missing_sprint26_domains,
 )
 from cognithor.channels.program_synthesis.domains.registry import (
     DomainAlreadyRegisteredError,
@@ -91,3 +93,113 @@ class TestRegisterAllSprint26Domains:
         for name in SPRINT26_DOMAIN_NAMES:
             metadata = reg.metadata(name)
             assert metadata.type_tags, f"{name!r} has no type tags"
+
+
+class TestRegisterMissingSprint26Domains:
+    """Idempotent variant for gateway-boot wiring (set-based, never raises)."""
+
+    def test_fresh_registry_registers_all_seven(self) -> None:
+        reg = DomainRegistry()
+        registered = register_missing_sprint26_domains(reg)
+        assert registered == list(SPRINT26_DOMAIN_NAMES)
+        assert len(reg) == 7
+
+    def test_owner_d3_order_preserved(self) -> None:
+        """Returned list of registered names must match Owner-D3 priority."""
+        reg = DomainRegistry()
+        registered = register_missing_sprint26_domains(reg)
+        # Stable ordering — ScoreCard column order depends on this
+        assert registered == [
+            "sql",
+            "json",
+            "datetime",
+            "ast",
+            "bytes",
+            "float",
+            "image_v2",
+        ]
+
+    def test_idempotent_on_fully_populated_registry(self) -> None:
+        """Calling twice on a complete registry must return [] and not raise."""
+        reg = DomainRegistry()
+        first = register_missing_sprint26_domains(reg)
+        assert len(first) == 7
+        second = register_missing_sprint26_domains(reg)
+        assert second == [], (
+            f"second call on fully-populated registry must register nothing — got {second}"
+        )
+        assert len(reg) == 7  # no duplicates / overrides
+
+    def test_partial_registry_fills_only_gaps(self) -> None:
+        """Pre-populate the registry with 2 of 7; helper fills the missing 5."""
+        reg = DomainRegistry()
+        # Use the bare register-functions to seed a partial state without
+        # going through register_all (which would fill all 7).
+        from cognithor.channels.program_synthesis.domains.json_dsl import (
+            register_json_domain,
+        )
+        from cognithor.channels.program_synthesis.domains.sql import (
+            register_sql_domain,
+        )
+
+        register_sql_domain(reg)
+        register_json_domain(reg)
+        assert len(reg) == 2
+
+        registered = register_missing_sprint26_domains(reg)
+        assert set(registered) == set(SPRINT26_DOMAIN_NAMES) - {"sql", "json"}
+        assert len(reg) == 7
+        # Owner-D3 order preserved among the gaps
+        assert registered == ["datetime", "ast", "bytes", "float", "image_v2"]
+
+    def test_does_not_raise_on_dupe(self) -> None:
+        """Unlike ``register_all_sprint26_domains`` (which raises), this
+        helper is the safe choice for boot paths that may run twice."""
+        reg = DomainRegistry()
+        register_all_sprint26_domains(reg)
+        # The non-idempotent variant would raise DomainAlreadyRegisteredError
+        with pytest.raises(DomainAlreadyRegisteredError):
+            register_all_sprint26_domains(reg)
+        # The idempotent variant must NOT raise
+        register_missing_sprint26_domains(reg)
+        register_missing_sprint26_domains(reg)
+        register_missing_sprint26_domains(reg)
+        assert len(reg) == 7
+
+    def test_foreign_domains_in_registry_are_ignored(self) -> None:
+        """A registry that already has non-Sprint-26 domains shouldn't
+        confuse the helper — it only manages the Sprint-26 catalog."""
+        reg = DomainRegistry()
+        # Manually inject a fake domain name not in SPRINT26_DOMAIN_NAMES
+        from cognithor.channels.program_synthesis.domains.base import (
+            DomainCapability,
+            DomainMetadata,
+        )
+
+        fake_meta = DomainMetadata(
+            name="fake_external_domain",
+            display_name="Fake",
+            description="Test fixture",
+            capabilities=frozenset({DomainCapability.PROPERTY}),
+            type_tags=frozenset({"int"}),
+            benchmark_name="fake_bench",
+            benchmark_target=0.5,
+        )
+        reg.register(fake_meta, lambda: None)  # type: ignore[arg-type, return-value]
+        assert "fake_external_domain" in reg
+
+        registered = register_missing_sprint26_domains(reg)
+        # All 7 sprint26 domains registered, foreign one untouched
+        assert set(registered) == set(SPRINT26_DOMAIN_NAMES)
+        assert "fake_external_domain" in reg  # still present
+        assert len(reg) == 8  # 7 sprint26 + 1 foreign
+
+    def test_return_type_is_list_for_immutability_in_logging(self) -> None:
+        """Audit logs receive the returned names directly. A list (not
+        a generator or set) is required so log handlers see a stable,
+        repeatable, JSON-serialisable value."""
+        reg = DomainRegistry()
+        result = register_missing_sprint26_domains(reg)
+        assert isinstance(result, list)
+        # Re-iterable
+        assert list(result) == list(result)


### PR DESCRIPTION
## Summary

Hardens the gateway-boot wiring for Sprint-26 Domain-Expansion catalogs (sql, json, datetime, ast, bytes, float, image_v2) and closes the test-coverage gap where ``init_tools`` triggered registration but no test verified the registry actually got populated.

## The bug it fixes

The previous gateway-boot guard used ``len(DOMAIN_REGISTRY) == 0`` to decide whether to register the seven Sprint-26 domains. Two edge cases slipped through silently:

1. **Partial registry** — if 1 of 7 domains was pre-seeded (test fixture, multi-process runner, hand-crafted plugin), the guard saw a non-empty registry and skipped the remaining 6. The synthesis pipeline then fell back to the free-form path on every cross-domain query for those 6 domains — no error, just degraded behaviour.
2. **Foreign domain** — a non-Sprint-26 domain in the registry would also block Sprint-26 registration entirely.

Both manifest deep in synthesis as missing-domain fall-throughs. Hard to debug without test coverage.

## Fix

- New ``register_missing_sprint26_domains(registry) -> list[str]`` helper. Set-based, walks the canonical ``_SPRINT26_REGISTRARS`` tuple, registers only what's missing, returns the names actually registered (empty when the registry is full). Never raises ``DomainAlreadyRegisteredError``.
- ``register_all_sprint26_domains`` refactored to share the same ``_SPRINT26_REGISTRARS`` tuple — single source of truth, no more parallel call sequences to drift.
- ``gateway/phases/tools.py`` switched from the ``len == 0`` guard to ``register_missing_sprint26_domains``. Audit log now reports newly-registered names + post-call total under ``domains``/``total`` keys; reviewers can tell first-boot from re-boot at a glance.

## Tests (+14 new)

**Helper unit tests** — ``test_pse/test_domains/test_register_all.py`` (+7):
- ``test_fresh_registry_registers_all_seven``
- ``test_owner_d3_order_preserved``
- ``test_idempotent_on_fully_populated_registry``
- ``test_partial_registry_fills_only_gaps``
- ``test_does_not_raise_on_dupe`` (explicit contrast vs. legacy variant)
- ``test_foreign_domains_in_registry_are_ignored``
- ``test_return_type_is_list_for_immutability_in_logging``

**Gateway-boot integration tests** — new ``TestToolsPhaseSprint26Registration`` class in ``test_gateway/test_phases_coverage.py`` (+7):
- ``test_init_tools_registers_all_seven_sprint26_domains``
- ``test_init_tools_idempotent_on_double_boot``
- ``test_init_tools_partial_registry_fills_gaps``
- ``test_init_tools_preserves_owner_d3_priority_order``
- ``test_init_tools_logs_newly_registered_names`` — uses ``patch.object`` on the structlog ``log.info`` because the project's structlog setup doesn't propagate to pytest's caplog
- ``test_init_tools_swallows_pse_import_error`` — best-effort wiring must not be gateway-fatal
- ``test_init_tools_does_not_register_duplicate_on_repeat_full_boot`` — asserts metadata-block ``id()`` stability across 4 boots

Each integration test uses a ``fresh_domain_registry`` fixture that monkeypatches BOTH the package re-export AND the registry submodule, so the function-local ``from … import DOMAIN_REGISTRY`` inside ``init_tools`` picks up the fresh instance — protecting against pollution from other tests in the same session.

## Test plan

- [x] ``mypy --strict`` over touched files → **0 issues**
- [x] ``ruff check src/ tests/`` → clean
- [x] ``ruff format --check src/ tests/`` → clean
- [x] ``pytest tests/test_pse/test_domains/test_register_all.py -q`` → **16 / 16 green** (was 9 + 7 new)
- [x] ``pytest tests/test_gateway/test_phases_coverage.py -q`` → **29 / 29 green** (was 22 + 7 new)
- [x] ``pytest`` over both files combined → 45 / 45 green in 31 s
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)