### PR TITLE
feat(trust): SQLite-backed PermissionScopeStore (TRUST disk persistence #6 — closes sprint)

### DIFF
--- a/src/cognithor/security/migration_ledger_store.py
+++ b/src/cognithor/security/migration_ledger_store.py
@@ -1,0 +1,378 @@
+"""SQLite-backed disk persistence for the TRUST-10 migration ledger.
+
+Companion to :mod:`cognithor.security.migration_ledger`. The
+in-memory ledger answers "what schema is this domain on right now"
+within a single process; this module turns the same query into one
+an operator can ask after a process restart — closing the
+reviewer-feedback gap "the migration trail is implicit".
+
+Design parity with :mod:`cognithor.security.backend_dispatch_store`
+(#515), :mod:`cognithor.security.cloud_escalation_store` (#516),
+:mod:`cognithor.security.fingerprint_store` (#517), and
+:mod:`cognithor.security.cost_ledger_store` (#518):
+
+* Plain SQLite, append-only, WAL journal mode +
+  ``check_same_thread=False``.
+* Schema-versioned via ``_schema_meta``; loud refusal on
+  newer-than-build databases.
+* Read-API parity with :class:`MigrationLedger`: ``__len__``,
+  ``steps``, ``for_domain``, ``head_version``, ``get``,
+  ``applied_only``, ``snapshot``.
+* Indices on ``domain``, ``status``, ``migration_id``,
+  ``applied_at`` — the four hot read paths. Pinned by a
+  ``TestIndices`` contract.
+
+What's different from the sibling stores
+----------------------------------------
+
+The migration ledger has a non-trivial **per-domain chain
+invariant**: ``record()`` rejects a step whose ``source_version``
+doesn't match the domain head (for APPLIED / ROLLED_BACK statuses),
+plus rollback-of and migration_id uniqueness.
+
+To avoid divergence, ``MigrationLedgerStore.record`` re-uses the
+in-memory ledger's validation by replaying the on-disk history
+through a fresh :class:`MigrationLedger` and letting it call its
+own ``record()``. If that raises :class:`MigrationChainError`, the
+on-disk write is rejected. If it accepts, we INSERT and commit.
+
+Cost: O(n) per record, where n is total steps for that ledger. For
+realistic migration ledgers (tens to low hundreds of steps over the
+project's lifetime) this is negligible. The alternative (re-implementing
+chain validation in SQL) would split the integrity contract into two
+copies that could drift apart silently — exactly the bug TRUST-10
+exists to prevent.
+
+Snapshot shape
+--------------
+
+The migration-ledger snapshot is a **dict** (not a list) containing
+``head_version`` + ``steps``. We mirror that contract exactly so
+Trace-UI consumers don't branch on source.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import sqlite3
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from cognithor.security.migration_ledger import (
+    MigrationDomain,
+    MigrationLedger,
+    MigrationStatus,
+    MigrationStep,
+)
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+log = get_logger(__name__)
+
+
+_SCHEMA_VERSION = 1
+
+
+_SCHEMA = f"""
+CREATE TABLE IF NOT EXISTS _schema_meta (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS migration_steps (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    domain TEXT NOT NULL,
+    source_version TEXT NOT NULL,
+    target_version TEXT NOT NULL,
+    status TEXT NOT NULL,
+    applied_at TEXT NOT NULL,
+    applied_by TEXT NOT NULL DEFAULT '',
+    item_count INTEGER NOT NULL DEFAULT -1,
+    checksum_before TEXT NOT NULL DEFAULT '',
+    checksum_after TEXT NOT NULL DEFAULT '',
+    rollback_of TEXT NOT NULL DEFAULT '',
+    migration_id TEXT NOT NULL DEFAULT '',
+    notes TEXT NOT NULL DEFAULT ''
+);
+
+-- Indices match the four hot read paths on the in-memory ledger:
+-- for_domain, applied_only (filters by status), get (by migration_id),
+-- and snapshot ordering (by applied_at). Pinning them prevents a
+-- future migration from silently dropping one — Trace-UI panels
+-- would table-scan on every render.
+CREATE INDEX IF NOT EXISTS idx_migration_steps_domain
+    ON migration_steps(domain);
+CREATE INDEX IF NOT EXISTS idx_migration_steps_status
+    ON migration_steps(status);
+CREATE INDEX IF NOT EXISTS idx_migration_steps_migration_id
+    ON migration_steps(migration_id);
+CREATE INDEX IF NOT EXISTS idx_migration_steps_applied_at
+    ON migration_steps(applied_at);
+
+INSERT OR IGNORE INTO _schema_meta (version, applied_at)
+    VALUES ({_SCHEMA_VERSION}, '{datetime.now(UTC).isoformat()}');
+"""
+
+
+class MigrationLedgerStoreError(Exception):
+    """Raised when the SQLite layer is in an unrecoverable state.
+
+    Mirrors the sibling stores. Examples include a schema version
+    this build doesn't know how to read, or a corrupt file whose
+    connection won't open cleanly.
+    """
+
+
+class MigrationLedgerStore:
+    """SQLite-backed append-only persistence for ``MigrationStep``.
+
+    Tests use ``:memory:`` databases for speed; production wires the
+    canonical instance to ``~/.cognithor/audit/migrations.sqlite``.
+
+    Lifecycle mirrors the sibling stores. Re-opening an existing file
+    is a no-op (idempotent schema script).
+    """
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = str(db_path)
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+        self._verify_schema_version()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> MigrationLedgerStore:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the SQLite connection. Safe to call multiple times."""
+        with contextlib.suppress(sqlite3.ProgrammingError):
+            self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Schema-version handshake
+    # ------------------------------------------------------------------
+
+    def _verify_schema_version(self) -> None:
+        cursor = self._conn.execute("SELECT MAX(version) FROM _schema_meta")
+        row = cursor.fetchone()
+        actual_version = row[0] if row else None
+        if actual_version is None:
+            return  # fresh DB
+        if actual_version > _SCHEMA_VERSION:
+            msg = (
+                f"MigrationLedgerStore at {self._db_path!r} reports schema "
+                f"version {actual_version} but this build only knows "
+                f"version {_SCHEMA_VERSION}. Refusing to open to avoid "
+                "data corruption — upgrade cognithor or point at a "
+                "different file."
+            )
+            raise MigrationLedgerStoreError(msg)
+
+    @property
+    def schema_version(self) -> int:
+        cursor = self._conn.execute("SELECT MAX(version) FROM _schema_meta")
+        row = cursor.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def record(self, step: MigrationStep) -> int:
+        """Append ``step`` and return its assigned row id.
+
+        Validation re-uses :class:`MigrationLedger`'s own ``record()``
+        — we replay the on-disk history into a fresh in-memory
+        ledger and let it call ``record(step)``. If the in-memory
+        ledger raises :class:`MigrationChainError` (chain mismatch,
+        unknown rollback target, duplicate migration_id, etc.), the
+        SQLite write is rejected and the exception propagates.
+
+        This deliberately keeps the chain-integrity contract in
+        exactly one place — divergence between the in-memory and
+        on-disk ledgers is the kind of bug TRUST-10 is supposed to
+        catch, so we don't risk it by re-implementing the rules in
+        SQL.
+        """
+        helper = self._rebuild_in_memory()
+        helper.record(step)  # raises on chain violations
+
+        cursor = self._conn.execute(
+            """
+            INSERT INTO migration_steps (
+                domain, source_version, target_version, status,
+                applied_at, applied_by, item_count,
+                checksum_before, checksum_after,
+                rollback_of, migration_id, notes
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                step.domain.value,
+                step.source_version,
+                step.target_version,
+                step.status.value,
+                step.applied_at.isoformat(),
+                step.applied_by,
+                step.item_count,
+                step.checksum_before,
+                step.checksum_after,
+                step.rollback_of,
+                step.migration_id,
+                step.notes,
+            ),
+        )
+        self._conn.commit()
+        row_id = cursor.lastrowid
+        if row_id is None:  # pragma: no cover — defensive
+            msg = "sqlite returned no lastrowid after migration_steps INSERT"
+            raise MigrationLedgerStoreError(msg)
+        return row_id
+
+    def clear(self) -> None:
+        """Drop all steps. Test helper; production never calls this."""
+        self._conn.execute("DELETE FROM migration_steps")
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Read API (mirror of MigrationLedger)
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        cursor = self._conn.execute("SELECT COUNT(*) FROM migration_steps")
+        row = cursor.fetchone()
+        return int(row[0]) if row else 0
+
+    def steps(self) -> tuple[MigrationStep, ...]:
+        """All steps in insertion order."""
+        cursor = self._conn.execute("SELECT * FROM migration_steps ORDER BY id ASC")
+        return tuple(_row_to_step(row, cursor) for row in cursor.fetchall())
+
+    def for_domain(self, domain: MigrationDomain) -> tuple[MigrationStep, ...]:
+        """Steps for a single domain in insertion order."""
+        cursor = self._conn.execute(
+            "SELECT * FROM migration_steps WHERE domain = ? ORDER BY id ASC",
+            (domain.value,),
+        )
+        return tuple(_row_to_step(row, cursor) for row in cursor.fetchall())
+
+    def head_version(self, domain: MigrationDomain) -> str | None:
+        """Current head version for ``domain``.
+
+        Computed from the in-memory replay so the answer matches
+        :meth:`MigrationLedger.head_version` exactly — including the
+        edge case where a ROLLED_BACK step moves the head backward
+        to a previous APPLIED target.
+        """
+        return self._rebuild_in_memory().head_version(domain)
+
+    def get(self, migration_id: str) -> MigrationStep | None:
+        """Return the step with ``migration_id`` or ``None``."""
+        if not migration_id:
+            return None
+        cursor = self._conn.execute(
+            "SELECT * FROM migration_steps WHERE migration_id = ? LIMIT 1",
+            (migration_id,),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return _row_to_step(row, cursor)
+
+    def applied_only(self, domain: MigrationDomain) -> tuple[MigrationStep, ...]:
+        """APPLIED + ROLLED_BACK steps for ``domain`` (head-moving subset)."""
+        cursor = self._conn.execute(
+            "SELECT * FROM migration_steps WHERE domain = ? AND status IN (?, ?) ORDER BY id ASC",
+            (
+                domain.value,
+                MigrationStatus.APPLIED.value,
+                MigrationStatus.ROLLED_BACK.value,
+            ),
+        )
+        return tuple(_row_to_step(row, cursor) for row in cursor.fetchall())
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def snapshot(self) -> dict[str, object]:
+        """JSON-serialisable representation, identical shape to the
+        in-memory :meth:`MigrationLedger.snapshot`. Trace-UI
+        consumers don't branch on source.
+
+        Shape::
+
+            {
+              "head_version": {"<domain>": "<version>", ...},
+              "steps": [<step-dict>, ...]
+            }
+        """
+        helper = self._rebuild_in_memory()
+        return helper.snapshot()
+
+    # ------------------------------------------------------------------
+    # Internal — rebuild an in-memory ledger from disk
+    # ------------------------------------------------------------------
+
+    def _rebuild_in_memory(self) -> MigrationLedger:
+        """Re-play the on-disk history into a fresh in-memory ledger.
+
+        Used by ``record`` (chain validation), ``head_version``, and
+        ``snapshot``. Bypasses the in-memory ledger's chain checks
+        for the replay itself — the on-disk history is already valid
+        because every step was validated when it was first written.
+        """
+        ledger = MigrationLedger()
+        for s in self.steps():
+            # Replay raw — the chain validation already happened on
+            # the way in. We want the resulting state, not another
+            # round of validation against a half-built head map.
+            ledger._steps.append(s)
+            if s.migration_id:
+                ledger._by_id[s.migration_id] = s
+            if s.status in {MigrationStatus.APPLIED, MigrationStatus.ROLLED_BACK}:
+                ledger._head_version[s.domain] = s.target_version
+        return ledger
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_step(row: tuple[object, ...], cursor: sqlite3.Cursor) -> MigrationStep:
+    """Parse one ``migration_steps`` row back into a frozen
+    :class:`MigrationStep`. Tolerates future column additions
+    (always at the end of the table) by indexing via column name."""
+    column_names = [d[0] for d in cursor.description]
+    data = dict(zip(column_names, row, strict=False))
+    return MigrationStep(
+        domain=MigrationDomain(str(data["domain"])),
+        source_version=str(data["source_version"]),
+        target_version=str(data["target_version"]),
+        status=MigrationStatus(str(data["status"])),
+        applied_at=datetime.fromisoformat(str(data["applied_at"])),
+        applied_by=str(data["applied_by"]),
+        item_count=int(data["item_count"]),
+        checksum_before=str(data["checksum_before"]),
+        checksum_after=str(data["checksum_after"]),
+        rollback_of=str(data["rollback_of"]),
+        migration_id=str(data["migration_id"]),
+        notes=str(data["notes"]),
+    )
+
+
+__all__ = [
+    "MigrationLedgerStore",
+    "MigrationLedgerStoreError",
+]

--- a/src/cognithor/security/permission_scope_store.py
+++ b/src/cognithor/security/permission_scope_store.py
@@ -1,0 +1,322 @@
+"""SQLite-backed disk persistence for the TRUST-5 scope registry.
+
+Companion to :mod:`cognithor.security.permission_scope`. Closes the
+remaining gap of the disk-persistence sprint: the gatekeeper's
+per-(axis, identity) scope rules survive a process restart and don't
+vanish into a re-loaded YAML config blob whose lineage is opaque.
+
+Design parity with :mod:`cognithor.security.backend_dispatch_store`
+(#515), :mod:`cognithor.security.cloud_escalation_store` (#516),
+:mod:`cognithor.security.fingerprint_store` (#517),
+:mod:`cognithor.security.cost_ledger_store` (#518), and
+:mod:`cognithor.security.migration_ledger_store` (#519):
+
+* Plain SQLite, WAL journal mode + ``check_same_thread=False``.
+* Schema-versioned via ``_schema_meta``; loud refusal on
+  newer-than-build databases.
+* Read-API parity with :class:`ScopeRegistry`: ``__len__``,
+  ``get``, ``list_scopes``, ``register``, ``remove``, ``clear``,
+  ``evaluate``, ``assert_allowed``.
+* Indices on ``axis`` for the hot ``list_scopes`` filter — the
+  primary read path is by ``(axis, identity)`` which the table's
+  composite primary key already covers.
+
+What's different from the sibling stores
+----------------------------------------
+
+The scope registry is a **registry**, not an append-only ledger:
+``register(scope)`` upserts on ``(axis, identity)``, replacing any
+prior scope for that key. The disk store mirrors this with
+``INSERT … ON CONFLICT(axis, identity) DO UPDATE`` so the contract
+"calling register twice on the same key keeps only the latest" is
+preserved across reopens.
+
+Single source of truth for evaluation
+-------------------------------------
+
+``evaluate`` and ``assert_allowed`` rebuild an in-memory
+:class:`ScopeRegistry` from the on-disk rows and delegate to its
+own evaluator, so the most-restrictive-wins precedence logic stays
+in exactly one place — divergence between in-memory and disk
+verdicts is the kind of bug TRUST-5 exists to prevent.
+
+Privacy contract
+----------------
+
+All columns are policy metadata. No prompts, no responses, no user
+content — only axis names, identity strings (e.g. ``"telegram"``,
+``"alex@cognithor.ai"``), tool names, and risk-level enums. Same
+auditor-friendly shape as the sibling stores.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import sqlite3
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from cognithor.models import RiskLevel
+from cognithor.security.permission_scope import (
+    PermissionScope,
+    ScopeAxis,
+    ScopeRegistry,
+    ScopeVerdict,
+    ScopeViolation,
+)
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+log = get_logger(__name__)
+
+
+_SCHEMA_VERSION = 1
+
+
+_SCHEMA = f"""
+CREATE TABLE IF NOT EXISTS _schema_meta (
+    version INTEGER PRIMARY KEY,
+    applied_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS scope_entries (
+    axis TEXT NOT NULL,
+    identity TEXT NOT NULL,
+    tool_allowlist TEXT NOT NULL DEFAULT '[]',
+    tool_denylist TEXT NOT NULL DEFAULT '[]',
+    max_risk TEXT NOT NULL DEFAULT 'red',
+    PRIMARY KEY (axis, identity)
+);
+
+-- Hot read path: list_scopes() filters / sorts by axis. The (axis,
+-- identity) PK already covers point lookups in the primary read
+-- direction. Pinning this index prevents a future migration from
+-- silently dropping it.
+CREATE INDEX IF NOT EXISTS idx_scope_entries_axis
+    ON scope_entries(axis);
+
+INSERT OR IGNORE INTO _schema_meta (version, applied_at)
+    VALUES ({_SCHEMA_VERSION}, '{datetime.now(UTC).isoformat()}');
+"""
+
+
+class PermissionScopeStoreError(Exception):
+    """Raised when the SQLite layer is in an unrecoverable state.
+
+    Mirrors the sibling stores. Examples include a schema version
+    this build doesn't know how to read, or a corrupt file whose
+    connection won't open cleanly.
+    """
+
+
+class PermissionScopeStore:
+    """SQLite-backed persistence for ``PermissionScope`` rules.
+
+    Tests use ``:memory:`` databases for speed; production wires the
+    canonical instance to ``~/.cognithor/audit/scope_registry.sqlite``.
+
+    Lifecycle mirrors the sibling stores. Re-opening an existing
+    file is a no-op (idempotent schema script).
+    """
+
+    def __init__(self, db_path: str | Path) -> None:
+        self._db_path = str(db_path)
+        self._conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode = WAL")
+        self._conn.execute("PRAGMA foreign_keys = ON")
+        self._conn.executescript(_SCHEMA)
+        self._conn.commit()
+        self._verify_schema_version()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def __enter__(self) -> PermissionScopeStore:
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        self.close()
+
+    def close(self) -> None:
+        """Close the SQLite connection. Safe to call multiple times."""
+        with contextlib.suppress(sqlite3.ProgrammingError):
+            self._conn.close()
+
+    # ------------------------------------------------------------------
+    # Schema-version handshake
+    # ------------------------------------------------------------------
+
+    def _verify_schema_version(self) -> None:
+        cursor = self._conn.execute("SELECT MAX(version) FROM _schema_meta")
+        row = cursor.fetchone()
+        actual_version = row[0] if row else None
+        if actual_version is None:
+            return  # fresh DB
+        if actual_version > _SCHEMA_VERSION:
+            msg = (
+                f"PermissionScopeStore at {self._db_path!r} reports schema "
+                f"version {actual_version} but this build only knows "
+                f"version {_SCHEMA_VERSION}. Refusing to open to avoid "
+                "data corruption — upgrade cognithor or point at a "
+                "different file."
+            )
+            raise PermissionScopeStoreError(msg)
+
+    @property
+    def schema_version(self) -> int:
+        cursor = self._conn.execute("SELECT MAX(version) FROM _schema_meta")
+        row = cursor.fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
+
+    # ------------------------------------------------------------------
+    # Mutation
+    # ------------------------------------------------------------------
+
+    def register(self, scope: PermissionScope) -> None:
+        """Upsert ``scope``. Existing key is overwritten silently —
+        scopes are config-driven and re-config should not raise.
+
+        Mirrors :meth:`ScopeRegistry.register` exactly.
+        """
+        self._conn.execute(
+            """
+            INSERT INTO scope_entries (
+                axis, identity, tool_allowlist, tool_denylist, max_risk
+            ) VALUES (?, ?, ?, ?, ?)
+            ON CONFLICT(axis, identity) DO UPDATE SET
+                tool_allowlist = excluded.tool_allowlist,
+                tool_denylist = excluded.tool_denylist,
+                max_risk = excluded.max_risk
+            """,
+            (
+                scope.axis.value,
+                scope.identity,
+                json.dumps(sorted(scope.tool_allowlist)),
+                json.dumps(sorted(scope.tool_denylist)),
+                scope.max_risk.value,
+            ),
+        )
+        self._conn.commit()
+
+    def remove(self, axis: ScopeAxis, identity: str) -> bool:
+        """Remove a scope by key. Returns True if a scope was deleted."""
+        cursor = self._conn.execute(
+            "DELETE FROM scope_entries WHERE axis = ? AND identity = ?",
+            (axis.value, identity),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def clear(self) -> None:
+        """Drop all scopes."""
+        self._conn.execute("DELETE FROM scope_entries")
+        self._conn.commit()
+
+    # ------------------------------------------------------------------
+    # Read API (mirror of ScopeRegistry)
+    # ------------------------------------------------------------------
+
+    def __len__(self) -> int:
+        cursor = self._conn.execute("SELECT COUNT(*) FROM scope_entries")
+        row = cursor.fetchone()
+        return int(row[0]) if row else 0
+
+    def get(self, axis: ScopeAxis, identity: str) -> PermissionScope | None:
+        cursor = self._conn.execute(
+            "SELECT * FROM scope_entries WHERE axis = ? AND identity = ? LIMIT 1",
+            (axis.value, identity),
+        )
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return _row_to_scope(row, cursor)
+
+    def list_scopes(self) -> list[PermissionScope]:
+        """Return all scopes sorted by (axis, identity) for stable display."""
+        cursor = self._conn.execute("SELECT * FROM scope_entries ORDER BY axis ASC, identity ASC")
+        return [_row_to_scope(row, cursor) for row in cursor.fetchall()]
+
+    # ------------------------------------------------------------------
+    # Evaluation — delegates to the in-memory registry
+    # ------------------------------------------------------------------
+
+    def evaluate(
+        self,
+        scope_keys: list[tuple[ScopeAxis, str]],
+        tool_name: str,
+        tool_risk: RiskLevel,
+    ) -> ScopeVerdict:
+        """Return the most-restrictive verdict for the given tool call.
+
+        Delegates to :meth:`ScopeRegistry.evaluate` over a fresh
+        in-memory registry built from the on-disk rows. The
+        precedence rules (deny > max_risk > allowlist) live in
+        exactly one place — the in-memory registry — and the disk
+        layer doesn't risk silent drift by re-implementing them.
+        """
+        return self._rebuild_in_memory().evaluate(scope_keys, tool_name, tool_risk)
+
+    def assert_allowed(
+        self,
+        scope_keys: list[tuple[ScopeAxis, str]],
+        tool_name: str,
+        tool_risk: RiskLevel,
+    ) -> None:
+        """Raise :class:`ScopeViolation` when the call is denied.
+
+        Mirrors :meth:`ScopeRegistry.assert_allowed` exactly via the
+        same delegation pattern.
+        """
+        self._rebuild_in_memory().assert_allowed(scope_keys, tool_name, tool_risk)
+
+    # ------------------------------------------------------------------
+    # Internal — rebuild an in-memory registry from disk
+    # ------------------------------------------------------------------
+
+    def _rebuild_in_memory(self) -> ScopeRegistry:
+        """Re-build a fresh in-memory ScopeRegistry from the on-disk rows.
+
+        Used by ``evaluate`` and ``assert_allowed``. Cost is O(n)
+        per call; for realistic scope sets (tens of rules) this is
+        negligible. Trade-off: keeps evaluation logic in exactly one
+        place.
+        """
+        registry = ScopeRegistry()
+        for scope in self.list_scopes():
+            registry.register(scope)
+        return registry
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _row_to_scope(row: tuple[object, ...], cursor: sqlite3.Cursor) -> PermissionScope:
+    """Parse one ``scope_entries`` row back into a frozen
+    :class:`PermissionScope`."""
+    column_names = [d[0] for d in cursor.description]
+    data = dict(zip(column_names, row, strict=False))
+    raw_allow = json.loads(str(data["tool_allowlist"]))
+    raw_deny = json.loads(str(data["tool_denylist"]))
+    if not isinstance(raw_allow, list) or not isinstance(raw_deny, list):
+        msg = "scope_entries row has malformed tool_allowlist/denylist"
+        raise PermissionScopeStoreError(msg)
+    return PermissionScope(
+        axis=ScopeAxis(str(data["axis"])),
+        identity=str(data["identity"]),
+        tool_allowlist=frozenset(str(t) for t in raw_allow),
+        tool_denylist=frozenset(str(t) for t in raw_deny),
+        max_risk=RiskLevel(str(data["max_risk"])),
+    )
+
+
+__all__ = [
+    "PermissionScopeStore",
+    "PermissionScopeStoreError",
+    "ScopeViolation",  # re-export for caller convenience
+]

--- a/tests/test_security/test_migration_ledger_store.py
+++ b/tests/test_security/test_migration_ledger_store.py
@@ -1,0 +1,446 @@
+"""Tests for the SQLite-backed MigrationLedgerStore (TRUST-10 disk persistence)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+
+import pytest
+
+from cognithor.security.migration_ledger import (
+    MigrationChainError,
+    MigrationDomain,
+    MigrationLedger,
+    MigrationStatus,
+    MigrationStep,
+)
+from cognithor.security.migration_ledger_store import (
+    MigrationLedgerStore,
+    MigrationLedgerStoreError,
+)
+
+
+def _hash(seed: str) -> str:
+    import hashlib
+
+    return hashlib.sha256(seed.encode()).hexdigest()
+
+
+def _step(
+    *,
+    domain: MigrationDomain = MigrationDomain.MEMORY_SEMANTIC,
+    source_version: str = "v0",
+    target_version: str = "v1",
+    status: MigrationStatus = MigrationStatus.APPLIED,
+    applied_at: datetime | None = None,
+    applied_by: str = "system",
+    item_count: int = -1,
+    checksum_before: str = "",
+    checksum_after: str = "",
+    rollback_of: str = "",
+    migration_id: str = "",
+    notes: str = "",
+) -> MigrationStep:
+    return MigrationStep(
+        domain=domain,
+        source_version=source_version,
+        target_version=target_version,
+        status=status,
+        applied_at=applied_at or datetime(2026, 5, 9, 12, 0, 0, tzinfo=UTC),
+        applied_by=applied_by,
+        item_count=item_count,
+        checksum_before=checksum_before,
+        checksum_after=checksum_after,
+        rollback_of=rollback_of,
+        migration_id=migration_id,
+        notes=notes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle + schema
+# ---------------------------------------------------------------------------
+
+
+class TestStoreLifecycle:
+    def test_creates_schema_in_memory(self) -> None:
+        with MigrationLedgerStore(":memory:") as store:
+            assert store.schema_version == 1
+            assert len(store) == 0
+
+    def test_context_manager_persists_to_disk(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        with MigrationLedgerStore(db) as store:
+            store.record(_step(migration_id="m1"))
+
+        with MigrationLedgerStore(db) as store:
+            assert len(store) == 1
+            assert store.head_version(MigrationDomain.MEMORY_SEMANTIC) == "v1"
+
+    def test_close_idempotent(self) -> None:
+        store = MigrationLedgerStore(":memory:")
+        store.close()
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Schema-version guard
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaVersionGuard:
+    def test_rejects_newer_schema(self, tmp_path) -> None:
+        db = tmp_path / "future.sqlite"
+        MigrationLedgerStore(db).close()
+        conn = sqlite3.connect(db)
+        try:
+            conn.execute(
+                "INSERT INTO _schema_meta (version, applied_at) VALUES (?, ?)",
+                (999, datetime.now(UTC).isoformat()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        with pytest.raises(MigrationLedgerStoreError, match="version 999"):
+            MigrationLedgerStore(db)
+
+    def test_accepts_equal_version(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        MigrationLedgerStore(db).close()
+        MigrationLedgerStore(db).close()
+
+
+# ---------------------------------------------------------------------------
+# Record + chain integrity
+# ---------------------------------------------------------------------------
+
+
+class TestChainIntegrity:
+    def test_first_step_with_no_head_succeeds(self) -> None:
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(_step())
+            assert store.head_version(MigrationDomain.MEMORY_SEMANTIC) == "v1"
+
+    def test_continued_chain_succeeds(self) -> None:
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(_step(source_version="v0", target_version="v1"))
+            store.record(_step(source_version="v1", target_version="v2"))
+            store.record(_step(source_version="v2", target_version="v3"))
+            assert store.head_version(MigrationDomain.MEMORY_SEMANTIC) == "v3"
+
+    def test_chain_mismatch_rejected(self) -> None:
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(_step(source_version="v0", target_version="v1"))
+            with pytest.raises(MigrationChainError, match="chain mismatch"):
+                store.record(_step(source_version="v5", target_version="v6"))
+
+    def test_chain_mismatch_does_not_partially_persist(self) -> None:
+        """If validation rejects a step, the row MUST NOT land on
+        disk — otherwise re-playing the history would corrupt the
+        chain on next open."""
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(_step(source_version="v0", target_version="v1"))
+            with pytest.raises(MigrationChainError):
+                store.record(_step(source_version="v5", target_version="v6"))
+            assert len(store) == 1
+            assert store.head_version(MigrationDomain.MEMORY_SEMANTIC) == "v1"
+
+    def test_pending_and_failed_skip_head_check(self) -> None:
+        """PENDING and FAILED don't move the head and don't require
+        ``source_version == head``. Mirrors the in-memory contract."""
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(_step(source_version="v0", target_version="v1"))
+            # PENDING must be allowed without head match
+            store.record(
+                _step(
+                    source_version="v99",
+                    target_version="v100",
+                    status=MigrationStatus.PENDING,
+                )
+            )
+            # FAILED also allowed
+            store.record(
+                _step(
+                    source_version="v99",
+                    target_version="v99",
+                    status=MigrationStatus.FAILED,
+                )
+            )
+            # Head still on v1
+            assert store.head_version(MigrationDomain.MEMORY_SEMANTIC) == "v1"
+
+    def test_rollback_of_unknown_id_rejected(self) -> None:
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(_step(source_version="v0", target_version="v1"))
+            with pytest.raises(MigrationChainError, match="unknown migration_id"):
+                store.record(
+                    _step(
+                        source_version="v1",
+                        target_version="v0",
+                        status=MigrationStatus.ROLLED_BACK,
+                        rollback_of="nope",
+                    )
+                )
+
+    def test_rollback_succeeds_then_head_moves_back(self) -> None:
+        """Happy-path rollback: head moves back to the rollback's
+        target_version."""
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(
+                _step(
+                    source_version="v0",
+                    target_version="v1",
+                    migration_id="m1",
+                )
+            )
+            store.record(
+                _step(
+                    source_version="v1",
+                    target_version="v0",
+                    status=MigrationStatus.ROLLED_BACK,
+                    rollback_of="m1",
+                )
+            )
+            assert store.head_version(MigrationDomain.MEMORY_SEMANTIC) == "v0"
+
+    def test_duplicate_migration_id_rejected(self) -> None:
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(
+                _step(
+                    source_version="v0",
+                    target_version="v1",
+                    migration_id="dup",
+                )
+            )
+            with pytest.raises(MigrationChainError, match="duplicate migration_id"):
+                store.record(
+                    _step(
+                        source_version="v1",
+                        target_version="v2",
+                        migration_id="dup",
+                    )
+                )
+
+
+# ---------------------------------------------------------------------------
+# Cross-process chain integrity
+# ---------------------------------------------------------------------------
+
+
+class TestCrossProcessChain:
+    def test_chain_mismatch_after_reopen_rejected(self, tmp_path) -> None:
+        """Re-open + new write must still respect the chain. Pins
+        the disk-layer's most load-bearing invariant: history persists."""
+        db = tmp_path / "x.sqlite"
+        with MigrationLedgerStore(db) as store:
+            store.record(_step(source_version="v0", target_version="v1"))
+
+        # New process, same db
+        with MigrationLedgerStore(db) as store:
+            assert store.head_version(MigrationDomain.MEMORY_SEMANTIC) == "v1"
+            with pytest.raises(MigrationChainError, match="chain mismatch"):
+                store.record(_step(source_version="v9", target_version="v10"))
+            # Still exactly one step on disk
+            assert len(store) == 1
+
+    def test_continued_chain_across_processes(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        with MigrationLedgerStore(db) as a:
+            a.record(_step(source_version="v0", target_version="v1"))
+        with MigrationLedgerStore(db) as b:
+            b.record(_step(source_version="v1", target_version="v2"))
+        with MigrationLedgerStore(db) as reader:
+            assert reader.head_version(MigrationDomain.MEMORY_SEMANTIC) == "v2"
+            assert len(reader) == 2
+
+
+# ---------------------------------------------------------------------------
+# Read API parity
+# ---------------------------------------------------------------------------
+
+
+class TestReadParity:
+    def test_steps_in_insertion_order(self) -> None:
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(_step(source_version="v0", target_version="v1"))
+            store.record(_step(source_version="v1", target_version="v2"))
+            store.record(_step(source_version="v2", target_version="v3"))
+            tgts = [s.target_version for s in store.steps()]
+            assert tgts == ["v1", "v2", "v3"]
+
+    def test_for_domain_filters_correctly(self) -> None:
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(
+                _step(
+                    domain=MigrationDomain.MEMORY_SEMANTIC,
+                    source_version="v0",
+                    target_version="v1",
+                )
+            )
+            store.record(
+                _step(
+                    domain=MigrationDomain.AUDIT_LOG,
+                    source_version="a0",
+                    target_version="a1",
+                )
+            )
+            store.record(
+                _step(
+                    domain=MigrationDomain.MEMORY_SEMANTIC,
+                    source_version="v1",
+                    target_version="v2",
+                )
+            )
+            sem = store.for_domain(MigrationDomain.MEMORY_SEMANTIC)
+            assert len(sem) == 2
+            audit = store.for_domain(MigrationDomain.AUDIT_LOG)
+            assert len(audit) == 1
+
+    def test_head_version_independent_per_domain(self) -> None:
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(
+                _step(
+                    domain=MigrationDomain.MEMORY_SEMANTIC,
+                    source_version="v0",
+                    target_version="v1",
+                )
+            )
+            store.record(
+                _step(
+                    domain=MigrationDomain.AUDIT_LOG,
+                    source_version="a0",
+                    target_version="a1",
+                )
+            )
+            assert store.head_version(MigrationDomain.MEMORY_SEMANTIC) == "v1"
+            assert store.head_version(MigrationDomain.AUDIT_LOG) == "a1"
+            assert store.head_version(MigrationDomain.MEMORY_VAULT) is None
+
+    def test_get_by_migration_id(self) -> None:
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(_step(source_version="v0", target_version="v1", migration_id="m1"))
+            assert store.get("m1") is not None
+            assert store.get("nope") is None
+            assert store.get("") is None
+
+    def test_applied_only_excludes_pending_and_failed(self) -> None:
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(
+                _step(
+                    source_version="v0",
+                    target_version="v1",
+                    status=MigrationStatus.APPLIED,
+                )
+            )
+            store.record(
+                _step(
+                    source_version="v99",
+                    target_version="v100",
+                    status=MigrationStatus.PENDING,
+                )
+            )
+            store.record(
+                _step(
+                    source_version="v99",
+                    target_version="v99",
+                    status=MigrationStatus.FAILED,
+                )
+            )
+            applied = store.applied_only(MigrationDomain.MEMORY_SEMANTIC)
+            assert len(applied) == 1
+
+
+# ---------------------------------------------------------------------------
+# Snapshot — dict shape mirrored from in-memory ledger
+# ---------------------------------------------------------------------------
+
+
+class TestSnapshot:
+    def test_empty_snapshot_shape(self) -> None:
+        with MigrationLedgerStore(":memory:") as store:
+            snap = store.snapshot()
+            assert snap == {"head_version": {}, "steps": []}
+
+    def test_round_trip_via_json(self) -> None:
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(
+                _step(
+                    source_version="v0",
+                    target_version="v1",
+                    migration_id="m1",
+                    item_count=1234,
+                    checksum_before=_hash("before"),
+                    checksum_after=_hash("after"),
+                    notes="memory schema bump",
+                )
+            )
+            snap = store.snapshot()
+            serialised = json.dumps(snap)
+            parsed = json.loads(serialised)
+            assert isinstance(parsed, dict)
+            assert parsed["head_version"]["memory_semantic"] == "v1"
+            assert len(parsed["steps"]) == 1
+            step = parsed["steps"][0]
+            assert step["migration_id"] == "m1"
+            assert step["item_count"] == 1234
+            assert step["checksum_before"] == _hash("before")
+
+    def test_snapshot_matches_in_memory_ledger_for_same_history(self) -> None:
+        """Trace-UI consumers must NOT branch on whether the source
+        is in-memory or on-disk. Pin the snapshot shape exactly."""
+        history = [
+            _step(source_version="v0", target_version="v1", migration_id="m1"),
+            _step(source_version="v1", target_version="v2", migration_id="m2"),
+        ]
+        memory_ledger = MigrationLedger()
+        for s in history:
+            memory_ledger.record(s)
+
+        with MigrationLedgerStore(":memory:") as store:
+            for s in history:
+                store.record(s)
+            assert store.snapshot() == memory_ledger.snapshot()
+
+
+# ---------------------------------------------------------------------------
+# Indices
+# ---------------------------------------------------------------------------
+
+
+class TestIndices:
+    def test_all_four_hot_indices_present(self) -> None:
+        with MigrationLedgerStore(":memory:") as store:
+            cursor = store._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='migration_steps'"
+            )
+            names = {row[0] for row in cursor.fetchall()}
+            assert "idx_migration_steps_domain" in names
+            assert "idx_migration_steps_status" in names
+            assert "idx_migration_steps_migration_id" in names
+            assert "idx_migration_steps_applied_at" in names
+
+
+# ---------------------------------------------------------------------------
+# Field round-trip — pin the rare/optional axes
+# ---------------------------------------------------------------------------
+
+
+class TestFieldRoundTrip:
+    def test_full_round_trip(self) -> None:
+        original = _step(
+            source_version="v0",
+            target_version="v1",
+            applied_at=datetime(2026, 5, 9, 14, 30, 15, tzinfo=UTC),
+            applied_by="alex@cognithor.ai",
+            item_count=42,
+            checksum_before=_hash("before"),
+            checksum_after=_hash("after"),
+            migration_id="m1",
+            notes="manual backfill",
+        )
+        with MigrationLedgerStore(":memory:") as store:
+            store.record(original)
+            recovered = store.steps()[0]
+            assert recovered == original

--- a/tests/test_security/test_permission_scope_store.py
+++ b/tests/test_security/test_permission_scope_store.py
@@ -1,0 +1,392 @@
+"""Tests for the SQLite-backed PermissionScopeStore (TRUST-5 disk persistence)."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime
+
+import pytest
+
+from cognithor.models import RiskLevel
+from cognithor.security.permission_scope import (
+    PermissionScope,
+    ScopeAxis,
+    ScopeRegistry,
+    ScopeViolation,
+)
+from cognithor.security.permission_scope_store import (
+    PermissionScopeStore,
+    PermissionScopeStoreError,
+)
+
+
+def _scope(
+    *,
+    axis: ScopeAxis = ScopeAxis.CHANNEL,
+    identity: str = "telegram",
+    allow: tuple[str, ...] = (),
+    deny: tuple[str, ...] = (),
+    max_risk: RiskLevel = RiskLevel.RED,
+) -> PermissionScope:
+    return PermissionScope(
+        axis=axis,
+        identity=identity,
+        tool_allowlist=frozenset(allow),
+        tool_denylist=frozenset(deny),
+        max_risk=max_risk,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle + schema
+# ---------------------------------------------------------------------------
+
+
+class TestStoreLifecycle:
+    def test_creates_schema_in_memory(self) -> None:
+        with PermissionScopeStore(":memory:") as store:
+            assert store.schema_version == 1
+            assert len(store) == 0
+
+    def test_context_manager_persists_to_disk(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        with PermissionScopeStore(db) as store:
+            store.register(_scope(identity="telegram", allow=("web_fetch",)))
+        with PermissionScopeStore(db) as store:
+            assert len(store) == 1
+            scope = store.get(ScopeAxis.CHANNEL, "telegram")
+            assert scope is not None
+            assert scope.tool_allowlist == frozenset({"web_fetch"})
+
+    def test_close_idempotent(self) -> None:
+        store = PermissionScopeStore(":memory:")
+        store.close()
+        store.close()
+
+
+# ---------------------------------------------------------------------------
+# Schema-version guard
+# ---------------------------------------------------------------------------
+
+
+class TestSchemaVersionGuard:
+    def test_rejects_newer_schema(self, tmp_path) -> None:
+        db = tmp_path / "future.sqlite"
+        PermissionScopeStore(db).close()
+        conn = sqlite3.connect(db)
+        try:
+            conn.execute(
+                "INSERT INTO _schema_meta (version, applied_at) VALUES (?, ?)",
+                (999, datetime.now(UTC).isoformat()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        with pytest.raises(PermissionScopeStoreError, match="version 999"):
+            PermissionScopeStore(db)
+
+    def test_accepts_equal_version(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        PermissionScopeStore(db).close()
+        PermissionScopeStore(db).close()
+
+
+# ---------------------------------------------------------------------------
+# Upsert (register replaces) + remove
+# ---------------------------------------------------------------------------
+
+
+class TestRegisterAndRemove:
+    def test_register_inserts_row(self) -> None:
+        with PermissionScopeStore(":memory:") as store:
+            store.register(_scope(identity="telegram"))
+            assert len(store) == 1
+
+    def test_register_upserts_on_same_key(self) -> None:
+        """``ScopeRegistry.register`` replaces silently. The disk
+        store must mirror that — re-registering the same
+        ``(axis, identity)`` overwrites, doesn't insert a duplicate."""
+        with PermissionScopeStore(":memory:") as store:
+            store.register(_scope(identity="telegram", allow=("web_fetch",)))
+            store.register(
+                _scope(
+                    identity="telegram",
+                    allow=("read_kanban",),
+                    max_risk=RiskLevel.YELLOW,
+                )
+            )
+            assert len(store) == 1
+            scope = store.get(ScopeAxis.CHANNEL, "telegram")
+            assert scope is not None
+            assert scope.tool_allowlist == frozenset({"read_kanban"})
+            assert scope.max_risk == RiskLevel.YELLOW
+
+    def test_register_distinct_keys_appends(self) -> None:
+        with PermissionScopeStore(":memory:") as store:
+            store.register(_scope(axis=ScopeAxis.CHANNEL, identity="telegram"))
+            store.register(_scope(axis=ScopeAxis.CHANNEL, identity="slack"))
+            store.register(_scope(axis=ScopeAxis.USER, identity="alex@cognithor.ai"))
+            assert len(store) == 3
+
+    def test_remove_returns_true_when_present(self) -> None:
+        with PermissionScopeStore(":memory:") as store:
+            store.register(_scope(identity="telegram"))
+            assert store.remove(ScopeAxis.CHANNEL, "telegram") is True
+            assert len(store) == 0
+
+    def test_remove_returns_false_when_absent(self) -> None:
+        with PermissionScopeStore(":memory:") as store:
+            assert store.remove(ScopeAxis.CHANNEL, "ghost") is False
+
+    def test_clear_drops_everything(self) -> None:
+        with PermissionScopeStore(":memory:") as store:
+            store.register(_scope(identity="t1"))
+            store.register(_scope(identity="t2"))
+            store.register(_scope(identity="t3"))
+            store.clear()
+            assert len(store) == 0
+
+
+# ---------------------------------------------------------------------------
+# Round-trip — every field
+# ---------------------------------------------------------------------------
+
+
+class TestFieldRoundTrip:
+    def test_full_round_trip(self) -> None:
+        original = _scope(
+            axis=ScopeAxis.WORKFLOW,
+            identity="morning_brief",
+            allow=("web_fetch", "read_calendar", "list_kanban"),
+            deny=("execute_shell", "delete_memory"),
+            max_risk=RiskLevel.YELLOW,
+        )
+        with PermissionScopeStore(":memory:") as store:
+            store.register(original)
+            recovered = store.get(ScopeAxis.WORKFLOW, "morning_brief")
+            assert recovered == original
+
+    def test_empty_allow_and_deny_lists_round_trip(self) -> None:
+        """The default-empty path matters: a scope with empty
+        allowlist must remain "all tools allowed (subject to denylist
+        + max_risk)" semantics on read-back."""
+        with PermissionScopeStore(":memory:") as store:
+            store.register(_scope(identity="telegram"))
+            scope = store.get(ScopeAxis.CHANNEL, "telegram")
+            assert scope is not None
+            assert scope.tool_allowlist == frozenset()
+            assert scope.tool_denylist == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Read API parity
+# ---------------------------------------------------------------------------
+
+
+class TestReadParity:
+    def test_get_present_and_absent(self) -> None:
+        with PermissionScopeStore(":memory:") as store:
+            store.register(_scope(identity="telegram"))
+            assert store.get(ScopeAxis.CHANNEL, "telegram") is not None
+            assert store.get(ScopeAxis.CHANNEL, "ghost") is None
+
+    def test_list_scopes_sorted(self) -> None:
+        with PermissionScopeStore(":memory:") as store:
+            store.register(_scope(axis=ScopeAxis.USER, identity="zeta"))
+            store.register(_scope(axis=ScopeAxis.CHANNEL, identity="slack"))
+            store.register(_scope(axis=ScopeAxis.CHANNEL, identity="telegram"))
+            store.register(_scope(axis=ScopeAxis.USER, identity="alpha"))
+            keys = [(s.axis.value, s.identity) for s in store.list_scopes()]
+            assert keys == [
+                ("channel", "slack"),
+                ("channel", "telegram"),
+                ("user", "alpha"),
+                ("user", "zeta"),
+            ]
+
+
+# ---------------------------------------------------------------------------
+# Evaluate / assert_allowed — must match in-memory verdict
+# ---------------------------------------------------------------------------
+
+
+class TestEvaluation:
+    def test_denylist_blocks_call(self) -> None:
+        """Denylisted tool is rejected even at GREEN risk."""
+        with PermissionScopeStore(":memory:") as store:
+            store.register(_scope(identity="telegram", deny=("execute_shell",)))
+            verdict = store.evaluate(
+                [(ScopeAxis.CHANNEL, "telegram")],
+                "execute_shell",
+                RiskLevel.GREEN,
+            )
+            assert verdict.allowed is False
+            assert "denylist" in verdict.reasons[0]
+
+    def test_max_risk_ceiling(self) -> None:
+        with PermissionScopeStore(":memory:") as store:
+            store.register(_scope(identity="telegram", max_risk=RiskLevel.YELLOW))
+            v_under = store.evaluate(
+                [(ScopeAxis.CHANNEL, "telegram")],
+                "web_fetch",
+                RiskLevel.YELLOW,
+            )
+            v_over = store.evaluate(
+                [(ScopeAxis.CHANNEL, "telegram")],
+                "execute_shell",
+                RiskLevel.RED,
+            )
+            assert v_under.allowed is True
+            assert v_over.allowed is False
+            assert "exceeds max_risk" in v_over.reasons[0]
+
+    def test_allowlist_blocks_unlisted_tool(self) -> None:
+        with PermissionScopeStore(":memory:") as store:
+            store.register(_scope(identity="telegram", allow=("web_fetch",)))
+            v_listed = store.evaluate(
+                [(ScopeAxis.CHANNEL, "telegram")],
+                "web_fetch",
+                RiskLevel.GREEN,
+            )
+            v_unlisted = store.evaluate(
+                [(ScopeAxis.CHANNEL, "telegram")],
+                "read_kanban",
+                RiskLevel.GREEN,
+            )
+            assert v_listed.allowed is True
+            assert v_unlisted.allowed is False
+            assert "not in allowlist" in v_unlisted.reasons[0]
+
+    def test_no_matching_scope_allows(self) -> None:
+        """No matching scope → allow (the gatekeeper applies the
+        global default in that case)."""
+        with PermissionScopeStore(":memory:") as store:
+            store.register(_scope(identity="telegram"))
+            verdict = store.evaluate(
+                [(ScopeAxis.CHANNEL, "ghost")],
+                "web_fetch",
+                RiskLevel.GREEN,
+            )
+            assert verdict.allowed is True
+
+    def test_evaluate_matches_in_memory_registry_for_same_rules(self) -> None:
+        """Trace-UI consumers must NOT see different verdicts based
+        on which registry the call hit. Pin verdict equality across
+        identical rule sets."""
+        rules = [
+            _scope(identity="telegram", allow=("web_fetch", "read_kanban")),
+            _scope(
+                axis=ScopeAxis.USER,
+                identity="alex@cognithor.ai",
+                max_risk=RiskLevel.ORANGE,
+            ),
+        ]
+        memory_registry = ScopeRegistry()
+        for r in rules:
+            memory_registry.register(r)
+
+        with PermissionScopeStore(":memory:") as store:
+            for r in rules:
+                store.register(r)
+
+            scope_keys = [
+                (ScopeAxis.CHANNEL, "telegram"),
+                (ScopeAxis.USER, "alex@cognithor.ai"),
+            ]
+            for tool, risk in (
+                ("web_fetch", RiskLevel.GREEN),
+                ("execute_shell", RiskLevel.RED),
+                ("read_kanban", RiskLevel.YELLOW),
+            ):
+                m = memory_registry.evaluate(scope_keys, tool, risk)
+                d = store.evaluate(scope_keys, tool, risk)
+                assert m.allowed == d.allowed
+                assert m.reasons == d.reasons
+
+    def test_assert_allowed_raises_on_deny(self) -> None:
+        with PermissionScopeStore(":memory:") as store:
+            store.register(_scope(identity="telegram", deny=("execute_shell",)))
+            with pytest.raises(ScopeViolation, match="execute_shell"):
+                store.assert_allowed(
+                    [(ScopeAxis.CHANNEL, "telegram")],
+                    "execute_shell",
+                    RiskLevel.GREEN,
+                )
+
+    def test_assert_allowed_returns_silently_on_allow(self) -> None:
+        with PermissionScopeStore(":memory:") as store:
+            store.register(_scope(identity="telegram"))
+            store.assert_allowed(
+                [(ScopeAxis.CHANNEL, "telegram")],
+                "web_fetch",
+                RiskLevel.GREEN,
+            )  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# File persistence + concurrency
+# ---------------------------------------------------------------------------
+
+
+class TestFilePersistence:
+    def test_writes_visible_after_reopen(self, tmp_path) -> None:
+        db = tmp_path / "x.sqlite"
+        with PermissionScopeStore(db) as store:
+            store.register(_scope(identity="telegram"))
+            store.register(_scope(identity="slack"))
+        with PermissionScopeStore(db) as store:
+            assert len(store) == 2
+            ids = {s.identity for s in store.list_scopes()}
+            assert ids == {"telegram", "slack"}
+
+    def test_upsert_persisted_across_processes(self, tmp_path) -> None:
+        """Two processes hitting the same key must both end up with
+        the latest value — the disk-layer's primary contract."""
+        db = tmp_path / "x.sqlite"
+        with PermissionScopeStore(db) as a:
+            a.register(_scope(identity="telegram", allow=("web_fetch",)))
+        with PermissionScopeStore(db) as b:
+            b.register(
+                _scope(
+                    identity="telegram",
+                    allow=("read_kanban",),
+                    max_risk=RiskLevel.YELLOW,
+                )
+            )
+        with PermissionScopeStore(db) as reader:
+            assert len(reader) == 1
+            scope = reader.get(ScopeAxis.CHANNEL, "telegram")
+            assert scope is not None
+            assert scope.tool_allowlist == frozenset({"read_kanban"})
+            assert scope.max_risk == RiskLevel.YELLOW
+
+
+# ---------------------------------------------------------------------------
+# Indices
+# ---------------------------------------------------------------------------
+
+
+class TestIndices:
+    def test_axis_index_present(self) -> None:
+        """Pin the secondary index — list_scopes() filters / sorts on
+        ``axis`` and would table-scan if the index disappears."""
+        with PermissionScopeStore(":memory:") as store:
+            cursor = store._conn.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='index' AND tbl_name='scope_entries' "
+                "AND name = 'idx_scope_entries_axis'"
+            )
+            assert cursor.fetchone() is not None
+
+    def test_composite_pk_present(self) -> None:
+        """The (axis, identity) composite primary key is the
+        idempotency contract — without it, ``register`` upsert
+        becomes plain insert and duplicates accumulate."""
+        with PermissionScopeStore(":memory:") as store:
+            cursor = store._conn.execute(
+                "SELECT sql FROM sqlite_master WHERE type='table' AND name='scope_entries'"
+            )
+            row = cursor.fetchone()
+            assert row is not None
+            sql = str(row[0])
+            assert "PRIMARY KEY (axis, identity)" in sql


### PR DESCRIPTION
## Summary

- Sixth and final module in the TRUST disk-persistence sprint — same pattern as #515 / #516 / #517 / #518 / #519, now applied to the TRUST-5 scope registry.
- Privacy contract preserved: axis names, identity strings, tool names, risk-level enums — no prompts, no responses, no user content.
- 26 new tests, mypy --strict clean, ruff lint + format clean.
- **Closes the disk-persistence sprint** — every operational-trust ledger now has a durable SQLite companion.

## Sprint summary (six PRs)

| Ledger | PR |
|---|---|
| BackendDispatchStore | #515 |
| CloudEscalationStore | #516 |
| FingerprintStore | #517 |
| CostLedgerStore | #518 |
| MigrationLedgerStore | #519 |
| **PermissionScopeStore** | **this PR** |

## Why a registry needs a different shape

The scope registry is not append-only — ``ScopeRegistry.register(scope)`` upserts on ``(axis, identity)`` and silently replaces any prior rule. The disk store mirrors this with a composite primary key and ``INSERT … ON CONFLICT(axis, identity) DO UPDATE``, so the cross-process upsert contract holds (``TestFilePersistence.test_upsert_persisted_across_processes`` pins this).

## Single source of truth for evaluation

``evaluate`` and ``assert_allowed`` rebuild a fresh in-memory ``ScopeRegistry`` from disk and delegate to its evaluator. The most-restrictive-wins precedence (denylist > max_risk > allowlist) stays in exactly one place — divergence between disk and memory verdicts is the kind of bug TRUST-5 exists to prevent. ``test_evaluate_matches_in_memory_registry_for_same_rules`` cross-checks verdict + reasons tuple over a multi-tool, multi-axis fixture.

## Test plan

- [x] ``mypy --strict src/cognithor/security/permission_scope_store.py`` — clean
- [x] ``ruff check`` + ``ruff format --check`` — clean
- [x] ``pytest tests/test_security/test_permission_scope_store.py -q`` — 26 / 26 passed in 0.46 s
- [x] Upsert contract pinned: same key registered twice keeps only the latest
- [x] Cross-process upsert preserves the latest write
- [x] Verdict + reasons tuple equality with in-memory ``ScopeRegistry`` over the same rules
- [x] All four evaluation paths (denylist, max_risk ceiling, allowlist filter, no-matching-scope) covered
- [x] Composite ``PRIMARY KEY (axis, identity)`` verified in schema SQL
- [x] ``axis`` index verified present
- [ ] Wiring into gateway boot (load scopes from this store on start) + reflowing the existing ``ScopeRegistry.from_config`` path to write into the store — separate follow-up PRs

## What ships next

After this lands, the disk-persistence sprint is **complete**. Remaining follow-ups:

1. Gateway boot wiring — load every store from ``~/.cognithor/audit/*.sqlite`` and keep the in-memory ledgers as a process-local cache.
2. Flutter UI consumption — Trace-UI panels that read directly from the disk stores so post-restart inspection works.
3. Production wiring of the ledgers that don't already have callers (TRUST-7 BINARY catalog, TRUST-10 self-audit emitters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)