### PR TITLE
chore(flutter): dart format setup_wizard_screen.dart

### DIFF
--- a/flutter_app/lib/screens/setup_wizard_screen.dart
+++ b/flutter_app/lib/screens/setup_wizard_screen.dart
@@ -401,7 +401,8 @@ class _SetupWizardScreenState extends State<SetupWizardScreen> {
                         'NVIDIA GPU with Docker — NVFP4 / FP8 quantised models',
                     tint: const Color(0xFFFF6E40),
                     selected: _selectedBackend == 'vllm',
-                    status: _backendInfo('vllm')['status'] as String? ??
+                    status:
+                        _backendInfo('vllm')['status'] as String? ??
                         'configure',
                     statusOk:
                         (_backendInfo('vllm')['status'] as String?) == 'ready',


### PR DESCRIPTION
Hotfix: PR #523 merged with one unformatted line in setup_wizard_screen.dart, breaking CI's dart format check. This applies dart format and unblocks the Flutter test step.