### PR TITLE
feat(trust): SQLite-backed FingerprintStore (TRUST disk persistence #3)

### DIFF
--- a/src/cognithor/security/fingerprint_store.py
+++ b/src/cognithor/security/fingerprint_store.py
@@ -1,0 +1,356 @@
+"""SQLite-backed disk persistence for the TRUST-7 fingerprint ledger.
+
+Companion to :mod:`cognithor.security.fingerprint`. The in-memory
+ledger answers "what bytes did I see during this process" in O(1);
+this module turns the same query into one an operator can ask the
+day after a process restart — answering "did this exact build of
+``ollama`` run yesterday's audit window?".
+
+Design parity with :mod:`cognithor.security.backend_dispatch_store`
+(#515) and :mod:`cognithor.security.cloud_escalation_store` (#516):
+
+* Plain SQLite — the artefact metadata is small and auditor-friendly.
+  No prompts, no responses, no model weights — just hashes and names.
+* Append-only on the hash dimension: registering a hash that already
+  exists is a no-op (mirrors the in-memory ledger's idempotency).
+* Schema-versioned via ``_schema_meta``; loud refusal on newer-than-
+  build databases.
+* WAL journal mode + ``check_same_thread=False`` so concurrent
+  gateway processes can share the file.
+* Read-API parity with :class:`FingerprintLedger`: ``__len__``,
+  ``__contains__``, ``get``, ``history``, ``names``, ``filter_by_kind``,
+  ``divergent_names``, ``snapshot``.
+* Indices on ``content_hash`` (UNIQUE), ``name``, ``kind``,
+  ``captured_at`` — the four hot read paths. Pinned by a
+  ``TestIndices`` contract.
+
+Schema notes:
+
+* ``content_hash`` is ``TEXT UNIQUE NOT NULL`` — the SQLite-level
+  enforcement of the in-memory ledger's "first-write wins" rule.
+* The ``register`` method swallows
+  :class:`sqlite3.IntegrityError` on the unique index and returns
+  ``False`` to mirror the in-memory contract exactly.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from cognithor.security.fingerprint import BinaryKind, ToolFingerprint
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+log = get_logger(__name__)
+
+
+_SCHEMA_VERSION = 1
+
+
+_SCHEMA = f"""
+CREATE TABLE IF NOT EXISTS _schema_meta (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS fingerprint_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    name TEXT NOT NULL,
+    kind TEXT NOT NULL,
+    content_hash TEXT NOT NULL UNIQUE,
+    version TEXT NOT NULL DEFAULT '',
+    captured_at TEXT NOT NULL,
+    source_path TEXT NOT NULL DEFAULT '',
+    upstream_url TEXT NOT NULL DEFAULT '',
+    notes TEXT NOT NULL DEFAULT ''
+);
+
+-- Indices match the four hot read paths on the in-memory ledger:
+-- get (by hash, already covered by UNIQUE), history (by name),
+-- filter_by_kind (by kind), and snapshot ordering (by captured_at).
+-- Pinning them in the schema prevents a future migration from
+-- silently dropping one — Trace-UI panels would table-scan on every
+-- render.
+CREATE INDEX IF NOT EXISTS idx_fingerprint_events_name
+    ON fingerprint_events(name);
+CREATE INDEX IF NOT EXISTS idx_fingerprint_events_kind
+    ON fingerprint_events(kind);
+CREATE INDEX IF NOT EXISTS idx_fingerprint_events_captured_at
+    ON fingerprint_events(captured_at);
+
+INSERT OR IGNORE INTO _schema_meta (version, applied_at)
+    VALUES ({_SCHEMA_VERSION}, '{datetime.now(UTC).isoformat()}');
+"""
+
+
+class FingerprintStoreError(Exception):
+    """Raised when the SQLite layer is in an unrecoverable state.
+
+    Mirrors :class:`BackendDispatchStoreError` and
+    :class:`CloudEscalationStoreError`. Examples include a schema
+    version this build doesn't know how to read, or a corrupt file
+    whose connection won't open cleanly.
+    """
+
+
+class FingerprintStore:
+    """SQLite-backed append-only persistence for ``ToolFingerprint``.
+
+    Tests use ``:memory:`` databases for speed; production wires the
+    canonical instance to ``~/.cognithor/audit/fingerprints.sqlite``.
+
+    Lifecycle mirrors :class:`BackendDispatchStore` and
+    :class:`CloudEscalationStore` — context-manager or explicit
+    ``close()``. Re-opening an existing file is a no-op (idempotent
+    schema script).
+    """
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = str(db_path)
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+        self._verify_schema_version()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> FingerprintStore:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the SQLite connection. Safe to call multiple times."""
+        with contextlib.suppress(sqlite3.ProgrammingError):
+            self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Schema-version handshake
+    # ------------------------------------------------------------------
+
+    def _verify_schema_version(self) -> None:
+        cursor = self._conn.execute("SELECT MAX(version) FROM _schema_meta")
+        row = cursor.fetchone()
+        actual_version = row[0] if row else None
+        if actual_version is None:
+            return  # fresh DB
+        if actual_version > _SCHEMA_VERSION:
+            msg = (
+                f"FingerprintStore at {self._db_path!r} reports schema "
+                f"version {actual_version} but this build only knows "
+                f"version {_SCHEMA_VERSION}. Refusing to open to avoid "
+                "data corruption — upgrade cognithor or point at a "
+                "different file."
+            )
+            raise FingerprintStoreError(msg)
+
+    @property
+    def schema_version(self) -> int:
+        cursor = self._conn.execute("SELECT MAX(version) FROM _schema_meta")
+        row = cursor.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def register(self, fingerprint: ToolFingerprint) -> bool:
+        """Register ``fingerprint``. Returns True if it was new.
+
+        Mirrors :meth:`FingerprintLedger.register` exactly:
+
+        * Re-registering an identical hash is a no-op and returns
+          False (the SQLite UNIQUE constraint enforces this; the
+          IntegrityError is caught and translated to ``False``).
+        * Registering a *new* hash for an existing name appends and
+          returns True — the name-history grows by one entry.
+        """
+        try:
+            self._conn.execute(
+                """
+                INSERT INTO fingerprint_events (
+                    name, kind, content_hash, version, captured_at,
+                    source_path, upstream_url, notes
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    fingerprint.name,
+                    fingerprint.kind.value,
+                    fingerprint.content_hash,
+                    fingerprint.version,
+                    fingerprint.captured_at.isoformat(),
+                    fingerprint.source_path,
+                    fingerprint.upstream_url,
+                    fingerprint.notes,
+                ),
+            )
+        except sqlite3.IntegrityError:
+            # Hash already present — idempotent register, mirrors
+            # the in-memory ledger's "return False on duplicate".
+            return False
+        self._conn.commit()
+        return True
+
+    def remove(self, content_hash: str) -> bool:
+        """Drop a fingerprint by hash. Returns True iff it existed.
+
+        Mirrors :meth:`FingerprintLedger.remove`. Used by the test
+        suite and post-mortem replay; production code shouldn't
+        normally forget fingerprints.
+        """
+        cursor = self._conn.execute(
+            "DELETE FROM fingerprint_events WHERE content_hash = ?",
+            (content_hash,),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def clear(self) -> None:
+        """Drop all fingerprints. Test helper; production never calls."""
+        self._conn.execute("DELETE FROM fingerprint_events")
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Read API (mirror of FingerprintLedger)
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        cursor = self._conn.execute("SELECT COUNT(*) FROM fingerprint_events")
+        row = cursor.fetchone()
+        return int(row[0]) if row else 0
+
+    def __contains__(self, content_hash: object) -> bool:
+        if not isinstance(content_hash, str):
+            return False
+        cursor = self._conn.execute(
+            "SELECT 1 FROM fingerprint_events WHERE content_hash = ? LIMIT 1",
+            (content_hash,),
+        )
+        return cursor.fetchone() is not None
+
+    def get(self, content_hash: str) -> ToolFingerprint | None:
+        """Return the fingerprint with ``content_hash`` or ``None``."""
+        cursor = self._conn.execute(
+            "SELECT * FROM fingerprint_events WHERE content_hash = ? LIMIT 1",
+            (content_hash,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return _row_to_fingerprint(row, cursor)
+
+    def history(self, name: str) -> tuple[ToolFingerprint, ...]:
+        """Return every fingerprint under ``name`` (oldest captured_at first).
+
+        Mirrors :meth:`FingerprintLedger.history`. Tie-break on row
+        ``id`` so two captures with the same timestamp keep insertion
+        order.
+        """
+        cursor = self._conn.execute(
+            "SELECT * FROM fingerprint_events WHERE name = ? ORDER BY captured_at ASC, id ASC",
+            (name,),
+        )
+        return tuple(_row_to_fingerprint(row, cursor) for row in cursor.fetchall())
+
+    def names(self) -> list[str]:
+        """Return the set of registered names, sorted."""
+        cursor = self._conn.execute(
+            "SELECT DISTINCT name FROM fingerprint_events ORDER BY name ASC"
+        )
+        return [str(row[0]) for row in cursor.fetchall()]
+
+    def filter_by_kind(self, kind: BinaryKind) -> list[ToolFingerprint]:
+        """Return all fingerprints of ``kind``, sorted by name then hash."""
+        cursor = self._conn.execute(
+            "SELECT * FROM fingerprint_events WHERE kind = ? ORDER BY name ASC, content_hash ASC",
+            (kind.value,),
+        )
+        return [_row_to_fingerprint(row, cursor) for row in cursor.fetchall()]
+
+    def divergent_names(self) -> list[str]:
+        """Names with more than one distinct hash registered.
+
+        Mirrors :meth:`FingerprintLedger.divergent_names`. The
+        smoking-gun query when post-mortem reconstruction shows
+        behaviour drift: "show me every tool that changed during this
+        audit window".
+        """
+        cursor = self._conn.execute(
+            "SELECT name FROM fingerprint_events "
+            "GROUP BY name "
+            "HAVING COUNT(DISTINCT content_hash) > 1 "
+            "ORDER BY name ASC"
+        )
+        return [str(row[0]) for row in cursor.fetchall()]
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> list[dict[str, object]]:
+        """JSON-serialisable snapshot, identical key set with the
+        in-memory ledger's ``snapshot()`` so downstream consumers
+        (Trace-UI, REST, run-receipt) don't branch on source.
+
+        Stable ordering: by ``name`` then ``captured_at`` then
+        ``content_hash`` — same as :meth:`FingerprintLedger.snapshot`.
+        """
+        cursor = self._conn.execute(
+            "SELECT * FROM fingerprint_events ORDER BY name ASC, captured_at ASC, content_hash ASC"
+        )
+        rows: list[dict[str, object]] = []
+        for row in cursor.fetchall():
+            fp = _row_to_fingerprint(row, cursor)
+            rows.append(
+                {
+                    "name": fp.name,
+                    "kind": fp.kind.value,
+                    "content_hash": fp.content_hash,
+                    "short_hash": fp.short_hash,
+                    "version": fp.version,
+                    "captured_at": fp.captured_at.isoformat(),
+                    "source_path": fp.source_path,
+                    "upstream_url": fp.upstream_url,
+                    "notes": fp.notes,
+                }
+            )
+        return rows
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_fingerprint(row: tuple[object, ...], cursor: sqlite3.Cursor) -> ToolFingerprint:
+    """Parse one ``fingerprint_events`` row back into a frozen
+    :class:`ToolFingerprint`. Tolerates future column additions
+    (always at the end of the table) by indexing via column name."""
+    column_names = [d[0] for d in cursor.description]
+    data = dict(zip(column_names, row, strict=False))
+    return ToolFingerprint(
+        name=str(data["name"]),
+        kind=BinaryKind(str(data["kind"])),
+        content_hash=str(data["content_hash"]),
+        version=str(data["version"]),
+        captured_at=datetime.fromisoformat(str(data["captured_at"])),
+        source_path=str(data["source_path"]),
+        upstream_url=str(data["upstream_url"]),
+        notes=str(data["notes"]),
+    )
+
+
+__all__ = [
+    "FingerprintStore",
+    "FingerprintStoreError",
+]

--- a/tests/test_security/test_fingerprint_store.py
+++ b/tests/test_security/test_fingerprint_store.py
@@ -1,0 +1,417 @@
+"""Tests for the SQLite-backed FingerprintStore (TRUST-7 disk persistence)."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from cognithor.security.fingerprint import (
+    BinaryKind,
+    FingerprintLedger,
+    ToolFingerprint,
+)
+from cognithor.security.fingerprint_store import (
+    FingerprintStore,
+    FingerprintStoreError,
+)
+
+
+def _hash(seed: str) -> str:
+    return hashlib.sha256(seed.encode()).hexdigest()
+
+
+def _fp(
+    *,
+    name: str = "web_fetch",
+    kind: BinaryKind = BinaryKind.TOOL,
+    content_hash: str | None = None,
+    version: str = "1.0.0",
+    captured_at: datetime | None = None,
+    source_path: str = "",
+    upstream_url: str = "",
+    notes: str = "",
+) -> ToolFingerprint:
+    return ToolFingerprint(
+        name=name,
+        kind=kind,
+        content_hash=content_hash or _hash(f"{name}:{version}"),
+        version=version,
+        captured_at=captured_at or datetime(2026, 5, 9, 12, 0, 0, tzinfo=UTC),
+        source_path=source_path,
+        upstream_url=upstream_url,
+        notes=notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle + schema
+# ---------------------------------------------------------------------------
+
+
+class TestStoreLifecycle:
+    def test_creates_schema_in_memory(self) -> None:
+        with FingerprintStore(":memory:") as store:
+            assert store.schema_version == 1
+            assert len(store) == 0
+
+    def test_context_manager_persists_to_disk(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        with FingerprintStore(db) as store:
+            store.register(_fp(name="web_fetch"))
+
+        with FingerprintStore(db) as store:
+            assert len(store) == 1
+            assert store.names() == ["web_fetch"]
+
+    def test_close_idempotent(self) -> None:
+        store = FingerprintStore(":memory:")
+        store.close()
+        store.close()  # must not raise
+
+    def test_reopen_existing_does_not_reset(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        with FingerprintStore(db) as store:
+            store.register(_fp())
+        with FingerprintStore(db) as store:
+            assert len(store) == 1
+
+
+# ---------------------------------------------------------------------------
+# Schema-version guard
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaVersionGuard:
+    def test_rejects_newer_schema(self, tmp_path) -> None:
+        db = tmp_path / "future.sqlite"
+        FingerprintStore(db).close()
+        conn = sqlite3.connect(db)
+        try:
+            conn.execute(
+                "INSERT INTO _schema_meta (version, applied_at) VALUES (?, ?)",
+                (999, datetime.now(UTC).isoformat()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        with pytest.raises(FingerprintStoreError, match="version 999"):
+            FingerprintStore(db)
+
+    def test_accepts_equal_version(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        FingerprintStore(db).close()
+        FingerprintStore(db).close()  # second open at same version is no-op
+
+
+# ---------------------------------------------------------------------------
+# Register + remove
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterAndRemove:
+    def test_register_returns_true_first_time(self) -> None:
+        with FingerprintStore(":memory:") as store:
+            assert store.register(_fp()) is True
+            assert len(store) == 1
+
+    def test_register_idempotent_on_same_hash(self) -> None:
+        """Mirrors the in-memory contract: re-registering an identical
+        hash is a no-op and returns ``False``. SQLite UNIQUE on
+        ``content_hash`` enforces this at the storage layer."""
+        fp = _fp()
+        with FingerprintStore(":memory:") as store:
+            assert store.register(fp) is True
+            assert store.register(fp) is False
+            assert len(store) == 1
+
+    def test_register_new_hash_for_existing_name_appends(self) -> None:
+        """Two different SHA-256s under the same logical name MUST
+        both land in storage — that's the smoking-gun query
+        ``divergent_names()`` exists to surface."""
+        v1 = _fp(name="web_fetch", version="1.0.0", content_hash=_hash("v1"))
+        v2 = _fp(name="web_fetch", version="1.1.0", content_hash=_hash("v2"))
+        with FingerprintStore(":memory:") as store:
+            assert store.register(v1) is True
+            assert store.register(v2) is True
+            assert len(store) == 2
+
+    def test_full_field_round_trip(self) -> None:
+        original = _fp(
+            name="qwen3:30b",
+            kind=BinaryKind.MODEL,
+            content_hash=_hash("qwen3-30b-v1"),
+            version="2026.04.16",
+            captured_at=datetime(2026, 5, 9, 14, 30, 15, tzinfo=UTC),
+            source_path="/models/qwen3.bin",
+            upstream_url="https://huggingface.co/Qwen/Qwen3-30B",
+            notes="planner default",
+        )
+        with FingerprintStore(":memory:") as store:
+            store.register(original)
+            recovered = store.get(original.content_hash)
+            assert recovered == original
+
+    def test_remove_returns_true_when_present(self) -> None:
+        with FingerprintStore(":memory:") as store:
+            fp = _fp()
+            store.register(fp)
+            assert store.remove(fp.content_hash) is True
+            assert len(store) == 0
+
+    def test_remove_returns_false_when_absent(self) -> None:
+        with FingerprintStore(":memory:") as store:
+            assert store.remove(_hash("nope")) is False
+
+    def test_clear_drops_everything(self) -> None:
+        with FingerprintStore(":memory:") as store:
+            for i in range(5):
+                store.register(_fp(content_hash=_hash(f"x{i}")))
+            assert len(store) == 5
+            store.clear()
+            assert len(store) == 0
+
+
+# ---------------------------------------------------------------------------
+# Lookup parity with FingerprintLedger
+# ---------------------------------------------------------------------------
+
+
+class TestLookupParity:
+    def test_get_present_and_absent(self) -> None:
+        with FingerprintStore(":memory:") as store:
+            fp = _fp()
+            store.register(fp)
+            assert store.get(fp.content_hash) == fp
+            assert store.get(_hash("missing")) is None
+
+    def test_contains_only_accepts_strings(self) -> None:
+        """Mirrors the in-memory ledger's ``__contains__`` shape:
+        non-string queries silently return False (don't raise) so a
+        caller passing a misshaped value gets the same answer
+        regardless of source."""
+        with FingerprintStore(":memory:") as store:
+            fp = _fp()
+            store.register(fp)
+            assert (fp.content_hash in store) is True
+            assert (_hash("missing") in store) is False
+            assert (123 in store) is False  # type: ignore[operator]
+            assert (None in store) is False  # type: ignore[operator]
+
+    def test_history_oldest_first(self) -> None:
+        base = datetime(2026, 5, 9, 10, 0, 0, tzinfo=UTC)
+        with FingerprintStore(":memory:") as store:
+            store.register(
+                _fp(
+                    name="web_fetch",
+                    content_hash=_hash("v1"),
+                    captured_at=base,
+                )
+            )
+            store.register(
+                _fp(
+                    name="web_fetch",
+                    content_hash=_hash("v2"),
+                    captured_at=base + timedelta(hours=1),
+                )
+            )
+            chain = store.history("web_fetch")
+            assert [fp.content_hash for fp in chain] == [_hash("v1"), _hash("v2")]
+
+    def test_history_missing_name_returns_empty(self) -> None:
+        with FingerprintStore(":memory:") as store:
+            assert store.history("nope") == ()
+
+    def test_names_sorted(self) -> None:
+        with FingerprintStore(":memory:") as store:
+            store.register(_fp(name="zebra", content_hash=_hash("z")))
+            store.register(_fp(name="alpha", content_hash=_hash("a")))
+            store.register(_fp(name="mango", content_hash=_hash("m")))
+            assert store.names() == ["alpha", "mango", "zebra"]
+
+    def test_filter_by_kind(self) -> None:
+        with FingerprintStore(":memory:") as store:
+            store.register(_fp(name="t1", kind=BinaryKind.TOOL, content_hash=_hash("t1")))
+            store.register(_fp(name="t2", kind=BinaryKind.TOOL, content_hash=_hash("t2")))
+            store.register(_fp(name="qwen3", kind=BinaryKind.MODEL, content_hash=_hash("m1")))
+            tools = store.filter_by_kind(BinaryKind.TOOL)
+            assert [fp.name for fp in tools] == ["t1", "t2"]
+            models = store.filter_by_kind(BinaryKind.MODEL)
+            assert len(models) == 1
+            packs = store.filter_by_kind(BinaryKind.PACK)
+            assert packs == []
+
+    def test_divergent_names(self) -> None:
+        """A name with two distinct hashes must show up; a name with
+        only one must not."""
+        with FingerprintStore(":memory:") as store:
+            # web_fetch — divergent (two hashes)
+            store.register(_fp(name="web_fetch", content_hash=_hash("wf-v1")))
+            store.register(_fp(name="web_fetch", content_hash=_hash("wf-v2")))
+            # stable_tool — only one hash
+            store.register(_fp(name="stable_tool", content_hash=_hash("st-v1")))
+            assert store.divergent_names() == ["web_fetch"]
+
+
+# ---------------------------------------------------------------------------
+# Snapshot — must match in-memory ledger contract
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshot:
+    def test_empty_snapshot(self) -> None:
+        with FingerprintStore(":memory:") as store:
+            assert store.snapshot() == []
+
+    def test_round_trip_via_json(self) -> None:
+        with FingerprintStore(":memory:") as store:
+            store.register(
+                _fp(
+                    name="qwen3:30b",
+                    kind=BinaryKind.MODEL,
+                    content_hash=_hash("q3"),
+                    version="2026.04.16",
+                    notes="planner",
+                )
+            )
+            rows = store.snapshot()
+            serialised = json.dumps(rows)
+            parsed = json.loads(serialised)
+            assert isinstance(parsed, list)
+            row = parsed[0]
+            assert row["name"] == "qwen3:30b"
+            assert row["kind"] == "model"
+            assert row["short_hash"] == _hash("q3")[:12]
+            assert row["version"] == "2026.04.16"
+
+    def test_snapshot_keys_match_in_memory_ledger(self) -> None:
+        """Trace-UI consumers must NOT branch on whether the source
+        is in-memory or on-disk. Pin the key set."""
+        memory_ledger = FingerprintLedger()
+        memory_ledger.register(_fp())
+        memory_keys = set(memory_ledger.snapshot()[0].keys())
+
+        with FingerprintStore(":memory:") as store:
+            store.register(_fp())
+            disk_keys = set(store.snapshot()[0].keys())
+
+        assert memory_keys == disk_keys, (
+            f"snapshot keys diverge — memory_only={memory_keys - disk_keys}, "
+            f"disk_only={disk_keys - memory_keys}"
+        )
+
+    def test_snapshot_ordering_matches_in_memory_ledger(self) -> None:
+        """Stable ordering: name → captured_at → content_hash. Pin
+        the order so Trace-UI rendering is deterministic."""
+        base = datetime(2026, 5, 9, 10, 0, 0, tzinfo=UTC)
+        events = [
+            _fp(name="zebra", content_hash=_hash("z"), captured_at=base),
+            _fp(
+                name="alpha",
+                content_hash=_hash("a1"),
+                captured_at=base + timedelta(hours=1),
+            ),
+            _fp(name="alpha", content_hash=_hash("a2"), captured_at=base),
+            _fp(
+                name="mango",
+                content_hash=_hash("m"),
+                captured_at=base + timedelta(hours=2),
+            ),
+        ]
+
+        memory_ledger = FingerprintLedger()
+        for e in events:
+            memory_ledger.register(e)
+
+        with FingerprintStore(":memory:") as store:
+            for e in events:
+                store.register(e)
+
+            mem_order = [(r["name"], r["captured_at"]) for r in memory_ledger.snapshot()]
+            disk_order = [(r["name"], r["captured_at"]) for r in store.snapshot()]
+            assert mem_order == disk_order
+
+
+# ---------------------------------------------------------------------------
+# File persistence + concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestFilePersistence:
+    def test_writes_visible_after_reopen(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        with FingerprintStore(db) as store:
+            store.register(_fp(name="ollama", content_hash=_hash("o1")))
+            store.register(_fp(name="vllm", content_hash=_hash("v1")))
+        with FingerprintStore(db) as store:
+            assert len(store) == 2
+            names = set(store.names())
+            assert names == {"ollama", "vllm"}
+
+    def test_concurrent_writers_share_db(self, tmp_path) -> None:
+        db = tmp_path / "shared.sqlite"
+        with (
+            FingerprintStore(db) as a,
+            FingerprintStore(db) as b,
+        ):
+            a.register(_fp(name="tool-a", content_hash=_hash("a")))
+            b.register(_fp(name="tool-b", content_hash=_hash("b")))
+        with FingerprintStore(db) as reader:
+            assert len(reader) == 2
+            assert {n for n in reader.names()} == {"tool-a", "tool-b"}
+
+    def test_concurrent_writers_dedupe_on_unique_hash(self, tmp_path) -> None:
+        """Two concurrent writers racing the same hash must converge —
+        the SQLite UNIQUE on ``content_hash`` is the authority. One
+        ``register`` returns True, the other returns False, and the
+        store ends with exactly one row."""
+        db = tmp_path / "race.sqlite"
+        fp = _fp(content_hash=_hash("dedupe"))
+        with (
+            FingerprintStore(db) as a,
+            FingerprintStore(db) as b,
+        ):
+            r1 = a.register(fp)
+            r2 = b.register(fp)
+            assert {r1, r2} == {True, False}
+        with FingerprintStore(db) as reader:
+            assert len(reader) == 1
+
+
+# ---------------------------------------------------------------------------
+# Indices — query-shape sanity
+# ---------------------------------------------------------------------------
+
+
+class TestIndices:
+    def test_all_three_secondary_indices_present(self) -> None:
+        """Pin the secondary indices: name, kind, captured_at. The
+        primary read path (by content_hash) is covered by the UNIQUE
+        constraint already, so it doesn't get its own named index."""
+        with FingerprintStore(":memory:") as store:
+            cursor = store._conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='index' AND tbl_name='fingerprint_events'"
+            )
+            names = {row[0] for row in cursor.fetchall()}
+            assert "idx_fingerprint_events_name" in names
+            assert "idx_fingerprint_events_kind" in names
+            assert "idx_fingerprint_events_captured_at" in names
+
+    def test_unique_content_hash_constraint_present(self) -> None:
+        """The hash-uniqueness contract is the single most load-bearing
+        invariant — without it, ``register()`` idempotency breaks. Pin
+        an explicit assertion against the schema."""
+        with FingerprintStore(":memory:") as store:
+            cursor = store._conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name='fingerprint_events'"
+            )
+            row = cursor.fetchone()
+            assert row is not None
+            sql = str(row[0])
+            assert "UNIQUE" in sql
+            assert "content_hash" in sql


### PR DESCRIPTION
## Summary

- Third module in the TRUST disk-persistence sprint — same pattern as #515 (BackendDispatchStore) and #516 (CloudEscalationStore), now applied to the TRUST-7 fingerprint ledger.
- The audit-trail privacy contract is honoured: name, kind, SHA-256 content hash, optional version + source_path + upstream_url + notes — no model weights, no source bytes, no prompts.
- 29 new tests, mypy --strict clean, ruff lint + format clean.

## Design parity with #515 / #516

| Property | This PR (fingerprint) |
|---|---|
| Storage | Plain SQLite |
| Mutation | Append-only on hash dimension, idempotent ``register()`` |
| Concurrency | WAL + check_same_thread=False |
| Schema versioning | ``_schema_meta`` + loud refusal on newer |
| Idempotency | ``content_hash`` UNIQUE constraint; ``IntegrityError`` caught and translated to ``False`` to mirror in-memory contract |
| Read API | full parity with FingerprintLedger |
| snapshot keys + order | identical to in-memory (TestSnapshot pins both) |
| Hot indices | name, kind, captured_at (content_hash via UNIQUE) |

## What's different from the dispatch + escalation stores

The fingerprint ledger has a **dual-axis identity**: one logical name (``web_fetch``) can have multiple distinct SHA-256s over time as the implementation evolves. The store mirrors that exactly:
- ``register()`` is idempotent on **hash** but appends a new row when an existing **name** gets a new hash.
- ``divergent_names()`` queries via SQL ``GROUP BY name HAVING COUNT(DISTINCT content_hash) > 1`` — the same smoking-gun query as in-memory.
- A new ``test_concurrent_writers_dedupe_on_unique_hash`` test pins the race-condition behaviour: two concurrent ``register()`` calls for the same hash converge to ``{True, False}`` with exactly one row stored.

## Test plan

- [x] ``mypy --strict src/cognithor/security/fingerprint_store.py`` — clean
- [x] ``ruff check`` + ``ruff format --check`` — clean
- [x] ``pytest tests/test_security/test_fingerprint_store.py -q`` — 29 / 29 passed in 0.53 s
- [x] Snapshot key set + ordering pinned against the in-memory ``FingerprintLedger.snapshot()``
- [x] ``__contains__`` non-string-input shape mirrored from in-memory contract (returns False, doesn't raise)
- [x] All three secondary indices verified present after schema apply
- [x] UNIQUE constraint on ``content_hash`` verified in schema SQL
- [ ] Wiring into gateway boot + Trace-UI consumption — separate follow-up PRs (TRUST disk-persistence sprint, modules #4-#6)

## Follow-ups

After this lands, the disk-persistence rollout continues to:
- ``cost_ledger_store.py``
- ``migration_ledger_store.py``
- ``permission_scope_store.py``

Then gateway boot wiring + Flutter UI consumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)