### PR TITLE
feat(trust7): wire native-binary fingerprinting into gateway boot

### DIFF
--- a/src/cognithor/gateway/phases/tools.py
+++ b/src/cognithor/gateway/phases/tools.py
@@ -232,6 +232,28 @@ async def init_tools(
     except Exception:
         log.debug("pse_sprint26_domains_not_available", exc_info=True)
 
+    # TRUST-7 BINARY: pin the SHA-256 + best-effort version of every
+    # native binary Cognithor depends on at runtime (Ollama, vLLM,
+    # ffmpeg, piper) into the canonical FINGERPRINT_LEDGER. Without
+    # this, the audit log can reconstruct *what happened* (TRUST-1
+    # receipts) and *why* (TRUST-2 explanations) but cannot pin
+    # *which build* of the underlying binary produced the result —
+    # so "same input, different output" can't be distinguished from
+    # "different binary version".
+    #
+    # Best-effort: a missing binary is debug-logged + skipped; a
+    # binary that hashes but won't tell us its version still lands in
+    # the ledger with empty ``version`` (the SHA itself is the
+    # canonical identity).
+    try:
+        from cognithor.security.binary_runtime_fingerprint import (
+            register_runtime_binaries,
+        )
+
+        register_runtime_binaries()
+    except Exception:
+        log.debug("trust7_binary_registration_not_available", exc_info=True)
+
     # Browser-Use v17: Autonomous browser automation (optional)
     browser_agent = None
     try:

--- a/src/cognithor/security/binary_runtime_fingerprint.py
+++ b/src/cognithor/security/binary_runtime_fingerprint.py
@@ -1,0 +1,200 @@
+"""Boot-path wiring for TRUST-7 BINARY fingerprints.
+
+Auto-discovers the native binaries Cognithor depends on at runtime
+(Ollama daemon, vLLM server, ffmpeg, piper TTS) and pins their on-disk
+SHA-256 + best-effort version into the canonical
+:data:`FINGERPRINT_LEDGER` so post-mortem reconstruction can answer
+"which build of Ollama produced this trace" from the audit log alone.
+
+Companion to :mod:`cognithor.security.fingerprint`, which ships the
+``hash_native_binary`` / ``fingerprint_native_binary`` helpers. This
+module owns the **discovery + boot-time registration** layer:
+
+* Knows the canonical list of binaries to fingerprint and the
+  version-probe flag each one uses.
+* Resolves each binary via :func:`shutil.which` so cognithor doesn't
+  depend on a hard-coded install path.
+* Calls the per-binary helper, registers in the ledger, and returns
+  the list of fingerprints captured.
+* Best-effort: a missing binary is logged at ``debug`` level and
+  skipped, never propagated. The boot path stays green even when
+  Ollama isn't installed.
+
+The ``init_tools`` gateway phase calls
+:func:`register_runtime_binaries` once at boot. The result is a list
+the caller can include in audit-log events ("the gateway booted with
+these 3 binaries pinned").
+"""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from cognithor.security.fingerprint import (
+    FINGERPRINT_LEDGER,
+    fingerprint_native_binary,
+)
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from cognithor.security.fingerprint import (
+        FingerprintLedger,
+        ToolFingerprint,
+    )
+
+log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Binary catalog
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _RuntimeBinarySpec:
+    """One entry in the catalog of binaries Cognithor depends on at runtime."""
+
+    name: str
+    """Stable logical name surfaced in fingerprints + audit logs."""
+
+    which_name: str
+    """Argument passed to :func:`shutil.which`. Usually equals ``name``
+    but can differ (e.g. ``"vllm"`` looks up ``"vllm"`` even though we
+    call the resulting fingerprint ``"vllm-openai"``)."""
+
+    version_flag: str = "--version"
+    """CLI flag the binary accepts to print its version. Default
+    ``--version`` covers Ollama, vLLM, ffmpeg, piper, etc."""
+
+    upstream_url: str = ""
+    """Best-effort upstream URL embedded into the fingerprint."""
+
+    notes: str = ""
+    """Free-text breadcrumb."""
+
+
+# Canonical catalog. Adding a new binary is an explicit review point —
+# the fingerprint becomes part of the audit-log surface, so we want
+# intentional decisions about what runtime artefacts are pinned.
+RUNTIME_BINARIES: tuple[_RuntimeBinarySpec, ...] = (
+    _RuntimeBinarySpec(
+        name="ollama",
+        which_name="ollama",
+        version_flag="--version",
+        upstream_url="https://github.com/ollama/ollama",
+        notes="Default LLM-serving daemon (cognithor.config.llm_backend_type='ollama').",
+    ),
+    _RuntimeBinarySpec(
+        name="vllm",
+        which_name="vllm",
+        version_flag="--version",
+        upstream_url="https://github.com/vllm-project/vllm",
+        notes="Optional GPU-accelerated LLM server (Enterprise/Power tiers).",
+    ),
+    _RuntimeBinarySpec(
+        name="ffmpeg",
+        which_name="ffmpeg",
+        version_flag="-version",  # ffmpeg uses single-dash -version
+        upstream_url="https://ffmpeg.org/",
+        notes="Media-tools dependency (audio analyse, video render).",
+    ),
+    _RuntimeBinarySpec(
+        name="piper",
+        which_name="piper",
+        version_flag="--version",
+        upstream_url="https://github.com/rhasspy/piper",
+        notes="Local TTS backend used by the voice channel.",
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Boot-time registration
+# ---------------------------------------------------------------------------
+
+
+def register_runtime_binaries(
+    ledger: FingerprintLedger | None = None,
+    *,
+    catalog: tuple[_RuntimeBinarySpec, ...] = RUNTIME_BINARIES,
+) -> list[ToolFingerprint]:
+    """Discover + fingerprint every runtime binary in ``catalog``.
+
+    For each spec:
+
+    1. Resolve the binary via ``shutil.which`` — skip if not on PATH.
+    2. Compute SHA-256 + best-effort version via
+       :func:`fingerprint_native_binary`.
+    3. Register into ``ledger`` (defaults to the canonical
+       :data:`FINGERPRINT_LEDGER`). Re-registering an unchanged binary
+       is a no-op (ledger idempotency).
+
+    Failure modes are absorbed individually so one missing or
+    misbehaving binary doesn't block the rest:
+
+    * Binary not on PATH → skipped, ``debug`` log.
+    * Binary exists but hashing raises (permission error, deleted
+      mid-read) → skipped, ``warning`` log.
+    * Binary exists and hashes but version probe fails → registered
+      with empty ``version`` field (ledger still gets the SHA).
+
+    Returns:
+        The fingerprints captured by THIS call (empty list when no
+        binaries were found). Useful for the caller to surface in a
+        boot-time audit event.
+    """
+    target_ledger = ledger if ledger is not None else FINGERPRINT_LEDGER
+    captured: list[ToolFingerprint] = []
+
+    for spec in catalog:
+        resolved = shutil.which(spec.which_name)
+        if resolved is None:
+            log.debug(
+                "runtime_binary_not_on_path",
+                name=spec.name,
+                which=spec.which_name,
+            )
+            continue
+
+        path = Path(resolved)
+        try:
+            fingerprint = fingerprint_native_binary(
+                name=spec.name,
+                path=path,
+                version_flag=spec.version_flag,
+                upstream_url=spec.upstream_url,
+                notes=spec.notes,
+            )
+        except (FileNotFoundError, IsADirectoryError, PermissionError, OSError) as exc:
+            # `which` returned a path that vanished by the time we read
+            # it (race) or whose bytes we can't access. Don't fail boot.
+            log.warning(
+                "runtime_binary_fingerprint_failed",
+                name=spec.name,
+                path=str(path),
+                error=type(exc).__name__,
+                error_msg=str(exc),
+            )
+            continue
+
+        was_new = target_ledger.register(fingerprint)
+        captured.append(fingerprint)
+        log.debug(
+            "runtime_binary_fingerprinted",
+            name=spec.name,
+            short_hash=fingerprint.short_hash,
+            version=fingerprint.version or "<no-version>",
+            new_to_ledger=was_new,
+        )
+
+    if captured:
+        log.info(
+            "runtime_binaries_registered",
+            names=[f.name for f in captured],
+            count=len(captured),
+        )
+
+    return captured

--- a/tests/test_security/test_binary_runtime_fingerprint.py
+++ b/tests/test_security/test_binary_runtime_fingerprint.py
@@ -1,0 +1,322 @@
+"""Tests for ``register_runtime_binaries`` — the TRUST-7 BINARY
+boot-path wiring that pins Ollama / vLLM / ffmpeg / piper into the
+canonical fingerprint ledger at gateway init."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+
+from cognithor.security.binary_runtime_fingerprint import (
+    RUNTIME_BINARIES,
+    _RuntimeBinarySpec,
+    register_runtime_binaries,
+)
+from cognithor.security.fingerprint import (
+    BinaryKind,
+    FingerprintLedger,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+@pytest.fixture
+def fake_ollama_binary(tmp_path):
+    """A fake binary on disk + a stub `shutil.which` resolver."""
+    binary = tmp_path / "ollama"
+    binary.write_bytes(b"\x7fELFfake-ollama")
+    return binary
+
+
+@pytest.fixture
+def fake_vllm_binary(tmp_path):
+    binary = tmp_path / "vllm"
+    binary.write_bytes(b"#!/usr/bin/env python\n# fake vllm shim\n")
+    return binary
+
+
+# ---------------------------------------------------------------------------
+# Catalog sanity
+# ---------------------------------------------------------------------------
+
+
+class TestRuntimeBinaryCatalog:
+    def test_catalog_has_at_least_ollama_and_vllm(self) -> None:
+        names = {spec.name for spec in RUNTIME_BINARIES}
+        assert "ollama" in names
+        assert "vllm" in names
+
+    def test_each_spec_has_non_empty_name_and_which_name(self) -> None:
+        for spec in RUNTIME_BINARIES:
+            assert spec.name, f"spec missing name: {spec}"
+            assert spec.which_name, f"spec missing which_name: {spec}"
+
+    def test_ffmpeg_uses_single_dash_version_flag(self) -> None:
+        """ffmpeg quirk — uses ``-version`` (single dash), not ``--version``.
+        If this assertion fails, the catalog regressed and ffmpeg's
+        version probe will time out on every gateway boot."""
+        ffmpeg = next((s for s in RUNTIME_BINARIES if s.name == "ffmpeg"), None)
+        assert ffmpeg is not None
+        assert ffmpeg.version_flag == "-version"
+
+    def test_unique_logical_names(self) -> None:
+        """Two specs claiming the same name would collide in the
+        ledger — surface the catalog error rather than allow it."""
+        names = [spec.name for spec in RUNTIME_BINARIES]
+        assert len(names) == len(set(names))
+
+
+# ---------------------------------------------------------------------------
+# register_runtime_binaries — discovery + fingerprint
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterRuntimeBinaries:
+    def test_returns_empty_when_no_binaries_on_path(self, tmp_path: Path) -> None:
+        """Cleanest case — no relevant binaries, no fingerprints."""
+        ledger = FingerprintLedger()
+        with patch(
+            "cognithor.security.binary_runtime_fingerprint.shutil.which",
+            return_value=None,
+        ):
+            captured = register_runtime_binaries(ledger)
+        assert captured == []
+        assert len(ledger) == 0
+
+    def test_fingerprints_only_present_binaries(self, fake_ollama_binary: Path) -> None:
+        """Only Ollama on PATH → only Ollama gets fingerprinted."""
+        ledger = FingerprintLedger()
+
+        def which_stub(name: str) -> str | None:
+            if name == "ollama":
+                return str(fake_ollama_binary)
+            return None
+
+        with (
+            patch(
+                "cognithor.security.binary_runtime_fingerprint.shutil.which",
+                side_effect=which_stub,
+            ),
+            patch(
+                "cognithor.security.binary_runtime_fingerprint.fingerprint_native_binary"
+            ) as mock_fp,
+        ):
+            # Use the real fingerprint helper but skip the version probe
+            # so the test stays deterministic + fast.
+            from cognithor.security.fingerprint import (
+                ToolFingerprint,
+                hash_native_binary,
+            )
+
+            mock_fp.return_value = ToolFingerprint(
+                name="ollama",
+                kind=BinaryKind.BINARY,
+                content_hash=hash_native_binary(fake_ollama_binary),
+                version="ollama 0.4.7",
+                source_path=str(fake_ollama_binary),
+            )
+
+            captured = register_runtime_binaries(ledger)
+
+        assert len(captured) == 1
+        assert captured[0].name == "ollama"
+        assert captured[0].kind == BinaryKind.BINARY
+        # Ledger received it
+        assert captured[0].content_hash in ledger
+
+    def test_skips_binary_when_hashing_raises(self, tmp_path: Path) -> None:
+        """A binary that vanishes mid-boot (which → path, but path
+        doesn't exist) must not crash the loop."""
+        ledger = FingerprintLedger()
+        ghost_path = str(tmp_path / "vanished")  # doesn't exist
+
+        def which_stub(name: str) -> str | None:
+            if name == "ollama":
+                return ghost_path
+            return None
+
+        with patch(
+            "cognithor.security.binary_runtime_fingerprint.shutil.which",
+            side_effect=which_stub,
+        ):
+            captured = register_runtime_binaries(ledger)
+
+        # Ollama was discovered but couldn't be hashed → skipped
+        assert captured == []
+        assert len(ledger) == 0
+
+    def test_continues_after_one_binary_fails(self, fake_vllm_binary: Path, tmp_path: Path) -> None:
+        """If Ollama fails to hash but vLLM is fine, vLLM still lands
+        in the ledger. Single-binary failure can't sink the rest."""
+        ledger = FingerprintLedger()
+        ghost_ollama = str(tmp_path / "ghost-ollama")
+
+        def which_stub(name: str) -> str | None:
+            if name == "ollama":
+                return ghost_ollama
+            if name == "vllm":
+                return str(fake_vllm_binary)
+            return None
+
+        with patch(
+            "cognithor.security.binary_runtime_fingerprint.shutil.which",
+            side_effect=which_stub,
+        ):
+            captured = register_runtime_binaries(ledger)
+
+        assert len(captured) == 1
+        assert captured[0].name == "vllm"
+        assert "vllm" in {f.name for f in ledger.filter_by_kind(BinaryKind.BINARY)}
+
+    def test_idempotent_on_repeat_call(self, fake_ollama_binary: Path) -> None:
+        """Calling the function twice in a single boot (test fixture
+        re-init) must NOT register duplicates — same hash → ledger
+        no-op (returns False)."""
+        ledger = FingerprintLedger()
+
+        def which_stub(name: str) -> str | None:
+            return str(fake_ollama_binary) if name == "ollama" else None
+
+        with patch(
+            "cognithor.security.binary_runtime_fingerprint.shutil.which",
+            side_effect=which_stub,
+        ):
+            first = register_runtime_binaries(ledger)
+            second = register_runtime_binaries(ledger)
+
+        # Both calls report the fingerprint they captured…
+        assert len(first) == 1
+        assert len(second) == 1
+        # …but the ledger has only ONE entry (same hash).
+        assert len(ledger) == 1
+
+    def test_uses_module_default_ledger_when_none(self, fake_ollama_binary: Path) -> None:
+        """``register_runtime_binaries(None)`` writes into the canonical
+        :data:`FINGERPRINT_LEDGER`. The boot path relies on this."""
+        from cognithor.security import binary_runtime_fingerprint as mod
+
+        scratch_ledger = FingerprintLedger()
+        with (
+            patch.object(mod, "FINGERPRINT_LEDGER", scratch_ledger),
+            patch(
+                "cognithor.security.binary_runtime_fingerprint.shutil.which",
+                side_effect=lambda n: (str(fake_ollama_binary) if n == "ollama" else None),
+            ),
+        ):
+            captured = register_runtime_binaries(None)
+
+        assert len(captured) == 1
+        assert captured[0].content_hash in scratch_ledger
+
+    def test_custom_catalog_overrides_default(self, fake_ollama_binary: Path) -> None:
+        """Passing a single-spec catalog limits discovery to that one
+        binary — useful for tests + targeted re-pinning."""
+        ledger = FingerprintLedger()
+        spec = _RuntimeBinarySpec(name="my-tool", which_name="my-tool")
+
+        def which_stub(name: str) -> str | None:
+            return str(fake_ollama_binary) if name == "my-tool" else None
+
+        with patch(
+            "cognithor.security.binary_runtime_fingerprint.shutil.which",
+            side_effect=which_stub,
+        ):
+            captured = register_runtime_binaries(ledger, catalog=(spec,))
+
+        assert len(captured) == 1
+        assert captured[0].name == "my-tool"
+
+    def test_passes_version_flag_to_helper(self, fake_ollama_binary: Path) -> None:
+        """The ffmpeg spec uses ``-version`` (single dash). The wiring
+        must forward each spec's flag verbatim — otherwise version
+        probes silently fail."""
+        ledger = FingerprintLedger()
+        ffmpeg_spec = _RuntimeBinarySpec(
+            name="ffmpeg", which_name="ffmpeg", version_flag="-version"
+        )
+
+        def which_stub(name: str) -> str | None:
+            return str(fake_ollama_binary) if name == "ffmpeg" else None
+
+        with (
+            patch(
+                "cognithor.security.binary_runtime_fingerprint.shutil.which",
+                side_effect=which_stub,
+            ),
+            patch(
+                "cognithor.security.binary_runtime_fingerprint.fingerprint_native_binary"
+            ) as mock_fp,
+        ):
+            from cognithor.security.fingerprint import (
+                ToolFingerprint,
+                hash_native_binary,
+            )
+
+            mock_fp.return_value = ToolFingerprint(
+                name="ffmpeg",
+                kind=BinaryKind.BINARY,
+                content_hash=hash_native_binary(fake_ollama_binary),
+            )
+
+            register_runtime_binaries(ledger, catalog=(ffmpeg_spec,))
+
+            mock_fp.assert_called_once()
+            kwargs = mock_fp.call_args.kwargs
+            assert kwargs["version_flag"] == "-version", (
+                f"expected version_flag='-version' to be forwarded, got: "
+                f"{kwargs.get('version_flag')!r}"
+            )
+
+    def test_preserves_upstream_url_and_notes_in_fingerprint(
+        self, fake_ollama_binary: Path
+    ) -> None:
+        """Audit-log surface depends on the metadata fields — they
+        must round-trip from the catalog to the captured fingerprint."""
+        ledger = FingerprintLedger()
+        spec = _RuntimeBinarySpec(
+            name="my-tool",
+            which_name="my-tool",
+            upstream_url="https://example.com/my-tool",
+            notes="critical-path dep",
+        )
+
+        def which_stub(name: str) -> str | None:
+            return str(fake_ollama_binary) if name == "my-tool" else None
+
+        with patch(
+            "cognithor.security.binary_runtime_fingerprint.shutil.which",
+            side_effect=which_stub,
+        ):
+            captured = register_runtime_binaries(ledger, catalog=(spec,))
+
+        assert len(captured) == 1
+        assert captured[0].upstream_url == "https://example.com/my-tool"
+        assert captured[0].notes == "critical-path dep"
+
+
+# ---------------------------------------------------------------------------
+# Integration — the real boot path absorbs all errors
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterRuntimeBinariesIntegration:
+    def test_real_call_does_not_raise_in_clean_environment(self) -> None:
+        """End-to-end smoke: calling against the real ``shutil.which``
+        and the real :data:`FINGERPRINT_LEDGER` must complete without
+        raising, regardless of which binaries happen to be installed
+        on the runner. Any installed binary lands in the ledger; any
+        missing one is silently skipped."""
+        # Use a fresh ledger so we don't pollute the global one with
+        # whatever the test runner happens to have installed.
+        ledger = FingerprintLedger()
+        captured = register_runtime_binaries(ledger)
+        # `captured` is a list (possibly empty if no runtime binaries
+        # are on PATH on the test runner). Type-check is the assertion.
+        assert isinstance(captured, list)
+        # Every captured entry is BINARY-kind and has a valid hash.
+        for fp in captured:
+            assert fp.kind == BinaryKind.BINARY
+            assert len(fp.content_hash) == 64


### PR DESCRIPTION
## Summary

Follow-up to **#511** (TRUST-7 BINARY helpers). #511 shipped ``hash_native_binary`` / ``fingerprint_native_binary`` in isolation; this PR turns the wiring on at gateway init, closing the deferred "boot-path call sites" item from the 2026-05-04 trust-stack session.

## What lands

### ``src/cognithor/security/binary_runtime_fingerprint.py`` (new module)

The discovery + boot-time registration layer:

- ``RUNTIME_BINARIES`` catalog — 4 specs for the binaries Cognithor depends on at runtime:
  - **Ollama** (default LLM-serving daemon)
  - **vLLM** (optional GPU-accelerated server)
  - **ffmpeg** (media-tools dep — uses ``-version`` single-dash quirk)
  - **piper** (local TTS backend)
- ``register_runtime_binaries(ledger=None, *, catalog=RUNTIME_BINARIES)`` — resolves each spec via ``shutil.which``, calls ``fingerprint_native_binary``, registers in the ledger (defaults to the canonical ``FINGERPRINT_LEDGER``). Returns the list of fingerprints captured by THIS call.

Three failure-mode layers, all best-effort:

1. ``which`` returns ``None`` → skip + ``debug`` log (binary not installed; not an error).
2. ``which`` returns a path that vanishes / permission-denies before hashing → skip + ``warning`` log (preserve the rest).
3. Hashing succeeds but version probe fails → register with empty ``version`` (the SHA itself is the canonical identity).

### ``gateway/phases/tools.py`` (wiring)

Adds the boot-time call site after the existing Sprint-26 PSE-domain registration block. Same defensive ``try / except`` pattern so a missing runtime binary or a regressed helper can't kill the gateway.

## Tests (+14 new across 3 classes)

**TestRuntimeBinaryCatalog** (4):
- ``test_catalog_has_at_least_ollama_and_vllm``
- ``test_each_spec_has_non_empty_name_and_which_name``
- ``test_ffmpeg_uses_single_dash_version_flag`` — regression guard against catalog edits
- ``test_unique_logical_names`` — collision sanity

**TestRegisterRuntimeBinaries** (9):
- ``test_returns_empty_when_no_binaries_on_path``
- ``test_fingerprints_only_present_binaries``
- ``test_skips_binary_when_hashing_raises`` — vanished-mid-boot race
- ``test_continues_after_one_binary_fails``
- ``test_idempotent_on_repeat_call`` — double boot, no dupe in ledger
- ``test_uses_module_default_ledger_when_none`` — boot-path contract
- ``test_custom_catalog_overrides_default``
- ``test_passes_version_flag_to_helper`` — ffmpeg's ``-version`` reaches the probe verbatim
- ``test_preserves_upstream_url_and_notes_in_fingerprint``

**TestRegisterRuntimeBinariesIntegration** (1):
- ``test_real_call_does_not_raise_in_clean_environment`` — end-to-end smoke against the real ``shutil.which``; assertion only on type-shape so the test passes regardless of which binaries the CI runner has installed.

## Test plan

- [x] ``mypy --strict src/cognithor/security/binary_runtime_fingerprint.py src/cognithor/gateway/phases/tools.py`` → **0 issues**
- [x] ``ruff check src/ tests/`` → clean
- [x] ``ruff format --check src/ tests/`` → clean
- [x] ``pytest tests/test_security/ tests/test_gateway/test_phases_coverage.py::TestToolsPhase -q`` → **1632 passed, 1 skipped** in 53 s
- [ ] CI green on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)