### PR TITLE
feat(trust): boot-wire TRUST disk-persistence stores into the gateway

### DIFF
--- a/src/cognithor/gateway/phases/tools.py
+++ b/src/cognithor/gateway/phases/tools.py
@@ -232,6 +232,24 @@ async def init_tools(
     except Exception:
         log.debug("pse_sprint26_domains_not_available", exc_info=True)
 
+    # TRUST disk-persistence (PRs #515-#520): open every audit-ledger
+    # SQLite store under ``~/.cognithor/audit/`` and wire write-through
+    # so every in-memory ledger.record() also lands on disk. Must run
+    # BEFORE register_runtime_binaries() below so the binary
+    # fingerprints captured on this boot persist immediately.
+    #
+    # Best-effort: a corrupt SQLite file or missing audit dir logs a
+    # warning and skips just that ledger — the in-memory ledger
+    # continues to work, the gateway still boots.
+    try:
+        from cognithor.security.ledger_persistence import (
+            open_canonical_stores_and_bind,
+        )
+
+        open_canonical_stores_and_bind()
+    except Exception:
+        log.debug("trust_disk_persistence_not_available", exc_info=True)
+
     # TRUST-7 BINARY: pin the SHA-256 + best-effort version of every
     # native binary Cognithor depends on at runtime (Ollama, vLLM,
     # ffmpeg, piper) into the canonical FINGERPRINT_LEDGER. Without
@@ -244,7 +262,8 @@ async def init_tools(
     # Best-effort: a missing binary is debug-logged + skipped; a
     # binary that hashes but won't tell us its version still lands in
     # the ledger with empty ``version`` (the SHA itself is the
-    # canonical identity).
+    # canonical identity). Disk persistence happens automatically via
+    # the write-through wired above.
     try:
         from cognithor.security.binary_runtime_fingerprint import (
             register_runtime_binaries,

--- a/src/cognithor/security/ledger_persistence.py
+++ b/src/cognithor/security/ledger_persistence.py
@@ -1,0 +1,599 @@
+"""Boot-time wiring of the six TRUST disk-persistence stores.
+
+This module is the production entry point for the disk-persistence
+sprint shipped in PRs #515-#520. It exists so that:
+
+1. Every operational-trust ledger has a canonical SQLite file under
+   ``~/.cognithor/audit/`` after first boot.
+2. Future writes through the canonical in-memory ledgers are
+   transparently mirrored to disk via best-effort write-through —
+   the in-memory ledger remains the authoritative read path during
+   the session, the disk stores are the cross-restart authority.
+3. Registry-style ledgers (fingerprint, migration, scope) seed
+   their in-memory caches from disk at boot so the Trace-UI shows
+   the historic state, not just what happened in this process.
+4. Append-style ledgers (backend-dispatch, escalation, cost) start
+   each session with an empty in-memory cache — disk is the long
+   tail, in-memory is the live tail.
+
+Failure model: every operation here is best-effort. A corrupt
+SQLite file, missing audit dir, or schema-version mismatch logs a
+warning and skips the binding for that ledger — the in-memory
+ledger continues to function so the gateway still boots. We do
+NOT raise; persistence is value-add, not a boot pre-requisite.
+
+Lifecycle::
+
+    from cognithor.security.ledger_persistence import (
+        open_canonical_stores_and_bind,
+    )
+
+    # Once during gateway boot, before register_runtime_binaries():
+    bound = open_canonical_stores_and_bind()
+    if bound.errors:
+        for ledger_name, exc in bound.errors.items():
+            log.warning("ledger_persistence_skipped", ledger=ledger_name, ...)
+
+The module is idempotent — calling ``open_canonical_stores_and_bind``
+twice is safe; the second call detects the already-bound flag and
+returns the existing handles.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from cognithor.utils.logging import get_logger
+
+if TYPE_CHECKING:
+    from cognithor.security.backend_dispatch_store import BackendDispatchStore
+    from cognithor.security.cloud_escalation_store import CloudEscalationStore
+    from cognithor.security.cost_ledger_store import CostLedgerStore
+    from cognithor.security.fingerprint_store import FingerprintStore
+    from cognithor.security.migration_ledger_store import MigrationLedgerStore
+    from cognithor.security.permission_scope_store import PermissionScopeStore
+
+log = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Canonical paths
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_AUDIT_SUBDIR = "audit"
+
+
+def default_audit_dir() -> Path:
+    """Return ``~/.cognithor/audit/``, creating it if missing.
+
+    The directory is the canonical home for every TRUST disk store.
+    Inno Setup, the bootstrap script, and the Flutter UI all assume
+    this layout.
+    """
+    home = Path.home() / ".cognithor"
+    audit_dir = home / _DEFAULT_AUDIT_SUBDIR
+    audit_dir.mkdir(parents=True, exist_ok=True)
+    return audit_dir
+
+
+def _store_path(audit_dir: Path, name: str) -> Path:
+    return audit_dir / f"{name}.sqlite"
+
+
+# ---------------------------------------------------------------------------
+# Public surface
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CanonicalStores:
+    """Handles to every opened TRUST store + binding diagnostics.
+
+    ``errors`` is keyed by ledger short name (``"dispatch"``,
+    ``"escalation"``, ``"fingerprint"``, ``"cost"``, ``"migration"``,
+    ``"scope"``) when an open or bind step failed for that ledger.
+    Empty when everything came up cleanly.
+    """
+
+    audit_dir: Path
+    dispatch: BackendDispatchStore | None = None
+    escalation: CloudEscalationStore | None = None
+    fingerprint: FingerprintStore | None = None
+    cost: CostLedgerStore | None = None
+    migration: MigrationLedgerStore | None = None
+    scope: PermissionScopeStore | None = None
+    errors: dict[str, str] = field(default_factory=dict)
+
+    def close_all(self) -> None:
+        """Close every successfully opened store. Safe to call
+        multiple times. Used by tests + graceful gateway shutdown."""
+        for s in (
+            self.dispatch,
+            self.escalation,
+            self.fingerprint,
+            self.cost,
+            self.migration,
+            self.scope,
+        ):
+            if s is not None:
+                with contextlib.suppress(Exception):
+                    s.close()
+
+
+# Module-global flag so a double-call is a no-op (defensive — gateway
+# boot phases run once, but tests + hot-reload paths may call again).
+_BOUND: CanonicalStores | None = None
+
+
+def open_canonical_stores_and_bind(
+    *,
+    audit_dir: Path | None = None,
+) -> CanonicalStores:
+    """Open every canonical TRUST store and wire write-through.
+
+    Steps (each independent — failure of one doesn't poison the rest):
+
+    1. Resolve ``audit_dir`` (default: ``~/.cognithor/audit/``).
+    2. Open each of the six SQLite stores in a fixed order.
+    3. Seed registry-style in-memory ledgers (fingerprint, migration,
+       scope) from disk so reads reflect historic state.
+    4. Patch the canonical in-memory ledgers' mutation methods to
+       write through to the corresponding store.
+
+    Args:
+        audit_dir: Override for tests. Production passes ``None``.
+
+    Returns:
+        A :class:`CanonicalStores` instance. Inspect ``errors`` to
+        see which ledgers (if any) couldn't be bound.
+    """
+    global _BOUND
+    if _BOUND is not None:
+        return _BOUND
+
+    target_dir = audit_dir if audit_dir is not None else default_audit_dir()
+    bundle = CanonicalStores(audit_dir=target_dir)
+
+    _open_dispatch_store(bundle)
+    _open_escalation_store(bundle)
+    _open_fingerprint_store(bundle)
+    _open_cost_store(bundle)
+    _open_migration_store(bundle)
+    _open_scope_store(bundle)
+
+    _seed_registry_ledgers_from_disk(bundle)
+    _bind_write_through(bundle)
+    _persist_pre_bind_migration_steps(bundle)
+
+    _BOUND = bundle
+    if bundle.errors:
+        log.warning(
+            "ledger_persistence_partial",
+            audit_dir=str(target_dir),
+            failed_ledgers=sorted(bundle.errors.keys()),
+        )
+    else:
+        log.info(
+            "ledger_persistence_ready",
+            audit_dir=str(target_dir),
+        )
+    return bundle
+
+
+def reset_for_tests() -> None:
+    """Drop the global handle so a fresh ``open_canonical_stores_and_bind``
+    can run. Test helper only — production never calls this."""
+    global _BOUND
+    if _BOUND is not None:
+        _BOUND.close_all()
+    _BOUND = None
+    _restore_canonical_methods()
+
+
+# ---------------------------------------------------------------------------
+# Per-ledger open helpers
+# ---------------------------------------------------------------------------
+
+
+def _open_dispatch_store(bundle: CanonicalStores) -> None:
+    try:
+        from cognithor.security.backend_dispatch_store import (
+            BackendDispatchStore,
+        )
+
+        bundle.dispatch = BackendDispatchStore(_store_path(bundle.audit_dir, "backend_dispatch"))
+    except Exception as exc:
+        bundle.errors["dispatch"] = repr(exc)
+        log.warning("ledger_persistence_open_failed", ledger="dispatch", error=str(exc))
+
+
+def _open_escalation_store(bundle: CanonicalStores) -> None:
+    try:
+        from cognithor.security.cloud_escalation_store import (
+            CloudEscalationStore,
+        )
+
+        bundle.escalation = CloudEscalationStore(_store_path(bundle.audit_dir, "cloud_escalation"))
+    except Exception as exc:
+        bundle.errors["escalation"] = repr(exc)
+        log.warning("ledger_persistence_open_failed", ledger="escalation", error=str(exc))
+
+
+def _open_fingerprint_store(bundle: CanonicalStores) -> None:
+    try:
+        from cognithor.security.fingerprint_store import FingerprintStore
+
+        bundle.fingerprint = FingerprintStore(_store_path(bundle.audit_dir, "fingerprints"))
+    except Exception as exc:
+        bundle.errors["fingerprint"] = repr(exc)
+        log.warning(
+            "ledger_persistence_open_failed",
+            ledger="fingerprint",
+            error=str(exc),
+        )
+
+
+def _open_cost_store(bundle: CanonicalStores) -> None:
+    try:
+        from cognithor.security.cost_ledger_store import CostLedgerStore
+
+        bundle.cost = CostLedgerStore(_store_path(bundle.audit_dir, "cost_ledger"))
+    except Exception as exc:
+        bundle.errors["cost"] = repr(exc)
+        log.warning("ledger_persistence_open_failed", ledger="cost", error=str(exc))
+
+
+def _open_migration_store(bundle: CanonicalStores) -> None:
+    try:
+        from cognithor.security.migration_ledger_store import (
+            MigrationLedgerStore,
+        )
+
+        bundle.migration = MigrationLedgerStore(_store_path(bundle.audit_dir, "migrations"))
+    except Exception as exc:
+        bundle.errors["migration"] = repr(exc)
+        log.warning(
+            "ledger_persistence_open_failed",
+            ledger="migration",
+            error=str(exc),
+        )
+
+
+def _open_scope_store(bundle: CanonicalStores) -> None:
+    try:
+        from cognithor.security.permission_scope_store import (
+            PermissionScopeStore,
+        )
+
+        bundle.scope = PermissionScopeStore(_store_path(bundle.audit_dir, "scope_registry"))
+    except Exception as exc:
+        bundle.errors["scope"] = repr(exc)
+        log.warning("ledger_persistence_open_failed", ledger="scope", error=str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Registry-style seeding (fingerprint, migration, scope)
+# ---------------------------------------------------------------------------
+
+
+def _seed_registry_ledgers_from_disk(bundle: CanonicalStores) -> None:
+    """Pull existing rows from registry-style stores into their
+    in-memory ledgers so reads reflect historic state.
+
+    Append-style ledgers (dispatch, escalation, cost) are NOT seeded
+    — those are write-only logs whose useful read shape is "what
+    happened during this session". The Trace-UI queries the disk
+    directly when it needs the long tail.
+    """
+    if bundle.fingerprint is not None:
+        try:
+            from cognithor.security.fingerprint import FINGERPRINT_LEDGER
+
+            for name in bundle.fingerprint.names():
+                for fp in bundle.fingerprint.history(name):
+                    # ``register`` is idempotent — re-registering an
+                    # already-known hash is a no-op.
+                    FINGERPRINT_LEDGER.register(fp)
+        except Exception as exc:
+            bundle.errors["fingerprint_seed"] = repr(exc)
+            log.warning(
+                "ledger_persistence_seed_failed",
+                ledger="fingerprint",
+                error=str(exc),
+            )
+
+    if bundle.migration is not None:
+        try:
+            from cognithor.security.migration_ledger import (
+                MIGRATION_LEDGER,
+                MigrationChainError,
+            )
+
+            for step in bundle.migration.steps():
+                with contextlib.suppress(MigrationChainError, ValueError):
+                    MIGRATION_LEDGER.record(step)
+        except Exception as exc:
+            bundle.errors["migration_seed"] = repr(exc)
+            log.warning(
+                "ledger_persistence_seed_failed",
+                ledger="migration",
+                error=str(exc),
+            )
+
+    if bundle.scope is not None:
+        try:
+            from cognithor.security.permission_scope import SCOPE_REGISTRY
+
+            for scope in bundle.scope.list_scopes():
+                SCOPE_REGISTRY.register(scope)
+        except Exception as exc:
+            bundle.errors["scope_seed"] = repr(exc)
+            log.warning(
+                "ledger_persistence_seed_failed",
+                ledger="scope",
+                error=str(exc),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Pre-bind migration replay (TRUST-10 self-audit emitter wiring)
+# ---------------------------------------------------------------------------
+
+
+def _persist_pre_bind_migration_steps(bundle: CanonicalStores) -> None:
+    """Replay every in-memory migration step into the disk store.
+
+    Several `_record_*_migration()` helpers across the security
+    package run at import time and append to the canonical
+    in-memory ``MIGRATION_LEDGER`` before this module's bind step
+    has a chance to wire write-through. Without this replay, the
+    TRUST-10 self-audit emitters would never reach disk.
+
+    Idempotent: ``MigrationLedgerStore.record`` rejects duplicate
+    ``migration_id`` via :class:`MigrationChainError`. We suppress
+    that — re-runs after the first boot are no-ops.
+    """
+    if bundle.migration is None:
+        return
+    try:
+        from cognithor.security.migration_ledger import (
+            MIGRATION_LEDGER,
+            MigrationChainError,
+        )
+
+        for step in MIGRATION_LEDGER.steps():
+            with contextlib.suppress(MigrationChainError, ValueError):
+                bundle.migration.record(step)
+    except Exception as exc:
+        bundle.errors["migration_replay"] = repr(exc)
+        log.warning(
+            "ledger_persistence_replay_failed",
+            ledger="migration",
+            error=str(exc),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Method-patching write-through
+# ---------------------------------------------------------------------------
+
+# Originals are saved here so ``reset_for_tests`` can restore them.
+_ORIGINAL_METHODS: dict[str, Any] = {}
+
+
+def _bind_write_through(bundle: CanonicalStores) -> None:
+    """Wrap each canonical in-memory ledger's mutation method so that
+    every successful in-memory write also fires the corresponding
+    store call. Disk failures are logged + swallowed so an unhealthy
+    SQLite file can't take down the live agent loop."""
+
+    if bundle.dispatch is not None:
+        _wrap_in_memory_record(
+            module_name="cognithor.security.backend_dispatch",
+            attr_name="BACKEND_DISPATCH_LEDGER",
+            method_name="record",
+            store_callable=bundle.dispatch.append,
+            ledger_label="dispatch",
+        )
+
+    if bundle.escalation is not None:
+        _wrap_in_memory_record(
+            module_name="cognithor.security.cloud_escalation",
+            attr_name="ESCALATION_LEDGER",
+            method_name="record",
+            store_callable=bundle.escalation.append,
+            ledger_label="escalation",
+        )
+
+    if bundle.fingerprint is not None:
+        _wrap_in_memory_record(
+            module_name="cognithor.security.fingerprint",
+            attr_name="FINGERPRINT_LEDGER",
+            method_name="register",
+            store_callable=bundle.fingerprint.register,
+            ledger_label="fingerprint_register",
+        )
+        _wrap_in_memory_record(
+            module_name="cognithor.security.fingerprint",
+            attr_name="FINGERPRINT_LEDGER",
+            method_name="remove",
+            store_callable=bundle.fingerprint.remove,
+            ledger_label="fingerprint_remove",
+        )
+
+    if bundle.cost is not None:
+        _wrap_in_memory_record(
+            module_name="cognithor.security.cost_ledger",
+            attr_name="COST_LEDGER",
+            method_name="record",
+            store_callable=bundle.cost.record,
+            ledger_label="cost",
+        )
+
+    if bundle.migration is not None:
+        _wrap_in_memory_record(
+            module_name="cognithor.security.migration_ledger",
+            attr_name="MIGRATION_LEDGER",
+            method_name="record",
+            store_callable=bundle.migration.record,
+            ledger_label="migration",
+        )
+
+    if bundle.scope is not None:
+        _wrap_in_memory_record(
+            module_name="cognithor.security.permission_scope",
+            attr_name="SCOPE_REGISTRY",
+            method_name="register",
+            store_callable=bundle.scope.register,
+            ledger_label="scope_register",
+        )
+        _wrap_scope_remove(bundle)
+        _wrap_scope_clear(bundle)
+
+
+def _wrap_in_memory_record(
+    *,
+    module_name: str,
+    attr_name: str,
+    method_name: str,
+    store_callable: Any,
+    ledger_label: str,
+) -> None:
+    """Replace ``<module>.<attr>.<method>`` with a wrapper that calls
+    the original AND then ``store_callable`` with the same args.
+
+    Idempotent: a previously-wrapped method is detected via the
+    ``__cognithor_disk_wrapped__`` marker and re-wrapping is skipped.
+    """
+    import importlib
+
+    module = importlib.import_module(module_name)
+    instance = getattr(module, attr_name)
+    original = getattr(instance, method_name)
+
+    # Already wrapped? Don't double-wrap (defensive against a
+    # resurrected boot path).
+    if getattr(original, "__cognithor_disk_wrapped__", False):
+        return
+
+    key = f"{module_name}.{attr_name}.{method_name}"
+    _ORIGINAL_METHODS[key] = original
+
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
+        result = original(*args, **kwargs)
+        try:
+            store_callable(*args, **kwargs)
+        except Exception as exc:
+            log.warning(
+                "ledger_disk_write_failed",
+                ledger=ledger_label,
+                error=type(exc).__name__,
+                error_msg=str(exc),
+            )
+        return result
+
+    wrapper.__cognithor_disk_wrapped__ = True  # type: ignore[attr-defined]
+    setattr(instance, method_name, wrapper)
+
+
+def _wrap_scope_remove(bundle: CanonicalStores) -> None:
+    """``ScopeRegistry.remove`` takes ``(axis, identity)`` and returns
+    bool; mirror that into the disk store."""
+    if bundle.scope is None:
+        return
+
+    import importlib
+
+    module = importlib.import_module("cognithor.security.permission_scope")
+    instance = module.SCOPE_REGISTRY
+    original = instance.remove
+    if getattr(original, "__cognithor_disk_wrapped__", False):
+        return
+
+    _ORIGINAL_METHODS["cognithor.security.permission_scope.SCOPE_REGISTRY.remove"] = original
+
+    def wrapper(*args: Any, **kwargs: Any) -> bool:
+        result = original(*args, **kwargs)
+        try:
+            assert bundle.scope is not None
+            bundle.scope.remove(*args, **kwargs)
+        except Exception as exc:
+            log.warning(
+                "ledger_disk_write_failed",
+                ledger="scope_remove",
+                error=type(exc).__name__,
+                error_msg=str(exc),
+            )
+        return bool(result)
+
+    wrapper.__cognithor_disk_wrapped__ = True  # type: ignore[attr-defined]
+    instance.remove = wrapper
+
+
+def _wrap_scope_clear(bundle: CanonicalStores) -> None:
+    if bundle.scope is None:
+        return
+
+    import importlib
+
+    module = importlib.import_module("cognithor.security.permission_scope")
+    instance = module.SCOPE_REGISTRY
+    original = instance.clear
+    if getattr(original, "__cognithor_disk_wrapped__", False):
+        return
+
+    _ORIGINAL_METHODS["cognithor.security.permission_scope.SCOPE_REGISTRY.clear"] = original
+
+    def wrapper() -> None:
+        original()
+        try:
+            assert bundle.scope is not None
+            bundle.scope.clear()
+        except Exception as exc:
+            log.warning(
+                "ledger_disk_write_failed",
+                ledger="scope_clear",
+                error=type(exc).__name__,
+                error_msg=str(exc),
+            )
+
+    wrapper.__cognithor_disk_wrapped__ = True  # type: ignore[attr-defined]
+    instance.clear = wrapper
+
+
+def _restore_canonical_methods() -> None:
+    """Reverse :func:`_bind_write_through` — used by tests so a
+    teardown leaves the canonical singletons untouched for the next
+    test that imports them."""
+    import importlib
+
+    for key, original in list(_ORIGINAL_METHODS.items()):
+        module_name, _, rest = key.partition(".")
+        # rebuild full module name (module path may contain dots)
+        # The keys all start with ``cognithor.security.<file>.``…
+        parts = key.rsplit(".", 2)
+        if len(parts) != 3:
+            continue
+        full_module, attr_name, method_name = parts
+        try:
+            module = importlib.import_module(full_module)
+        except Exception:
+            continue
+        instance = getattr(module, attr_name, None)
+        if instance is None:
+            continue
+        with contextlib.suppress(AttributeError):
+            setattr(instance, method_name, original)
+    _ORIGINAL_METHODS.clear()
+
+
+__all__ = [
+    "CanonicalStores",
+    "default_audit_dir",
+    "open_canonical_stores_and_bind",
+    "reset_for_tests",
+]

--- a/tests/test_security/test_ledger_persistence.py
+++ b/tests/test_security/test_ledger_persistence.py
@@ -1,0 +1,325 @@
+"""Tests for boot-time TRUST disk-persistence wiring."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+
+import pytest
+
+from cognithor.models import RiskLevel
+from cognithor.security.backend_dispatch import (
+    BACKEND_DISPATCH_LEDGER,
+    BackendDispatchEvent,
+    DispatchOutcome,
+)
+from cognithor.security.cloud_escalation import (
+    ESCALATION_LEDGER,
+    EscalationEvent,
+    EscalationReason,
+)
+from cognithor.security.cost_ledger import (
+    COST_LEDGER,
+    CostEntry,
+    CostKind,
+)
+from cognithor.security.fingerprint import (
+    FINGERPRINT_LEDGER,
+    BinaryKind,
+    ToolFingerprint,
+)
+from cognithor.security.ledger_persistence import (
+    CanonicalStores,
+    default_audit_dir,
+    open_canonical_stores_and_bind,
+    reset_for_tests,
+)
+from cognithor.security.migration_ledger import (
+    MIGRATION_LEDGER,
+    MigrationDomain,
+    MigrationStatus,
+    MigrationStep,
+)
+from cognithor.security.permission_scope import (
+    SCOPE_REGISTRY,
+    PermissionScope,
+    ScopeAxis,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(tmp_path):
+    """Each test gets a fresh audit dir and a clean global bind state."""
+    reset_for_tests()
+    BACKEND_DISPATCH_LEDGER.clear()
+    ESCALATION_LEDGER.clear()
+    FINGERPRINT_LEDGER.clear()
+    COST_LEDGER.clear()
+    MIGRATION_LEDGER.clear()
+    SCOPE_REGISTRY.clear()
+    yield
+    reset_for_tests()
+    BACKEND_DISPATCH_LEDGER.clear()
+    ESCALATION_LEDGER.clear()
+    FINGERPRINT_LEDGER.clear()
+    COST_LEDGER.clear()
+    MIGRATION_LEDGER.clear()
+    SCOPE_REGISTRY.clear()
+
+
+def _hash(seed: str) -> str:
+    return hashlib.sha256(seed.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Bundle / lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestBundleLifecycle:
+    def test_open_creates_audit_files(self, tmp_path) -> None:
+        bundle = open_canonical_stores_and_bind(audit_dir=tmp_path)
+        assert isinstance(bundle, CanonicalStores)
+        assert bundle.errors == {}
+        for name in (
+            "backend_dispatch.sqlite",
+            "cloud_escalation.sqlite",
+            "fingerprints.sqlite",
+            "cost_ledger.sqlite",
+            "migrations.sqlite",
+            "scope_registry.sqlite",
+        ):
+            assert (tmp_path / name).exists(), f"{name} not created"
+
+    def test_double_call_is_idempotent(self, tmp_path) -> None:
+        first = open_canonical_stores_and_bind(audit_dir=tmp_path)
+        second = open_canonical_stores_and_bind(audit_dir=tmp_path)
+        assert first is second
+
+    def test_default_audit_dir_creates_under_home(self, tmp_path, monkeypatch) -> None:
+        """Production callers go through ``default_audit_dir()`` —
+        verify it builds the canonical layout under ``~/.cognithor/audit/``."""
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
+        # On Windows ``Path.home()`` reads USERPROFILE; on POSIX, HOME.
+        target = default_audit_dir()
+        assert target.exists()
+        assert target.name == "audit"
+        assert target.parent.name == ".cognithor"
+
+
+# ---------------------------------------------------------------------------
+# Write-through — append-style ledgers
+# ---------------------------------------------------------------------------
+
+
+class TestWriteThroughAppendLedgers:
+    def test_dispatch_record_persists_to_disk(self, tmp_path) -> None:
+        bundle = open_canonical_stores_and_bind(audit_dir=tmp_path)
+        ev = BackendDispatchEvent(
+            backend_type="ollama",
+            model="qwen3:30b",
+            outcome=DispatchOutcome.SUCCESS,
+            prompt_tokens=100,
+            response_tokens=50,
+            started_at=datetime(2026, 5, 9, 12, 0, 0, tzinfo=UTC),
+            completed_at=datetime(2026, 5, 9, 12, 0, 1, tzinfo=UTC),
+            run_id="run-1",
+        )
+        BACKEND_DISPATCH_LEDGER.record(ev)
+        assert bundle.dispatch is not None
+        assert len(bundle.dispatch) == 1
+        recovered = bundle.dispatch.events()[0]
+        assert recovered.run_id == "run-1"
+        assert recovered.outcome == DispatchOutcome.SUCCESS
+
+    def test_escalation_record_persists_to_disk(self, tmp_path) -> None:
+        bundle = open_canonical_stores_and_bind(audit_dir=tmp_path)
+        ev = EscalationEvent(
+            reason=EscalationReason.OWNER_OVERRIDE,
+            from_backend="ollama",
+            to_backend="anthropic",
+            prompt_tokens=200,
+            response_tokens=80,
+            started_at=datetime(2026, 5, 9, 12, 0, 0, tzinfo=UTC),
+            completed_at=datetime(2026, 5, 9, 12, 0, 5, tzinfo=UTC),
+            run_id="run-1",
+        )
+        ESCALATION_LEDGER.record(ev)
+        assert bundle.escalation is not None
+        assert len(bundle.escalation) == 1
+        assert bundle.escalation.events()[0].run_id == "run-1"
+
+    def test_cost_record_persists_to_disk(self, tmp_path) -> None:
+        bundle = open_canonical_stores_and_bind(audit_dir=tmp_path)
+        e = CostEntry(
+            kind=CostKind.LLM_INFERENCE,
+            tool="qwen3:30b",
+            cost_usd_micro=1500,
+            backend="ollama",
+            run_id="run-1",
+        )
+        COST_LEDGER.record(e)
+        assert bundle.cost is not None
+        assert len(bundle.cost) == 1
+
+
+# ---------------------------------------------------------------------------
+# Write-through — registry-style ledgers
+# ---------------------------------------------------------------------------
+
+
+class TestWriteThroughRegistryLedgers:
+    def test_fingerprint_register_persists(self, tmp_path) -> None:
+        bundle = open_canonical_stores_and_bind(audit_dir=tmp_path)
+        fp = ToolFingerprint(
+            name="ollama",
+            kind=BinaryKind.BINARY,
+            content_hash=_hash("ollama-bytes"),
+            version="0.5.7",
+        )
+        FINGERPRINT_LEDGER.register(fp)
+        assert bundle.fingerprint is not None
+        assert len(bundle.fingerprint) == 1
+        assert bundle.fingerprint.get(fp.content_hash) == fp
+
+    def test_scope_register_persists(self, tmp_path) -> None:
+        bundle = open_canonical_stores_and_bind(audit_dir=tmp_path)
+        scope = PermissionScope(
+            axis=ScopeAxis.CHANNEL,
+            identity="telegram",
+            tool_allowlist=frozenset({"web_fetch"}),
+            max_risk=RiskLevel.YELLOW,
+        )
+        SCOPE_REGISTRY.register(scope)
+        assert bundle.scope is not None
+        assert len(bundle.scope) == 1
+        recovered = bundle.scope.get(ScopeAxis.CHANNEL, "telegram")
+        assert recovered == scope
+
+    def test_scope_remove_persists(self, tmp_path) -> None:
+        bundle = open_canonical_stores_and_bind(audit_dir=tmp_path)
+        scope = PermissionScope(axis=ScopeAxis.CHANNEL, identity="telegram")
+        SCOPE_REGISTRY.register(scope)
+        assert bundle.scope is not None
+        assert len(bundle.scope) == 1
+        SCOPE_REGISTRY.remove(ScopeAxis.CHANNEL, "telegram")
+        assert len(bundle.scope) == 0
+
+    def test_migration_record_persists(self, tmp_path) -> None:
+        bundle = open_canonical_stores_and_bind(audit_dir=tmp_path)
+        step = MigrationStep(
+            domain=MigrationDomain.MEMORY_VAULT,
+            source_version="v0",
+            target_version="v1",
+            status=MigrationStatus.APPLIED,
+            applied_by="system",
+            migration_id="memory_vault:v0:v1",
+        )
+        MIGRATION_LEDGER.record(step)
+        assert bundle.migration is not None
+        # Disk has at least the new step (plus any TRUST-10 self-audit
+        # emitter steps replayed at bind time).
+        recovered = bundle.migration.get("memory_vault:v0:v1")
+        assert recovered is not None
+        assert recovered.target_version == "v1"
+
+
+# ---------------------------------------------------------------------------
+# Cross-restart seeding (registry-style ledgers)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossRestartSeeding:
+    def test_fingerprint_seeded_from_disk_on_second_open(self, tmp_path) -> None:
+        # First boot: register a fingerprint
+        open_canonical_stores_and_bind(audit_dir=tmp_path)
+        fp = ToolFingerprint(
+            name="ollama",
+            kind=BinaryKind.BINARY,
+            content_hash=_hash("ollama-v1"),
+            version="0.5.7",
+        )
+        FINGERPRINT_LEDGER.register(fp)
+        assert fp.content_hash in FINGERPRINT_LEDGER
+
+        # Simulate restart: reset bind state + clear the in-memory ledger
+        reset_for_tests()
+        FINGERPRINT_LEDGER.clear()
+        assert fp.content_hash not in FINGERPRINT_LEDGER
+
+        # Second boot: in-memory ledger should be re-seeded from disk
+        open_canonical_stores_and_bind(audit_dir=tmp_path)
+        assert fp.content_hash in FINGERPRINT_LEDGER
+
+    def test_scope_seeded_from_disk_on_second_open(self, tmp_path) -> None:
+        open_canonical_stores_and_bind(audit_dir=tmp_path)
+        scope = PermissionScope(
+            axis=ScopeAxis.CHANNEL,
+            identity="telegram",
+            max_risk=RiskLevel.YELLOW,
+        )
+        SCOPE_REGISTRY.register(scope)
+
+        reset_for_tests()
+        SCOPE_REGISTRY.clear()
+        assert SCOPE_REGISTRY.get(ScopeAxis.CHANNEL, "telegram") is None
+
+        open_canonical_stores_and_bind(audit_dir=tmp_path)
+        seeded = SCOPE_REGISTRY.get(ScopeAxis.CHANNEL, "telegram")
+        assert seeded is not None
+        assert seeded.max_risk == RiskLevel.YELLOW
+
+    def test_migration_replay_persists_pre_bind_steps(self, tmp_path) -> None:
+        """A migration step appended to MIGRATION_LEDGER BEFORE
+        ``open_canonical_stores_and_bind`` runs must still reach
+        disk via the replay step. This is the TRUST-10 self-audit
+        emitter use case: many security modules call
+        ``_record_*_migration()`` at import time."""
+        # Pre-bind: emit a step into the in-memory ledger
+        step = MigrationStep(
+            domain=MigrationDomain.MEMORY_VAULT,
+            source_version="v0",
+            target_version="v1",
+            status=MigrationStatus.APPLIED,
+            applied_by="system",
+            migration_id="pre-bind-replay-target",
+        )
+        MIGRATION_LEDGER.record(step)
+        assert len(MIGRATION_LEDGER) >= 1
+
+        # Bind with a fresh (empty) disk store — the replay step
+        # should pull the in-memory step onto disk.
+        bundle = open_canonical_stores_and_bind(audit_dir=tmp_path)
+        assert bundle.migration is not None
+        recovered = bundle.migration.get("pre-bind-replay-target")
+        assert recovered is not None
+
+
+# ---------------------------------------------------------------------------
+# Best-effort error suppression
+# ---------------------------------------------------------------------------
+
+
+class TestErrorSuppression:
+    def test_disk_write_failure_does_not_break_in_memory_ledger(self, tmp_path) -> None:
+        """If the disk store raises, the in-memory ledger MUST still
+        accept the write. This is the boot-survival contract."""
+        bundle = open_canonical_stores_and_bind(audit_dir=tmp_path)
+        assert bundle.dispatch is not None
+
+        # Force the disk store into a bad state — close the underlying
+        # connection mid-flight. Subsequent writes raise sqlite3.ProgrammingError.
+        bundle.dispatch.close()
+
+        ev = BackendDispatchEvent(
+            backend_type="ollama",
+            model="qwen3:30b",
+            outcome=DispatchOutcome.SUCCESS,
+            prompt_tokens=10,
+            response_tokens=5,
+            started_at=datetime(2026, 5, 9, 12, 0, 0, tzinfo=UTC),
+            completed_at=datetime(2026, 5, 9, 12, 0, 1, tzinfo=UTC),
+        )
+        BACKEND_DISPATCH_LEDGER.record(ev)  # must not raise
+        assert len(BACKEND_DISPATCH_LEDGER) == 1


### PR DESCRIPTION
## Summary

- Closes the wiring leg of the TRUST disk-persistence sprint. PRs #515–#520 shipped the six SQLite stores; this PR makes them fire on every boot.
- New module `cognithor.security.ledger_persistence` with one entry point: `open_canonical_stores_and_bind()`.
- Hook in `gateway/phases/tools.py` calls it immediately before `register_runtime_binaries()`, so TRUST-7 BINARY fingerprints captured on this boot persist via the write-through wired one line earlier.
- 14 new tests, mypy --strict clean, ruff lint + format clean.

## What the wiring does

1. **Open**: every store opens at `~/.cognithor/audit/<name>.sqlite`. WAL journal mode + `check_same_thread=False`.
2. **Seed**: registry-style ledgers (fingerprint, migration, scope) pull existing rows back into the canonical in-memory singletons so a restart does not lose visibility.
3. **Bind**: monkey-patches the canonical ledger mutation methods (`record` / `register` / `remove` / `clear`). A successful in-memory write fires the corresponding store call as a best-effort follow-up — disk failures are logged + swallowed so an unhealthy SQLite file cannot take down the live agent loop.
4. **Replay**: all `_record_*_migration()` self-audit emitters across the security package run at import time and land in `MIGRATION_LEDGER` BEFORE this module gets a chance to bind. After bind, we replay the in-memory steps into the disk store; `MigrationLedgerStore.record` rejects duplicates via `MigrationChainError` so subsequent boots are no-ops.
5. **Idempotent**: a double-call returns the existing bundle. A test helper `reset_for_tests()` un-binds + restores the originals.

## Failure model

Every step is best-effort. A corrupt `~/.cognithor/audit/*.sqlite`, a missing audit dir, or a schema-version mismatch logs a warning and skips that ledger — the in-memory ledger still works, the gateway still boots. The `errors` dict on `CanonicalStores` records which ledgers were skipped so an operator can see it in the boot log.

`TestErrorSuppression.test_disk_write_failure_does_not_break_in_memory_ledger` pins this contract.

## Smoke test

```
audit_dir=C:\Users\…\Temp\cognithor_smoke_…
ledger_persistence_ready  audit_dir=…
errors={}
files=[backend_dispatch.sqlite + 5 more, all 6 ledgers]
runtime_binaries_registered  names=['ollama', 'vllm', 'ffmpeg', 'piper']
fingerprints_on_disk=4
migrations_on_disk=4
```

All 6 stores created, 4 runtime binaries fingerprinted into disk on first boot, 4 TRUST-10 self-audit emitter steps replayed onto disk.

## Test plan

- [x] `mypy --strict src/cognithor/security/ledger_persistence.py` — clean
- [x] `ruff check` + `ruff format --check` — clean
- [x] `pytest tests/test_security/test_ledger_persistence.py -q` — 14 / 14 passed in 1.45 s
- [x] Smoke test on local machine: `~/.cognithor/audit/*.sqlite` files appear, 4 binaries persist, 4 migration emitter steps land on disk
- [x] Cross-restart seeding pinned for fingerprint + scope (registry-style)
- [x] Migration pre-bind replay pinned (TRUST-10 self-audit)
- [x] Best-effort error suppression pinned (closed disk store does NOT break in-memory ledger)
- [ ] Flutter Trace-UI consumption from disk — separate follow-up

## Why this unblocks production

After this lands:

```bash
pip install cognithor==<next-version>
cognithor --init-only
ls ~/.cognithor/audit/
# backend_dispatch.sqlite  cloud_escalation.sqlite  fingerprints.sqlite
# cost_ledger.sqlite        migrations.sqlite        scope_registry.sqlite
```

Every operational-trust ledger now survives a process restart. An operator inspecting yesterday's audit window can answer "which build of ollama ran" / "what was last week's spend" without grepping process state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)