### PR TITLE
feat(trust): SQLite-backed CloudEscalationStore (TRUST disk persistence #2)

### DIFF
--- a/src/cognithor/security/cloud_escalation_store.py
+++ b/src/cognithor/security/cloud_escalation_store.py
@@ -1,0 +1,359 @@
+"""SQLite-backed disk persistence for the TRUST-8 cloud-escalation ledger.
+
+Companion to :mod:`cognithor.security.cloud_escalation`. The in-memory
+ledger answers "did this request leave the box" in O(1) within a
+single process; this module turns the same query into one an operator
+can ask the day after a process restart.
+
+Design parity with :mod:`cognithor.security.backend_dispatch_store`
+(landed in PR #515):
+
+* Plain SQLite — metadata-only privacy contract (backend ids, token
+  counts, USD cost in micro-units, reason taxonomy). No prompts, no
+  responses.
+* Append-only — ``append(event)`` is the single mutation.
+* Schema-versioned — ``_schema_meta`` table tracks the current
+  version; loud refusal to open DBs whose version is > current build.
+* WAL journal mode + ``check_same_thread=False`` so concurrent
+  gateway processes can share the file safely.
+* Read-API parity with :class:`EscalationLedger` (in-memory):
+  ``__len__``, ``events``, ``by_reason``, ``by_destination``,
+  ``by_run``, ``in_window``, ``summarise``, ``snapshot``.
+* Indices on ``run_id``, ``to_backend``, ``reason``, ``started_at``
+  for the four hot Trace-UI read paths.
+
+The escalation events have one extra field vs dispatch events:
+``cost_usd_micro`` (integer micro-USD, summable without float drift).
+The schema reserves an integer column for it; the in-memory summary
+matches the on-disk one.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from cognithor.security.cloud_escalation import (
+    EscalationEvent,
+    EscalationReason,
+    EscalationSummary,
+)
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+log = get_logger(__name__)
+
+
+_SCHEMA_VERSION = 1
+
+
+_SCHEMA = f"""
+CREATE TABLE IF NOT EXISTS _schema_meta (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS escalation_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    reason TEXT NOT NULL,
+    from_backend TEXT NOT NULL,
+    to_backend TEXT NOT NULL,
+    prompt_tokens INTEGER NOT NULL DEFAULT 0,
+    response_tokens INTEGER NOT NULL DEFAULT 0,
+    cost_usd_micro INTEGER NOT NULL DEFAULT 0,
+    started_at TEXT NOT NULL,
+    completed_at TEXT,
+    owner_consented INTEGER NOT NULL DEFAULT 0,
+    run_id TEXT NOT NULL DEFAULT '',
+    request_id TEXT NOT NULL DEFAULT '',
+    notes TEXT NOT NULL DEFAULT ''
+);
+
+-- Indices match the four hot read paths on the in-memory ledger:
+-- by_reason, by_destination, by_run, in_window. Pinning them in the
+-- schema prevents a future migration from silently dropping one.
+CREATE INDEX IF NOT EXISTS idx_escalation_events_run_id
+    ON escalation_events(run_id);
+CREATE INDEX IF NOT EXISTS idx_escalation_events_to_backend
+    ON escalation_events(to_backend);
+CREATE INDEX IF NOT EXISTS idx_escalation_events_reason
+    ON escalation_events(reason);
+CREATE INDEX IF NOT EXISTS idx_escalation_events_started_at
+    ON escalation_events(started_at);
+
+INSERT OR IGNORE INTO _schema_meta (version, applied_at)
+    VALUES ({_SCHEMA_VERSION}, '{datetime.now(UTC).isoformat()}');
+"""
+
+
+class CloudEscalationStoreError(Exception):
+    """Raised when the SQLite layer is in an unrecoverable state.
+
+    Mirrors :class:`BackendDispatchStoreError` — examples include a
+    schema version this build doesn't know how to read, or a corrupt
+    file whose connection won't open cleanly.
+    """
+
+
+class CloudEscalationStore:
+    """SQLite-backed append-only persistence for ``EscalationEvent``.
+
+    Tests use ``:memory:`` databases for speed; production wires the
+    canonical instance to ``~/.cognithor/audit/cloud_escalation.sqlite``.
+
+    Lifecycle mirrors :class:`BackendDispatchStore` — context-manager
+    or explicit ``close()``. Re-opening an existing file is a no-op
+    (idempotent schema script).
+    """
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = str(db_path)
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+        self._verify_schema_version()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> CloudEscalationStore:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the SQLite connection. Safe to call multiple times."""
+        with contextlib.suppress(sqlite3.ProgrammingError):
+            self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Schema-version handshake
+    # ------------------------------------------------------------------
+
+    def _verify_schema_version(self) -> None:
+        cursor = self._conn.execute("SELECT MAX(version) FROM _schema_meta")
+        row = cursor.fetchone()
+        actual_version = row[0] if row else None
+        if actual_version is None:
+            return  # fresh DB
+        if actual_version > _SCHEMA_VERSION:
+            msg = (
+                f"CloudEscalationStore at {self._db_path!r} reports schema "
+                f"version {actual_version} but this build only knows "
+                f"version {_SCHEMA_VERSION}. Refusing to open to avoid "
+                "data corruption — upgrade cognithor or point at a "
+                "different file."
+            )
+            raise CloudEscalationStoreError(msg)
+
+    @property
+    def schema_version(self) -> int:
+        cursor = self._conn.execute("SELECT MAX(version) FROM _schema_meta")
+        row = cursor.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def append(self, event: EscalationEvent) -> int:
+        """Insert ``event`` and return its assigned row id."""
+        cursor = self._conn.execute(
+            """
+            INSERT INTO escalation_events (
+                reason, from_backend, to_backend,
+                prompt_tokens, response_tokens, cost_usd_micro,
+                started_at, completed_at, owner_consented,
+                run_id, request_id, notes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                event.reason.value,
+                event.from_backend,
+                event.to_backend,
+                event.prompt_tokens,
+                event.response_tokens,
+                event.cost_usd_micro,
+                event.started_at.isoformat(),
+                event.completed_at.isoformat() if event.completed_at else None,
+                1 if event.owner_consented else 0,
+                event.run_id,
+                event.request_id,
+                event.notes,
+            ),
+        )
+        self._conn.commit()
+        row_id = cursor.lastrowid
+        if row_id is None:  # pragma: no cover — defensive
+            msg = "sqlite returned no lastrowid after escalation_events INSERT"
+            raise CloudEscalationStoreError(msg)
+        return row_id
+
+    def clear(self) -> None:
+        """Drop all events. Test helper; production never calls this."""
+        self._conn.execute("DELETE FROM escalation_events")
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Read API (mirror of EscalationLedger)
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        cursor = self._conn.execute("SELECT COUNT(*) FROM escalation_events")
+        row = cursor.fetchone()
+        return int(row[0]) if row else 0
+
+    def events(self) -> tuple[EscalationEvent, ...]:
+        """Return every event in insertion order."""
+        cursor = self._conn.execute("SELECT * FROM escalation_events ORDER BY id ASC")
+        return tuple(_row_to_event(row, cursor) for row in cursor.fetchall())
+
+    def by_reason(self, reason: EscalationReason) -> tuple[EscalationEvent, ...]:
+        cursor = self._conn.execute(
+            "SELECT * FROM escalation_events WHERE reason = ? ORDER BY id ASC",
+            (reason.value,),
+        )
+        return tuple(_row_to_event(row, cursor) for row in cursor.fetchall())
+
+    def by_destination(self, to_backend: str) -> tuple[EscalationEvent, ...]:
+        cursor = self._conn.execute(
+            "SELECT * FROM escalation_events WHERE to_backend = ? ORDER BY id ASC",
+            (to_backend,),
+        )
+        return tuple(_row_to_event(row, cursor) for row in cursor.fetchall())
+
+    def by_run(self, run_id: str) -> tuple[EscalationEvent, ...]:
+        """Events tied to ``run_id`` — the TRUST-1 cross-reference query.
+
+        Mirrors the in-memory ledger's empty-string short-circuit so
+        sentinel values used by un-tracked runs don't accidentally
+        return the entire ledger."""
+        if not run_id:
+            return ()
+        cursor = self._conn.execute(
+            "SELECT * FROM escalation_events WHERE run_id = ? ORDER BY id ASC",
+            (run_id,),
+        )
+        return tuple(_row_to_event(row, cursor) for row in cursor.fetchall())
+
+    def in_window(self, *, start: datetime, end: datetime) -> tuple[EscalationEvent, ...]:
+        """Events with ``start <= started_at <= end``.
+
+        Validates the window orientation up-front to match the
+        in-memory ledger's contract — a swapped window is a caller
+        bug worth surfacing immediately.
+        """
+        if start > end:
+            msg = "in_window: start must be <= end"
+            raise ValueError(msg)
+        cursor = self._conn.execute(
+            "SELECT * FROM escalation_events "
+            "WHERE started_at >= ? AND started_at <= ? "
+            "ORDER BY id ASC",
+            (start.isoformat(), end.isoformat()),
+        )
+        return tuple(_row_to_event(row, cursor) for row in cursor.fetchall())
+
+    # ------------------------------------------------------------------
+    # Aggregation
+    # ------------------------------------------------------------------
+
+    def summarise(
+        self,
+        events: tuple[EscalationEvent, ...] | None = None,
+    ) -> EscalationSummary:
+        """Compute an :class:`EscalationSummary` over ``events``
+        (default: all). Same contract as the in-memory ledger so the
+        rendered Trace-UI tile is identical regardless of source.
+        """
+        scope = events if events is not None else self.events()
+        by_reason: dict[EscalationReason, int] = {}
+        by_destination: dict[str, int] = {}
+        total_prompt = 0
+        total_response = 0
+        total_cost = 0
+        for ev in scope:
+            by_reason[ev.reason] = by_reason.get(ev.reason, 0) + 1
+            by_destination[ev.to_backend] = by_destination.get(ev.to_backend, 0) + 1
+            total_prompt += ev.prompt_tokens
+            total_response += ev.response_tokens
+            total_cost += ev.cost_usd_micro
+        return EscalationSummary(
+            event_count=len(scope),
+            total_prompt_tokens=total_prompt,
+            total_response_tokens=total_response,
+            total_cost_usd_micro=total_cost,
+            by_reason=by_reason,
+            by_destination=by_destination,
+        )
+
+    def snapshot(self) -> list[dict[str, object]]:
+        """JSON-serialisable list of all events, identical key set
+        with the in-memory ledger's ``snapshot()`` so downstream
+        consumers (Trace-UI, REST, run-receipt) don't branch on
+        source."""
+        rows: list[dict[str, object]] = []
+        for ev in self.events():
+            rows.append(
+                {
+                    "reason": ev.reason.value,
+                    "from_backend": ev.from_backend,
+                    "to_backend": ev.to_backend,
+                    "prompt_tokens": ev.prompt_tokens,
+                    "response_tokens": ev.response_tokens,
+                    "cost_usd_micro": ev.cost_usd_micro,
+                    "cost_usd": round(ev.cost_usd, 6),
+                    "started_at": ev.started_at.isoformat(),
+                    "completed_at": (
+                        ev.completed_at.isoformat() if ev.completed_at is not None else None
+                    ),
+                    "owner_consented": ev.owner_consented,
+                    "run_id": ev.run_id,
+                    "request_id": ev.request_id,
+                    "notes": ev.notes,
+                }
+            )
+        return rows
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_event(row: tuple[object, ...], cursor: sqlite3.Cursor) -> EscalationEvent:
+    """Parse one ``escalation_events`` row back into a frozen
+    :class:`EscalationEvent`. Tolerates future column additions
+    (always at the end of the table) by indexing via column name."""
+    column_names = [d[0] for d in cursor.description]
+    data = dict(zip(column_names, row, strict=False))
+    return EscalationEvent(
+        reason=EscalationReason(str(data["reason"])),
+        from_backend=str(data["from_backend"]),
+        to_backend=str(data["to_backend"]),
+        prompt_tokens=int(data["prompt_tokens"]),
+        response_tokens=int(data["response_tokens"]),
+        cost_usd_micro=int(data["cost_usd_micro"]),
+        started_at=datetime.fromisoformat(str(data["started_at"])),
+        completed_at=(
+            datetime.fromisoformat(str(data["completed_at"])) if data.get("completed_at") else None
+        ),
+        owner_consented=bool(data["owner_consented"]),
+        run_id=str(data["run_id"]),
+        request_id=str(data["request_id"]),
+        notes=str(data["notes"]),
+    )
+
+
+__all__ = [
+    "CloudEscalationStore",
+    "CloudEscalationStoreError",
+]

--- a/tests/test_security/test_cloud_escalation_store.py
+++ b/tests/test_security/test_cloud_escalation_store.py
@@ -1,0 +1,435 @@
+"""Tests for the SQLite-backed CloudEscalationStore (TRUST-8 disk persistence)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from cognithor.security.cloud_escalation import (
+    EscalationEvent,
+    EscalationReason,
+    EscalationSummary,
+)
+from cognithor.security.cloud_escalation_store import (
+    CloudEscalationStore,
+    CloudEscalationStoreError,
+)
+
+
+def _utc(
+    year: int, month: int, day: int, hour: int = 0, minute: int = 0, second: int = 0
+) -> datetime:
+    return datetime(year, month, day, hour, minute, second, tzinfo=UTC)
+
+
+def _event(
+    *,
+    reason: EscalationReason = EscalationReason.OWNER_OVERRIDE,
+    from_backend: str = "ollama",
+    to_backend: str = "anthropic",
+    prompt_tokens: int = 100,
+    response_tokens: int = 50,
+    cost_usd_micro: int = 0,
+    started_at: datetime | None = None,
+    completed_at: datetime | None = None,
+    owner_consented: bool = True,
+    run_id: str = "",
+    request_id: str = "",
+    notes: str = "",
+) -> EscalationEvent:
+    started = started_at or _utc(2026, 5, 9, 12, 0, 0)
+    return EscalationEvent(
+        reason=reason,
+        from_backend=from_backend,
+        to_backend=to_backend,
+        prompt_tokens=prompt_tokens,
+        response_tokens=response_tokens,
+        cost_usd_micro=cost_usd_micro,
+        started_at=started,
+        completed_at=completed_at or started + timedelta(milliseconds=500),
+        owner_consented=owner_consented,
+        run_id=run_id,
+        request_id=request_id,
+        notes=notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle + schema
+# ---------------------------------------------------------------------------
+
+
+class TestStoreLifecycle:
+    def test_creates_schema_in_memory(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            assert store.schema_version == 1
+            assert len(store) == 0
+
+    def test_context_manager_persists_to_disk(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        with CloudEscalationStore(db) as store:
+            store.append(_event(run_id="run-1"))
+
+        with CloudEscalationStore(db) as store:
+            assert len(store) == 1
+            assert store.events()[0].run_id == "run-1"
+
+    def test_close_idempotent(self) -> None:
+        store = CloudEscalationStore(":memory:")
+        store.close()
+        store.close()  # must not raise
+
+    def test_reopen_existing_does_not_reset(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        with CloudEscalationStore(db) as store:
+            store.append(_event())
+        # Re-open
+        with CloudEscalationStore(db) as store:
+            assert len(store) == 1
+
+
+# ---------------------------------------------------------------------------
+# Schema-version guard
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaVersionGuard:
+    def test_rejects_newer_schema(self, tmp_path) -> None:
+        db = tmp_path / "future.sqlite"
+        CloudEscalationStore(db).close()
+        conn = sqlite3.connect(db)
+        try:
+            conn.execute(
+                "INSERT INTO _schema_meta (version, applied_at) VALUES (?, ?)",
+                (999, datetime.now(UTC).isoformat()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        with pytest.raises(CloudEscalationStoreError, match="version 999"):
+            CloudEscalationStore(db)
+
+    def test_accepts_equal_version(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        CloudEscalationStore(db).close()
+        # Re-open at v1 must be a no-op
+        CloudEscalationStore(db).close()
+
+
+# ---------------------------------------------------------------------------
+# Append + read-back
+# ---------------------------------------------------------------------------
+
+
+class TestAppendAndRead:
+    def test_returns_row_id(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            assert store.append(_event(run_id="r1")) == 1
+            assert store.append(_event(run_id="r2")) == 2
+
+    def test_full_field_round_trip(self) -> None:
+        original = _event(
+            reason=EscalationReason.CONTEXT_TOO_LARGE,
+            from_backend="ollama",
+            to_backend="anthropic",
+            prompt_tokens=420,
+            response_tokens=80,
+            cost_usd_micro=15_000,  # $0.015
+            started_at=_utc(2026, 5, 9, 14, 30, 15),
+            completed_at=_utc(2026, 5, 9, 14, 30, 16),
+            owner_consented=True,
+            run_id="run-abc",
+            request_id="req-1",
+            notes="planner step #3",
+        )
+        with CloudEscalationStore(":memory:") as store:
+            store.append(original)
+            ev = store.events()[0]
+            assert ev.reason == original.reason
+            assert ev.from_backend == original.from_backend
+            assert ev.to_backend == original.to_backend
+            assert ev.prompt_tokens == original.prompt_tokens
+            assert ev.response_tokens == original.response_tokens
+            assert ev.cost_usd_micro == original.cost_usd_micro
+            assert ev.started_at == original.started_at
+            assert ev.completed_at == original.completed_at
+            assert ev.owner_consented is True
+            assert ev.run_id == original.run_id
+            assert ev.request_id == original.request_id
+            assert ev.notes == original.notes
+
+    def test_completed_at_none_round_trips(self) -> None:
+        ev = EscalationEvent(
+            reason=EscalationReason.UNKNOWN,
+            from_backend="ollama",
+            to_backend="anthropic",
+            prompt_tokens=0,
+            response_tokens=0,
+            completed_at=None,
+        )
+        with CloudEscalationStore(":memory:") as store:
+            store.append(ev)
+            recovered = store.events()[0]
+            assert recovered.completed_at is None
+
+    def test_owner_consented_false_round_trips(self) -> None:
+        """Boolean must survive the SQLite-INTEGER round-trip in both
+        directions — a False mistakenly stored as truthy would silently
+        flip the privacy-relevant ``owner_consented`` flag."""
+        ev = _event(owner_consented=False)
+        with CloudEscalationStore(":memory:") as store:
+            store.append(ev)
+            assert store.events()[0].owner_consented is False
+
+    def test_clear_drops_everything(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            for _ in range(5):
+                store.append(_event())
+            assert len(store) == 5
+            store.clear()
+            assert len(store) == 0
+
+    def test_events_returned_in_insertion_order(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            store.append(_event(reason=EscalationReason.OWNER_OVERRIDE))
+            store.append(_event(reason=EscalationReason.LOCAL_BACKEND_DOWN))
+            store.append(_event(reason=EscalationReason.CONTEXT_TOO_LARGE))
+            evs = store.events()
+            assert [e.reason for e in evs] == [
+                EscalationReason.OWNER_OVERRIDE,
+                EscalationReason.LOCAL_BACKEND_DOWN,
+                EscalationReason.CONTEXT_TOO_LARGE,
+            ]
+
+
+# ---------------------------------------------------------------------------
+# Read filters — parity with EscalationLedger
+# ---------------------------------------------------------------------------
+
+
+class TestReadFilters:
+    def test_by_reason(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            store.append(_event(reason=EscalationReason.OWNER_OVERRIDE))
+            store.append(_event(reason=EscalationReason.OWNER_OVERRIDE))
+            store.append(_event(reason=EscalationReason.UNKNOWN))
+            assert len(store.by_reason(EscalationReason.OWNER_OVERRIDE)) == 2
+            assert len(store.by_reason(EscalationReason.UNKNOWN)) == 1
+            # Empty-bucket query
+            assert store.by_reason(EscalationReason.RATE_LIMITED_LOCAL) == ()
+
+    def test_by_destination(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            store.append(_event(to_backend="anthropic"))
+            store.append(_event(to_backend="openai"))
+            store.append(_event(to_backend="anthropic"))
+            assert len(store.by_destination("anthropic")) == 2
+            assert len(store.by_destination("openai")) == 1
+            assert store.by_destination("missing-provider") == ()
+
+    def test_by_run_empty_string_returns_empty(self) -> None:
+        """The in-memory ledger short-circuits on empty run_id so
+        sentinel values used by un-tracked runs don't accidentally
+        leak the entire ledger. The store must mirror this exactly."""
+        with CloudEscalationStore(":memory:") as store:
+            store.append(_event(run_id="run-1"))
+            store.append(_event(run_id="run-2"))
+            store.append(_event(run_id=""))
+            # Even though one event has run_id="" stored, we don't return
+            # the whole ledger when queried with empty string.
+            assert store.by_run("") == ()
+            assert len(store.by_run("run-1")) == 1
+
+    def test_by_run_missing_returns_empty(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            store.append(_event(run_id="run-1"))
+            assert store.by_run("nope") == ()
+
+    def test_in_window_inclusive(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            early = _utc(2026, 5, 9, 10)
+            mid = _utc(2026, 5, 9, 11)
+            late = _utc(2026, 5, 9, 12)
+            for ts in (early, mid, late):
+                store.append(_event(started_at=ts))
+            assert len(store.in_window(start=early, end=late)) == 3
+            assert len(store.in_window(start=mid, end=mid)) == 1
+
+    def test_in_window_swapped_window_raises(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            with pytest.raises(ValueError, match="start must be <= end"):
+                store.in_window(
+                    start=_utc(2026, 5, 9, 12),
+                    end=_utc(2026, 5, 9, 10),
+                )
+
+
+# ---------------------------------------------------------------------------
+# Aggregation
+# ---------------------------------------------------------------------------
+
+
+class TestSummarise:
+    def test_empty_summary_is_zero(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            summary = store.summarise()
+            assert summary.event_count == 0
+            assert summary.total_cost_usd_micro == 0
+            assert summary.total_prompt_tokens == 0
+            assert summary.total_response_tokens == 0
+
+    def test_buckets_match_in_memory_contract(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            store.append(_event(reason=EscalationReason.OWNER_OVERRIDE, to_backend="anthropic"))
+            store.append(_event(reason=EscalationReason.OWNER_OVERRIDE, to_backend="anthropic"))
+            store.append(_event(reason=EscalationReason.UNKNOWN, to_backend="openai"))
+            s = store.summarise()
+            assert s.event_count == 3
+            assert s.by_reason[EscalationReason.OWNER_OVERRIDE] == 2
+            assert s.by_reason[EscalationReason.UNKNOWN] == 1
+            assert s.by_destination == {"anthropic": 2, "openai": 1}
+
+    def test_token_and_cost_totals(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            store.append(
+                _event(
+                    prompt_tokens=100,
+                    response_tokens=50,
+                    cost_usd_micro=10_000,
+                )
+            )
+            store.append(
+                _event(
+                    prompt_tokens=200,
+                    response_tokens=80,
+                    cost_usd_micro=25_000,
+                )
+            )
+            s = store.summarise()
+            assert s.total_prompt_tokens == 300
+            assert s.total_response_tokens == 130
+            assert s.total_cost_usd_micro == 35_000  # $0.035 cumulative
+            assert s.total_cost_usd == pytest.approx(0.035)
+
+    def test_summarise_with_explicit_subset(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            store.append(_event(run_id="run-1"))
+            store.append(_event(run_id="run-2"))
+            scoped = store.by_run("run-1")
+            s = store.summarise(events=scoped)
+            assert s.event_count == 1
+
+    def test_summary_is_immutable(self) -> None:
+        import dataclasses
+
+        with CloudEscalationStore(":memory:") as store:
+            s = store.summarise()
+        assert isinstance(s, EscalationSummary)
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            s.event_count = 99  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# Snapshot — JSON-safe
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshot:
+    def test_empty_snapshot(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            assert store.snapshot() == []
+
+    def test_round_trip_via_json(self) -> None:
+        with CloudEscalationStore(":memory:") as store:
+            store.append(
+                _event(
+                    reason=EscalationReason.CONTEXT_TOO_LARGE,
+                    to_backend="anthropic",
+                    prompt_tokens=200,
+                    response_tokens=120,
+                    cost_usd_micro=12_000,
+                    run_id="run-x",
+                )
+            )
+            rows = store.snapshot()
+            serialised = json.dumps(rows)
+            parsed = json.loads(serialised)
+            assert isinstance(parsed, list)
+            row = parsed[0]
+            assert row["reason"] == "context_too_large"
+            assert row["to_backend"] == "anthropic"
+            assert row["cost_usd_micro"] == 12_000
+            assert row["cost_usd"] == pytest.approx(0.012)
+            assert row["run_id"] == "run-x"
+
+    def test_snapshot_keys_match_in_memory_ledger(self) -> None:
+        """Trace-UI consumers must NOT branch on whether the source is
+        in-memory or on-disk. Pin the key set."""
+        from cognithor.security.cloud_escalation import EscalationLedger
+
+        memory_ledger = EscalationLedger()
+        memory_ledger.record(_event(run_id="r"))
+        memory_keys = set(memory_ledger.snapshot()[0].keys())
+
+        with CloudEscalationStore(":memory:") as store:
+            store.append(_event(run_id="r"))
+            disk_keys = set(store.snapshot()[0].keys())
+
+        assert memory_keys == disk_keys, (
+            f"snapshot keys diverge — memory_only={memory_keys - disk_keys}, "
+            f"disk_only={disk_keys - memory_keys}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# File persistence + concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestFilePersistence:
+    def test_writes_visible_after_reopen(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        with CloudEscalationStore(db) as store:
+            store.append(_event(run_id="run-1", to_backend="anthropic"))
+            store.append(_event(run_id="run-2", to_backend="openai"))
+        with CloudEscalationStore(db) as store:
+            assert len(store) == 2
+            backends = {e.to_backend for e in store.events()}
+            assert backends == {"anthropic", "openai"}
+
+    def test_concurrent_writers_share_db(self, tmp_path) -> None:
+        db = tmp_path / "shared.sqlite"
+        with (
+            CloudEscalationStore(db) as a,
+            CloudEscalationStore(db) as b,
+        ):
+            a.append(_event(run_id="run-a"))
+            b.append(_event(run_id="run-b"))
+        with CloudEscalationStore(db) as reader:
+            assert len(reader) == 2
+            assert {e.run_id for e in reader.events()} == {"run-a", "run-b"}
+
+
+# ---------------------------------------------------------------------------
+# Indices — query-shape sanity
+# ---------------------------------------------------------------------------
+
+
+class TestIndices:
+    def test_all_four_hot_indices_present(self) -> None:
+        """Pin the four hot read-path indices: run_id, to_backend,
+        reason, started_at. Future schema edits MUST NOT silently
+        drop one — Trace-UI panels would table-scan on every render."""
+        with CloudEscalationStore(":memory:") as store:
+            cursor = store._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='escalation_events'"
+            )
+            names = {row[0] for row in cursor.fetchall()}
+            assert "idx_escalation_events_run_id" in names
+            assert "idx_escalation_events_to_backend" in names
+            assert "idx_escalation_events_reason" in names
+            assert "idx_escalation_events_started_at" in names


### PR DESCRIPTION
## Summary

- Second module in the TRUST disk-persistence sprint — same pattern as #515 (BackendDispatchStore), now applied to the cloud-escalation ledger.
- Privacy contract preserved: backend ids, token counts, cost in micro-USD, reason taxonomy only — no prompts, no responses.
- 29 new tests, mypy --strict clean, ruff lint + format clean.

## Design parity with #515

| Property | #515 (dispatch) | This PR (escalation) |
|---|---|---|
| Storage | Plain SQLite | Plain SQLite |
| Mutation | Append-only | Append-only |
| Concurrency | WAL + check_same_thread=False | Same |
| Schema versioning | `_schema_meta` + loud refusal on newer | Same |
| Read API | parity with in-memory ledger | parity with in-memory ledger |
| snapshot keys | identical to in-memory | identical to in-memory (TestSnapshot pins this) |
| Hot indices | run_id, backend_type, started_at | run_id, to_backend, reason, started_at |

The escalation events have one extra summable field (`cost_usd_micro`) that the dispatch events don't — already part of the in-memory `EscalationSummary`, so the disk summary is a drop-in match.

## Test plan

- [x] `mypy --strict src/cognithor/security/cloud_escalation_store.py` — clean
- [x] `ruff check` + `ruff format --check` — clean
- [x] `pytest tests/test_security/test_cloud_escalation_store.py -q` — 29 / 29 passed in 0.49 s
- [x] Snapshot key set pinned against the in-memory `EscalationLedger.snapshot()` so Trace-UI consumers can't branch on source
- [x] Empty-string `by_run("")` short-circuit mirrored from in-memory contract
- [x] `owner_consented` False round-trip explicitly tested (privacy-relevant boolean)
- [x] All four hot indices verified present after schema apply
- [ ] Wiring into gateway + Flutter UI consumption — separate follow-up PRs (TRUST disk-persistence sprint, modules #3+)

## Follow-ups

After this lands, the disk-persistence rollout continues to:
- `fingerprint_store.py` (TRUST-7)
- `cost_ledger_store.py`
- `migration_ledger_store.py`
- `permission_scope_store.py`

Then gateway boot wiring and Flutter UI consumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)