### PR TITLE
fix: bootstrap multi-use + vllm setup screen dark theme

### DIFF
--- a/flutter_app/lib/screens/setup_wizard_screen.dart
+++ b/flutter_app/lib/screens/setup_wizard_screen.dart
@@ -9,6 +9,7 @@ import 'package:cognithor_ui/widgets/glass_panel.dart';
 import 'package:cognithor_ui/widgets/gradient_background.dart';
 import 'package:cognithor_ui/widgets/neon_card.dart';
 import 'package:cognithor_ui/screens/main_shell.dart';
+import 'package:cognithor_ui/screens/vllm_setup_screen.dart';
 
 /// First-run setup wizard -- 3-step onboarding shown once on initial launch.
 ///
@@ -134,6 +135,28 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
           setState(() {
             _testState = _TestState.error;
             _testMessage = l.notInstalled;
+          });
+        }
+      } else if (_selectedBackend == 'vllm') {
+        // vllm setup happens in the dedicated screen — refresh status
+        await _loadBackendStatus();
+        final status = _backendInfo('vllm')['status'] as String? ?? 'configure';
+        if (status == 'ready') {
+          setState(() {
+            _testState = _TestState.success;
+            _testMessage = 'vLLM container running and ready.';
+          });
+        } else if (status == 'configured') {
+          setState(() {
+            _testState = _TestState.success;
+            _testMessage =
+                'vLLM is configured. Start the container from the Setup screen before chatting.';
+          });
+        } else {
+          setState(() {
+            _testState = _TestState.error;
+            _testMessage =
+                'vLLM not configured yet. Open the vLLM Setup above.';
           });
         }
       } else if (_selectedBackend == 'ollama') {
@@ -370,7 +393,23 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
                   ),
                   const SizedBox(height: 10),
 
-                  // 5. OpenRouter / Custom OpenAI-compatible
+                  // 5. vLLM (Local GPU)
+                  _BackendCard(
+                    icon: Icons.memory,
+                    title: 'vLLM (Local GPU)',
+                    subtitle:
+                        'NVIDIA GPU with Docker — NVFP4 / FP8 quantised models',
+                    tint: const Color(0xFFFF6E40),
+                    selected: _selectedBackend == 'vllm',
+                    status: _backendInfo('vllm')['status'] as String? ??
+                        'configure',
+                    statusOk:
+                        (_backendInfo('vllm')['status'] as String?) == 'ready',
+                    onTap: () => setState(() => _selectedBackend = 'vllm'),
+                  ),
+                  const SizedBox(height: 10),
+
+                  // 6. OpenRouter / Custom OpenAI-compatible
                   _BackendCard(
                     icon: Icons.hub,
                     title: 'OpenRouter / Custom',
@@ -417,6 +456,8 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
               ? l.claudeSubscription
               : _selectedBackend == 'ollama'
               ? l.ollamaConfiguration
+              : _selectedBackend == 'vllm'
+              ? 'vLLM (Local GPU)'
               : l.cloudApiConfiguration,
           style: Theme.of(context).textTheme.titleLarge,
         ),
@@ -523,6 +564,59 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
               prefixIcon: Icon(Icons.link),
             ),
           ),
+        ],
+
+        // vLLM — defer to dedicated setup screen (Docker / GPU / model)
+        if (_selectedBackend == 'vllm') ...[
+          GlassPanel(
+            tint: const Color(0xFFFF6E40),
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'vLLM has its own configuration flow',
+                  style: Theme.of(context).textTheme.titleSmall,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'GPU detection, Docker container, NVFP4/FP8 model selection — '
+                  'open the dedicated vLLM setup, then return here.',
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(height: 16),
+          SizedBox(
+            width: double.infinity,
+            height: 48,
+            child: OutlinedButton.icon(
+              icon: const Icon(Icons.open_in_new),
+              label: const Text('Open vLLM Setup'),
+              onPressed: () async {
+                // Wrap in CognithorTheme so the pushed setup screen
+                // doesn't render against the system's default light
+                // theme (which made everything look white-on-grey
+                // when launched from the dark wizard).
+                await Navigator.of(context).push(
+                  MaterialPageRoute<void>(
+                    builder: (_) => Theme(
+                      data: CognithorTheme.dark,
+                      child: const VllmSetupScreen(),
+                    ),
+                  ),
+                );
+                // refresh status when user returns
+                if (mounted) await _loadBackendStatus();
+              },
+              style: OutlinedButton.styleFrom(
+                foregroundColor: const Color(0xFFFF6E40),
+                side: const BorderSide(color: Color(0xFFFF6E40)),
+              ),
+            ),
+          ),
+          const SizedBox(height: 12),
         ],
 
         // OpenAI / Anthropic / OpenRouter
@@ -668,6 +762,10 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
         return 'Claude Code uses your existing Claude subscription. No API key needed.';
       case 'ollama':
         return 'Enter the URL where Ollama is running.';
+      case 'vllm':
+        return 'vLLM runs in Docker on your local NVIDIA GPU. Use the dedicated setup below.';
+      case 'openrouter':
+        return 'Enter your OpenAI-compatible base URL and API key.';
       default:
         return 'Enter your API key to connect.';
     }
@@ -682,6 +780,8 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
       'ollama' => 'Ollama',
       'openai' => 'OpenAI',
       'anthropic' => 'Anthropic',
+      'vllm' => 'vLLM (Local GPU)',
+      'openrouter' => 'OpenRouter / Custom',
       _ => '',
     };
 

--- a/src/cognithor/__main__.py
+++ b/src/cognithor/__main__.py
@@ -1328,11 +1328,8 @@ def main() -> None:
                     def _is_trusted(ip: str) -> bool:
                         return ip.startswith("127.") or ip in ("::1", "localhost")
 
-                _bootstrap_consumed = False
-
                 @api_app.get("/api/v1/bootstrap")
                 async def _cc_bootstrap(request: _BootstrapRequest) -> dict[str, str]:
-                    nonlocal _bootstrap_consumed
                     client_ip = request.client.host if request.client else ""
                     if not _is_trusted(client_ip):
                         from fastapi.responses import JSONResponse as _JR
@@ -1345,14 +1342,13 @@ def main() -> None:
                             status_code=403,
                             content={"detail": "Bootstrap endpoint is localhost-only"},
                         )
-                    if _bootstrap_consumed:
-                        from fastapi.responses import JSONResponse as _JR
-
-                        return _JR(  # type: ignore[return-value]
-                            status_code=403,
-                            content={"detail": "Bootstrap token already consumed"},
-                        )
-                    _bootstrap_consumed = True
+                    # Loopback-only is the gate. Single-use was the wrong
+                    # threat model — every UI restart, crash, or hot-reload
+                    # used to leave the user staring at "backend nicht
+                    # erreichbar" until the gateway itself was restarted.
+                    # Any process on the local host can already read this
+                    # token from cognithor's RAM; rate-limiting via
+                    # _is_trusted is sufficient.
                     return {"token": _internal_api_token}
 
                 # ── Token verification dependency ─────────────────────


### PR DESCRIPTION
## Summary

Two bugs that surfaced when the owner first installed v0.99.0:

1. **Single-use bootstrap token** broke every UI restart. The endpoint minted the per-session token once and 403-locked itself. Any subsequent UI launch (crash, hot-reload, second window) was permanently stuck on "backend nicht erreichbar" until the gateway itself was restarted.
2. **VLLM setup screen rendered white-on-grey** when pushed from the dark setup wizard.

## Why drop single-use

Every process on the local host can already read the token from cognithor's RAM. Single-use was theatre at the cost of stability. The IP filter (loopback-only via ``_is_trusted``) is the real gate — wenn jemand auf 127.0.0.1 prozessieren kann, hat er sowieso den vollen Zugang. Owner-confirmed via in-session Auswahl "Ja, fix shippen".

## Why wrap VllmSetupScreen in CognithorTheme

The wizard wraps step-1/2/3 in ``Theme(data: CognithorTheme.dark, ...)`` but ``Navigator.push`` starts the next route's MaterialPageRoute with the **root system theme** (light, by default). Cards / dropdowns / text rendered nearly invisible against the gradient background. Wrapping the pushed screen in the same theme fixes it.

## Test plan

- [x] ``pytest tests/test_security/test_bootstrap_binding.py -q`` — 2 / 2 passed
- [x] ``ruff check`` + ``ruff format --check`` on changed files — clean
- [ ] CI matrix green
- [ ] Owner first-install: vllm card visible → click → setup screen renders correctly → backend stays reachable across UI restarts

Refs: owner first-install report (Cognithor v0.99.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)