### PR TITLE
fix(launcher): auto-open default UI when backend reaches Healthy

### DIFF
--- a/launcher/Cognithor/AppShell.cs
+++ b/launcher/Cognithor/AppShell.cs
@@ -14,6 +14,7 @@ sealed class AppShell : IDisposable
     readonly NotifyIcon _trayIcon;
     readonly ToolStripMenuItem _statusItem;
     readonly ToolStripMenuItem _defaultToggle;
+    bool _didAutoOpen;
 
     static readonly string Version = typeof(AppShell).Assembly
         .GetCustomAttribute<AssemblyInformationalVersionAttribute>()
@@ -85,6 +86,19 @@ sealed class AppShell : IDisposable
         _health.StatusChanged += (prev, next) =>
         {
             SetStatus(next);
+            // Auto-open the default UI the first time the backend
+            // becomes healthy after launch — otherwise users land in
+            // the system tray invisible-icon trap and assume "nothing
+            // happened" when in fact the backend is humming along on
+            // port 8741.
+            if (next == AppStatus.Healthy && !_didAutoOpen)
+            {
+                _didAutoOpen = true;
+                _trayIcon.ShowBalloonTip(4000, "Cognithor",
+                    "Backend ready. Opening UI…",
+                    ToolTipIcon.Info);
+                OpenDefault();
+            }
             if (next == AppStatus.Stopped && prev != AppStatus.Starting)
             {
                 _trayIcon.ShowBalloonTip(5000, "Cognithor",


### PR DESCRIPTION
Closes the silent-tray-app UX trap surfaced during owner's first install. The C# Cognithor.exe is a system-tray app; without this hook, clicking 'Run Cognithor' from the Inno-Setup post-install dialog opens no window — the user has no visual signal that the backend is in fact starting. The first Healthy status now triggers OpenDefault() exactly once (gated by a _didAutoOpen flag) plus a balloon tip pointing at the tray icon.