### PR TITLE
feat(trust): SQLite-backed CostLedgerStore (TRUST disk persistence #4)

### DIFF
--- a/src/cognithor/security/cost_ledger_store.py
+++ b/src/cognithor/security/cost_ledger_store.py
@@ -1,0 +1,379 @@
+"""SQLite-backed disk persistence for the TRUST-6 cost ledger.
+
+Companion to :mod:`cognithor.security.cost_ledger`. The in-memory
+ledger answers "how much have I spent today" within a single process;
+this module turns the same query into one an operator can ask the
+day after a process restart — the reviewer-feedback budget question
+without grepping process state.
+
+Design parity with :mod:`cognithor.security.backend_dispatch_store`
+(#515), :mod:`cognithor.security.cloud_escalation_store` (#516), and
+:mod:`cognithor.security.fingerprint_store` (#517):
+
+* Plain SQLite — privacy contract preserved (no prompts, no responses,
+  no model weights). All columns are budget metadata only.
+* Append-only — ``record(entry)`` is the single mutation.
+* Schema-versioned via ``_schema_meta``; loud refusal on
+  newer-than-build databases.
+* WAL journal mode + ``check_same_thread=False`` so concurrent
+  gateway processes can share the file.
+* Read-API parity with :class:`CostLedger`: ``__len__``, ``entries``,
+  ``by_run``, ``by_tool``, ``by_kind``, ``in_window``, ``summarise``,
+  ``budget_status``, ``snapshot``.
+* Indices on ``tool``, ``run_id``, ``kind``, ``occurred_at`` —
+  the four hot read paths. Pinned by a ``TestIndices`` contract.
+
+Cost-axis specifics:
+
+* ``cost_usd_micro`` is stored as ``INTEGER NOT NULL`` and summed
+  via SQL where convenient — but ``summarise`` builds a six-axis
+  histogram which is cheaper to compute in Python over the result
+  set than to issue six grouped queries. Budget alerting reuses the
+  same shared aggregator.
+* ``-1`` token / unit counts mean "unknown" (per the in-memory
+  contract); they round-trip as-is through the integer column.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from cognithor.security.cost_ledger import (
+    BudgetReport,
+    CostEntry,
+    CostKind,
+    CostLedger,
+    CostSummary,
+)
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+log = get_logger(__name__)
+
+
+_SCHEMA_VERSION = 1
+
+
+_SCHEMA = f"""
+CREATE TABLE IF NOT EXISTS _schema_meta (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS cost_entries (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    kind TEXT NOT NULL,
+    tool TEXT NOT NULL,
+    cost_usd_micro INTEGER NOT NULL,
+    backend TEXT NOT NULL DEFAULT '',
+    run_id TEXT NOT NULL DEFAULT '',
+    channel TEXT NOT NULL DEFAULT '',
+    domain TEXT NOT NULL DEFAULT '',
+    prompt_tokens INTEGER NOT NULL DEFAULT -1,
+    response_tokens INTEGER NOT NULL DEFAULT -1,
+    unit_count INTEGER NOT NULL DEFAULT -1,
+    occurred_at TEXT NOT NULL,
+    notes TEXT NOT NULL DEFAULT ''
+);
+
+-- Indices match the four hot read paths on the in-memory ledger:
+-- by_tool, by_run, by_kind, in_window. Pinning them prevents a
+-- future migration from silently dropping one — Trace-UI budget
+-- panels would table-scan on every render.
+CREATE INDEX IF NOT EXISTS idx_cost_entries_tool
+    ON cost_entries(tool);
+CREATE INDEX IF NOT EXISTS idx_cost_entries_run_id
+    ON cost_entries(run_id);
+CREATE INDEX IF NOT EXISTS idx_cost_entries_kind
+    ON cost_entries(kind);
+CREATE INDEX IF NOT EXISTS idx_cost_entries_occurred_at
+    ON cost_entries(occurred_at);
+
+INSERT OR IGNORE INTO _schema_meta (version, applied_at)
+    VALUES ({_SCHEMA_VERSION}, '{datetime.now(UTC).isoformat()}');
+"""
+
+
+class CostLedgerStoreError(Exception):
+    """Raised when the SQLite layer is in an unrecoverable state.
+
+    Mirrors the sibling stores. Examples include a schema version
+    this build doesn't know how to read, or a corrupt file whose
+    connection won't open cleanly.
+    """
+
+
+class CostLedgerStore:
+    """SQLite-backed append-only persistence for ``CostEntry``.
+
+    Tests use ``:memory:`` databases for speed; production wires the
+    canonical instance to ``~/.cognithor/audit/cost_ledger.sqlite``.
+
+    Lifecycle mirrors the sibling stores — context-manager or
+    explicit ``close()``. Re-opening an existing file is a no-op
+    (idempotent schema script).
+    """
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = str(db_path)
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+        self._verify_schema_version()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> CostLedgerStore:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the SQLite connection. Safe to call multiple times."""
+        with contextlib.suppress(sqlite3.ProgrammingError):
+            self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Schema-version handshake
+    # ------------------------------------------------------------------
+
+    def _verify_schema_version(self) -> None:
+        cursor = self._conn.execute("SELECT MAX(version) FROM _schema_meta")
+        row = cursor.fetchone()
+        actual_version = row[0] if row else None
+        if actual_version is None:
+            return  # fresh DB
+        if actual_version > _SCHEMA_VERSION:
+            msg = (
+                f"CostLedgerStore at {self._db_path!r} reports schema "
+                f"version {actual_version} but this build only knows "
+                f"version {_SCHEMA_VERSION}. Refusing to open to avoid "
+                "data corruption — upgrade cognithor or point at a "
+                "different file."
+            )
+            raise CostLedgerStoreError(msg)
+
+    @property
+    def schema_version(self) -> int:
+        cursor = self._conn.execute("SELECT MAX(version) FROM _schema_meta")
+        row = cursor.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def record(self, entry: CostEntry) -> int:
+        """Append ``entry`` and return its assigned row id."""
+        cursor = self._conn.execute(
+            """
+            INSERT INTO cost_entries (
+                kind, tool, cost_usd_micro,
+                backend, run_id, channel, domain,
+                prompt_tokens, response_tokens, unit_count,
+                occurred_at, notes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                entry.kind.value,
+                entry.tool,
+                entry.cost_usd_micro,
+                entry.backend,
+                entry.run_id,
+                entry.channel,
+                entry.domain,
+                entry.prompt_tokens,
+                entry.response_tokens,
+                entry.unit_count,
+                entry.occurred_at.isoformat(),
+                entry.notes,
+            ),
+        )
+        self._conn.commit()
+        row_id = cursor.lastrowid
+        if row_id is None:  # pragma: no cover — defensive
+            msg = "sqlite returned no lastrowid after cost_entries INSERT"
+            raise CostLedgerStoreError(msg)
+        return row_id
+
+    def clear(self) -> None:
+        """Drop all entries. Test helper; production never calls this."""
+        self._conn.execute("DELETE FROM cost_entries")
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Read API (mirror of CostLedger)
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        cursor = self._conn.execute("SELECT COUNT(*) FROM cost_entries")
+        row = cursor.fetchone()
+        return int(row[0]) if row else 0
+
+    def entries(self) -> tuple[CostEntry, ...]:
+        """Return every entry in insertion order."""
+        cursor = self._conn.execute("SELECT * FROM cost_entries ORDER BY id ASC")
+        return tuple(_row_to_entry(row, cursor) for row in cursor.fetchall())
+
+    def by_run(self, run_id: str) -> tuple[CostEntry, ...]:
+        """Entries tied to ``run_id`` — the TRUST-1 cross-reference query.
+
+        Mirrors the in-memory ledger's empty-string short-circuit so
+        sentinel values used by un-tracked runs don't accidentally
+        return the entire ledger."""
+        if not run_id:
+            return ()
+        cursor = self._conn.execute(
+            "SELECT * FROM cost_entries WHERE run_id = ? ORDER BY id ASC",
+            (run_id,),
+        )
+        return tuple(_row_to_entry(row, cursor) for row in cursor.fetchall())
+
+    def by_tool(self, tool: str) -> tuple[CostEntry, ...]:
+        """Entries for a single tool — same empty-string contract as
+        the in-memory ledger."""
+        if not tool:
+            return ()
+        cursor = self._conn.execute(
+            "SELECT * FROM cost_entries WHERE tool = ? ORDER BY id ASC",
+            (tool,),
+        )
+        return tuple(_row_to_entry(row, cursor) for row in cursor.fetchall())
+
+    def by_kind(self, kind: CostKind) -> tuple[CostEntry, ...]:
+        cursor = self._conn.execute(
+            "SELECT * FROM cost_entries WHERE kind = ? ORDER BY id ASC",
+            (kind.value,),
+        )
+        return tuple(_row_to_entry(row, cursor) for row in cursor.fetchall())
+
+    def in_window(self, *, start: datetime, end: datetime) -> tuple[CostEntry, ...]:
+        """Entries with ``start <= occurred_at <= end``.
+
+        Validates the window orientation up-front to match the
+        in-memory ledger's contract — a swapped window is a caller
+        bug worth surfacing immediately.
+        """
+        if start > end:
+            msg = "in_window: start must be <= end"
+            raise ValueError(msg)
+        cursor = self._conn.execute(
+            "SELECT * FROM cost_entries "
+            "WHERE occurred_at >= ? AND occurred_at <= ? "
+            "ORDER BY id ASC",
+            (start.isoformat(), end.isoformat()),
+        )
+        return tuple(_row_to_entry(row, cursor) for row in cursor.fetchall())
+
+    # ------------------------------------------------------------------
+    # Aggregation
+    # ------------------------------------------------------------------
+
+    def summarise(
+        self,
+        entries: tuple[CostEntry, ...] | None = None,
+    ) -> CostSummary:
+        """Compute a :class:`CostSummary` over ``entries`` (default:
+        all). Delegates to the in-memory :class:`CostLedger` so the
+        six-axis histogram lives in exactly one place — any future
+        change to the bucketing rule lands in both ledgers
+        simultaneously.
+        """
+        scope = entries if entries is not None else self.entries()
+        # Re-use the in-memory ledger's aggregator. We don't keep
+        # the helper ledger around — it's a stateless calculator
+        # here, not a parallel store.
+        helper = CostLedger()
+        for e in scope:
+            helper.record(e)
+        return helper.summarise()
+
+    def budget_status(
+        self,
+        *,
+        limit_usd_micro: int,
+        scope: tuple[CostEntry, ...] | None = None,
+        approaching_threshold: float = 0.80,
+    ) -> BudgetReport:
+        """Compare cumulative cost against a budget. Delegates to the
+        in-memory ledger so the threshold rules stay in one place."""
+        helper = CostLedger()
+        for e in scope if scope is not None else self.entries():
+            helper.record(e)
+        return helper.budget_status(
+            limit_usd_micro=limit_usd_micro,
+            approaching_threshold=approaching_threshold,
+        )
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> list[dict[str, object]]:
+        """JSON-serialisable insertion-order snapshot, identical key
+        set with the in-memory ledger's ``snapshot()`` so downstream
+        consumers (Trace-UI, REST, run-receipt) don't branch on
+        source."""
+        rows: list[dict[str, object]] = []
+        for e in self.entries():
+            rows.append(
+                {
+                    "kind": e.kind.value,
+                    "tool": e.tool,
+                    "cost_usd_micro": e.cost_usd_micro,
+                    "cost_usd": round(e.cost_usd, 6),
+                    "backend": e.backend,
+                    "run_id": e.run_id,
+                    "channel": e.channel,
+                    "domain": e.domain,
+                    "prompt_tokens": e.prompt_tokens,
+                    "response_tokens": e.response_tokens,
+                    "unit_count": e.unit_count,
+                    "occurred_at": e.occurred_at.isoformat(),
+                    "notes": e.notes,
+                }
+            )
+        return rows
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_entry(row: tuple[object, ...], cursor: sqlite3.Cursor) -> CostEntry:
+    """Parse one ``cost_entries`` row back into a frozen
+    :class:`CostEntry`. Tolerates future column additions (always at
+    the end of the table) by indexing via column name."""
+    column_names = [d[0] for d in cursor.description]
+    data = dict(zip(column_names, row, strict=False))
+    return CostEntry(
+        kind=CostKind(str(data["kind"])),
+        tool=str(data["tool"]),
+        cost_usd_micro=int(data["cost_usd_micro"]),
+        backend=str(data["backend"]),
+        run_id=str(data["run_id"]),
+        channel=str(data["channel"]),
+        domain=str(data["domain"]),
+        prompt_tokens=int(data["prompt_tokens"]),
+        response_tokens=int(data["response_tokens"]),
+        unit_count=int(data["unit_count"]),
+        occurred_at=datetime.fromisoformat(str(data["occurred_at"])),
+        notes=str(data["notes"]),
+    )
+
+
+__all__ = [
+    "CostLedgerStore",
+    "CostLedgerStoreError",
+]

--- a/tests/test_security/test_cost_ledger_store.py
+++ b/tests/test_security/test_cost_ledger_store.py
@@ -1,0 +1,504 @@
+"""Tests for the SQLite-backed CostLedgerStore (TRUST-6 disk persistence)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from cognithor.security.cost_ledger import (
+    BudgetStatus,
+    CostEntry,
+    CostKind,
+    CostLedger,
+    CostSummary,
+)
+from cognithor.security.cost_ledger_store import (
+    CostLedgerStore,
+    CostLedgerStoreError,
+)
+
+
+def _utc(
+    year: int, month: int, day: int, hour: int = 0, minute: int = 0, second: int = 0
+) -> datetime:
+    return datetime(year, month, day, hour, minute, second, tzinfo=UTC)
+
+
+def _entry(
+    *,
+    kind: CostKind = CostKind.LLM_INFERENCE,
+    tool: str = "qwen3:30b",
+    cost_usd_micro: int = 100,
+    backend: str = "ollama",
+    run_id: str = "",
+    channel: str = "",
+    domain: str = "",
+    prompt_tokens: int = 100,
+    response_tokens: int = 50,
+    unit_count: int = -1,
+    occurred_at: datetime | None = None,
+    notes: str = "",
+) -> CostEntry:
+    return CostEntry(
+        kind=kind,
+        tool=tool,
+        cost_usd_micro=cost_usd_micro,
+        backend=backend,
+        run_id=run_id,
+        channel=channel,
+        domain=domain,
+        prompt_tokens=prompt_tokens,
+        response_tokens=response_tokens,
+        unit_count=unit_count,
+        occurred_at=occurred_at or _utc(2026, 5, 9, 12, 0, 0),
+        notes=notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle + schema
+# ---------------------------------------------------------------------------
+
+
+class TestStoreLifecycle:
+    def test_creates_schema_in_memory(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            assert store.schema_version == 1
+            assert len(store) == 0
+
+    def test_context_manager_persists_to_disk(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        with CostLedgerStore(db) as store:
+            store.record(_entry(run_id="run-1"))
+
+        with CostLedgerStore(db) as store:
+            assert len(store) == 1
+            assert store.entries()[0].run_id == "run-1"
+
+    def test_close_idempotent(self) -> None:
+        store = CostLedgerStore(":memory:")
+        store.close()
+        store.close()  # must not raise
+
+    def test_reopen_existing_does_not_reset(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        with CostLedgerStore(db) as store:
+            store.record(_entry())
+        with CostLedgerStore(db) as store:
+            assert len(store) == 1
+
+
+# ---------------------------------------------------------------------------
+# Schema-version guard
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaVersionGuard:
+    def test_rejects_newer_schema(self, tmp_path) -> None:
+        db = tmp_path / "future.sqlite"
+        CostLedgerStore(db).close()
+        conn = sqlite3.connect(db)
+        try:
+            conn.execute(
+                "INSERT INTO _schema_meta (version, applied_at) VALUES (?, ?)",
+                (999, datetime.now(UTC).isoformat()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        with pytest.raises(CostLedgerStoreError, match="version 999"):
+            CostLedgerStore(db)
+
+    def test_accepts_equal_version(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        CostLedgerStore(db).close()
+        CostLedgerStore(db).close()
+
+
+# ---------------------------------------------------------------------------
+# Append + read-back
+# ---------------------------------------------------------------------------
+
+
+class TestAppendAndRead:
+    def test_returns_row_id(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            assert store.record(_entry(run_id="r1")) == 1
+            assert store.record(_entry(run_id="r2")) == 2
+
+    def test_full_field_round_trip(self) -> None:
+        original = _entry(
+            kind=CostKind.VISION_TOKENS,
+            tool="qwen3-vl-32b",
+            cost_usd_micro=42_500,
+            backend="vllm",
+            run_id="run-vl-7",
+            channel="webui",
+            domain="vision",
+            prompt_tokens=2048,
+            response_tokens=180,
+            unit_count=3,
+            occurred_at=_utc(2026, 5, 9, 14, 30, 15),
+            notes="frame-batch /pse/run/7",
+        )
+        with CostLedgerStore(":memory:") as store:
+            store.record(original)
+            recovered = store.entries()[0]
+            assert recovered == original
+
+    def test_unknown_token_counts_round_trip_as_minus_one(self) -> None:
+        """The in-memory contract uses ``-1`` to mean "unknown"; if
+        the disk store accidentally coerced it (e.g. via DEFAULT
+        clauses overriding NULLs), summaries on storage-class costs
+        would silently flip from ``unknown`` to ``0`` and skew
+        budget alerts."""
+        ev = _entry(
+            kind=CostKind.STORAGE,
+            tool="s3-bucket-snapshots",
+            cost_usd_micro=2_000,
+            prompt_tokens=-1,
+            response_tokens=-1,
+            unit_count=-1,
+        )
+        with CostLedgerStore(":memory:") as store:
+            store.record(ev)
+            r = store.entries()[0]
+            assert r.prompt_tokens == -1
+            assert r.response_tokens == -1
+            assert r.unit_count == -1
+
+    def test_clear_drops_everything(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            for _ in range(5):
+                store.record(_entry())
+            assert len(store) == 5
+            store.clear()
+            assert len(store) == 0
+
+    def test_entries_returned_in_insertion_order(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            for tool in ("a", "b", "c"):
+                store.record(_entry(tool=tool))
+            tools = [e.tool for e in store.entries()]
+            assert tools == ["a", "b", "c"]
+
+
+# ---------------------------------------------------------------------------
+# Read filters
+# ---------------------------------------------------------------------------
+
+
+class TestReadFilters:
+    def test_by_run_filters_correctly(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            store.record(_entry(run_id="run-1"))
+            store.record(_entry(run_id="run-1"))
+            store.record(_entry(run_id="run-2"))
+            assert len(store.by_run("run-1")) == 2
+            assert len(store.by_run("run-2")) == 1
+
+    def test_by_run_empty_string_short_circuits(self) -> None:
+        """Mirrors the in-memory ledger's contract: empty run_id
+        returns ``()`` so sentinel queries don't leak the whole
+        ledger."""
+        with CostLedgerStore(":memory:") as store:
+            store.record(_entry(run_id=""))
+            assert store.by_run("") == ()
+
+    def test_by_run_missing_returns_empty(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            store.record(_entry(run_id="run-1"))
+            assert store.by_run("nope") == ()
+
+    def test_by_tool_filters_correctly(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            store.record(_entry(tool="qwen3:30b"))
+            store.record(_entry(tool="qwen3:30b"))
+            store.record(_entry(tool="openai:gpt"))
+            assert len(store.by_tool("qwen3:30b")) == 2
+            assert len(store.by_tool("openai:gpt")) == 1
+
+    def test_by_tool_empty_string_short_circuits(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            # cannot store a CostEntry with tool="" — __post_init__
+            # rejects it. So we just probe the empty-input contract.
+            assert store.by_tool("") == ()
+
+    def test_by_kind_filters_correctly(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            store.record(_entry(kind=CostKind.LLM_INFERENCE))
+            store.record(_entry(kind=CostKind.EMBEDDING))
+            store.record(_entry(kind=CostKind.LLM_INFERENCE))
+            assert len(store.by_kind(CostKind.LLM_INFERENCE)) == 2
+            assert len(store.by_kind(CostKind.EMBEDDING)) == 1
+            assert store.by_kind(CostKind.STORAGE) == ()
+
+    def test_in_window_inclusive(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            early = _utc(2026, 5, 9, 10)
+            mid = _utc(2026, 5, 9, 11)
+            late = _utc(2026, 5, 9, 12)
+            for ts in (early, mid, late):
+                store.record(_entry(occurred_at=ts))
+            assert len(store.in_window(start=early, end=late)) == 3
+            assert len(store.in_window(start=mid, end=mid)) == 1
+
+    def test_in_window_swapped_window_raises(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            with pytest.raises(ValueError, match="start must be <= end"):
+                store.in_window(
+                    start=_utc(2026, 5, 9, 12),
+                    end=_utc(2026, 5, 9, 10),
+                )
+
+
+# ---------------------------------------------------------------------------
+# Aggregation — must agree with in-memory ledger
+# ---------------------------------------------------------------------------
+
+
+class TestSummarise:
+    def test_empty_summary_is_zero(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            summary = store.summarise()
+            assert summary.entry_count == 0
+            assert summary.total_cost_usd_micro == 0
+
+    def test_six_axis_histograms(self) -> None:
+        events = [
+            _entry(
+                kind=CostKind.LLM_INFERENCE,
+                tool="qwen3",
+                backend="ollama",
+                run_id="r1",
+                channel="cli",
+                domain="planner",
+                cost_usd_micro=1_000,
+            ),
+            _entry(
+                kind=CostKind.LLM_INFERENCE,
+                tool="qwen3",
+                backend="ollama",
+                run_id="r1",
+                channel="cli",
+                domain="planner",
+                cost_usd_micro=2_000,
+            ),
+            _entry(
+                kind=CostKind.EMBEDDING,
+                tool="oai-embed",
+                backend="openai",
+                run_id="r2",
+                channel="webui",
+                domain="memory",
+                cost_usd_micro=500,
+            ),
+        ]
+        with CostLedgerStore(":memory:") as store:
+            for e in events:
+                store.record(e)
+            s = store.summarise()
+            assert isinstance(s, CostSummary)
+            assert s.entry_count == 3
+            assert s.total_cost_usd_micro == 3_500
+            assert s.by_kind[CostKind.LLM_INFERENCE] == 3_000
+            assert s.by_kind[CostKind.EMBEDDING] == 500
+            assert s.by_tool == {"qwen3": 3_000, "oai-embed": 500}
+            assert s.by_backend == {"ollama": 3_000, "openai": 500}
+            assert s.by_channel == {"cli": 3_000, "webui": 500}
+            assert s.by_domain == {"planner": 3_000, "memory": 500}
+            assert s.by_run == {"r1": 3_000, "r2": 500}
+
+    def test_summary_matches_in_memory_for_same_entries(self) -> None:
+        """Double-bookkeeping check: the disk store's summary MUST
+        agree key-for-key with the in-memory ledger's summary over
+        the same entries — otherwise budget alerts diverge based on
+        which ledger the dashboard happens to query."""
+        events = [
+            _entry(
+                kind=CostKind.LLM_INFERENCE,
+                tool="qwen3",
+                backend="",  # falls into "_unknown"
+                cost_usd_micro=1_500,
+            ),
+            _entry(
+                kind=CostKind.TOOL_API,
+                tool="search",
+                cost_usd_micro=750,
+            ),
+        ]
+        memory_ledger = CostLedger()
+        with CostLedgerStore(":memory:") as store:
+            for e in events:
+                memory_ledger.record(e)
+                store.record(e)
+            mem = memory_ledger.summarise()
+            disk = store.summarise()
+            assert mem.total_cost_usd_micro == disk.total_cost_usd_micro
+            assert mem.by_kind == disk.by_kind
+            assert mem.by_tool == disk.by_tool
+            assert mem.by_backend == disk.by_backend
+            assert mem.by_channel == disk.by_channel
+            assert mem.by_domain == disk.by_domain
+            assert mem.by_run == disk.by_run
+
+    def test_summarise_with_explicit_subset(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            store.record(_entry(run_id="r1", cost_usd_micro=100))
+            store.record(_entry(run_id="r2", cost_usd_micro=900))
+            scoped = store.by_run("r1")
+            s = store.summarise(entries=scoped)
+            assert s.entry_count == 1
+            assert s.total_cost_usd_micro == 100
+
+
+# ---------------------------------------------------------------------------
+# Budget alerting
+# ---------------------------------------------------------------------------
+
+
+class TestBudgetStatus:
+    def test_under_when_well_below_limit(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            store.record(_entry(cost_usd_micro=1_000))
+            r = store.budget_status(limit_usd_micro=10_000)
+            assert r.status == BudgetStatus.UNDER
+            assert r.spent_usd_micro == 1_000
+            assert r.remaining_usd_micro == 9_000
+
+    def test_approaching_at_eighty_percent(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            store.record(_entry(cost_usd_micro=8_000))
+            r = store.budget_status(limit_usd_micro=10_000)
+            assert r.status == BudgetStatus.APPROACHING
+
+    def test_exceeded_above_limit(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            store.record(_entry(cost_usd_micro=15_000))
+            r = store.budget_status(limit_usd_micro=10_000)
+            assert r.status == BudgetStatus.EXCEEDED
+            assert r.remaining_usd_micro == -5_000
+
+    def test_zero_limit_with_spend_is_exceeded(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            store.record(_entry(cost_usd_micro=1))
+            r = store.budget_status(limit_usd_micro=0)
+            assert r.status == BudgetStatus.EXCEEDED
+
+
+# ---------------------------------------------------------------------------
+# Snapshot — JSON-safe + key parity
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshot:
+    def test_empty_snapshot(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            assert store.snapshot() == []
+
+    def test_round_trip_via_json(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            store.record(
+                _entry(
+                    kind=CostKind.NETWORK,
+                    tool="vercel-egress",
+                    cost_usd_micro=12_500,
+                    domain="hosting",
+                    notes="weekly egress sample",
+                )
+            )
+            rows = store.snapshot()
+            serialised = json.dumps(rows)
+            parsed = json.loads(serialised)
+            row = parsed[0]
+            assert row["kind"] == "network"
+            assert row["tool"] == "vercel-egress"
+            assert row["cost_usd_micro"] == 12_500
+            assert row["cost_usd"] == pytest.approx(0.0125)
+            assert row["domain"] == "hosting"
+            assert row["notes"] == "weekly egress sample"
+
+    def test_snapshot_keys_match_in_memory_ledger(self) -> None:
+        memory_ledger = CostLedger()
+        memory_ledger.record(_entry(run_id="r"))
+        memory_keys = set(memory_ledger.snapshot()[0].keys())
+
+        with CostLedgerStore(":memory:") as store:
+            store.record(_entry(run_id="r"))
+            disk_keys = set(store.snapshot()[0].keys())
+
+        assert memory_keys == disk_keys, (
+            f"snapshot keys diverge — memory_only={memory_keys - disk_keys}, "
+            f"disk_only={disk_keys - memory_keys}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# File persistence
+# ---------------------------------------------------------------------------
+
+
+class TestFilePersistence:
+    def test_writes_visible_after_reopen(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        with CostLedgerStore(db) as store:
+            store.record(_entry(run_id="r1", cost_usd_micro=100))
+            store.record(_entry(run_id="r2", cost_usd_micro=200))
+        with CostLedgerStore(db) as store:
+            assert len(store) == 2
+            assert store.summarise().total_cost_usd_micro == 300
+
+    def test_concurrent_writers_share_db(self, tmp_path) -> None:
+        db = tmp_path / "shared.sqlite"
+        with (
+            CostLedgerStore(db) as a,
+            CostLedgerStore(db) as b,
+        ):
+            a.record(_entry(run_id="run-a", cost_usd_micro=10))
+            b.record(_entry(run_id="run-b", cost_usd_micro=20))
+        with CostLedgerStore(db) as reader:
+            assert len(reader) == 2
+            assert reader.summarise().total_cost_usd_micro == 30
+
+
+# ---------------------------------------------------------------------------
+# Indices — query-shape sanity
+# ---------------------------------------------------------------------------
+
+
+class TestIndices:
+    def test_all_four_hot_indices_present(self) -> None:
+        """Pin the four hot read-path indices: tool, run_id, kind,
+        occurred_at."""
+        with CostLedgerStore(":memory:") as store:
+            cursor = store._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='cost_entries'"
+            )
+            names = {row[0] for row in cursor.fetchall()}
+            assert "idx_cost_entries_tool" in names
+            assert "idx_cost_entries_run_id" in names
+            assert "idx_cost_entries_kind" in names
+            assert "idx_cost_entries_occurred_at" in names
+
+
+# ---------------------------------------------------------------------------
+# Window edge case — explicit window over a few days
+# ---------------------------------------------------------------------------
+
+
+class TestWindowEdgeCases:
+    def test_window_excludes_outside(self) -> None:
+        with CostLedgerStore(":memory:") as store:
+            base = _utc(2026, 5, 9, 0, 0, 0)
+            for delta_h in (0, 6, 12, 18, 24, 30, 36):
+                store.record(_entry(occurred_at=base + timedelta(hours=delta_h)))
+            window = store.in_window(
+                start=base + timedelta(hours=6),
+                end=base + timedelta(hours=24),
+            )
+            # 6h, 12h, 18h, 24h → 4 entries
+            assert len(window) == 4


### PR DESCRIPTION
## Summary

- Fourth module in the TRUST disk-persistence sprint — same pattern as #515 / #516 / #517, now applied to the TRUST-6 cost ledger.
- Privacy contract preserved: backend ids, tool names, micro-USD amounts, token counts, channel + domain axes — no prompts, no responses, no model weights.
- 34 new tests, mypy --strict clean, ruff lint + format clean.

## Design parity with #515 / #516 / #517

| Property | This PR (cost) |
|---|---|
| Storage | Plain SQLite |
| Mutation | Append-only ``record()`` |
| Concurrency | WAL + check_same_thread=False |
| Schema versioning | ``_schema_meta`` + loud refusal on newer |
| Read API | full parity with CostLedger |
| Aggregation | delegates to in-memory aggregator (single source of truth for 6-axis histogram + budget thresholds) |
| Empty-input guards | ``by_run("")`` and ``by_tool("")`` short-circuit to ``()`` (mirrors in-memory contract) |
| ``-1`` semantics | unknown-token sentinel survives the SQLite-INTEGER round-trip exactly (test pins this) |
| snapshot keys | identical to in-memory ledger |
| Hot indices | tool, run_id, kind, occurred_at — pinned by TestIndices |

## Why ``-1`` round-trip matters

The in-memory contract uses ``prompt_tokens=-1`` / ``response_tokens=-1`` / ``unit_count=-1`` to mean "this cost isn't token-/unit-bearing" (e.g. monthly storage charges). SQLite ``DEFAULT`` clauses can silently coerce ``NULL → 0`` on a misconfigured schema; the explicit ``DEFAULT -1`` plus the ``test_unknown_token_counts_round_trip_as_minus_one`` test pin the boundary.

## Test plan

- [x] ``mypy --strict src/cognithor/security/cost_ledger_store.py`` — clean
- [x] ``ruff check`` + ``ruff format --check`` — clean
- [x] ``pytest tests/test_security/test_cost_ledger_store.py -q`` — 34 / 34 passed in 0.54 s
- [x] Six-axis histogram (kind / tool / backend / channel / domain / run) cross-checked against the in-memory ledger over the same entries
- [x] BudgetStatus UNDER / APPROACHING / EXCEEDED cases covered
- [x] Window edge case (24-hour slice over 7 entries spread across 36 hours) verified
- [x] Snapshot key set pinned against in-memory contract
- [ ] Wiring into existing PSE cost tracker + TRUST-8 escalation cost capture — separate follow-up PRs

## Follow-ups

After this lands, the disk-persistence rollout continues to:
- ``migration_ledger_store.py``
- ``permission_scope_store.py``

Then gateway boot wiring + Flutter UI consumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)