### PR TITLE
fix(test): re-emit TRUST-10 self-audit migrations after ledger-persistence fixture teardown

### DIFF
--- a/tests/test_security/test_ledger_persistence.py
+++ b/tests/test_security/test_ledger_persistence.py
@@ -47,9 +47,39 @@ from cognithor.security.permission_scope import (
 )
 
 
+def _reemit_import_time_migrations() -> None:
+    """Re-fire the four ``_record_*_migration()`` self-audit emitters
+    that normally run at module import. Used by the autouse fixture's
+    teardown so a cleared MIGRATION_LEDGER doesn't leak into other
+    test files (TRUST-10 self-audit assertions).
+    """
+    from cognithor.security.cloud_escalation import (
+        _record_escalation_ledger_migration,
+    )
+    from cognithor.security.cost_ledger import (
+        _record_cost_ledger_migration,
+    )
+    from cognithor.security.fingerprint import (
+        _record_fingerprint_ledger_migration,
+    )
+    from cognithor.security.permission_scope import (
+        _record_scope_registry_migration,
+    )
+
+    _record_escalation_ledger_migration()
+    _record_cost_ledger_migration()
+    _record_fingerprint_ledger_migration()
+    _record_scope_registry_migration()
+
+
 @pytest.fixture(autouse=True)
 def _reset_state(tmp_path):
-    """Each test gets a fresh audit dir and a clean global bind state."""
+    """Each test gets a fresh audit dir and a clean global bind state.
+
+    Teardown restores the four TRUST-10 import-time migration steps so
+    cross-file tests (``TestScopeRegistrySelfAuditMigration`` etc.)
+    still see them in the canonical ``MIGRATION_LEDGER``.
+    """
     reset_for_tests()
     BACKEND_DISPATCH_LEDGER.clear()
     ESCALATION_LEDGER.clear()
@@ -65,6 +95,7 @@ def _reset_state(tmp_path):
     COST_LEDGER.clear()
     MIGRATION_LEDGER.clear()
     SCOPE_REGISTRY.clear()
+    _reemit_import_time_migrations()
 
 
 def _hash(seed: str) -> str:


### PR DESCRIPTION
## Summary

- Hotfix for the CI red landed by PR #521 on main.
- The autouse fixture in ``tests/test_security/test_ledger_persistence.py`` clears ``MIGRATION_LEDGER`` between tests so the disk-persistence write-through contracts can be exercised against a known-empty starting state. The teardown previously left the canonical ledger empty — breaking any later test in the same pytest session that relied on the import-time TRUST-10 self-audit emitters having landed.
- ``tests/test_security/test_permission_scope.py::TestScopeRegistrySelfAuditMigration::test_migration_step_landed`` was the first casualty; the lookup returned ``None`` on the entire matrix (Win/Linux × py3.12/3.13).

## Fix

Adds a small ``_reemit_import_time_migrations()`` helper that re-fires the four ``_record_*_migration()`` emitters across cloud_escalation, cost_ledger, fingerprint, and permission_scope at the end of the fixture. The result matches the post-import state of a clean Python process — same migration_id, same domain head_version — so cross-file tests see what they expect.

## Test plan

- [x] ``pytest tests/test_security/test_ledger_persistence.py tests/test_security/test_permission_scope.py -q`` — 36 / 36 passed in 1.56 s
- [x] ``ruff check`` + ``ruff format --check`` — clean
- [ ] CI matrix green (Win/Linux × py3.12/3.13 + coverage gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)